### PR TITLE
Update the database seeding process to make use of fixtures

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,44 +1,7 @@
-## Órgiva
-place = INE::Places::Place.find_by_slug 'orgiva'
+fixtures_to_load = [
+  "sites",
+  "admins"
+]
 
-site = Site.find_or_create_by! name: 'Órgiva Participa', domain: 'orgiva.gobierto.dev', location_name: 'Órgiva', location_type: place.class.name,
-  external_id: place.id, institution_url: 'http://orgiva.es', institution_type: 'Ayuntamiento'
-
-site.configuration.links = ['http://orgiva.es']
-site.configuration.logo = 'http://www.aytoorgiva.org/web/sites/all/themes/aytoorgiva_COPSEG/logo.png'
-site.configuration.demo = true
-site.configuration.modules = ['GobiertoBudgets']
-site.save!
-
-## Burjassot
-place = INE::Places::Place.find_by_slug 'burjassot'
-
-site = Site.find_or_create_by! name: 'Burjassot Transparente', domain: 'gobierto.burjassot.dev', location_name: 'Burjassot', location_type: place.class.name,
-  external_id: place.id, institution_url: 'http://burjassot.es', institution_type: 'Ayuntamiento'
-
-site.configuration.links = ['http://burjassot.es']
-site.configuration.logo = 'http://www.burjassot.org/wp-content/themes/ajuntament/images/_logo-burjassot.jpg'
-site.configuration.modules = ['GobiertoBudgets']
-site.save!
-
-## Santander
-place = INE::Places::Place.find_by_slug 'santander'
-
-site = Site.find_or_create_by! name: 'Santander Participa', domain: 'santander.gobierto.dev', location_name: 'Santander', location_type: place.class.name,
-  external_id: place.id, institution_url: 'http://santander.es', institution_type: 'Ayuntamiento'
-
-site.configuration.links = ['http://santander.es']
-site.configuration.logo = 'http://santander.es/sites/default/themes/custom/ayuntamiento/img/logo-ayto-santander.png'
-site.configuration.modules = ['GobiertoBudgets']
-site.save!
-
-## Madrid
-place = INE::Places::Place.find_by_slug 'madrid'
-
-site = Site.find_or_create_by! name: 'Madrid', domain: 'madrid.gobierto.dev', location_name: 'Madrid', location_type: place.class.name,
-  external_id: place.id, institution_url: 'http://www.madrid.es', institution_type: 'Ayuntamiento'
-
-site.configuration.links = ['http://www.madrid.es']
-site.configuration.logo = 'http://www.madrid.es/assets/images/logo-madrid.png'
-site.configuration.modules = ['GobiertoBudgets']
-site.save!
+ENV["FIXTURES"] = fixtures_to_load.join(",")
+Rake::Task["db:fixtures:load"].invoke


### PR DESCRIPTION
### What does this PR do?

It updates the `db:seeds` task to perform a fixture load operation. This way we can take advantage of the current fixtures to properly seed new databases without having to maintain them twice.

### How should this be manually tested?

Run the `rake db:seeds` task and check you have proper `Site` and `Admin` records.