### PR TITLE
Quick and dirty strategy for hiding draft Sites

### DIFF
--- a/lib/constraints/gobierto_site_constraint.rb
+++ b/lib/constraints/gobierto_site_constraint.rb
@@ -5,7 +5,8 @@ class GobiertoSiteConstraint
   def matches?(request)
     full_domain = (request.env['HTTP_HOST'] || request.env['SERVER_NAME'] || request.env['SERVER_ADDR']).split(':').first
 
-    if site = Site.find_by(domain: full_domain)
+    # FIXME. This is a quick and dirty way of hiding draft Sites
+    if site = Site.active.find_by(domain: full_domain)
       request.env['gobierto_site'] = site
       return true
     end


### PR DESCRIPTION
This PR implements #17.

### What does this PR do?

It implements a quick and dirty strategy for hiding draft Sites, just as a first approach.

### How should this be manually tested?

Check that none of the draft Sites can't be accessed through the default namespace.