### PR TITLE
Refactor SiteForm object implementation for convenience

### DIFF
--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -8,7 +8,7 @@ class Admin::SitesController < Admin::BaseController
   end
 
   def new
-    @site_form = SiteForm.new
+    @site_form = Admin::SiteForm.new
     @site_modules = get_site_modules
     @site_visibility_levels = get_site_visibility_levels
     @dns_config = get_dns_config
@@ -16,14 +16,14 @@ class Admin::SitesController < Admin::BaseController
 
   def edit
     @site = find_site
-    @site_form = SiteForm.new(@site.attributes)
+    @site_form = Admin::SiteForm.new(@site.attributes)
     @site_modules = get_site_modules
     @site_visibility_levels = get_site_visibility_levels
     @dns_config = get_dns_config
   end
 
   def create
-    @site_form = SiteForm.new(site_params.merge(creation_ip: remote_ip))
+    @site_form = Admin::SiteForm.new(site_params.merge(creation_ip: remote_ip))
     @site_modules = get_site_modules
     @site_visibility_levels = get_site_visibility_levels
     @dns_config = get_dns_config
@@ -36,7 +36,7 @@ class Admin::SitesController < Admin::BaseController
   end
 
   def update
-    @site_form = SiteForm.new(site_params.merge(id: params[:id]))
+    @site_form = Admin::SiteForm.new(site_params.merge(id: params[:id]))
     @site_modules = get_site_modules
     @site_visibility_levels = get_site_visibility_levels
     @dns_config = get_dns_config
@@ -75,7 +75,7 @@ class Admin::SitesController < Admin::BaseController
   end
 
   def site_params
-    params.require(:site_form).permit(
+    params.require(:site).permit(
       :title,
       :name,
       :domain,

--- a/app/forms/admin/site_form.rb
+++ b/app/forms/admin/site_form.rb
@@ -1,4 +1,4 @@
-class SiteForm
+class Admin::SiteForm
   include ActiveModel::Model
 
   GOOGLE_ANALYTICS_ID_REGEXP = /\AUA-\d{4,10}-\d{1,4}\z/
@@ -27,10 +27,12 @@ class SiteForm
     :creation_ip
   )
 
-  delegate :persisted?, to: :site
+  delegate :persisted?, :to_model, to: :site
 
-  validates :google_analytics_id, format: { with: GOOGLE_ANALYTICS_ID_REGEXP },
-    allow_nil: true
+  validates :google_analytics_id,
+    format: { with: GOOGLE_ANALYTICS_ID_REGEXP },
+    allow_nil: true,
+    allow_blank: true
 
   def save
     save_site if valid?

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "admin/shared/validation_errors", resource: @site_form %>
 
-<%= form_for(@site_form, url: @site_form.persisted? ? admin_site_path(@site_form) : :admin_sites) do |f| %>
+<%= form_for(@site_form, as: :site, url: @site_form.persisted? ? admin_site_path(@site_form) : :admin_sites) do |f| %>
 
   <div class="pure-g">
 
@@ -107,7 +107,7 @@
 
         </div>
 
-        <%= f.submit "Save", class: "button" %>
+        <%= f.submit class: "button" %>
       </div>
 
     </div>

--- a/test/forms/admin/site_form_test.rb
+++ b/test/forms/admin/site_form_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class SiteFormTest < ActiveSupport::TestCase
+class Admin::SiteFormTest < ActiveSupport::TestCase
   def valid_site_form
-    @valid_site_form ||= SiteForm.new(
+    @valid_site_form ||= Admin::SiteForm.new(
       title: site.title,
       name: new_site_name, # To ensure uniqueness
       domain: new_site_domain, # To ensure uniqueness
@@ -11,7 +11,7 @@ class SiteFormTest < ActiveSupport::TestCase
   end
 
   def invalid_site_form
-    @invalid_site_form ||= SiteForm.new(
+    @invalid_site_form ||= Admin::SiteForm.new(
       title: nil,
       name: nil,
       domain: site.domain,
@@ -20,13 +20,13 @@ class SiteFormTest < ActiveSupport::TestCase
   end
 
   def valid_google_analytics_id_site_form
-    @valid_google_analytics_id_site_form ||= SiteForm.new(
+    @valid_google_analytics_id_site_form ||= Admin::SiteForm.new(
       google_analytics_id: "UA-000000-01"
     )
   end
 
   def invalid_google_analytics_id_site_form
-    @invalid_google_analytics_id_site_form ||= SiteForm.new(
+    @invalid_google_analytics_id_site_form ||= Admin::SiteForm.new(
       google_analytics_id: "UA-WADUS"
     )
   end

--- a/test/integration/admin/site_create_test.rb
+++ b/test/integration/admin/site_create_test.rb
@@ -14,14 +14,14 @@ class Admin::SiteCreateTest < ActionDispatch::IntegrationTest
     with_signed_in_admin(admin) do
       visit @path
 
-      within "form.new_site_form" do
-        fill_in "Title", with: "Site Title"
-        fill_in "Name", with: "Site Name"
-        fill_in "Location name", with: "Site Location"
-        fill_in "Domain", with: "test.gobierto.dev"
-        fill_in "Head markup", with: "Site Head markup"
-        fill_in "Foot markup", with: "Site Foot markup"
-        fill_in "Google analytics", with: "UA-000000-01"
+      within "form.new_site" do
+        fill_in "site_title", with: "Site Title"
+        fill_in "site_name", with: "Site Name"
+        fill_in "site_location_name", with: "Site Location"
+        fill_in "site_domain", with: "test.gobierto.dev"
+        fill_in "site_head_markup", with: "Site Head markup"
+        fill_in "site_foot_markup", with: "Site Foot markup"
+        fill_in "site_google_analytics_id", with: "UA-000000-01"
 
         within ".site-module-check-boxes" do
           check "Gobierto Development"
@@ -31,7 +31,7 @@ class Admin::SiteCreateTest < ActionDispatch::IntegrationTest
           choose "Active"
         end
 
-        click_button "Save"
+        click_button "Create Site"
       end
 
       assert has_content?("Site was successfully created.")

--- a/test/integration/admin/site_update_test.rb
+++ b/test/integration/admin/site_update_test.rb
@@ -18,14 +18,14 @@ class Admin::SiteUpdateTest < ActionDispatch::IntegrationTest
     with_signed_in_admin(admin) do
       visit @path
 
-      within "form.edit_site_form" do
-        fill_in "Title", with: "Site Title"
-        fill_in "Name", with: "Site Name"
-        fill_in "Location name", with: "Site Location"
-        fill_in "Domain", with: "test.gobierto.dev"
-        fill_in "Head markup", with: "Site Head markup"
-        fill_in "Foot markup", with: "Site Foot markup"
-        fill_in "Google analytics", with: "UA-000000-01"
+      within "form.edit_site" do
+        fill_in "site_title", with: "Site Title"
+        fill_in "site_name", with: "Site Name"
+        fill_in "site_location_name", with: "Site Location"
+        fill_in "site_domain", with: "test.gobierto.dev"
+        fill_in "site_head_markup", with: "Site Head markup"
+        fill_in "site_foot_markup", with: "Site Foot markup"
+        fill_in "site_google_analytics_id", with: "UA-000000-01"
 
         within ".site-module-check-boxes" do
           check "Gobierto Development"
@@ -35,7 +35,7 @@ class Admin::SiteUpdateTest < ActionDispatch::IntegrationTest
           choose "Active"
         end
 
-        click_button "Save"
+        click_button "Update Site"
       end
 
       assert has_content?("Site was successfully updated.")
@@ -57,12 +57,12 @@ class Admin::SiteUpdateTest < ActionDispatch::IntegrationTest
 
       visit @path
 
-      within "form.edit_site_form" do
+      within "form.edit_site" do
         within ".site-visibility-level-radio-buttons" do
           choose "Draft"
         end
 
-        click_button "Save"
+        click_button "Update Site"
       end
 
       within "table.site-list tbody tr#site-item-#{site.id}" do


### PR DESCRIPTION
This PR implements #17.

### What does this PR do?

- Namespace `SiteForm` with `Admin` module.
- Let's pretend any `SiteForm` represents an actual Rails model by delegating `to_model` method.
- Submit SiteForm parameters under `site` key.

### How should this be manually tested?

Check that any Site management actions still works as expected.