### PR TITLE
Add activities to admin UI

### DIFF
--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -1,0 +1,5 @@
+class Admin::ActivitiesController < Admin::BaseController
+  def index
+    @activities = ActivityCollectionDecorator.new(Activity.global_admin_activities)
+  end
+end

--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -23,6 +23,7 @@ class Admin::AdminsController < Admin::BaseController
     set_site_modules
     set_sites
     set_authorization_levels
+    set_activities
   end
 
   def create
@@ -47,6 +48,7 @@ class Admin::AdminsController < Admin::BaseController
     set_site_modules
     set_sites
     set_authorization_levels
+    set_activities
 
     if @admin_form.save
       redirect_to admin_admins_path, notice: 'Admin was successfully updated.'
@@ -99,5 +101,9 @@ class Admin::AdminsController < Admin::BaseController
     return if @admin_policy && !@admin_policy.manage_authorization_levels?
 
     @admin_authorization_levels = Admin.authorization_levels
+  end
+
+  def set_activities
+    @activities = ActivityCollectionDecorator.new(Activity.admin_activities(@admin))
   end
 end

--- a/app/decorators/activity_collection_decorator.rb
+++ b/app/decorators/activity_collection_decorator.rb
@@ -1,0 +1,9 @@
+class ActivityCollectionDecorator < BaseDecorator
+  attr_reader :collection, :total_pages
+
+  def initialize(activities)
+    @collection = activities
+
+    @object = @collection.map { |activity| ActivityDecorator.new(activity) }
+  end
+end

--- a/app/decorators/activity_decorator.rb
+++ b/app/decorators/activity_decorator.rb
@@ -1,0 +1,31 @@
+class ActivityDecorator < BaseDecorator
+  def initialize(activity)
+    @object = activity
+  end
+
+  def subject_name
+    fetch_relation(:subject)
+  end
+
+  def author_name
+    fetch_relation(:author)
+  end
+
+  def recipient_name
+    fetch_relation(:recipient)
+  end
+
+  private
+
+  def fetch_relation(relation_name)
+    if object.send(relation_name).present?
+      object.send(relation_name).try(:name)
+    else
+      if object.send("#{relation_name}_type").present?
+        "(deleted) #{object.send("#{relation_name}_type")} - #{object.send("#{relation_name}_id")}"
+      else
+        "-"
+      end
+    end
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -8,4 +8,17 @@ class Activity < ApplicationRecord
   validates :subject_ip, presence: true
   validates :admin_activity, presence: true
 
+  scope :sorted, -> { order(id: :desc) }
+  scope :admin, -> { where(admin_activity: true) }
+  scope :global, -> { where(site_id: nil) }
+  scope :in_site, ->(site_id) { where(site_id: site_id) }
+
+  def self.global_admin_activities
+    global.admin.sorted.includes(:subject, :author, :recipient)
+  end
+
+  def self.admin_activities(admin)
+    where(author_type: admin.class.name, author_id: admin.id).sorted.includes(:subject, :author, :recipient)
+  end
+
 end

--- a/app/views/admin/activities/_activities_list.html.erb
+++ b/app/views/admin/activities/_activities_list.html.erb
@@ -1,0 +1,37 @@
+<% if @activities && @activities.any? %>
+<table class="admin-list">
+  <tr>
+    <th></th>
+    <th>Acción</th>
+    <th>Sujeto</th>
+    <th>Usuario</th>
+    <th>Receptor</th>
+    <th>IP</th>
+    <th>Fecha</th>
+  </tr>
+
+  <tbody>
+    <% @activities.each do |activity| %>
+      <tr id="activity-<%= activity.id %>" class="<%= cycle("odd", "even") %>">
+        <td>#<%= activity.id %></td>
+        <td><%= activity.action %></td>
+        <td>
+          <%= activity.subject_name %>
+        </td>
+        <td>
+          <%= activity.author_name %>
+        </td>
+        <td>
+          <%= activity.recipient_name %>
+        </td>
+        <td>
+          <span class="soft ip"><%= activity.subject_ip %></span>
+        </td>
+        <td>
+          <%= time_ago_in_words(activity.created_at) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% end %>

--- a/app/views/admin/activities/index.html.erb
+++ b/app/views/admin/activities/index.html.erb
@@ -1,0 +1,3 @@
+<h1>LOG DE ACTIVIDADES</h1>
+
+<%= render 'activities_list' %>

--- a/app/views/admin/admins/_form.html.erb
+++ b/app/views/admin/admins/_form.html.erb
@@ -71,6 +71,16 @@
         </div>
       <% end %>
 
+      <% if @admin_form.persisted? %>
+        <div class="form_block">
+
+          <h2>LOG ACTIVIDAD</h2>
+
+          <%= render 'admin/activities/activities_list' %>
+
+        </div>
+      <% end %>
+
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     end
 
     resources :admins, only: [:index, :show, :new, :create, :edit, :update]
+
+    resources :activities, only: [:index]
   end
 
   localized do

--- a/db/migrate/20161114161441_add_timestamp_to_activities.rb
+++ b/db/migrate/20161114161441_add_timestamp_to_activities.rb
@@ -1,0 +1,5 @@
+class AddTimestampToActivities < ActiveRecord::Migration[5.0]
+  def change
+    add_column :activities, :created_at, :timestamp, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114111038) do
+ActiveRecord::Schema.define(version: 20161114161441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "activities", force: :cascade do |t|
-    t.string  "action",         null: false
-    t.string  "subject_type"
-    t.integer "subject_id"
-    t.string  "author_type"
-    t.integer "author_id"
-    t.string  "recipient_type"
-    t.integer "recipient_id"
-    t.inet    "subject_ip",     null: false
-    t.boolean "admin_activity", null: false
-    t.integer "site_id"
+    t.string   "action",         null: false
+    t.string   "subject_type"
+    t.integer  "subject_id"
+    t.string   "author_type"
+    t.integer  "author_id"
+    t.string   "recipient_type"
+    t.integer  "recipient_id"
+    t.inet     "subject_ip",     null: false
+    t.boolean  "admin_activity", null: false
+    t.integer  "site_id"
+    t.datetime "created_at",     null: false
     t.index ["admin_activity"], name: "index_activities_on_admin_activity", using: :btree
     t.index ["author_type", "author_id"], name: "index_activities_on_author_type_and_author_id", using: :btree
     t.index ["recipient_type", "recipient_id"], name: "index_activities_on_recipient_type_and_recipient_id", using: :btree

--- a/test/decorators/activity_decorator_test.rb
+++ b/test/decorators/activity_decorator_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class ActivityDecoratorTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = ActivityDecorator.new(activity)
+  end
+
+  def activity
+    @activity ||= activities(:site_updated_by_admin)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def admin
+    @admin ||= admins(:tony)
+  end
+
+  def test_subject_name
+    assert_equal site.name, @subject.subject_name
+  end
+
+  def test_author_name
+    assert_equal admin.name, @subject.author_name
+  end
+
+  def test_recipient_name
+    assert_equal "-", @subject.recipient_name
+  end
+end

--- a/test/fixtures/activities.yml
+++ b/test/fixtures/activities.yml
@@ -1,0 +1,8 @@
+site_updated_by_admin:
+  action: 'sites.site_updated'
+  subject: madrid (Site)
+  author: tony (Admin)
+  recipient: nil
+  subject_ip: '1.2.3.4'
+  admin_activity: true
+

--- a/test/integration/admin/activities_test.rb
+++ b/test/integration/admin/activities_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Admin::ActivitiesTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @path = admin_activities_path
+  end
+
+  def admin
+    @admin ||= admins(:tony)
+  end
+
+  def test_view_activities
+    with_signed_in_admin(admin) do
+      visit @path
+
+      assert has_content?("sites.site_updated")
+      assert has_content?("Ayuntamiento de Madrid")
+      assert has_content?("Tony Stark")
+      assert has_content?("1.2.3.4")
+    end
+  end
+end

--- a/test/pub_sub/subscribers/site_activity_test.rb
+++ b/test/pub_sub/subscribers/site_activity_test.rb
@@ -22,13 +22,12 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_created_event_handling
-    assert_equal 0, Activity.count
+    assert_difference 'Activity.count' do
+      subject.site_created Event.new(name: "activities/sites.site_created", payload: {
+        subject: site, author: admin, ip: IP
+      })
+    end
 
-    subject.site_created Event.new(name: "activities/sites.site_created", payload: {
-      subject: site, author: admin, ip: IP
-    })
-
-    assert_equal 1, Activity.count
     activity = Activity.last
     assert_equal site, activity.subject
     assert_equal admin, activity.author
@@ -39,14 +38,13 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_updated_event_handling
-    assert_equal 0, Activity.count
+    assert_difference 'Activity.count' do
+      subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
+        subject: site, author: admin, ip: IP,
+        changes: {"name"=>["Ayuntamiento de Madrid", "Ayuntamiento de los Madriles"]}
+      })
+    end
 
-    subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
-      subject: site, author: admin, ip: IP,
-      changes: {"name"=>["Ayuntamiento de Madrid", "Ayuntamiento de los Madriles"]}
-    })
-
-    assert_equal 1, Activity.count
     activity = Activity.last
     assert_equal site, activity.subject
     assert_equal admin, activity.author
@@ -57,15 +55,14 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_deleted_event_handling
-    assert_equal 0, Activity.count
+    assert_difference 'Activity.count' do
+      site.destroy
 
-    site.destroy
+      subject.site_deleted Event.new(name: "activities/sites.site_destroyed", payload: {
+        subject: site, author: admin, ip: IP
+      })
+    end
 
-    subject.site_deleted Event.new(name: "activities/sites.site_destroyed", payload: {
-      subject: site, author: admin, ip: IP
-    })
-
-    assert_equal 1, Activity.count
     activity = Activity.last
     assert_nil activity.subject
     assert_equal admin, activity.author


### PR DESCRIPTION
This PR implements part of #29

### What does this PR do?

This PR adds a couple of lists for activities in the UI

1 - a list just for admins with activities non related to any site specifically

2 - a list of the activities performed by an admin

### How should this be manually tested?

First, update a site, or create a new site. After that:

1 - Go to /admin/activities and see if there are activities

2 - Go to your admin user page and see the activities



