### PR TITLE
Require no authentication in determined User session related actions

### DIFF
--- a/app/controllers/admin/admin/confirmations_controller.rb
+++ b/app/controllers/admin/admin/confirmations_controller.rb
@@ -1,5 +1,6 @@
 class Admin::Admin::ConfirmationsController < Admin::BaseController
   skip_before_action :authenticate_admin!
+  before_action :require_no_authentication
 
   layout "admin/sessions"
 

--- a/app/controllers/admin/admin/invitation_acceptances_controller.rb
+++ b/app/controllers/admin/admin/invitation_acceptances_controller.rb
@@ -1,5 +1,6 @@
 class Admin::Admin::InvitationAcceptancesController < Admin::BaseController
   skip_before_action :authenticate_admin!
+  before_action :require_no_authentication
 
   layout "admin/sessions"
 
@@ -17,8 +18,8 @@ class Admin::Admin::InvitationAcceptancesController < Admin::BaseController
       # TODO. Redirect to Edit Profile URL to set a new password.
       redirect_to(after_sign_in_path, notice: "Signed in successfully.")
     else
-      flash.now[:alert] = "This URL doesn't seem to be valid."
-      redirect_to admin_root_path
+      flash[:alert] = "This URL doesn't seem to be valid."
+      redirect_to new_admin_sessions_path
     end
   end
 end

--- a/app/controllers/admin/admin/passwords_controller.rb
+++ b/app/controllers/admin/admin/passwords_controller.rb
@@ -1,5 +1,6 @@
 class Admin::Admin::PasswordsController < Admin::BaseController
   skip_before_action :authenticate_admin!
+  before_action :require_no_authentication
 
   layout "admin/sessions"
 

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,5 +1,6 @@
 class Admin::SessionsController < Admin::BaseController
-  skip_before_action :authenticate_admin!
+  skip_before_action :authenticate_admin!, only: [:new, :create]
+  before_action :require_no_authentication, only: [:new, :create]
 
   layout "admin/sessions"
 

--- a/app/controllers/concerns/admin/session_helper.rb
+++ b/app/controllers/concerns/admin/session_helper.rb
@@ -23,6 +23,10 @@ module Admin::SessionHelper
     raise_admin_not_signed_in unless admin_signed_in?
   end
 
+  def require_no_authentication
+    raise_admin_already_authenticated if admin_signed_in?
+  end
+
   def find_current_admin
     Admin.confirmed.find_by(id: session[:admin_id])
   end
@@ -46,6 +50,13 @@ module Admin::SessionHelper
     redirect_to(
       request.referrer || admin_root_path,
       alert: "You are not authorized to perform this action."
+    )
+  end
+
+  def raise_admin_already_authenticated
+    redirect_to(
+      after_sign_in_path,
+      alert: "You are already signed in."
     )
   end
 end

--- a/app/controllers/concerns/user/session_helper.rb
+++ b/app/controllers/concerns/user/session_helper.rb
@@ -23,6 +23,10 @@ module User::SessionHelper
     raise_user_not_signed_in unless user_signed_in?
   end
 
+  def require_no_authentication
+    raise_user_already_authenticated if user_signed_in?
+  end
+
   def find_current_user
     User.confirmed.find_by(id: session[:user_id])
   end
@@ -46,6 +50,13 @@ module User::SessionHelper
     redirect_to(
       request.referrer || user_root_path,
       alert: "You are not authorized to perform this action."
+    )
+  end
+
+  def raise_user_already_authenticated
+    redirect_to(
+      after_sign_in_path,
+      alert: "You are already signed in."
     )
   end
 end

--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -1,4 +1,6 @@
 class User::ConfirmationsController < User::BaseController
+  before_action :require_no_authentication
+
   def new
     @user_confirmation_form = User::ConfirmationForm.new
   end

--- a/app/controllers/user/passwords_controller.rb
+++ b/app/controllers/user/passwords_controller.rb
@@ -1,4 +1,6 @@
 class User::PasswordsController < User::BaseController
+  before_action :require_no_authentication
+
   def new
     @user_password_form = User::NewPasswordForm.new
   end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,4 +1,6 @@
 class User::RegistrationsController < User::BaseController
+  before_action :require_no_authentication
+
   def new
     @user_registration_form = User::RegistrationForm.new
   end

--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -1,4 +1,7 @@
 class User::SessionsController < User::BaseController
+  before_action :authenticate_user!, only: [:destroy]
+  before_action :require_no_authentication, only: [:new, :create]
+
   def new; end
 
   def create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   # Admin module
   namespace :admin do
     get '/' => 'welcome#index', as: :root
+    get '/login' => 'sessions#new'
 
     resource :sessions, only: [:new, :create, :destroy]
     resources :sites, only: [:index, :new, :create, :edit, :update, :destroy]

--- a/test/integration/admin/admin_confirmation_test.rb
+++ b/test/integration/admin/admin_confirmation_test.rb
@@ -29,4 +29,12 @@ class Admin::AdminConfirmationTest < ActionDispatch::IntegrationTest
 
     assert has_content?("The email address specified doesn't seem to be valid.")
   end
+
+  def test_confirmation_request_when_already_signed_in
+    with_signed_in_admin(admin) do
+      visit @confirmation_path
+
+      assert has_content?("You are already signed in.")
+    end
+  end
 end

--- a/test/integration/admin/admin_invitation_acceptance_test.rb
+++ b/test/integration/admin/admin_invitation_acceptance_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Admin::AdminInvitationAcceptanceTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @invitation_acceptance_path = admin_admin_invitation_acceptances_path(invitation_token: admin.invitation_token)
+  end
+
+  def admin
+    @admin ||= admins(:tony)
+  end
+
+  def test_invitation_acceptance
+    visit @invitation_acceptance_path
+
+    assert has_content?("Signed in successfully.")
+  end
+
+  def test_invalid_invitation_acceptance
+    visit admin_admin_invitation_acceptances_path(invitation_token: "foo")
+
+    assert has_content?("This URL doesn't seem to be valid.")
+  end
+
+  def test_invitation_acceptance_when_already_signed_in
+    with_signed_in_admin(admin) do
+      visit @invitation_acceptance_path
+
+      assert has_content?("You are already signed in.")
+    end
+  end
+end

--- a/test/integration/admin/admin_invitation_create_test.rb
+++ b/test/integration/admin/admin_invitation_create_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Admin::AdminInvitationCreateTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @new_invitation_path = new_admin_admin_invitations_path
+  end
+
+  def admin
+    @admin ||= admins(:tony)
+  end
+
+  def test_invitation_create
+    with_signed_in_admin(admin) do
+      visit @new_invitation_path
+
+      fill_in :admin_invitation_emails, with: "foo@gobierto.dev, bar@gobierto.dev"
+
+      within ".site-check-boxes" do
+        check "madrid.gobierto.dev"
+      end
+
+      click_on "Send"
+
+      assert has_content?("The invitations have been successfully sent.")
+    end
+  end
+end

--- a/test/integration/admin/admin_password_reset_test.rb
+++ b/test/integration/admin/admin_password_reset_test.rb
@@ -31,6 +31,14 @@ class Admin::AdminPasswordResetTest < ActionDispatch::IntegrationTest
     assert has_content?("The email address specified doesn't seem to be valid.")
   end
 
+  def test_password_reset_request_when_already_signed_in
+    with_signed_in_admin(admin) do
+      visit @password_request_path
+
+      assert has_content?("You are already signed in.")
+    end
+  end
+
   def test_password_change
     visit @password_change_path
 
@@ -51,5 +59,13 @@ class Admin::AdminPasswordResetTest < ActionDispatch::IntegrationTest
     click_on "Send"
 
     assert has_content?("There was a problem changing your password.")
+  end
+
+  def test_password_change_when_already_signed_in
+    with_signed_in_admin(admin) do
+      visit @password_change_path
+
+      assert has_content?("You are already signed in.")
+    end
   end
 end

--- a/test/integration/admin/session_test.rb
+++ b/test/integration/admin/session_test.rb
@@ -45,4 +45,12 @@ class Admin::SessionTest < ActionDispatch::IntegrationTest
 
     assert has_content?("The data you entered doesn't seem to be valid. Please try again.")
   end
+
+  def test_sign_in_when_already_signed_in
+    with_signed_in_admin(admin) do
+      visit @sign_in_path
+
+      assert has_content?("You are already signed in.")
+    end
+  end
 end

--- a/test/integration/user/confirmation_test.rb
+++ b/test/integration/user/confirmation_test.rb
@@ -37,4 +37,14 @@ class User::ConfirmationTest < ActionDispatch::IntegrationTest
       assert has_content?("The email address specified doesn't seem to be valid.")
     end
   end
+
+  def test_confirmation_request_when_already_signed_in
+    with_current_user(user) do
+      with_current_site(site) do
+        visit @confirmation_path
+
+        assert has_content?("You are already signed in.")
+      end
+    end
+  end
 end

--- a/test/integration/user/password_reset_test.rb
+++ b/test/integration/user/password_reset_test.rb
@@ -39,6 +39,16 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_password_reset_request_when_already_signed_in
+    with_current_user(user) do
+      with_current_site(site) do
+        visit @password_request_path
+
+        assert has_content?("You are already signed in.")
+      end
+    end
+  end
+
   def test_password_change
     with_current_site(site) do
       visit @password_change_path
@@ -62,6 +72,16 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
       click_on "Send"
 
       assert has_content?("There was a problem changing your password.")
+    end
+  end
+
+  def test_password_change_when_already_signed_in
+    with_current_user(user) do
+      with_current_site(site) do
+        visit @password_change_path
+
+        assert has_content?("You are already signed in.")
+      end
     end
   end
 end

--- a/test/integration/user/registration_test.rb
+++ b/test/integration/user/registration_test.rb
@@ -43,4 +43,14 @@ class User::RegistrationTest < ActionDispatch::IntegrationTest
       assert has_content?("The data you entered doesn't seem to be valid. Please try again.")
     end
   end
+
+  def test_registration_when_already_signed_in
+    with_current_user(user) do
+      with_current_site(site) do
+        visit @registration_path
+
+        assert has_content?("You are already signed in.")
+      end
+    end
+  end
 end

--- a/test/integration/user/session_test.rb
+++ b/test/integration/user/session_test.rb
@@ -41,4 +41,14 @@ class User::SessionTest < ActionDispatch::IntegrationTest
       assert has_content?("The data you entered doesn't seem to be valid. Please try again.")
     end
   end
+
+  def test_sign_in_when_already_signed_in
+    with_current_user(user) do
+      with_current_site(site) do
+        visit @sign_in_path
+
+        assert has_content?("You are already signed in.")
+      end
+    end
+  end
 end

--- a/test/support/integration/authentication_helpers.rb
+++ b/test/support/integration/authentication_helpers.rb
@@ -6,6 +6,12 @@ module Integration
       sign_out_admin
     end
 
+    def with_signed_in_user(user)
+      sign_in_user(user)
+      yield
+      sign_out_user
+    end
+
     private
 
     def sign_in_admin(admin)
@@ -19,6 +25,20 @@ module Integration
     end
 
     def sign_out_admin
+      within("header") { click_link "Sign Out" }
+    end
+
+    def sign_in_user(user)
+      visit new_user_sessions_path
+
+      within("#user-session-form") do
+        fill_in :session_email, with: user.email
+        fill_in :session_password, with: "gobierto"
+        click_on "Log in"
+      end
+    end
+
+    def sign_out_user
       within("header") { click_link "Sign Out" }
     end
   end

--- a/test/support/session_helpers.rb
+++ b/test/support/session_helpers.rb
@@ -4,4 +4,10 @@ module SessionHelpers
       yield
     end
   end
+
+  def with_current_user(user)
+    User::BaseController.stub_any_instance(:current_user, user) do
+      yield
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,5 +67,6 @@ class ActionDispatch::IntegrationTest
 
   def teardown
     DatabaseCleaner.clean
+    Capybara.reset_session!
   end
 end


### PR DESCRIPTION
Connects to #59.

### What does this PR do?

As the title says, we're requiring no authentication on every User and Admin session related actions. Those are:

#### In Admin namespace

- Sign in
- Confirmation
- Invitation acceptance
- Password change request
- Password change

#### In User namespace

- Registration
- Sign in
- Confirmation
- Invitation acceptance
- Password change request
- Password change

It also increases the test coverage and normalizes implementations across namespaces.

### How should this be manually tested?

Just check every single action from the list above halts the workflow by showing the "You are already signed in" message.