### PR TITLE
Set UserVerification’s site as User’s source site when it succeeds

### DIFF
--- a/app/models/user/verification/census_verification.rb
+++ b/app/models/user/verification/census_verification.rb
@@ -22,12 +22,13 @@ class User::Verification::CensusVerification < User::Verification
   end
 
   def will_verify?
-    census_repository.exists?
+    @will_verify ||= census_repository.exists?
   end
 
   def verify!
     ActiveRecord::Base.transaction do
       update_columns(verified: will_verify?)
+      user.update_columns(source_site_id: site_id) if will_verify?
       user.update_columns(census_verified: will_verify?)
     end
   end

--- a/docs/user-namespace.md
+++ b/docs/user-namespace.md
@@ -8,11 +8,11 @@ URL: http://madrid.gobierto.dev/user/login
 
 Available users:
 
-| Email               | Password | Notes                                                                                     |
-| ---                 | ---      | ---                                                                                       |
-| dennis@gobierto.dev | gobierto | regular user, madrid.gobierto.dev as source site, not verified but with verification item |
-| reed@gobierto.dev   | gobierto | regular user, unconfirmed, madrid.gobierto.dev as source site                             |
-| susan@gobierto.dev  | gobierto | regular user, santander.gobierto.dev as source site, unsuccesfuly verified against census |
+| Email               | Password | Notes                                                                                      |
+| ---                 | ---      | ---                                                                                        |
+| dennis@gobierto.dev | gobierto | regular user, madrid.gobierto.dev as source site, not verified against census              |
+| reed@gobierto.dev   | gobierto | regular user, unconfirmed, madrid.gobierto.dev as source site, not verified against census |
+| susan@gobierto.dev  | gobierto | regular user, santander.gobierto.dev as source site, verified against census               |
 
 Available sites:
 

--- a/test/fixtures/user_census_verifications.yml
+++ b/test/fixtures/user_census_verifications.yml
@@ -8,8 +8,8 @@ dennis_verified:
   version: 0
   verified: true
 
-susan_unverified:
-  user: susan
+reed_unverified:
+  user: reed
   site: santander
   verification_type: <%= User::Verification.verification_types["census"] %>
   verification_data: <%= {
@@ -17,3 +17,13 @@ susan_unverified:
     "date_of_birth" => "1996-01-01" }.to_yaml.inspect %>
   version: 0
   verified: false
+
+susan_verified:
+  user: susan
+  site: santander
+  verification_type: <%= User::Verification.verification_types["census"] %>
+  verification_data: <%= {
+    "document_number" => "00000000C",
+    "date_of_birth" => "1992-01-01" }.to_yaml.inspect %>
+  version: 0
+  verified: true

--- a/test/integration/user/census_verification_test.rb
+++ b/test/integration/user/census_verification_test.rb
@@ -12,7 +12,7 @@ class User::CensusVerificationTest < ActionDispatch::IntegrationTest
   end
 
   def verified_user
-    @user ||= users(:susan)
+    @verified_user ||= users(:susan)
   end
 
   def site

--- a/test/models/user/verification/census_verification_test.rb
+++ b/test/models/user/verification/census_verification_test.rb
@@ -5,6 +5,10 @@ class User::Verification::CensusVerificationTest < ActiveSupport::TestCase
     @user_verification ||= user_census_verifications(:dennis_verified)
   end
 
+  def unverified_user_verification
+    @unverified_user_verification ||= user_census_verifications(:reed_unverified)
+  end
+
   def test_valid
     assert user_verification.valid?
   end
@@ -22,11 +26,16 @@ class User::Verification::CensusVerificationTest < ActiveSupport::TestCase
   end
 
   def test_verify!
-    user_verification.stub(:will_verify?, true) do
-      user_verification.verify!
+    refute unverified_user_verification.verified?
+    refute unverified_user_verification.user.census_verified?
+    refute_equal user_verification.user.source_site, unverified_user_verification.site
 
-      assert user_verification.verified?
-      assert user_verification.user.census_verified?
+    unverified_user_verification.stub(:will_verify?, true) do
+      unverified_user_verification.verify!
+
+      assert unverified_user_verification.reload.verified?
+      assert unverified_user_verification.user.reload.census_verified?
+      assert_equal unverified_user_verification.user.source_site, unverified_user_verification.site
     end
   end
 end


### PR DESCRIPTION
Connects to #76.

### What does this PR do?

This PR implements the User's Source Site switch when a Verification process against Census data succeeds.

Digging a little deeper, it also stabilizes the test fixtures by making then more consistent and increases test coverage.

### How should this be manually tested?

This can't be tested in the UI actually because the Source Site attribute is just for internal purposes. Anyways, the main thing here is that the User's source site should be updated in database when verified.