### PR TITLE
Fix `Permission::GobiertoBudgetConsultations` namespace

### DIFF
--- a/app/models/admin/permission/gobierto_budget_consultations.rb
+++ b/app/models/admin/permission/gobierto_budget_consultations.rb
@@ -1,5 +1,0 @@
-class Admin::Permission::GobiertoBudgetConsultations < Admin::Permission
-  default_scope -> do
-    where(namespace: "site_module", resource_name: "gobierto_budget_consultations")
-  end
-end

--- a/app/models/gobierto_admin/permission/gobierto_budget_consultations.rb
+++ b/app/models/gobierto_admin/permission/gobierto_budget_consultations.rb
@@ -1,0 +1,7 @@
+module GobiertoAdmin
+  class Permission::GobiertoBudgetConsultations < Permission
+    default_scope -> do
+      where(namespace: "site_module", resource_name: "gobierto_budget_consultations")
+    end
+  end
+end


### PR DESCRIPTION
Unplanned.

### What does this PR do?

This PR fixes an issue on `Permission::GobiertoBudgetConsultations` class loading. This class should be namespaced under the `GobiertoAdmin` module instead, probably due to a bad merge process.