### PR TITLE
Set up permissions for the `GobiertoBudgetConsultation` module at Admin level

### DIFF
--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -17,9 +17,9 @@ module GobiertoAdmin
     has_many :global_permissions, class_name: "Permission::Global"
 
     # TODO. Build these associations dynamically.
-    #
     has_many :gobierto_development_permissions, class_name: "Permission::GobiertoDevelopment"
     has_many :gobierto_budgets_permissions, class_name: "Permission::GobiertoBudgets"
+    has_many :gobierto_budget_consultations_permissions, class_name: "Permission::GobiertoBudgetConsultations"
 
     has_many :census_imports
 


### PR DESCRIPTION
Unplanned.

### What does this PR do?

This is a follow up of https://github.com/PopulateTools/gobierto-dev/pull/86. It is not a big deal at all, and adds a specific association to retrieve permissions for the `GobiertoBudgetConsultation` module at `GobiertoAdmin::Admin` level, for consistency.

### How should this be manually tested?

Just check any `GobiertoAdmin::Admin` instance has an association named `gobierto_budget_consultations_permissions`. That's all.