### PR TITLE
Implement single active Consultation behavior

### DIFF
--- a/app/controllers/gobierto_budget_consultations/consultations_controller.rb
+++ b/app/controllers/gobierto_budget_consultations/consultations_controller.rb
@@ -4,6 +4,10 @@ module GobiertoBudgetConsultations
       consultations = current_site.budget_consultations
 
       @active_consultations = consultations.active
+
+      # Skip the index view when there's only one active Consultation
+      redirect_to @active_consultations.first if @active_consultations.size == 1
+
       @past_consultations = consultations.past
     end
 

--- a/test/fixtures/gobierto_budget_consultations/consultations.yml
+++ b/test/fixtures/gobierto_budget_consultations/consultations.yml
@@ -14,6 +14,22 @@ madrid_open:
   budget_amount: 50.0
   visibility_level: <%= GobiertoBudgetConsultations::Consultation.visibility_levels["active"] %>
 
+madrid_open_attached:
+  site: madrid
+  admin: tony
+  title: Consulta adjunta sobre la presupuestos de Madrid
+  description: |
+    Esta política de gasto comprende los originados por los servicios a que se
+    refiere su denominación, tales como promoción y difusión deportiva, gastos
+    de creación, conservación y funcionamiento de los edificios destinados a
+    piscinas, instalaciones deportivas de todo tipo o cualquier otra actuación
+    directamente relacionada con el deporte o la política deportiva de la
+    respectiva Entidad local.
+  opens_on: <%= Date.today %>
+  closes_on: <%= 1.year.from_now.to_date %>
+  budget_amount: 90.0
+  visibility_level: <%= GobiertoBudgetConsultations::Consultation.visibility_levels["active"] %>
+
 madrid_past:
   site: madrid
   admin: tony

--- a/test/integration/gobierto_budget_consultations/consultation_index_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_index_test.rb
@@ -9,7 +9,10 @@ module GobiertoBudgetConsultations
 
     def active_consultations
       @active_consultations ||= begin
-        [gobierto_budget_consultations_consultations(:madrid_open)]
+        [
+          gobierto_budget_consultations_consultations(:madrid_open),
+          gobierto_budget_consultations_consultations(:madrid_open_attached),
+        ]
       end
     end
 
@@ -42,6 +45,20 @@ module GobiertoBudgetConsultations
             assert has_link?(consultation.title)
           end
         end
+      end
+    end
+
+    def test_consultation_index_with_single_active_consultation
+      with_current_site(site) do
+        remaining_consultation = active_consultations.first
+
+        Consultation.where.not(id: remaining_consultation.id).delete_all
+        assert_equal 1, Consultation.active.count
+
+        visit @path
+
+        assert has_selector?("h1", text: remaining_consultation.title)
+        assert has_selector?(".intro", text: remaining_consultation.description.gsub("\n", " ").strip)
       end
     end
   end


### PR DESCRIPTION
Connects to #117.

### What does this PR do?

This PR implements a special behavior in the Consultations index when there's only one active Consultation. In that case we're skipping the index view and moving forward to that Consultation's view.

### How should this be manually tested?

Check that, when only one active Consultation is present, requesting http://madrid.gobierto.dev/presupuestos/consultas/ redirects to `http://madrid.gobierto.dev/presupuestos/consultas/<consultation_id>`.