### PR TITLE
Change GobiertoBudgetConsultations module base path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
         get 'terminado', to: 'consultations/consultation_confirmations#show', as: :show_confirmation
       end
 
-      resources :consultation_participations, only: [:show], path: :participations
+      resources :consultation_participations, only: [:show], path: 'participaciones'
     end
   end
 


### PR DESCRIPTION
Connects to #128.

### What does this PR do?

- Replaces `/presupuestos/consultas` routes format with `/consultas_presupuestos`.
- Localizes the publicly shareable URL: http://madrid.gobierto.dev/consultas_presupuestos/participaciones/dennismadridopentoken.

### How should this be manually tested?

Check that all these new routes are reachable:

- http://madrid.gobierto.dev/consultas_presupuestos
- `http://madrid.gobierto.dev/consultas_presupuestos/<consultation_id>`
- `http://madrid.gobierto.dev/consultas_presupuestos/<consultation_id>/participa`
- `http://madrid.gobierto.dev/consultas_presupuestos/<consultation_id>/resumen`
- `http://madrid.gobierto.dev/consultas_presupuestos/<consultation_id>/terminado`
- http://madrid.gobierto.dev/consultas_presupuestos/participaciones/dennismadridopentoken

While the old ones are not:

- http://madrid.gobierto.dev/presupuestos/consultas
- `http://madrid.gobierto.dev/presupuestos/consultas/<consultation_id>`
- ...