### PR TITLE
Show feedback before trying to respond to closed Consultations

### DIFF
--- a/app/models/gobierto_budget_consultations/consultation.rb
+++ b/app/models/gobierto_budget_consultations/consultation.rb
@@ -22,6 +22,14 @@ module GobiertoBudgetConsultations
       visibility_level == "active" && opening_range.include?(Date.current)
     end
 
+    def past?
+      closes_on < Date.current
+    end
+
+    def upcoming?
+      opens_on > Date.current
+    end
+
     def calculate_budget_amount
       update_columns(budget_amount: consultation_items.sum(:budget_line_amount))
     end

--- a/app/views/gobierto_budget_consultations/consultations/show.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/show.html.erb
@@ -13,30 +13,50 @@
 
   <div class="box p_v_2">
 
-    <div class="inner center">
+    <div class="inner center feedback-block">
 
-      <p>
-        <strong>
-          Sólo te llevará
-          <%= distance_of_time_in_words(@consultation.estimated_completion_time_in_seconds) %>
-        </strong>
-      </p>
+      <% if @consultation.open? %>
 
-      <%= link_to [@consultation, :new_response], class: "button gigantic" do %>
-        Participa en la consulta
-      <% end %>
-
-      <p>
-        Destinado a cualquier ciudadano de
-        <%= current_site.location_name %>
-      </p>
-
-      <% unless user_signed_in? %>
         <p>
-          <%= link_to new_user_sessions_path do %>
-            Necesitas estar identificado y verificado para participar
-          <% end %>
+          <strong>
+            Sólo te llevará
+            <%= distance_of_time_in_words(@consultation.estimated_completion_time_in_seconds) %>
+          </strong>
         </p>
+
+        <%= link_to [@consultation, :new_response], class: "button gigantic" do %>
+          Participa en la consulta
+        <% end %>
+
+        <p>
+          Destinado a cualquier ciudadano de
+          <%= current_site.location_name %>
+        </p>
+
+        <% unless user_signed_in? %>
+          <p>
+            <%= link_to new_user_sessions_path do %>
+              Necesitas estar identificado y verificado para participar
+            <% end %>
+          </p>
+        <% end %>
+
+      <% else %>
+
+        <% if @consultation.upcoming? %>
+
+          <p>
+            Podrás participar en esta consulta a partir del <%= l(@consultation.opens_on, format: :short) %>
+          </p>
+
+        <% else %>
+
+          <p>
+            Lo sentimos, esta consulta está cerrada
+          </p>
+
+        <% end %>
+
       <% end %>
 
     </div>

--- a/test/fixtures/gobierto_budget_consultations/consultations.yml
+++ b/test/fixtures/gobierto_budget_consultations/consultations.yml
@@ -29,3 +29,19 @@ madrid_past:
   closes_on: <%= Date.yesterday %>
   budget_amount: 19.99
   visibility_level: <%= GobiertoBudgetConsultations::Consultation.visibility_levels["active"] %>
+
+madrid_upcoming:
+  site: madrid
+  admin: tony
+  title: Consulta sobre partidas destinadas a Museos en Madrid
+  description: |
+    Esta política de gasto comprende los originados por los servicios a que se
+    refiere su denominación, tales como promoción y difusión deportiva, gastos
+    de creación, conservación y funcionamiento de los edificios destinados a
+    piscinas, instalaciones deportivas de todo tipo o cualquier otra actuación
+    directamente relacionada con el deporte o la política deportiva de la
+    respectiva Entidad local.
+  opens_on: <%= Date.tomorrow %>
+  closes_on: <%= 1.year.from_now.to_date %>
+  budget_amount: 19.99
+  visibility_level: <%= GobiertoBudgetConsultations::Consultation.visibility_levels["active"] %>

--- a/test/integration/gobierto_budget_consultations/consultation_show_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_show_test.rb
@@ -2,13 +2,25 @@ require "test_helper"
 
 module GobiertoBudgetConsultations
   class ConsultationShowTest < ActionDispatch::IntegrationTest
+    include ActionView::Helpers::TranslationHelper
+
     def setup
       super
       @path = gobierto_budget_consultations_consultation_path(consultation)
+      @past_consultation_path = gobierto_budget_consultations_consultation_path(past_consultation)
+      @upcoming_consultation_path = gobierto_budget_consultations_consultation_path(upcoming_consultation)
     end
 
     def consultation
       @consultation ||= gobierto_budget_consultations_consultations(:madrid_open)
+    end
+
+    def past_consultation
+      @past_consultation ||= gobierto_budget_consultations_consultations(:madrid_past)
+    end
+
+    def upcoming_consultation
+      @upcoming_consultation ||= gobierto_budget_consultations_consultations(:madrid_upcoming)
     end
 
     def site
@@ -22,6 +34,30 @@ module GobiertoBudgetConsultations
         assert has_selector?("h1", text: consultation.title)
         assert has_selector?(".intro", text: consultation.description.gsub("\n", " ").strip)
         assert has_link?("Participa en la consulta")
+      end
+    end
+
+    def test_past_consultation_show
+      with_current_site(site) do
+        visit @past_consultation_path
+
+        refute has_link?("Participa en la consulta")
+        assert has_selector?(
+          ".feedback-block",
+          text: "Lo sentimos, esta consulta está cerrada"
+        )
+      end
+    end
+
+    def test_upcoming_consultation_show
+      with_current_site(site) do
+        visit @upcoming_consultation_path
+
+        refute has_link?("Participa en la consulta")
+        assert has_selector?(
+          ".feedback-block",
+          text: "Podrás participar en esta consulta a partir del #{l(upcoming_consultation.opens_on, format: :short)}"
+        )
       end
     end
   end

--- a/test/models/gobierto_budget_consultations/consultation_test.rb
+++ b/test/models/gobierto_budget_consultations/consultation_test.rb
@@ -6,8 +6,34 @@ module GobiertoBudgetConsultations
       @consultation ||= gobierto_budget_consultations_consultations(:madrid_open)
     end
 
+    def past_consultation
+      @past_consultation ||= gobierto_budget_consultations_consultations(:madrid_past)
+    end
+
+    def upcoming_consultation
+      @upcoming_consultation ||= gobierto_budget_consultations_consultations(:madrid_upcoming)
+    end
+
     def test_valid
       assert consultation.valid?
+    end
+
+    def test_open?
+      assert consultation.open?
+      refute past_consultation.open?
+      refute upcoming_consultation.open?
+    end
+
+    def test_past?
+      assert past_consultation.past?
+      refute consultation.past?
+      refute upcoming_consultation.past?
+    end
+
+    def test_upcoming?
+      assert upcoming_consultation.upcoming?
+      refute past_consultation.upcoming?
+      refute consultation.upcoming?
     end
 
     def test_open_in_range


### PR DESCRIPTION
Connects to #123.

### What does this PR do?

This one shows feedback before trying to respond to closed Consultations.

Note that this is only adding feedback in the UI since we were already protecting this action in [this `ConsultationResponsesController`'s callback](https://github.com/PopulateTools/gobierto-dev/blob/514959e50208bbb9a642d5efa486b7d0480ebd23/app/controllers/gobierto_budget_consultations/consultations/consultation_responses_controller.rb#L6).

### How should this be manually tested?

These are the three possible scenarios when reaching a Consultation screen at `http://madrid.gobierto.dev/presupuestos/consultas/<consultation_id>`:

1. The Consultation is just open normally:

![screen shot 2016-12-09 at 6 00 09 pm](https://cloud.githubusercontent.com/assets/126392/21058070/96ba4bb2-be3c-11e6-926c-024d688ba5dc.jpg)

2. The Consultation is closed for some reason:

![screen shot 2016-12-09 at 6 00 16 pm](https://cloud.githubusercontent.com/assets/126392/21058077/a56c0ce0-be3c-11e6-9123-4ef6be52715f.jpg)

3. The Consultation is not yet open:

![screen shot 2016-12-09 at 5 59 58 pm](https://cloud.githubusercontent.com/assets/126392/21058099/bbd6fa62-be3c-11e6-9889-789fcd2b65c2.jpg)
