### PR TITLE
Make `PopulateData` lib usage explicit to deal with autoloading issues

### DIFF
--- a/app/services/gobierto_admin/gobierto_budget_consultations/budget_line_collection_builder.rb
+++ b/app/services/gobierto_admin/gobierto_budget_consultations/budget_line_collection_builder.rb
@@ -1,3 +1,5 @@
+require "populate_data"
+
 module GobiertoAdmin
   module GobiertoBudgetConsultations
     class BudgetLineCollectionBuilder

--- a/lib/populate_data.rb
+++ b/lib/populate_data.rb
@@ -1,0 +1,4 @@
+require_relative "populate_data/gobierto"
+
+module PopulateData
+end

--- a/lib/populate_data/gobierto.rb
+++ b/lib/populate_data/gobierto.rb
@@ -1,0 +1,10 @@
+require_relative "gobierto/logging"
+require_relative "gobierto/client"
+require_relative "gobierto/budget_line"
+require_relative "gobierto/category"
+require_relative "gobierto/entity"
+
+module PopulateData
+  module Gobierto
+  end
+end


### PR DESCRIPTION
Connects to #140.

### What does this PR do?

This is is likely a class autoloading problem in staging/production. Even when everything under `/app` is autoloaded in development and eager loaded in staging/production, I'd keep this library out of the app context so we're making the `PopulateData::Gobierto` class usage explicit. It is now needed to `require "populate_data"` when making use of that library.

### How should this be manually tested?

Ensure that the `PopulateData::Gobierto` is properly loaded from `GobiertoAdmin::GobiertoBudgetConsultations::BudgetLineCollectionBuilder` in an eager loaded environment config such as `staging` or `production`.

It is only used in the Consultation Item management action so let's check this form still works:

`http://gobierto.dev/admin/budgets/consultations/<consultation_id>/items/<consultation_item_id>/edit`.