### PR TITLE
Cover empty parameters edge case in Confirmable behavior

### DIFF
--- a/app/controllers/gobierto_admin/admin/confirmations_controller.rb
+++ b/app/controllers/gobierto_admin/admin/confirmations_controller.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
     def show
       # TODO. Consider extracting this whole action into a service object.
       #
-      admin = Admin.find_by(confirmation_token: params[:confirmation_token])
+      admin = Admin.find_by_confirmation_token(params[:confirmation_token])
 
       if admin
         admin.confirm!

--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -22,7 +22,7 @@ class User::ConfirmationsController < User::BaseController
   def show
     # TODO. Consider extracting this logic into a service object.
     #
-    user = User.find_by(confirmation_token: params[:confirmation_token])
+    user = User.find_by_confirmation_token(params[:confirmation_token])
 
     if user
       user.confirm!

--- a/app/models/concerns/authentication/confirmable.rb
+++ b/app/models/concerns/authentication/confirmable.rb
@@ -2,7 +2,12 @@ module Authentication::Confirmable
   extend ActiveSupport::Concern
 
   included do
-    scope :confirmed, -> { where(confirmation_token: nil) }
+    scope :confirmed,   -> { where(confirmation_token: nil) }
+    scope :unconfirmed, -> { where.not(confirmation_token: nil) }
+
+    def self.find_by_confirmation_token(confirmation_token)
+      unconfirmed.find_by(confirmation_token: confirmation_token)
+    end
   end
 
   def regenerate_confirmation_token

--- a/test/support/concerns/authentication/confirmable_test.rb
+++ b/test/support/concerns/authentication/confirmable_test.rb
@@ -6,6 +6,24 @@ module Authentication::ConfirmableTest
     refute_includes subject, unconfirmed_user
   end
 
+  def test_unconfirmed_scope
+    subject = user.class.unconfirmed
+
+    assert_includes subject, unconfirmed_user
+    refute_includes subject, user
+  end
+
+  def test_find_by_confirmation_token
+    confirmation_token = unconfirmed_user.confirmation_token
+    subject = unconfirmed_user.class.find_by_confirmation_token(confirmation_token)
+
+    assert_equal unconfirmed_user, subject
+
+    subject = unconfirmed_user.class.find_by_confirmation_token(nil)
+
+    assert_nil subject
+  end
+
   def test_confirmed?
     assert user.confirmed?
     refute unconfirmed_user.confirmed?


### PR DESCRIPTION
Unplanned.

### What does this PR do?

This PR is enhancing the User Confirmable behavior by covering an edge case in which the User can pass a empty `confirmation_token` parameter.

Due to this module nature, it can be applied to both `User` and `GobiertoAdmin::Admin` resources.

### How should this be manually tested?

Just check that a Confirmation URL with empty or missing `confirmation_token` parameter doesn't match any Users:

- http://gobierto.dev/admin/admin/confirmations?confirmation_token=
- http://gobierto.dev/admin/admin/confirmations