### PR TITLE
Cover empty parameters edge case in Recoverable behavior

### DIFF
--- a/app/controllers/gobierto_admin/admin/passwords_controller.rb
+++ b/app/controllers/gobierto_admin/admin/passwords_controller.rb
@@ -22,7 +22,7 @@ module GobiertoAdmin
     end
 
     def edit
-      admin = Admin.find_by(reset_password_token: params[:reset_password_token])
+      admin = Admin.find_by_reset_password_token(params[:reset_password_token])
 
       if admin
         @admin_password_form = AdminEditPasswordForm.new(admin_id: admin.id)

--- a/app/controllers/gobierto_admin/admin/passwords_controller.rb
+++ b/app/controllers/gobierto_admin/admin/passwords_controller.rb
@@ -22,7 +22,7 @@ module GobiertoAdmin
     end
 
     def edit
-      admin = Admin.find_by_reset_password_token(params[:reset_password_token])
+      admin = Admin.confirmed.find_by_reset_password_token(params[:reset_password_token])
 
       if admin
         @admin_password_form = AdminEditPasswordForm.new(admin_id: admin.id)

--- a/app/controllers/user/passwords_controller.rb
+++ b/app/controllers/user/passwords_controller.rb
@@ -20,7 +20,7 @@ class User::PasswordsController < User::BaseController
   end
 
   def edit
-    user = User.find_by_reset_password_token(params[:reset_password_token])
+    user = User.confirmed.find_by_reset_password_token(params[:reset_password_token])
 
     if user
       @user_password_form = User::EditPasswordForm.new(user_id: user.id)

--- a/app/controllers/user/passwords_controller.rb
+++ b/app/controllers/user/passwords_controller.rb
@@ -20,7 +20,7 @@ class User::PasswordsController < User::BaseController
   end
 
   def edit
-    user = User.find_by(reset_password_token: params[:reset_password_token])
+    user = User.find_by_reset_password_token(params[:reset_password_token])
 
     if user
       @user_password_form = User::EditPasswordForm.new(user_id: user.id)

--- a/app/models/concerns/authentication/recoverable.rb
+++ b/app/models/concerns/authentication/recoverable.rb
@@ -3,6 +3,10 @@ module Authentication::Recoverable
 
   included do
     scope :recoverable, -> { where.not(reset_password_token: nil) }
+
+    def self.find_by_reset_password_token(reset_password_token)
+      recoverable.find_by(reset_password_token: reset_password_token)
+    end
   end
 
   def regenerate_reset_password_token

--- a/docs/admin-namespace.md
+++ b/docs/admin-namespace.md
@@ -8,12 +8,12 @@ URL: http://gobierto.dev/admin/
 
 Available admins:
 
-| Email                 | Password | Notes                      |
-| ---                   | ---      | ---                        |
-| tony@gobierto.dev     | gobierto | regular admin              |
-| steve@gobierto.dev    | gobierto | regular admin, unconfirmed |
-| nick@gobierto.dev     | gobierto | manager admin              |
-| natasha@gobierto.dev  | gobierto | god manager admin          |
+| Email                | Password | Notes                               |
+| ---                  | ---      | ---                                 |
+| tony@gobierto.dev    | gobierto | regular admin, password recoverable |
+| steve@gobierto.dev   | gobierto | regular admin, unconfirmed          |
+| nick@gobierto.dev    | gobierto | manager admin                       |
+| natasha@gobierto.dev | gobierto | god manager admin                   |
 
 Available sites:
 

--- a/docs/user-namespace.md
+++ b/docs/user-namespace.md
@@ -8,11 +8,11 @@ URL: http://madrid.gobierto.dev/user/login
 
 Available users:
 
-| Email               | Password | Notes                                                                                      |
-| ---                 | ---      | ---                                                                                        |
-| dennis@gobierto.dev | gobierto | regular user, madrid.gobierto.dev as source site, verified against census                  |
-| reed@gobierto.dev   | gobierto | regular user, unconfirmed, madrid.gobierto.dev as source site, not verified against census |
-| susan@gobierto.dev  | gobierto | regular user, santander.gobierto.dev as source site, not verified against census           |
+| Email               | Password | Notes                                                                                           |
+| ---                 | ---      | ---                                                                                             |
+| dennis@gobierto.dev | gobierto | regular user, madrid.gobierto.dev as source site, verified against census, password recoverable |
+| reed@gobierto.dev   | gobierto | regular user, unconfirmed, madrid.gobierto.dev as source site, not verified against census      |
+| susan@gobierto.dev  | gobierto | regular user, santander.gobierto.dev as source site, not verified against census                |
 
 Available sites:
 

--- a/test/fixtures/gobierto_admin/admins.yml
+++ b/test/fixtures/gobierto_admin/admins.yml
@@ -3,7 +3,7 @@ tony:
   name: Tony Stark
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
   confirmation_token:
-  reset_password_token:
+  reset_password_token: wadus
   authorization_level: <%= GobiertoAdmin::Admin.authorization_levels["regular"] %>
   created_at: 2016-11-01 00:00:00
   updated_at: 2016-11-01 00:00:00
@@ -16,7 +16,7 @@ steve:
   name: Steve Rogers
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
   confirmation_token: wadus
-  reset_password_token: wadus
+  reset_password_token:
   invitation_token: wadus
   invitation_sent_at: 2016-11-01 00:01:00
   authorization_level: <%= GobiertoAdmin::Admin.authorization_levels["regular"] %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,7 +4,7 @@ dennis:
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
   source_site: madrid
   confirmation_token:
-  reset_password_token:
+  reset_password_token: wadus
   created_at: 2016-11-02 00:00:00
   updated_at: 2016-11-02 00:00:00
   last_sign_in_at: 2016-12-01 00:00:00
@@ -17,7 +17,7 @@ reed:
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
   source_site: madrid
   confirmation_token: wadus
-  reset_password_token: wadus
+  reset_password_token:
   created_at: 2016-11-02 00:01:00
   updated_at: 2016-11-02 00:01:00
   last_sign_in_at: 2016-12-01 00:01:00

--- a/test/integration/gobierto_admin/admin_password_reset_test.rb
+++ b/test/integration/gobierto_admin/admin_password_reset_test.rb
@@ -13,7 +13,7 @@ module GobiertoAdmin
     end
 
     def recoverable_admin
-      @recoverable_admin ||= gobierto_admin_admins(:steve)
+      @recoverable_admin ||= gobierto_admin_admins(:tony)
     end
 
     def test_password_reset_request

--- a/test/integration/gobierto_admin/admin_password_reset_test.rb
+++ b/test/integration/gobierto_admin/admin_password_reset_test.rb
@@ -5,11 +5,15 @@ module GobiertoAdmin
     def setup
       super
       @password_request_path = new_admin_admin_passwords_path
-      @password_change_path = edit_admin_admin_passwords_path(reset_password_token: admin.reset_password_token)
+      @password_change_path = edit_admin_admin_passwords_path(reset_password_token: recoverable_admin.reset_password_token)
     end
 
     def admin
       @admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def recoverable_admin
+      @recoverable_admin ||= gobierto_admin_admins(:steve)
     end
 
     def test_password_reset_request

--- a/test/integration/user/password_reset_test.rb
+++ b/test/integration/user/password_reset_test.rb
@@ -4,11 +4,15 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
   def setup
     super
     @password_request_path = new_user_passwords_path
-    @password_change_path = edit_user_passwords_path(reset_password_token: user.reset_password_token)
+    @password_change_path = edit_user_passwords_path(reset_password_token: recoverable_user.reset_password_token)
   end
 
   def user
     @user ||= users(:dennis)
+  end
+
+  def recoverable_user
+    @recoverable_user ||= users(:reed)
   end
 
   def site

--- a/test/integration/user/password_reset_test.rb
+++ b/test/integration/user/password_reset_test.rb
@@ -12,7 +12,7 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
   end
 
   def recoverable_user
-    @recoverable_user ||= users(:reed)
+    @recoverable_user ||= users(:dennis)
   end
 
   def site

--- a/test/models/gobierto_admin/admin_test.rb
+++ b/test/models/gobierto_admin/admin_test.rb
@@ -37,9 +37,14 @@ module GobiertoAdmin
     alias invited_user invited_admin
 
     def recoverable_admin
-      @recoverable_admin ||= gobierto_admin_admins(:steve)
+      @recoverable_admin ||= gobierto_admin_admins(:tony)
     end
     alias recoverable_user recoverable_admin
+
+    def not_recoverable_admin
+      @not_recoverable_admin ||= gobierto_admin_admins(:nick)
+    end
+    alias not_recoverable_user not_recoverable_admin
 
     def test_preset_scope_when_god_admin_is_present
       assert_equal god_admin, Admin.preset

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -19,7 +19,11 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def recoverable_user
-    @recoverable_user ||= users(:reed)
+    @recoverable_user ||= users(:dennis)
+  end
+
+  def not_recoverable_user
+    @not_recoverable_user ||= users(:susan)
   end
 
   def madrid_site

--- a/test/support/concerns/authentication/recoverable_test.rb
+++ b/test/support/concerns/authentication/recoverable_test.rb
@@ -6,6 +6,17 @@ module Authentication::RecoverableTest
     refute_includes subject, user
   end
 
+  def test_find_by_reset_password_token
+    reset_password_token = recoverable_user.reset_password_token
+    subject = recoverable_user.class.find_by_reset_password_token(reset_password_token)
+
+    assert_equal recoverable_user, subject
+
+    subject = recoverable_user.class.find_by_reset_password_token(nil)
+
+    assert_nil subject
+  end
+
   def test_recoverable?
     assert recoverable_user.recoverable?
     refute user.recoverable?

--- a/test/support/concerns/authentication/recoverable_test.rb
+++ b/test/support/concerns/authentication/recoverable_test.rb
@@ -1,9 +1,9 @@
 module Authentication::RecoverableTest
   def test_recoverable_scope
-    subject = user.class.recoverable
+    subject = recoverable_user.class.recoverable
 
     assert_includes subject, recoverable_user
-    refute_includes subject, user
+    refute_includes subject, not_recoverable_user
   end
 
   def test_find_by_reset_password_token
@@ -19,7 +19,7 @@ module Authentication::RecoverableTest
 
   def test_recoverable?
     assert recoverable_user.recoverable?
-    refute user.recoverable?
+    refute not_recoverable_user.recoverable?
   end
 
   def test_recovered!


### PR DESCRIPTION
Unplanned.

### What does this PR do?

Similar to https://github.com/PopulateTools/gobierto-dev/pull/144, this PR is enhancing the User Recoverable behavior by covering an edge case in which the User can pass a empty `reset_password_token` parameter.

Due to this module nature, it can be applied to both `User` and `GobiertoAdmin::Admin` resources.

It is also refactoring the current fixtures to be more specific about that behavior.

### How should this be manually tested?

Just check that a Password reset URL with empty or missing `reset_password_token` parameter doesn't match any Users:

- http://gobierto.dev/admin/admin/passwords/edit?reset_password_token=
- http://gobierto.dev/admin/admin/passwords/edit