### PR TITLE
Add filtering to budgets entities load

### DIFF
--- a/lib/populate_data/gobierto/entity.rb
+++ b/lib/populate_data/gobierto/entity.rb
@@ -14,17 +14,11 @@ module PopulateData
         super(options)
       end
 
-      def fetch
-        super.select do |entity|
-          entity["municipality_id"] == @municipality_id
-        end
-      end
-
       private
 
       def request_body
         {
-          municipality_id: @municipality_id
+          filter_by_municipality_id: @municipality_id
         }.to_json
       end
 


### PR DESCRIPTION
Improvement

### What does this PR do?

This PR takes advantage of a improvement in TBI API which allows collection items to be filtered using a `filter_by` parameter.

So, we have updated how entities are filtered to fetch a single one.

### How should this be manually tested?

You should check that when creating or updating a consultation item you see the correct budget lines.

