### PR TITLE
Cover empty parameters edge case in Invitable behavior

### DIFF
--- a/app/controllers/gobierto_admin/admin/invitation_acceptances_controller.rb
+++ b/app/controllers/gobierto_admin/admin/invitation_acceptances_controller.rb
@@ -8,7 +8,7 @@ module GobiertoAdmin
     def show
       # TODO. Consider extracting this logic into a service object.
       #
-      admin = Admin.find_by(invitation_token: params[:invitation_token])
+      admin = Admin.find_by_invitation_token(params[:invitation_token])
 
       if admin
         admin.accept_invitation!

--- a/app/models/concerns/authentication/invitable.rb
+++ b/app/models/concerns/authentication/invitable.rb
@@ -5,6 +5,10 @@ module Authentication::Invitable
     scope :invitation, -> { where.not(invitation_sent_at: nil) }
     scope :invitation_pending, -> { invitation.where.not(invitation_token: nil) }
     scope :invitation_accepted, -> { invitation.where(invitation_token: nil) }
+
+    def self.find_by_invitation_token(invitation_token)
+      invitation_pending.find_by(invitation_token: invitation_token)
+    end
   end
 
   def invitation?

--- a/test/fixtures/gobierto_admin/admins.yml
+++ b/test/fixtures/gobierto_admin/admins.yml
@@ -22,7 +22,7 @@ steve:
   authorization_level: <%= GobiertoAdmin::Admin.authorization_levels["regular"] %>
   created_at: 2016-11-01 00:01:00
   updated_at: 2016-11-01 00:01:00
-  sites:
+  sites: madrid
 
 nick:
   email: nick@gobierto.dev

--- a/test/integration/gobierto_admin/admin_invitation_acceptance_test.rb
+++ b/test/integration/gobierto_admin/admin_invitation_acceptance_test.rb
@@ -4,11 +4,15 @@ module GobiertoAdmin
   class AdminInvitationAcceptanceTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @invitation_acceptance_path = admin_admin_invitation_acceptances_path(invitation_token: admin.invitation_token)
+      @invitation_acceptance_path = admin_admin_invitation_acceptances_path(invitation_token: invited_admin.invitation_token)
     end
 
     def admin
       @admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def invited_admin
+      @invited_admin ||= gobierto_admin_admins(:steve)
     end
 
     def test_invitation_acceptance

--- a/test/support/concerns/authentication/invitable_test.rb
+++ b/test/support/concerns/authentication/invitable_test.rb
@@ -22,6 +22,17 @@ module Authentication::InvitableTest
     refute_includes subject, user
   end
 
+  def test_find_by_invitation_token
+    invitation_token = invited_user.invitation_token
+    subject = invited_user.class.find_by_invitation_token(invitation_token)
+
+    assert_equal invited_user, subject
+
+    subject = invited_user.class.find_by_invitation_token(nil)
+
+    assert_nil subject
+  end
+
   def test_invitation?
     assert invited_user.invitation?
     refute user.invitation?


### PR DESCRIPTION
Unplanned.

### What does this PR do?

Similar to https://github.com/PopulateTools/gobierto-dev/pull/144 and https://github.com/PopulateTools/gobierto-dev/pull/147, this PR is enhancing the User Invitable behavior by covering an edge case in which the User can pass a empty `invitation_token` parameter.

It is only being applied to `GobiertoAdmin::Admin` entities.

### How should this be manually tested?

Just check that an Invitation acceptance URL with empty or missing `invitation_token` parameter doesn't match any Users:

- http://gobierto.dev/admin/admin/invitation_acceptances?invitation_token=
- http://gobierto.dev/admin/admin/invitation_acceptances