### PR TITLE
Update Site fixtures to match the current configuration schema

### DIFF
--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -3,7 +3,7 @@ madrid:
   name: Ayuntamiento de Madrid
   domain: madrid.gobierto.dev
   configuration_data: <%= {
-    "links" => ["http://www.madrid.es"],
+    "links_markup" => %Q{<a href="http://madrid.es">Ayuntamiento de Madrid</a>},
     "logo" => "http://www.madrid.es/assets/images/logo-madrid.png",
     "modules" => ["GobiertoBudgets", "GobiertoBudgetConsultations"],
     "locale" => "en",
@@ -24,7 +24,7 @@ santander:
   name: Ayuntamiento de Santander
   domain: santander.gobierto.dev
   configuration_data: <%= {
-    "links" => ["http://www.santander.es"],
+    "links_markup" => %Q{<a href="http://santander.es">Ayuntamiento de Santander</a>},
     "logo" => "http://santander.es/sites/default/themes/custom/ayuntamiento/img/logo-ayto-santander.png",
     "modules" => ["GobiertoBudgets"],
     "locale" => "en",


### PR DESCRIPTION
Unplanned. Relates to #157.

### What does this PR do?

It just updates the Sites fixtures to make use of the `links_markup` attribute instead of the `links` array. This is good to have since they are used to populate both test and development databases as part of the seeding process.

### How should this be manually tested?

Execute the seeding process to ensure the `@site.configuration.links_markup` struct has some content.
