### PR TITLE
Keep context after User sign in

### DIFF
--- a/app/controllers/concerns/user/session_helper.rb
+++ b/app/controllers/concerns/user/session_helper.rb
@@ -37,8 +37,8 @@ module User::SessionHelper
     User.confirmed.find_by(id: session[:user_id])
   end
 
-  def after_sign_in_path
-    root_path
+  def after_sign_in_path(referrer_url = nil)
+    referrer_url.presence || user_root_path
   end
 
   def after_sign_out_path

--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -3,7 +3,7 @@ class User::SessionsController < User::BaseController
   before_action :require_no_authentication, only: [:new, :create]
 
   def new
-    @user_session_form = User::SessionForm.new
+    @user_session_form = User::SessionForm.new(referrer_url: request.referrer)
     @user_registration_form = User::RegistrationForm.new
     @user_password_form = User::NewPasswordForm.new
   end
@@ -16,7 +16,11 @@ class User::SessionsController < User::BaseController
 
       user.update_session_data(remote_ip)
       sign_in_user(user.id)
-      redirect_to after_sign_in_path, notice: t(".success")
+
+      redirect_to(
+        after_sign_in_path(@user_session_form.referrer_url),
+        notice: t(".success")
+      )
     else
       @user_registration_form = User::RegistrationForm.new
       @user_password_form = User::NewPasswordForm.new
@@ -34,6 +38,6 @@ class User::SessionsController < User::BaseController
   private
 
   def user_session_params
-    params.require(:user_session).permit(:email, :password)
+    params.require(:user_session).permit(:email, :password, :referrer_url)
   end
 end

--- a/app/forms/user/session_form.rb
+++ b/app/forms/user/session_form.rb
@@ -3,7 +3,8 @@ class User::SessionForm
 
   attr_accessor(
     :email,
-    :password
+    :password,
+    :referrer_url
   )
 
   attr_reader :user

--- a/app/views/user/sessions/_session_form.html.erb
+++ b/app/views/user/sessions/_session_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_for(@user_session_form, as: :user_session, url: :user_sessions, html: { id: "user-session-form" }) do |f| %>
+  <%= f.hidden_field :referrer_url %>
+
   <div class="form_item input_text">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true %>

--- a/test/controllers/user/sessions_controller_test.rb
+++ b/test/controllers/user/sessions_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class User::SessionsControllerTest < GobiertoControllerTest
+  def confirmed_user
+    @confirmed_user ||= users(:dennis)
+  end
+
+  def referrer_url
+    "http://example.com/home"
+  end
+
+  def valid_session_params
+    {
+      email: confirmed_user.email,
+      password: "gobierto"
+    }
+  end
+
+  def test_create
+    post(
+      user_sessions_url,
+      params: { user_session: valid_session_params }
+    )
+    assert_redirected_to user_root_path
+  end
+
+  def test_create_with_referrer
+    post(
+      user_sessions_url,
+      params: {
+        user_session: valid_session_params.merge(referrer_url: referrer_url)
+      }
+    )
+    assert_redirected_to referrer_url
+  end
+end

--- a/test/forms/user/session_form_test.rb
+++ b/test/forms/user/session_form_test.rb
@@ -5,6 +5,7 @@ class User::SessionFormTest < ActiveSupport::TestCase
     @valid_user_session_form ||= User::SessionForm.new(
       email: confirmed_user.email,
       password: "gobierto",
+      referrer_url: "http://example.com/home"
     )
   end
 

--- a/test/support/gobierto_site_constraint_helpers.rb
+++ b/test/support/gobierto_site_constraint_helpers.rb
@@ -1,0 +1,5 @@
+class GobiertoSiteConstraint
+  def matches?(_)
+    true
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ require "webmock/minitest"
 require "support/session_helpers"
 require "support/site_session_helpers"
 require "support/message_delivery_helpers"
+require "support/gobierto_site_constraint_helpers"
 
 if ENV["CI"] || ENV["RUN_COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
Connects to #124.

### What does this PR do?

This one updates the `after_sign_in_path` behavior at User (`GobiertoCore`) level to take a referrer URL into account. To do so, the `HTTP_REFERER` is passed through the sign in form to keep a context to which we can redirect on success.

### How should this be manually tested?

Just check that the context is kept after a sign in action. In example, a sign in request from http://madrid.gobierto.dev/presupuestos/ejecucion/2016 should redirect back to the same URL.