### PR TITLE
Make sandbox’s default layout static to avoid dealing with changes

### DIFF
--- a/app/views/layouts/sandbox/application.html.erb
+++ b/app/views/layouts/sandbox/application.html.erb
@@ -36,15 +36,11 @@
 
     <div class="column pure-g">
       <div class="desktop_only">
-        <% if @site.configuration.links.any? %>
         <div class="pure-u-md-1-2">
           <ul>
-            <% @site.configuration.links.each do |link| %>
-              <li><%= link_to url_host(link), link, target: '_blank' %></li>
-            <% end %>
+            <li><a href="http://madrid.es">Ayuntamiento de Madrid</a></li>
           </ul>
         </div>
-        <% end %>
 
         <div class="pure-u-md-1-2 right">
         
@@ -213,11 +209,7 @@
       <div class="pure-g">
         <div class="pure-u-1 pure-u-md-1-2">
           <ul>
-            <% if @site.configuration.links.any? %>
-              <% @site.configuration.links.each do |link| %>
-                <li><%= link_to url_host(link), link, target: '_blank' %></li>
-              <% end %>
-            <% end %>
+            <li><a href="http://madrid.es">Ayuntamiento de Madrid</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Unplanned.

### What does this PR do?

The sandbox's default layout was throwing an error due to recent changes in back-end. I'm in process of making it static so we avoid having them in sync.
