### PR TITLE
GobiertoCommon::Trackable extension and User Notifications feature starting point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ___this is a development version, not ready for production___
 - [Setting up the development environment](docs/development-environment.md)
 - [Accessing the Admin namespace](docs/admin-namespace.md)
 - [Accessing the User namespace](docs/user-namespace.md)
+- [Integrating the Trackable extension](docs/trackable-extension.md)
 
 ## License
 

--- a/app/controllers/user/notifications_controller.rb
+++ b/app/controllers/user/notifications_controller.rb
@@ -1,0 +1,16 @@
+class User::NotificationsController < User::BaseController
+  before_action :authenticate_user!
+
+  def index
+    @user_notifications = find_user_notifications.sorted
+  end
+
+  private
+
+  def find_user_notifications
+    User::Notification.where(
+      user: current_user,
+      site: current_site
+    )
+  end
+end

--- a/app/extensions/gobierto_common/trackable.rb
+++ b/app/extensions/gobierto_common/trackable.rb
@@ -1,0 +1,104 @@
+module GobiertoCommon
+  module Trackable
+    module ClassMethods
+      attr_reader :trackable
+
+      def notify_changed(*attribute_names)
+        changed_attributes_to_notify.push(*attribute_names)
+      end
+
+      def trackable_on(trackable)
+        @trackable = trackable
+      end
+
+      private
+
+      def changed_attributes_to_notify
+        @changed_attributes_to_notify ||= []
+      end
+    end
+
+    def self.prepended(base)
+      base.extend(ClassMethods)
+
+      base.class_eval do
+        extend ActiveModel::Callbacks
+        define_model_callbacks :save, only: [:before, :after]
+        before_save :store_changes
+      end
+    end
+
+    def save
+      perform_notifications if super
+    end
+
+    def notify?
+      return super if defined?(super)
+
+      true
+    end
+
+    def trackable
+      @trackable ||= send(self.class.trackable)
+    end
+
+    private
+
+    def perform_notifications
+      unless notify?
+        Rails.logger.debug("Skipping notifications for #{trackable.to_gid}")
+        return true
+      end
+
+      if created?
+        publish_created
+        return true
+      end
+
+      self.class.send(:changed_attributes_to_notify).each do |attribute_name|
+        publish_changed(attribute_name)
+      end
+
+      true
+    end
+
+    protected
+
+    def publish_created
+      broadcast_event("created")
+    end
+
+    def publish_changed(attribute_name)
+      broadcast_event("#{attribute_name}_changed") if changed?(attribute_name)
+    end
+
+    def broadcast_event(event_name)
+      Rails.logger.debug("Broadcasting event \"#{event_name}\" with payload: #{event_payload}")
+      Publishers::Trackable.broadcast_event(event_name, event_payload)
+    end
+
+    def event_payload
+      { gid: trackable.to_gid, site_id: trackable.site_id }
+    end
+
+    def store_changes
+      @changed   = trackable.changed
+      @persisted = trackable.persisted?
+
+      # Always return successfully to avoid halting execution.
+      true
+    end
+
+    def changed?(attribute_name)
+      Array(@changed).include?(attribute_name.to_s)
+    end
+
+    def updated?
+      @persisted
+    end
+
+    def created?
+      !updated?
+    end
+  end
+end

--- a/app/helpers/user/notifications_helper.rb
+++ b/app/helpers/user/notifications_helper.rb
@@ -1,0 +1,12 @@
+module User::NotificationsHelper
+  def render_notification_item(user_notification)
+    subject = user_notification.subject
+    action = user_notification.action
+
+    render(
+      "user/notifications/#{subject.model_name}".underscore,
+      subject: subject,
+      action: action
+    )
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -9,6 +9,7 @@ class Site < ApplicationRecord
 
   # User integrations
   has_many :subscriptions, dependent: :destroy, class_name: "User::Subscription"
+  has_many :notifications, dependent: :destroy, class_name: "User::Notification"
 
   # GobiertoBudgetConsultations integration
   has_many :budget_consultations, dependent: :destroy, class_name: "GobiertoBudgetConsultations::Consultation"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :verifications, class_name: "User::Verification", dependent: :destroy
   has_many :census_verifications, class_name: "User::Verification::CensusVerification"
   has_many :subscriptions, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   validates :email, uniqueness: true
 

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -1,0 +1,7 @@
+class User::Notification < ApplicationRecord
+  belongs_to :user
+  belongs_to :site
+  belongs_to :subject, polymorphic: true
+
+  scope :sorted, -> { order(created_at: :desc) }
+end

--- a/app/pub_sub/publishers/trackable.rb
+++ b/app/pub_sub/publishers/trackable.rb
@@ -1,0 +1,7 @@
+module Publishers
+  class Trackable
+    include Publisher
+
+    self.pub_sub_namespace = 'trackable'
+  end
+end

--- a/app/services/user/notification_builder.rb
+++ b/app/services/user/notification_builder.rb
@@ -1,0 +1,51 @@
+class User::NotificationBuilder
+  GENERIC_EVENT_NAMES = %w(created)
+
+  attr_reader :event_name, :model_name, :model_id, :site_id
+
+  def initialize(event_name, model_name, model_id, site_id)
+    @event_name = event_name
+    @model_name = model_name
+    @model_id = model_id
+    @site_id = site_id
+  end
+
+  def call
+    user_notifications = []
+
+    User::Notification.transaction do
+      User::Subscription
+        .select(:id, :user_id)
+        .where(
+          subscribable_type: model_name,
+          subscribable_id: (model_id unless generic_event?),
+          site_id: site_id
+        )
+        .find_each do |user_subscription|
+          user_notification = build_user_notification_for(user_subscription.user_id)
+
+          if user_notification.save(validate: false)
+            user_notifications << user_notification
+          end
+        end
+    end
+
+    user_notifications
+  end
+
+  private
+
+  def build_user_notification_for(user_id)
+    User::Notification.new(
+      user_id: user_id,
+      site_id: site_id,
+      action: event_name,
+      subject_type: model_name,
+      subject_id: model_id
+    )
+  end
+
+  def generic_event?
+    GENERIC_EVENT_NAMES.include?(event_name)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
                           <% end %>
                         </li>
                         <li class="pure-menu-item">
-                          <%= link_to "#", class: "pure-menu-link" do %>
+                          <%= link_to user_notifications_path, class: "pure-menu-link" do %>
                             <i class="fa fa-envelope-o"></i>
                             <%= t(".session.alerts") %>
                           <% end %>

--- a/app/views/user/notifications/gobierto_budget_consultations/_consultation.html.erb
+++ b/app/views/user/notifications/gobierto_budget_consultations/_consultation.html.erb
@@ -1,0 +1,2 @@
+<%= link_to subject.title, subject %>
+(<%= action %>)

--- a/app/views/user/notifications/index.html.erb
+++ b/app/views/user/notifications/index.html.erb
@@ -1,0 +1,31 @@
+<% content_for :breadcrumb_current_item do %>
+  <strong>
+    <%= link_to t("user.layouts.menu_subsections.alerts"), user_notifications_path %>
+  </strong>
+<% end %>
+
+<div class="column">
+
+  <h3><%= title t(".title") %></h3>
+
+  <table class="user-notification-list">
+    <tr>
+      <th><%= t(".headers.created") %></th>
+      <th><%= t(".headers.subject") %></th>
+      <th></th>
+    </tr>
+    <tbody>
+      <% @user_notifications.each do |user_notification| %>
+        <tr id="user-notification-item-<%= user_notification.id %>">
+          <td>
+            <%= l(user_notification.created_at, format: :long) %>
+          </td>
+          <td>
+            <%= render_notification_item(user_notification) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+</div>

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -1,1 +1,16 @@
+# Common subscribers (`Subscribers::Base` pattern)
 Subscribers::SiteActivity.attach_to('activities/sites')
+
+# Custom subscribers
+ActiveSupport::Notifications.subscribe(/trackable/) do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  event_name = event.name.split(".").last
+  model_name = event.payload[:gid].model_name
+  model_id = event.payload[:gid].model_id
+  site_id = event.payload[:site_id]
+
+  # TODO. Perform asynchronously.
+  #
+  User::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
+end

--- a/config/locales/user/views/notifications/ca.yml
+++ b/config/locales/user/views/notifications/ca.yml
@@ -3,7 +3,7 @@ ca:
   user:
     notifications:
       index:
-        title: Tus Alertas
+        title: Les teves Alertes
         headers:
-          created: Creado
-          subject: Asunto
+          created: Creat
+          subject: Asumpte

--- a/config/locales/user/views/notifications/ca.yml
+++ b/config/locales/user/views/notifications/ca.yml
@@ -1,0 +1,9 @@
+---
+ca:
+  user:
+    notifications:
+      index:
+        title: Tus Alertas
+        headers:
+          created: Creado
+          subject: Asunto

--- a/config/locales/user/views/notifications/en.yml
+++ b/config/locales/user/views/notifications/en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  user:
+    notifications:
+      index:
+        title: Your Alertas
+        headers:
+          created: Created
+          subject: Subject

--- a/config/locales/user/views/notifications/es.yml
+++ b/config/locales/user/views/notifications/es.yml
@@ -1,0 +1,9 @@
+---
+es:
+  user:
+    notifications:
+      index:
+        title: Tus Alertas
+        headers:
+          created: Creado
+          subject: Asunto

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
       resource :census_verifications, only: [:show, :new, :create], path: :verifications
 
       resources :subscriptions, only: [:index, :create, :destroy]
+      resources :notifications, only: [:index]
     end
   end
 

--- a/db/migrate/20161219132627_create_user_notifications.rb
+++ b/db/migrate/20161219132627_create_user_notifications.rb
@@ -1,0 +1,17 @@
+class CreateUserNotifications < ActiveRecord::Migration[5.0]
+  def change
+    create_table :user_notifications do |t|
+      t.references :user, index: true
+      t.references :site, index: true
+      t.string :action
+      t.string :subject_type
+      t.integer :subject_id
+
+      t.timestamps
+    end
+
+    add_index :user_notifications, [:user_id, :site_id]
+    add_index :user_notifications, [:subject_type, :subject_id, :site_id], name: "index_user_notifications_on_subject_and_site_id"
+    add_index :user_notifications, [:subject_type, :subject_id, :site_id, :user_id], name: "index_user_notifications_on_subject_and_site_id_and_user_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161216132408) do
+ActiveRecord::Schema.define(version: 20161219132627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -156,6 +156,21 @@ ActiveRecord::Schema.define(version: 20161216132408) do
     t.integer  "visibility_level",            default: 0,  null: false
     t.inet     "creation_ip"
     t.integer  "municipality_id"
+  end
+
+  create_table "user_notifications", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "site_id"
+    t.string   "action"
+    t.string   "subject_type"
+    t.integer  "subject_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["site_id"], name: "index_user_notifications_on_site_id", using: :btree
+    t.index ["subject_type", "subject_id", "site_id", "user_id"], name: "index_user_notifications_on_subject_and_site_id_and_user_id", using: :btree
+    t.index ["subject_type", "subject_id", "site_id"], name: "index_user_notifications_on_subject_and_site_id", using: :btree
+    t.index ["user_id", "site_id"], name: "index_user_notifications_on_user_id_and_site_id", using: :btree
+    t.index ["user_id"], name: "index_user_notifications_on_user_id", using: :btree
   end
 
   create_table "user_subscriptions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ fixtures_to_load = [
   "gobierto_admin/admins",
   "user/verification/census_verifications",
   "user/subscriptions",
+  "user/notifications",
   "gobierto_budget_consultations/consultations",
   "gobierto_budget_consultations/consultation_items",
   "gobierto_budget_consultations/consultation_responses"

--- a/docs/trackable-extension.md
+++ b/docs/trackable-extension.md
@@ -1,0 +1,81 @@
+![Gobierto](https://gobierto.es/assets/logo_gobierto.png)
+
+# Gobierto (dev)
+
+## Integrating the Trackable extension
+
+> Date: 2016-12-20  
+> Author: Populate tools dev team  
+> Version: Draft
+
+### Concept
+
+The `GobiertoCommon::Trackable` module extends the current Form class by
+providing a way to track changes in a specific resource, which can
+correspond to a well-known `ActiveRecord` model.
+
+*Note: This is still under development.*
+
+### Implementation
+
+An implementation sample can be found at
+[`GobiertoAdmin::GobiertoBudgetConsultations::ConsultationForm`](https://github.com/PopulateTools/gobierto-dev/blob/5c4efc0870b7bc830d2b4869289ddb854a723d12/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_form.rb). There are just a few sections to highlight:
+
+First of all, the `GobiertoCommon::Trackable` extension must be loaded
+by prepending the module in the corresponding class. e.g.:
+
+```ruby
+module GobiertoAdmin
+  module GobiertoBudgetConsultations
+    class ConsultationForm
+      ...
+
+      prepend GobiertoCommon::Trackable
+    end
+  end
+end
+```
+
+After having loaded the extension, its behavior can be configured
+through a quite simple DSL. We would need to specify which will
+be the main resource to watch (it should correspond to a `ActiveRecord`
+model for now) to produce the notification events. In this case, we're
+delegating it in the `consultation` method, as follows:
+
+```ruby
+trackable_on :consultation
+```
+
+It also provides syntax to limit the attributes that are going to be
+tracked. In this case, only changes in `title`, `visibility_level`,
+`opens_on` and `closes_on` attributes will be notified:
+
+```ruby
+notify_changed :title
+notify_changed :visibility_level
+notify_changed :opens_on
+notify_changed :closes_on
+...
+```
+
+To let the extension track those changes, it is also required to wrap
+the saving action within a `run_callbacks(:save)` block since it makes
+use of the [`ActiveModel::Dirty`](http://api.rubyonrails.org/classes/ActiveModel/Dirty.html)
+feature. The model's callbacks are already defined so this is the only
+needed change:
+
+```ruby
+run_callbacks(:save) do
+  @consultation.save
+end
+```
+
+Finally, there is a method that can be defined at class level to limit
+notifications based on its own business logic. It is not required so the
+notification will be performed if no `notify?` method is defined. e.g.:
+
+```ruby
+def notify?
+  consultation.active?
+end
+```

--- a/test/fixtures/user/notifications.yml
+++ b/test/fixtures/user/notifications.yml
@@ -1,0 +1,17 @@
+dennis_consultation_created:
+  user: dennis
+  site: madrid
+  action: created
+  subject: madrid_open (GobiertoBudgetConsultations::Consultation)
+
+dennis_consultation_title_changed:
+  user: dennis
+  site: madrid
+  action: title_changed
+  subject: madrid_open (GobiertoBudgetConsultations::Consultation)
+
+dennis_consultation_visibility_level_changed:
+  user: dennis
+  site: madrid
+  action: visibility_level_changed
+  subject: madrid_open (GobiertoBudgetConsultations::Consultation)

--- a/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_form_test.rb
@@ -1,8 +1,15 @@
 require "test_helper"
+require "support/extensions/gobierto_common/trackable_test"
 
 module GobiertoAdmin
   module GobiertoBudgetConsultations
     class ConsultationFormTest < ActiveSupport::TestCase
+      include GobiertoCommon::TrackableTest
+
+      def subject_class
+        ConsultationForm
+      end
+
       def valid_consultation_form
         @valid_consultation_form ||= ConsultationForm.new(
           admin_id: admin.id,
@@ -10,9 +17,11 @@ module GobiertoAdmin
           title: consultation.title,
           description: consultation.description,
           opens_on: consultation.opens_on,
-          closes_on: consultation.closes_on
+          closes_on: consultation.closes_on,
+          visibility_level: consultation.visibility_level
         )
       end
+      alias trackable valid_consultation_form
 
       def valid_consultation_with_opening_date_range_form
         @valid_consultation_with_opening_date_range_form ||= ConsultationForm.new(

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class User::NotificationTest < ActiveSupport::TestCase
+  def notification
+    @notification ||= user_notifications(:dennis_consultation_created)
+  end
+
+  def test_valid
+    assert notification.valid?
+  end
+end

--- a/test/services/user/notification_builder_test.rb
+++ b/test/services/user/notification_builder_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class User::NotificationBuilderTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = User::NotificationBuilder.new(
+      event_name,
+      subscribable.model_name.to_s,
+      subscribable.id,
+      site.id
+    )
+  end
+
+  def user_subscription
+    @user_subscription ||= user_subscriptions(:dennis_consultation_madrid_open)
+  end
+
+  def subscribable
+    @subscribable ||= user_subscription.subscribable
+  end
+
+  def user
+    @user ||= user_subscription.user
+  end
+
+  def site
+    @site ||= subscribable.site
+  end
+
+  def event_name
+    "created"
+  end
+
+  def test_call
+    assert_difference "User::Notification.count", 1 do
+      @subject.call
+    end
+
+    user_notifications = @subject.call
+    first_user_notification = user_notifications.first
+
+    assert_equal 1, user_notifications.size
+    assert_equal User::Notification, first_user_notification.class
+    assert_equal user.id, first_user_notification.user_id
+    assert_equal site.id, first_user_notification.site_id
+    assert_equal event_name, first_user_notification.action
+    assert_equal subscribable.model_name.to_s, first_user_notification.subject_type
+    assert_equal subscribable.id, first_user_notification.subject_id
+  end
+end

--- a/test/support/extensions/gobierto_common/trackable_test.rb
+++ b/test/support/extensions/gobierto_common/trackable_test.rb
@@ -1,0 +1,51 @@
+module GobiertoCommon::TrackableTest
+  def setup
+    super
+    @trackable_publisher_spy = Spy.on(Publishers::Trackable, :broadcast_event)
+  end
+
+  def test_trackable_extension
+    assert subject_class.respond_to?(:notify_changed)
+    assert subject_class.respond_to?(:trackable_on)
+    refute subject_class.respond_to?(:changed_attributes_to_notify)
+  end
+
+  def test_trackable_save
+    assert trackable.save
+    assert @trackable_publisher_spy.has_been_called?
+
+    event_payload = [
+      "created",
+      {
+        gid: trackable.trackable.to_gid,
+        site_id: trackable.site_id
+      }
+    ]
+
+    assert_trackable_publisher_call(event_payload)
+  end
+
+  def test_trackable_notify?
+    if trackable.trackable.respond_to?(:active?)
+      trackable.trackable.stub(:active?, true) do
+        assert trackable.notify?
+      end
+
+      trackable.trackable.stub(:active?, false) do
+        refute trackable.notify?
+      end
+    else
+      assert trackable.notify?
+    end
+  end
+
+  private
+
+  def assert_trackable_publisher_call(event_payload)
+    first_call = @trackable_publisher_spy.calls.first
+
+    assert_equal Publishers::Trackable, first_call.object
+    assert_equal event_payload, first_call.args
+    assert_nil first_call.result
+  end
+end


### PR DESCRIPTION
Connects to #167.

### What does this PR do?

This PR implements an extension library that allows any of the `Form` objects in the system to track changes on its managed resources. Those changes also produce events to be consumed through our pub/sub implementation.

To cover a complete first iteration, the `GobiertoCommon::Trackable` extension is being integrated into the `GobiertoAdmin::GobiertoBudgetConsultations::ConsultationForm` class so that we're producing events that are consumed by a custom Subscriber.

It also adds the `User::Notification` implementation which is the first resource populated through events within the `trackable` namespace. The logic for building those `User::Notification` records based on User Subscriptions is abstracted in the `User::NotificationBuilder` service class.

Some other details on the implementation can be found in the doc that comes with this PR: https://github.com/PopulateTools/gobierto-dev/blob/fb34ccd159c470238d3bc82fe0e0f2601f963a50/docs/trackable-extension.md

### How should this be manually tested?

Since the `User::Notification` implementation is already there, a starting User notifications view can be reached at http://madrid.gobierto.dev/user/notifications. It is being populated through changes in the `GobiertoBudgetConsultations::Consultation` model which the user is subscribed to (see https://github.com/PopulateTools/gobierto-dev/pull/171).

#### ✏️ Known improvements

- The `User::Notification` population process should be done asynchronously, in a background job.
- The User's activity/alerts view should be formatted properly.
- It would be great to have some end-to-end tests regarding changes in Trackable Form objects.