### PR TITLE
User Notification mailers starting point

### DIFF
--- a/app/forms/user/notification_form.rb
+++ b/app/forms/user/notification_form.rb
@@ -28,7 +28,7 @@ class User::NotificationForm
   end
 
   def run_callbacks
-    true
+    deliver_notification_email
   end
 
   def create_notification
@@ -41,5 +41,11 @@ class User::NotificationForm
     end
 
     @notification.save(validate: false)
+  end
+
+  protected
+
+  def deliver_notification_email
+    User::NotificationMailer.single_notification(user_notification).deliver_later
   end
 end

--- a/app/forms/user/notification_form.rb
+++ b/app/forms/user/notification_form.rb
@@ -1,0 +1,45 @@
+class User::NotificationForm
+  include ActiveModel::Model
+
+  attr_accessor(
+    :user_id,
+    :site_id,
+    :action,
+    :subject_type,
+    :subject_id
+  )
+
+  validates :user_id, :site_id, :action, :subject_type, :subject_id, presence: true
+
+  def save
+    return unless valid?
+
+    run_callbacks if create_notification
+  end
+
+  def record
+    user_notification
+  end
+
+  private
+
+  def user_notification
+    @user_notification ||= User::Notification.new
+  end
+
+  def run_callbacks
+    true
+  end
+
+  def create_notification
+    @notification = user_notification.tap do |user_notification_attributes|
+      user_notification_attributes.user_id = user_id
+      user_notification_attributes.site_id = site_id
+      user_notification_attributes.action = action
+      user_notification_attributes.subject_type = subject_type
+      user_notification_attributes.subject_id = subject_id
+    end
+
+    @notification.save(validate: false)
+  end
+end

--- a/app/helpers/user/notifications_helper.rb
+++ b/app/helpers/user/notifications_helper.rb
@@ -1,12 +1,25 @@
 module User::NotificationsHelper
-  def render_notification_item(user_notification)
-    subject = user_notification.subject
-    action = user_notification.action
-
-    render(
-      "user/notifications/#{subject.model_name}".underscore,
-      subject: subject,
-      action: action
-    )
+  def render_notification_item(user_notification, absolute_url = false)
+    content_tag :span do
+      capture do
+        concat(
+          I18n.t(
+            "#{user_notification.subject.model_name.i18n_key}.notifications.subject.#{user_notification.action}"
+          )
+        )
+        concat(
+          ": "
+        )
+        concat(
+          link_to(
+            user_notification.subject.subscribable_label,
+            polymorphic_url(
+              user_notification.subject,
+              domain: (user_notification.site.domain if absolute_url)
+            )
+          )
+        )
+      end
+    end
   end
 end

--- a/app/mailers/user/notification_mailer.rb
+++ b/app/mailers/user/notification_mailer.rb
@@ -1,0 +1,33 @@
+class User::NotificationMailer < ApplicationMailer
+  helper User::NotificationsHelper
+
+  def single_notification(user_notification)
+    @user_notification = user_notification
+
+    @user = user_notification.user
+    @site = user_notification.site
+    @subject = user_notification.subject
+    @action = user_notification.action
+
+    mail(
+      from: default_from,
+      reply_to: default_reply_to,
+      to: @user.email,
+      subject: I18n.t("#{user_notification.subject.model_name.i18n_key}.notifications.subject.#{user_notification.action}"),
+      template_path: "#{user_notification.subject.model_name.collection}/notifications",
+      template_name: user_notification.action
+    )
+  end
+
+  def notification_digest(user, user_notifications, periodicity)
+    @user = user
+    @user_notifications = user_notifications
+
+    mail(
+      from: default_from,
+      reply_to: default_reply_to,
+      to: @user.email,
+      subject: default_i18n_subject(periodicity: periodicity)
+    )
+  end
+end

--- a/app/services/user/subscription/notification_builder.rb
+++ b/app/services/user/subscription/notification_builder.rb
@@ -1,4 +1,4 @@
-class User::NotificationBuilder
+class User::Subscription::NotificationBuilder
   GENERIC_EVENT_NAMES = %w(created)
 
   attr_reader :event_name, :model_name, :model_id, :site_id
@@ -24,8 +24,8 @@ class User::NotificationBuilder
         .find_each do |user_subscription|
           user_notification = build_user_notification_for(user_subscription.user_id)
 
-          if user_notification.save(validate: false)
-            user_notifications << user_notification
+          if user_notification.save
+            user_notifications << user_notification.record
           end
         end
     end
@@ -36,7 +36,7 @@ class User::NotificationBuilder
   private
 
   def build_user_notification_for(user_id)
-    User::Notification.new(
+    User::NotificationForm.new(
       user_id: user_id,
       site_id: site_id,
       action: event_name,

--- a/app/services/user/subscription/notification_builder.rb
+++ b/app/services/user/subscription/notification_builder.rb
@@ -3,7 +3,7 @@ class User::Subscription::NotificationBuilder
 
   attr_reader :event_name, :model_name, :model_id, :site_id
 
-  def initialize(event_name, model_name, model_id, site_id)
+  def initialize(event_name:, model_name:, model_id:, site_id:)
     @event_name = event_name
     @model_name = model_name
     @model_id = model_id

--- a/app/views/gobierto_budget_consultations/consultations/notifications/closes_on_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/closes_on_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been updated:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/created.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/created.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been created:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/opens_on_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/opens_on_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been updated:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/title_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/title_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been updated:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/visibility_level_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/visibility_level_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been open:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/user/notification_mailer/notification_digest.html.erb
+++ b/app/views/user/notification_mailer/notification_digest.html.erb
@@ -1,0 +1,15 @@
+<p>
+  Hey,
+</p>
+
+<p>
+  Here is the recent activity in your municipality:
+</p>
+
+<ul>
+  <% @user_notifications.each do |user_notification| %>
+    <li>
+      <%= render_notification_item(user_notification, true) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/user/notification_mailer/notification_digest.txt.erb
+++ b/app/views/user/notification_mailer/notification_digest.txt.erb
@@ -1,0 +1,7 @@
+Hey,
+
+Here is the recent activity in your municipality:
+
+<% @user_notifications.each do |user_notification| %>
+  <%= render_notification_item(user_notification, true) -%>
+<% end %>

--- a/app/views/user/notifications/gobierto_budget_consultations/_consultation.html.erb
+++ b/app/views/user/notifications/gobierto_budget_consultations/_consultation.html.erb
@@ -1,2 +1,0 @@
-<%= link_to subject.title, subject %>
-(<%= action %>)

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -12,5 +12,5 @@ ActiveSupport::Notifications.subscribe(/trackable/) do |*args|
 
   # TODO. Perform asynchronously.
   #
-  User::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
+  User::Subscription::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
 end

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -4,13 +4,14 @@ Subscribers::SiteActivity.attach_to('activities/sites')
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
-
-  event_name = event.name.split(".").last
-  model_name = event.payload[:gid].model_name
-  model_id = event.payload[:gid].model_id
-  site_id = event.payload[:site_id]
+  Rails.logger.debug("Consuming event \"#{event.name}\" with payload: #{event.payload}")
 
   # TODO. Perform asynchronously.
   #
-  User::Subscription::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
+  User::Subscription::NotificationBuilder.new(
+    event_name: event.name.split(".").last,
+    model_name: event.payload[:gid].model_name,
+    model_id: event.payload[:gid].model_id,
+    site_id: event.payload[:site_id]
+  ).call
 end

--- a/config/locales/gobierto_budget_consultations/notifications/ca.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/ca.yml
@@ -1,0 +1,10 @@
+---
+ca:
+  gobierto_budget_consultations/consultation:
+    notifications:
+      subject:
+        created: "Se ha añadido una consulta"
+        visibility_level_changed: "Se ha abierto una consulta"
+        title_changed: "Se ha actualizado una consulta"
+        opens_on_changed: "Se ha actualizado una consulta"
+        closes_on_changed: "Se ha actualizado una consulta"

--- a/config/locales/gobierto_budget_consultations/notifications/ca.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/ca.yml
@@ -3,8 +3,8 @@ ca:
   gobierto_budget_consultations/consultation:
     notifications:
       subject:
-        created: "Se ha añadido una consulta"
-        visibility_level_changed: "Se ha abierto una consulta"
-        title_changed: "Se ha actualizado una consulta"
-        opens_on_changed: "Se ha actualizado una consulta"
-        closes_on_changed: "Se ha actualizado una consulta"
+        created: "S'ha afeggit una consulta"
+        visibility_level_changed: "S'ha obert una consulta"
+        title_changed: "S'ha actualitzat una consulta"
+        opens_on_changed: "S'ha actualitzat una consulta"
+        closes_on_changed: "S'ha actualitzat una consulta"

--- a/config/locales/gobierto_budget_consultations/notifications/en.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  gobierto_budget_consultations/consultation:
+    notifications:
+      subject:
+        created: "A consultation has been added"
+        visibility_level_changed: "A consultation has been open"
+        title_changed: "A consultation has been updated"
+        opens_on_changed: "A consultation has been updated"
+        closes_on_changed: "A consultation has been updated"

--- a/config/locales/gobierto_budget_consultations/notifications/es.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  gobierto_budget_consultations/consultation:
+    notifications:
+      subject:
+        created: "Se ha agregado una consulta"
+        visibility_level_changed: "Se ha abierto una consulta"
+        title_changed: "Se ha actualizado una consulta"
+        opens_on_changed: "Se ha actualizado una consulta"
+        closes_on_changed: "Se ha actualizado una consulta"

--- a/config/locales/user/mailers/ca.yml
+++ b/config/locales/user/mailers/ca.yml
@@ -1,0 +1,6 @@
+---
+ca:
+  user:
+    notification_mailer:
+      notification_digest:
+        subject: "Actividad reciente en tu municipio"

--- a/config/locales/user/mailers/ca.yml
+++ b/config/locales/user/mailers/ca.yml
@@ -3,4 +3,4 @@ ca:
   user:
     notification_mailer:
       notification_digest:
-        subject: "Actividad reciente en tu municipio"
+        subject: "Activitat recent al teu municipi"

--- a/config/locales/user/mailers/en.yml
+++ b/config/locales/user/mailers/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  user:
+    notification_mailer:
+      notification_digest:
+        subject: "Recent activity in your municipality"

--- a/config/locales/user/mailers/es.yml
+++ b/config/locales/user/mailers/es.yml
@@ -1,0 +1,6 @@
+---
+es:
+  user:
+    notification_mailer:
+      notification_digest:
+        subject: "Actividad reciente en tu municipio"

--- a/test/forms/user/notification_form_test.rb
+++ b/test/forms/user/notification_form_test.rb
@@ -60,4 +60,10 @@ class User::NotificationFormTest < ActiveSupport::TestCase
       valid_user_notification_form.save
     end
   end
+
+  def test_notification_email_delivery
+    assert_difference "ActionMailer::Base.deliveries.size", 1 do
+      valid_user_notification_form.save
+    end
+  end
 end

--- a/test/forms/user/notification_form_test.rb
+++ b/test/forms/user/notification_form_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class User::NotificationFormTest < ActiveSupport::TestCase
+  def valid_user_notification_form
+    @valid_user_notification_form ||= User::NotificationForm.new(
+      user_id: user.id,
+      site_id: site.id,
+      action: action,
+      subject_type: subject.model_name.to_s,
+      subject_id: subject.id
+    )
+  end
+
+  def invalid_user_notification_form
+    @invalid_user_notification_form ||= User::NotificationForm.new(
+      user_id: nil,
+      site_id: nil,
+      action: nil,
+      subject_type: nil,
+      subject_id: nil
+    )
+  end
+
+  def action
+    "created"
+  end
+
+  def user
+    @user ||= users(:dennis)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def subject
+    @subject ||= gobierto_budget_consultations_consultations(:madrid_open)
+  end
+
+  def test_validation
+    assert valid_user_notification_form.valid?
+  end
+
+  def test_error_messages_with_invalid_attributes
+    invalid_user_notification_form.save
+
+    assert_equal 1, invalid_user_notification_form.errors.messages[:user_id].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:site_id].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:action].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:subject_type].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:subject_id].size
+  end
+
+  def test_save
+    assert valid_user_notification_form.save
+  end
+
+  def test_resource_creation
+    assert_difference "User::Notification.count", 1 do
+      valid_user_notification_form.save
+    end
+  end
+end

--- a/test/mailers/user/notification_mailer_test.rb
+++ b/test/mailers/user/notification_mailer_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class User::NotificationMailerTest < ActionMailer::TestCase
+  def user_notification
+    @user_notification ||= user_notifications(:dennis_consultation_created)
+  end
+
+  def user
+    @user ||= user_notification.user
+  end
+
+  def test_single_notification
+    email = User::NotificationMailer.single_notification(user_notification).deliver_now
+
+    refute ActionMailer::Base.deliveries.empty?
+
+    assert_equal ["admin@gobierto.dev"], email.from
+    assert_equal ["admin@gobierto.dev"], email.reply_to
+    assert_equal [user.email], email.to
+    assert_equal "A consultation has been added", email.subject
+  end
+
+  def test_notification_digest
+    email = User::NotificationMailer.notification_digest(user, [user_notification], :daily).deliver_now
+
+    refute ActionMailer::Base.deliveries.empty?
+
+    assert_equal ["admin@gobierto.dev"], email.from
+    assert_equal ["admin@gobierto.dev"], email.reply_to
+    assert_equal [user.email], email.to
+    assert_equal "Recent activity in your municipality", email.subject
+  end
+end

--- a/test/services/user/subscription/notification_builder_test.rb
+++ b/test/services/user/subscription/notification_builder_test.rb
@@ -4,10 +4,10 @@ class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
   def setup
     super
     @subject = User::Subscription::NotificationBuilder.new(
-      event_name,
-      subscribable.model_name.to_s,
-      subscribable.id,
-      site.id
+      event_name: event_name,
+      model_name: subscribable.model_name.to_s,
+      model_id: subscribable.id,
+      site_id: site.id
     )
   end
 

--- a/test/services/user/subscription/notification_builder_test.rb
+++ b/test/services/user/subscription/notification_builder_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
-class User::NotificationBuilderTest < ActiveSupport::TestCase
+class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
   def setup
     super
-    @subject = User::NotificationBuilder.new(
+    @subject = User::Subscription::NotificationBuilder.new(
       event_name,
       subscribable.model_name.to_s,
       subscribable.id,


### PR DESCRIPTION
Connects to #167.

### What does this PR do?

This one implements the first approach for delivering User Notification-related emails for each notification type.

We're adding mailer templates per event name (e.g. `created`, `title_changed`, `visibility_level_changed`...) so that any of them can be completely customised. Also, we can customise any email subject through the localisation files.

That's slightly out of context, but it also adds some enhancements in the `User::NotificationBuilder` service class, and wraps any `User::Notification` database accesses in a well-known `User::NotificationForm` class.

In addition, any new messages are being localised into the three languages available now, so once again I'd need some help from my beloved Catalan translator @ferblape 🙏 

### How should this be manually tested?

At this time we can check that changing any watched attribute in a Consultation, such as the title, an event is produced and immediately consumed by the subscriber, creating a new `User::Notification` record and delivering the corresponding email. That email should have a consistent subject and body, that are just ready to be localised when we get the definitive texts.

Please note that the notification digest mailer is implemented too, but it isn't reached actually for now.

Don't forget about the User alerts panel, which is still there showing these notification records in the same format: http://madrid.gobierto.dev/user/notifications.