### PR TITLE
User Settings management and section sorting

### DIFF
--- a/app/controllers/gobierto_admin/users_controller.rb
+++ b/app/controllers/gobierto_admin/users_controller.rb
@@ -55,6 +55,7 @@ module GobiertoAdmin
       census_verified
       year_of_birth
       gender
+      notification_frequency
       )
     end
   end

--- a/app/controllers/user/settings_controller.rb
+++ b/app/controllers/user/settings_controller.rb
@@ -1,0 +1,34 @@
+class User::SettingsController < User::BaseController
+  before_action :authenticate_user!
+
+  def show
+    @user_settings_form = User::SettingsForm.new(user_id: current_user.id)
+    @user_notification_frequencies = get_user_notification_frequencies
+  end
+
+  def update
+    @user_settings_form = User::SettingsForm.new(
+      user_settings_params.merge(user_id: current_user.id)
+    )
+
+    if @user_settings_form.save
+      flash[:notice] = t(".success")
+    else
+      flash[:alert] = t(".error")
+    end
+
+    redirect_to user_settings_path
+  end
+
+  private
+
+  def user_settings_params
+    params.require(:user_settings).permit(
+      :notification_frequency
+    )
+  end
+
+  def get_user_notification_frequencies
+    User.notification_frequencies
+  end
+end

--- a/app/forms/user/confirmation_form.rb
+++ b/app/forms/user/confirmation_form.rb
@@ -53,6 +53,7 @@ class User::ConfirmationForm
   def confirm_user
     user.confirm!
     deliver_welcome_email
+    enable_notifications
   end
 
   protected
@@ -65,5 +66,9 @@ class User::ConfirmationForm
 
   def deliver_welcome_email
     User::UserMailer.welcome(user, user.source_site).deliver_later
+  end
+
+  def enable_notifications
+    user.immediate_notifications!
   end
 end

--- a/app/forms/user/notification_form.rb
+++ b/app/forms/user/notification_form.rb
@@ -28,7 +28,7 @@ class User::NotificationForm
   end
 
   def run_callbacks
-    true
+    deliver_notification_email
   end
 
   def create_notification
@@ -41,5 +41,11 @@ class User::NotificationForm
     end
 
     @notification.save(validate: false)
+  end
+
+  protected
+
+  def deliver_notification_email
+    User::NotificationMailer.single_notification(user_notification).deliver_later
   end
 end

--- a/app/forms/user/notification_form.rb
+++ b/app/forms/user/notification_form.rb
@@ -1,0 +1,45 @@
+class User::NotificationForm
+  include ActiveModel::Model
+
+  attr_accessor(
+    :user_id,
+    :site_id,
+    :action,
+    :subject_type,
+    :subject_id
+  )
+
+  validates :user_id, :site_id, :action, :subject_type, :subject_id, presence: true
+
+  def save
+    return unless valid?
+
+    run_callbacks if create_notification
+  end
+
+  def record
+    user_notification
+  end
+
+  private
+
+  def user_notification
+    @user_notification ||= User::Notification.new
+  end
+
+  def run_callbacks
+    true
+  end
+
+  def create_notification
+    @notification = user_notification.tap do |user_notification_attributes|
+      user_notification_attributes.user_id = user_id
+      user_notification_attributes.site_id = site_id
+      user_notification_attributes.action = action
+      user_notification_attributes.subject_type = subject_type
+      user_notification_attributes.subject_id = subject_id
+    end
+
+    @notification.save(validate: false)
+  end
+end

--- a/app/forms/user/settings_form.rb
+++ b/app/forms/user/settings_form.rb
@@ -1,0 +1,36 @@
+class User::SettingsForm
+  include ActiveModel::Model
+
+  attr_accessor(
+    :user_id,
+    :notification_frequency
+  )
+
+  def save
+    save_user_settings if valid?
+  end
+
+  def user
+    @user ||= User.find_by(id: user_id)
+  end
+
+  def notification_frequency
+    @notification_frequency ||= user.notification_frequency
+  end
+
+  private
+
+  def save_user_settings
+    @user = user.tap do |user_attributes|
+      user_attributes.notification_frequency = notification_frequency
+    end
+
+    if @user.valid?
+      @user.save
+
+      @user
+    else
+      false
+    end
+  end
+end

--- a/app/helpers/user/notifications_helper.rb
+++ b/app/helpers/user/notifications_helper.rb
@@ -1,12 +1,25 @@
 module User::NotificationsHelper
-  def render_notification_item(user_notification)
-    subject = user_notification.subject
-    action = user_notification.action
-
-    render(
-      "user/notifications/#{subject.model_name}".underscore,
-      subject: subject,
-      action: action
-    )
+  def render_notification_item(user_notification, absolute_url = false)
+    content_tag :span do
+      capture do
+        concat(
+          I18n.t(
+            "#{user_notification.subject.model_name.i18n_key}.notifications.subject.#{user_notification.action}"
+          )
+        )
+        concat(
+          ": "
+        )
+        concat(
+          link_to(
+            user_notification.subject.subscribable_label,
+            polymorphic_url(
+              user_notification.subject,
+              domain: (user_notification.site.domain if absolute_url)
+            )
+          )
+        )
+      end
+    end
   end
 end

--- a/app/mailers/user/notification_mailer.rb
+++ b/app/mailers/user/notification_mailer.rb
@@ -19,7 +19,7 @@ class User::NotificationMailer < ApplicationMailer
     )
   end
 
-  def notification_digest(user, user_notifications, periodicity)
+  def notification_digest(user, user_notifications, frequency)
     @user = user
     @user_notifications = user_notifications
 
@@ -27,7 +27,7 @@ class User::NotificationMailer < ApplicationMailer
       from: default_from,
       reply_to: default_reply_to,
       to: @user.email,
-      subject: default_i18n_subject(periodicity: periodicity)
+      subject: default_i18n_subject(frequency: frequency)
     )
   end
 end

--- a/app/mailers/user/notification_mailer.rb
+++ b/app/mailers/user/notification_mailer.rb
@@ -1,0 +1,33 @@
+class User::NotificationMailer < ApplicationMailer
+  helper User::NotificationsHelper
+
+  def single_notification(user_notification)
+    @user_notification = user_notification
+
+    @user = user_notification.user
+    @site = user_notification.site
+    @subject = user_notification.subject
+    @action = user_notification.action
+
+    mail(
+      from: default_from,
+      reply_to: default_reply_to,
+      to: @user.email,
+      subject: I18n.t("#{user_notification.subject.model_name.i18n_key}.notifications.subject.#{user_notification.action}"),
+      template_path: "#{user_notification.subject.model_name.collection}/notifications",
+      template_name: user_notification.action
+    )
+  end
+
+  def notification_digest(user, user_notifications, periodicity)
+    @user = user
+    @user_notifications = user_notifications
+
+    mail(
+      from: default_from,
+      reply_to: default_reply_to,
+      to: @user.email,
+      subject: default_i18n_subject(periodicity: periodicity)
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,7 @@ class User < ApplicationRecord
   scope :by_source_site, ->(source_site) { where(source_site: source_site) }
 
   enum gender: { male: 0, female: 1 }
+  enum notification_frequency: {
+    disabled: 0, immediate: 1, hourly: 2, daily: 3, weekly: 4
+  }, _suffix: :notifications
 end

--- a/app/services/user/subscription/notification_builder.rb
+++ b/app/services/user/subscription/notification_builder.rb
@@ -1,4 +1,4 @@
-class User::NotificationBuilder
+class User::Subscription::NotificationBuilder
   GENERIC_EVENT_NAMES = %w(created)
 
   attr_reader :event_name, :model_name, :model_id, :site_id
@@ -24,8 +24,8 @@ class User::NotificationBuilder
         .find_each do |user_subscription|
           user_notification = build_user_notification_for(user_subscription.user_id)
 
-          if user_notification.save(validate: false)
-            user_notifications << user_notification
+          if user_notification.save
+            user_notifications << user_notification.record
           end
         end
     end
@@ -36,7 +36,7 @@ class User::NotificationBuilder
   private
 
   def build_user_notification_for(user_id)
-    User::Notification.new(
+    User::NotificationForm.new(
       user_id: user_id,
       site_id: site_id,
       action: event_name,

--- a/app/services/user/subscription/notification_builder.rb
+++ b/app/services/user/subscription/notification_builder.rb
@@ -3,7 +3,7 @@ class User::Subscription::NotificationBuilder
 
   attr_reader :event_name, :model_name, :model_id, :site_id
 
-  def initialize(event_name, model_name, model_id, site_id)
+  def initialize(event_name:, model_name:, model_id:, site_id:)
     @event_name = event_name
     @model_name = model_name
     @model_id = model_id

--- a/app/views/gobierto_budget_consultations/consultations/notifications/closes_on_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/closes_on_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been updated:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/created.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/created.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been created:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/opens_on_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/opens_on_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been updated:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/title_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/title_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been updated:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/visibility_level_changed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/visibility_level_changed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been open:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,19 +57,19 @@
                       </a>
                       <ul class="pure-menu-children">
                         <li class="pure-menu-item">
-                          <%= link_to user_root_path, class: "pure-menu-link" do %>
+                          <%= link_to user_notifications_path, class: "pure-menu-link" do %>
                             <i class="fa fa-th"></i>
                             <%= t(".session.profile") %>
                           <% end %>
                         </li>
                         <li class="pure-menu-item">
-                          <%= link_to user_notifications_path, class: "pure-menu-link" do %>
+                          <%= link_to user_subscriptions_path, class: "pure-menu-link" do %>
                             <i class="fa fa-envelope-o"></i>
                             <%= t(".session.alerts") %>
                           <% end %>
                         </li>
                         <li class="pure-menu-item">
-                          <%= link_to user_subscriptions_path, class: "pure-menu-link" do %>
+                          <%= link_to user_settings_path, class: "pure-menu-link" do %>
                             <i class="fa fa-ship"></i>
                             <%= t(".session.admin") %>
                           <% end %>

--- a/app/views/user/layouts/_menu_subsections.html.erb
+++ b/app/views/user/layouts/_menu_subsections.html.erb
@@ -1,9 +1,9 @@
 <menu class="sub_sections">
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
     <ul>
-      <li><%= link_to t('.profile'), user_root_path %></li>
-      <li><%= link_to t('.alerts'), '#' %></li>
-      <li><%= link_to t('.admin'), user_subscriptions_path %></li>
+      <li><%= link_to t('.profile'), user_notifications_path %></li>
+      <li><%= link_to t('.alerts'), user_subscriptions_path %></li>
+      <li><%= link_to t('.admin'), user_settings_path %></li>
     </ul>
   </div>
 </menu>

--- a/app/views/user/notification_mailer/notification_digest.html.erb
+++ b/app/views/user/notification_mailer/notification_digest.html.erb
@@ -1,0 +1,15 @@
+<p>
+  Hey,
+</p>
+
+<p>
+  Here is the recent activity in your municipality:
+</p>
+
+<ul>
+  <% @user_notifications.each do |user_notification| %>
+    <li>
+      <%= render_notification_item(user_notification, true) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/user/notification_mailer/notification_digest.txt.erb
+++ b/app/views/user/notification_mailer/notification_digest.txt.erb
@@ -1,0 +1,7 @@
+Hey,
+
+Here is the recent activity in your municipality:
+
+<% @user_notifications.each do |user_notification| %>
+  <%= render_notification_item(user_notification, true) -%>
+<% end %>

--- a/app/views/user/notifications/gobierto_budget_consultations/_consultation.html.erb
+++ b/app/views/user/notifications/gobierto_budget_consultations/_consultation.html.erb
@@ -1,2 +1,0 @@
-<%= link_to subject.title, subject %>
-(<%= action %>)

--- a/app/views/user/notifications/index.html.erb
+++ b/app/views/user/notifications/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumb_current_item do %>
   <strong>
-    <%= link_to t("user.layouts.menu_subsections.alerts"), user_notifications_path %>
+    <%= link_to t("user.layouts.menu_subsections.profile"), user_notifications_path %>
   </strong>
 <% end %>
 

--- a/app/views/user/settings/_form.html.erb
+++ b/app/views/user/settings/_form.html.erb
@@ -1,0 +1,31 @@
+<%= render "user/shared/validation_errors", resource: @user_settings_form %>
+
+<%= form_for(@user_settings_form, as: :user_settings, url: :user_settings, method: :patch) do |f| %>
+
+  <div class="form_item">
+
+    <div class="options options_cont">
+
+      <%= f.label :notification_frequency %>
+
+      <div class="pure-g">
+        <%= f.collection_radio_buttons(:notification_frequency, @user_notification_frequencies, :first, :first) do |b| %>
+          <div class="pure-u-md-1-2">
+            <div class="option ">
+              <%= b.radio_button %>
+              <%= b.label do %>
+                <span></span>
+                <%= t(".notification_frequency.#{b.text}") %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+    </div>
+
+  </div>
+
+  <%= f.submit t(".submit"), class: "button" %>
+
+<% end %>

--- a/app/views/user/settings/show.html.erb
+++ b/app/views/user/settings/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for :breadcrumb_current_item do %>
+  <strong>
+    <%= link_to t("user.layouts.menu_subsections.admin"), user_settings_path %>
+  </strong>
+<% end %>
+
+<div class="column">
+
+  <div class="pure-g">
+
+    <div class="pure-u-1 pure-u-md-1-2 padded_line_box m_v_2">
+
+      <h1><%= t(".title") %></h1>
+
+      <%= render "form" %>
+
+    </div>
+
+  </div>
+
+</div>

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumb_current_item do %>
   <strong>
-    <%= link_to t("user.layouts.menu_subsections.admin"), user_subscriptions_path %>
+    <%= link_to t("user.layouts.menu_subsections.alerts"), user_subscriptions_path %>
   </strong>
 <% end %>
 

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -12,5 +12,5 @@ ActiveSupport::Notifications.subscribe(/trackable/) do |*args|
 
   # TODO. Perform asynchronously.
   #
-  User::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
+  User::Subscription::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
 end

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -4,13 +4,14 @@ Subscribers::SiteActivity.attach_to('activities/sites')
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
-
-  event_name = event.name.split(".").last
-  model_name = event.payload[:gid].model_name
-  model_id = event.payload[:gid].model_id
-  site_id = event.payload[:site_id]
+  Rails.logger.debug("Consuming event \"#{event.name}\" with payload: #{event.payload}")
 
   # TODO. Perform asynchronously.
   #
-  User::Subscription::NotificationBuilder.new(event_name, model_name, model_id, site_id).call
+  User::Subscription::NotificationBuilder.new(
+    event_name: event.name.split(".").last,
+    model_name: event.payload[:gid].model_name,
+    model_id: event.payload[:gid].model_id,
+    site_id: event.payload[:site_id]
+  ).call
 end

--- a/config/locales/gobierto_budget_consultations/notifications/ca.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/ca.yml
@@ -1,0 +1,10 @@
+---
+ca:
+  gobierto_budget_consultations/consultation:
+    notifications:
+      subject:
+        created: "Se ha añadido una consulta"
+        visibility_level_changed: "Se ha abierto una consulta"
+        title_changed: "Se ha actualizado una consulta"
+        opens_on_changed: "Se ha actualizado una consulta"
+        closes_on_changed: "Se ha actualizado una consulta"

--- a/config/locales/gobierto_budget_consultations/notifications/en.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  gobierto_budget_consultations/consultation:
+    notifications:
+      subject:
+        created: "A consultation has been added"
+        visibility_level_changed: "A consultation has been open"
+        title_changed: "A consultation has been updated"
+        opens_on_changed: "A consultation has been updated"
+        closes_on_changed: "A consultation has been updated"

--- a/config/locales/gobierto_budget_consultations/notifications/es.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  gobierto_budget_consultations/consultation:
+    notifications:
+      subject:
+        created: "Se ha agregado una consulta"
+        visibility_level_changed: "Se ha abierto una consulta"
+        title_changed: "Se ha actualizado una consulta"
+        opens_on_changed: "Se ha actualizado una consulta"
+        closes_on_changed: "Se ha actualizado una consulta"

--- a/config/locales/user/controllers/settings/ca.yml
+++ b/config/locales/user/controllers/settings/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  user:
+    settings:
+      update:
+        success: Ajustes guardados con éxito
+        error: Ha habido un error al guardar tus ajustes

--- a/config/locales/user/controllers/settings/ca.yml
+++ b/config/locales/user/controllers/settings/ca.yml
@@ -3,5 +3,5 @@ ca:
   user:
     settings:
       update:
-        success: Ajustes guardados con éxito
-        error: Ha habido un error al guardar tus ajustes
+        success: Ajusts guardats amb éxit
+        error: Hi ha hagut un error al guardar els teus ajusts

--- a/config/locales/user/controllers/settings/en.yml
+++ b/config/locales/user/controllers/settings/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  user:
+    settings:
+      update:
+        success: Settings saved successfully
+        error: There was a problem when saving your settings

--- a/config/locales/user/controllers/settings/es.yml
+++ b/config/locales/user/controllers/settings/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  user:
+    settings:
+      update:
+        success: Ajustes guardados con éxito
+        error: Ha habido un error al guardar tus ajustes

--- a/config/locales/user/mailers/ca.yml
+++ b/config/locales/user/mailers/ca.yml
@@ -1,0 +1,6 @@
+---
+ca:
+  user:
+    notification_mailer:
+      notification_digest:
+        subject: "Actividad reciente en tu municipio"

--- a/config/locales/user/mailers/ca.yml
+++ b/config/locales/user/mailers/ca.yml
@@ -3,4 +3,4 @@ ca:
   user:
     notification_mailer:
       notification_digest:
-        subject: "Actividad reciente en tu municipio"
+        subject: "Activitat recent al teu municipi"

--- a/config/locales/user/mailers/en.yml
+++ b/config/locales/user/mailers/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  user:
+    notification_mailer:
+      notification_digest:
+        subject: "Recent activity in your municipality"

--- a/config/locales/user/mailers/es.yml
+++ b/config/locales/user/mailers/es.yml
@@ -1,0 +1,6 @@
+---
+es:
+  user:
+    notification_mailer:
+      notification_digest:
+        subject: "Actividad reciente en tu municipio"

--- a/config/locales/user/models/ca.yml
+++ b/config/locales/user/models/ca.yml
@@ -9,6 +9,7 @@ ca:
       user/confirmation_form: Confirmació
       user/confirmation_request_form: Sol·licitud de confirmació
       user/subscription_form: Subscripció
+      user/settings_form: Ajustes
     attributes:
       user/session_form:
         email: El teu Correu-e
@@ -33,3 +34,5 @@ ca:
         user: Usuari
         user_email: Correu-e
         subscribable: Recurs
+      user/settings_form:
+        notification_frequency: Frecuencia de notificaciones

--- a/config/locales/user/models/ca.yml
+++ b/config/locales/user/models/ca.yml
@@ -9,7 +9,7 @@ ca:
       user/confirmation_form: Confirmació
       user/confirmation_request_form: Sol·licitud de confirmació
       user/subscription_form: Subscripció
-      user/settings_form: Ajustes
+      user/settings_form: Ajusts
     attributes:
       user/session_form:
         email: El teu Correu-e
@@ -35,4 +35,4 @@ ca:
         user_email: Correu-e
         subscribable: Recurs
       user/settings_form:
-        notification_frequency: Frecuencia de notificaciones
+        notification_frequency: Freqüència de notificacions

--- a/config/locales/user/models/en.yml
+++ b/config/locales/user/models/en.yml
@@ -9,6 +9,7 @@ en:
       user/confirmation_form: Confirmation
       user/confirmation_request_form: Confirmation request
       user/subscription_form: Subscription
+      user/settings_form: Settings
     attributes:
       user/session_form:
         email: Your e-mail
@@ -33,3 +34,5 @@ en:
         user: User
         user_email: E-mail
         subscribable: Resource
+      user/settings_form:
+        notification_frequency: Notification frequency

--- a/config/locales/user/models/es.yml
+++ b/config/locales/user/models/es.yml
@@ -9,6 +9,7 @@ es:
       user/confirmation_form: Confirmación
       user/confirmation_request_form: Solicitud de confirmación
       user/subscription_form: Suscripción
+      user/settings_form: Ajustes
     attributes:
       user/session_form:
         email: Tu Correo-e
@@ -33,3 +34,5 @@ es:
         user: Usuario
         user_email: Correo-e
         subscribable: Recurso
+      user/settings_form:
+        notification_frequency: Frecuencia de notificaciones

--- a/config/locales/user/views/notifications/ca.yml
+++ b/config/locales/user/views/notifications/ca.yml
@@ -3,7 +3,7 @@ ca:
   user:
     notifications:
       index:
-        title: Les teves Alertes
+        title: Activitat recent
         headers:
           created: Creat
           subject: Asumpte

--- a/config/locales/user/views/notifications/en.yml
+++ b/config/locales/user/views/notifications/en.yml
@@ -3,7 +3,7 @@ en:
   user:
     notifications:
       index:
-        title: Your Alertas
+        title: Recent activity
         headers:
           created: Created
           subject: Subject

--- a/config/locales/user/views/notifications/es.yml
+++ b/config/locales/user/views/notifications/es.yml
@@ -3,7 +3,7 @@ es:
   user:
     notifications:
       index:
-        title: Tus Alertas
+        title: Actividad reciente
         headers:
           created: Creado
           subject: Asunto

--- a/config/locales/user/views/settings/ca.yml
+++ b/config/locales/user/views/settings/ca.yml
@@ -3,12 +3,12 @@ ca:
   user:
     settings:
       show:
-        title: Ajustes de tu cuenta
+        title: Ajusts del teu compte
       form:
         notification_frequency:
-          disabled: Deshabilitadas
-          immediate: Inmediatas
-          hourly: Digest horario
-          daily: Digest diario
-          weekly: Digest semanal
+          disabled: Deshabilitades
+          immediate: Inmediates
+          hourly: Resum horari
+          daily: Resum diari
+          weekly: Resum semanal
         submit: Guardar

--- a/config/locales/user/views/settings/ca.yml
+++ b/config/locales/user/views/settings/ca.yml
@@ -1,0 +1,14 @@
+---
+ca:
+  user:
+    settings:
+      show:
+        title: Ajustes de tu cuenta
+      form:
+        notification_frequency:
+          disabled: Deshabilitadas
+          immediate: Inmediatas
+          hourly: Digest horario
+          daily: Digest diario
+          weekly: Digest semanal
+        submit: Guardar

--- a/config/locales/user/views/settings/en.yml
+++ b/config/locales/user/views/settings/en.yml
@@ -1,0 +1,14 @@
+---
+en:
+  user:
+    settings:
+      show:
+        title: Settings
+      form:
+        notification_frequency:
+          disabled: Disabled
+          immediate: Immediate
+          hourly: Hourly digest
+          daily: Daily digest
+          weekly: Weekly digest
+        submit: Save

--- a/config/locales/user/views/settings/es.yml
+++ b/config/locales/user/views/settings/es.yml
@@ -1,0 +1,14 @@
+---
+es:
+  user:
+    settings:
+      show:
+        title: Ajustes de tu cuenta
+      form:
+        notification_frequency:
+          disabled: Deshabilitadas
+          immediate: Inmediatas
+          hourly: Digest horario
+          daily: Digest diario
+          weekly: Digest semanal
+        submit: Guardar

--- a/config/locales/user/views/subscriptions/ca.yml
+++ b/config/locales/user/views/subscriptions/ca.yml
@@ -3,7 +3,7 @@ ca:
   user:
     subscriptions:
       index:
-        title: Les teves suscripcions
+        title: Les teves alertes
         headers:
           title: Títol
         cancel: Cancelar suscripció

--- a/config/locales/user/views/subscriptions/en.yml
+++ b/config/locales/user/views/subscriptions/en.yml
@@ -3,7 +3,7 @@ en:
   user:
     subscriptions:
       index:
-        title: Your subscriptions
+        title: Your alerts
         headers:
           title: Title
         cancel: Cancel subscription

--- a/config/locales/user/views/subscriptions/es.yml
+++ b/config/locales/user/views/subscriptions/es.yml
@@ -3,7 +3,7 @@ es:
   user:
     subscriptions:
       index:
-        title: Tus suscripciones
+        title: Tus alertas
         headers:
           title: Título
         cancel: Cancelar suscripción

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
       resource :confirmation_requests, only: [:create]
       resource :passwords, only: [:create, :edit, :update]
       resource :census_verifications, only: [:show, :new, :create], path: :verifications
+      resource :settings, only: [:show, :update]
 
       resources :subscriptions, only: [:index, :create, :destroy]
       resources :notifications, only: [:index]

--- a/db/migrate/20161221062928_add_notification_frequency_to_users.rb
+++ b/db/migrate/20161221062928_add_notification_frequency_to_users.rb
@@ -1,0 +1,6 @@
+class AddNotificationFrequencyToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :notification_frequency, :integer, null: false, default: 0
+    add_index :users, :notification_frequency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161219132627) do
+ActiveRecord::Schema.define(version: 20161221062928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 20161219132627) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                                null: false
+    t.string   "email",                                  null: false
     t.string   "name"
     t.string   "bio"
     t.string   "password_digest"
@@ -212,14 +212,16 @@ ActiveRecord::Schema.define(version: 20161219132627) do
     t.inet     "creation_ip"
     t.datetime "last_sign_in_at"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.integer  "source_site_id"
-    t.boolean  "census_verified",      default: false, null: false
+    t.boolean  "census_verified",        default: false, null: false
     t.integer  "year_of_birth"
     t.integer  "gender"
+    t.integer  "notification_frequency", default: 0,     null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["notification_frequency"], name: "index_users_on_notification_frequency", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
     t.index ["source_site_id"], name: "index_users_on_source_site_id", using: :btree
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,6 +12,7 @@ dennis:
   census_verified: true
   year_of_birth: 1990
   gender: <%= User.genders["female"] %>
+  notification_frequency: <%= User.notification_frequencies["immediate"] %>
 
 reed:
   email: reed@gobierto.dev
@@ -27,6 +28,7 @@ reed:
   census_verified: false
   year_of_birth: 1980
   gender: <%= User.genders["male"] %>
+  notification_frequency: <%= User.notification_frequencies["disabled"] %>
 
 susan:
   email: susan@gobierto.dev
@@ -42,3 +44,4 @@ susan:
   census_verified: false
   year_of_birth: 1970
   gender: <%= User.genders["female"] %>
+  notification_frequency: <%= User.notification_frequencies["weekly"] %>

--- a/test/forms/user/confirmation_form_test.rb
+++ b/test/forms/user/confirmation_form_test.rb
@@ -52,6 +52,13 @@ class User::ConfirmationFormTest < ActiveSupport::TestCase
     assert unconfirmed_user.reload.confirmed?
   end
 
+  def test_user_notifications_set_up
+    assert unconfirmed_user.disabled_notifications?
+
+    valid_user_confirmation_form.save
+    assert unconfirmed_user.reload.immediate_notifications?
+  end
+
   def test_welcome_email_delivery
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
       valid_user_confirmation_form.save

--- a/test/forms/user/notification_form_test.rb
+++ b/test/forms/user/notification_form_test.rb
@@ -60,4 +60,10 @@ class User::NotificationFormTest < ActiveSupport::TestCase
       valid_user_notification_form.save
     end
   end
+
+  def test_notification_email_delivery
+    assert_difference "ActionMailer::Base.deliveries.size", 1 do
+      valid_user_notification_form.save
+    end
+  end
 end

--- a/test/forms/user/notification_form_test.rb
+++ b/test/forms/user/notification_form_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class User::NotificationFormTest < ActiveSupport::TestCase
+  def valid_user_notification_form
+    @valid_user_notification_form ||= User::NotificationForm.new(
+      user_id: user.id,
+      site_id: site.id,
+      action: action,
+      subject_type: subject.model_name.to_s,
+      subject_id: subject.id
+    )
+  end
+
+  def invalid_user_notification_form
+    @invalid_user_notification_form ||= User::NotificationForm.new(
+      user_id: nil,
+      site_id: nil,
+      action: nil,
+      subject_type: nil,
+      subject_id: nil
+    )
+  end
+
+  def action
+    "created"
+  end
+
+  def user
+    @user ||= users(:dennis)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def subject
+    @subject ||= gobierto_budget_consultations_consultations(:madrid_open)
+  end
+
+  def test_validation
+    assert valid_user_notification_form.valid?
+  end
+
+  def test_error_messages_with_invalid_attributes
+    invalid_user_notification_form.save
+
+    assert_equal 1, invalid_user_notification_form.errors.messages[:user_id].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:site_id].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:action].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:subject_type].size
+    assert_equal 1, invalid_user_notification_form.errors.messages[:subject_id].size
+  end
+
+  def test_save
+    assert valid_user_notification_form.save
+  end
+
+  def test_resource_creation
+    assert_difference "User::Notification.count", 1 do
+      valid_user_notification_form.save
+    end
+  end
+end

--- a/test/forms/user/settings_form_test.rb
+++ b/test/forms/user/settings_form_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class User::SettingsFormTest < ActiveSupport::TestCase
+  def valid_user_settings_form
+    @valid_user_settings_form ||= User::SettingsForm.new(
+      user_id: user.id,
+      notification_frequency: User.notification_frequencies["immediate"]
+    )
+  end
+
+  def user
+    @user ||= users(:reed)
+  end
+
+  def test_validation
+    assert valid_user_settings_form.valid?
+  end
+
+  def test_save
+    assert valid_user_settings_form.save
+  end
+end

--- a/test/mailers/user/notification_mailer_test.rb
+++ b/test/mailers/user/notification_mailer_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class User::NotificationMailerTest < ActionMailer::TestCase
+  def user_notification
+    @user_notification ||= user_notifications(:dennis_consultation_created)
+  end
+
+  def user
+    @user ||= user_notification.user
+  end
+
+  def test_single_notification
+    email = User::NotificationMailer.single_notification(user_notification).deliver_now
+
+    refute ActionMailer::Base.deliveries.empty?
+
+    assert_equal ["admin@gobierto.dev"], email.from
+    assert_equal ["admin@gobierto.dev"], email.reply_to
+    assert_equal [user.email], email.to
+    assert_equal "A consultation has been added", email.subject
+  end
+
+  def test_notification_digest
+    email = User::NotificationMailer.notification_digest(user, [user_notification], :daily).deliver_now
+
+    refute ActionMailer::Base.deliveries.empty?
+
+    assert_equal ["admin@gobierto.dev"], email.from
+    assert_equal ["admin@gobierto.dev"], email.reply_to
+    assert_equal [user.email], email.to
+    assert_equal "Recent activity in your municipality", email.subject
+  end
+end

--- a/test/services/user/subscription/notification_builder_test.rb
+++ b/test/services/user/subscription/notification_builder_test.rb
@@ -4,10 +4,10 @@ class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
   def setup
     super
     @subject = User::Subscription::NotificationBuilder.new(
-      event_name,
-      subscribable.model_name.to_s,
-      subscribable.id,
-      site.id
+      event_name: event_name,
+      model_name: subscribable.model_name.to_s,
+      model_id: subscribable.id,
+      site_id: site.id
     )
   end
 

--- a/test/services/user/subscription/notification_builder_test.rb
+++ b/test/services/user/subscription/notification_builder_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
-class User::NotificationBuilderTest < ActiveSupport::TestCase
+class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
   def setup
     super
-    @subject = User::NotificationBuilder.new(
+    @subject = User::Subscription::NotificationBuilder.new(
       event_name,
       subscribable.model_name.to_s,
       subscribable.id,


### PR DESCRIPTION
Connects to #167.

### Review notes

These changes depend on https://github.com/PopulateTools/gobierto-dev/pull/179, so let's try to get that one merged before start reviewing this.

### What does this PR do?

This PR introduces a new section in Users namespace to manage their settings. The first setting available corresponds to the `notification_frequency` attribute, which will be taken into account when delivering User notifications.

---

Any new strings are being localised into the three languages available now, so once again I'd need some help from my beloved Catalan translator @ferblape 🙏 

### How should this be manually tested?

In terms of usability, let's ensure that every single section on the main menu's User dropdown links to the right section. I mean:

![screen shot 2016-12-21 at 8 37 12 am](https://cloud.githubusercontent.com/assets/126392/21381105/ac7aaa84-c759-11e6-947c-535627216cf3.jpg)

Particularly from this PR, check that the Settings section is reachable and lets the User to choose her notification frequency from the list, as follows:

http://madrid.gobierto.dev/user/settings

![screen shot 2016-12-21 at 8 37 07 am](https://cloud.githubusercontent.com/assets/126392/21381117/c3826276-c759-11e6-9af7-905d80b8c890.jpg)
