### PR TITLE
User Notification Digest Agent and common interface

### DIFF
--- a/app/forms/user/notification_form.rb
+++ b/app/forms/user/notification_form.rb
@@ -14,25 +14,29 @@ class User::NotificationForm
   def save
     return unless valid?
 
-    run_callbacks if create_notification
+    run_callbacks if save_user_notification
   end
-
-  def record
-    user_notification
-  end
-
-  private
 
   def user_notification
     @user_notification ||= User::Notification.new
   end
+  alias record user_notification
 
-  def run_callbacks
-    deliver_notification_email
+  private
+
+  def user
+    user_notification.user
   end
 
-  def create_notification
-    @notification = user_notification.tap do |user_notification_attributes|
+  def run_callbacks
+    return true unless deliver_notification_email?
+
+    deliver_notification_email
+    mark_as_sent
+  end
+
+  def save_user_notification
+    @user_notification = user_notification.tap do |user_notification_attributes|
       user_notification_attributes.user_id = user_id
       user_notification_attributes.site_id = site_id
       user_notification_attributes.action = action
@@ -40,12 +44,20 @@ class User::NotificationForm
       user_notification_attributes.subject_id = subject_id
     end
 
-    @notification.save(validate: false)
+    @user_notification.save(validate: false)
   end
 
   protected
 
+  def deliver_notification_email?
+    user.immediate_notifications?
+  end
+
   def deliver_notification_email
     User::NotificationMailer.single_notification(user_notification).deliver_later
+  end
+
+  def mark_as_sent
+    user_notification.sent!
   end
 end

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -4,4 +4,22 @@ class User::Notification < ApplicationRecord
   belongs_to :subject, polymorphic: true
 
   scope :sorted, -> { order(created_at: :desc) }
+  scope :sent,   -> { where(sent: true) }
+  scope :unsent, -> { where(sent: false) }
+
+  def self.sent!
+    update_all(sent: true)
+  end
+
+  def self.unsent!
+    update_all(sent: false)
+  end
+
+  def sent!
+    update_columns(sent: true)
+  end
+
+  def unsent!
+    update_columns(sent: false)
+  end
 end

--- a/app/services/user/notification_digest.rb
+++ b/app/services/user/notification_digest.rb
@@ -1,0 +1,41 @@
+class User::NotificationDigest
+  attr_reader :user_id, :frequency
+
+  def initialize(user_id, frequency)
+    @user_id = user_id
+    @frequency = frequency
+  end
+
+  def call
+    if user_notifications.any?
+      deliver_notification_digest
+      mark_as_sent
+    end
+
+    [user_id, user_notifications.size]
+  end
+
+  private
+
+  def deliver_notification_digest
+    User::NotificationMailer.notification_digest(
+      user,
+      user_notifications.to_a,
+      frequency.to_s
+    ).deliver_later
+  end
+
+  def mark_as_sent
+    user_notifications.sent!
+  end
+
+  protected
+
+  def user
+    @user ||= User.find_by(id: user_id)
+  end
+
+  def user_notifications
+    @user_notifications ||= User::Notification.unsent.where(user_id: user_id)
+  end
+end

--- a/app/services/user/notification_digest_agent.rb
+++ b/app/services/user/notification_digest_agent.rb
@@ -1,0 +1,32 @@
+class User::NotificationDigestAgent
+  class User::InvalidNotificationFrequency < StandardError; end
+
+  attr_reader :frequency
+
+  def initialize(frequency)
+    @frequency = frequency.to_s
+  end
+
+  def call
+    unless User.respond_to?("#{frequency}_notifications")
+      raise(
+        User::InvalidNotificationFrequency,
+        "Valid notification frequencies are: #{User.notification_frequencies.keys}"
+      )
+    end
+
+    build_notification_digests_for("#{frequency}_notifications")
+  end
+
+  private
+
+  def build_notification_digests_for(notification_frequency_name)
+    [].tap do |notification_digest_summary|
+      User.select(:id).send(notification_frequency_name).find_each do |user|
+        notification_digest_summary.push(
+          User::NotificationDigest.new(user.id, frequency).call
+        )
+      end
+    end
+  end
+end

--- a/db/migrate/20161221101641_add_sent_flag_to_user_notifications.rb
+++ b/db/migrate/20161221101641_add_sent_flag_to_user_notifications.rb
@@ -1,0 +1,5 @@
+class AddSentFlagToUserNotifications < ActiveRecord::Migration[5.0]
+  def change
+    add_column :user_notifications, :sent, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161221062928) do
+ActiveRecord::Schema.define(version: 20161221101641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,8 +164,9 @@ ActiveRecord::Schema.define(version: 20161221062928) do
     t.string   "action"
     t.string   "subject_type"
     t.integer  "subject_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "sent",         default: false, null: false
     t.index ["site_id"], name: "index_user_notifications_on_site_id", using: :btree
     t.index ["subject_type", "subject_id", "site_id", "user_id"], name: "index_user_notifications_on_subject_and_site_id_and_user_id", using: :btree
     t.index ["subject_type", "subject_id", "site_id"], name: "index_user_notifications_on_subject_and_site_id", using: :btree

--- a/lib/tasks/user/notification_digest_agent.rake
+++ b/lib/tasks/user/notification_digest_agent.rake
@@ -1,0 +1,18 @@
+namespace :user do
+  namespace :notification_digest_agent do
+    desc "Delivers hourly notification digests"
+    task hourly: :environment do
+      User::NotificationDigestAgent.new(:hourly).call
+    end
+
+    desc "Delivers daily notification digests"
+    task daily: :environment do
+      User::NotificationDigestAgent.new(:daily).call
+    end
+
+    desc "Delivers weekly notification digests"
+    task weekly: :environment do
+      User::NotificationDigestAgent.new(:weekly).call
+    end
+  end
+end

--- a/test/fixtures/user/notifications.yml
+++ b/test/fixtures/user/notifications.yml
@@ -3,15 +3,18 @@ dennis_consultation_created:
   site: madrid
   action: created
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
+  sent: true
 
 dennis_consultation_title_changed:
   user: dennis
   site: madrid
   action: title_changed
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
+  sent: false
 
 dennis_consultation_visibility_level_changed:
   user: dennis
   site: madrid
   action: visibility_level_changed
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
+  sent: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,7 +12,7 @@ dennis:
   census_verified: true
   year_of_birth: 1990
   gender: <%= User.genders["female"] %>
-  notification_frequency: <%= User.notification_frequencies["immediate"] %>
+  notification_frequency: <%= User.notification_frequencies["hourly"] %>
 
 reed:
   email: reed@gobierto.dev
@@ -44,4 +44,4 @@ susan:
   census_verified: false
   year_of_birth: 1970
   gender: <%= User.genders["female"] %>
-  notification_frequency: <%= User.notification_frequencies["weekly"] %>
+  notification_frequency: <%= User.notification_frequencies["immediate"] %>

--- a/test/forms/user/notification_form_test.rb
+++ b/test/forms/user/notification_form_test.rb
@@ -11,6 +11,16 @@ class User::NotificationFormTest < ActiveSupport::TestCase
     )
   end
 
+  def valid_delayed_user_notification_form
+    @valid_delayed_user_notification_form ||= User::NotificationForm.new(
+      user_id: delayed_notifications_user.id,
+      site_id: site.id,
+      action: action,
+      subject_type: subject.model_name.to_s,
+      subject_id: subject.id
+    )
+  end
+
   def invalid_user_notification_form
     @invalid_user_notification_form ||= User::NotificationForm.new(
       user_id: nil,
@@ -26,7 +36,11 @@ class User::NotificationFormTest < ActiveSupport::TestCase
   end
 
   def user
-    @user ||= users(:dennis)
+    @user ||= users(:susan)
+  end
+
+  def delayed_notifications_user
+    @delayed_notifications_user ||= users(:dennis)
   end
 
   def site
@@ -61,9 +75,15 @@ class User::NotificationFormTest < ActiveSupport::TestCase
     end
   end
 
-  def test_notification_email_delivery
+  def test_immediate_notification_email_delivery
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
       valid_user_notification_form.save
+    end
+  end
+
+  def test_delayed_notification_email_delivery
+    assert_no_difference "ActionMailer::Base.deliveries.size" do
+      valid_delayed_user_notification_form.save
     end
   end
 end

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -5,7 +5,53 @@ class User::NotificationTest < ActiveSupport::TestCase
     @notification ||= user_notifications(:dennis_consultation_created)
   end
 
+  def sent_user_notification
+    @sent_user_notification ||= user_notifications(:dennis_consultation_created)
+  end
+
+  def unsent_user_notification
+    @unsent_user_notification ||= user_notifications(:dennis_consultation_title_changed)
+  end
+
   def test_valid
     assert notification.valid?
+  end
+
+  def test_sent_scope
+    assert_includes User::Notification.sent, sent_user_notification
+    refute_includes User::Notification.sent, unsent_user_notification
+  end
+
+  def test_unsent_scope
+    assert_includes User::Notification.unsent, unsent_user_notification
+    refute_includes User::Notification.unsent, sent_user_notification
+  end
+
+  def test_class_sent!
+    assert User::Notification.unsent.any?
+
+    User::Notification.sent!
+    refute User::Notification.unsent.any?
+  end
+
+  def test_class_unsent!
+    assert User::Notification.sent.any?
+
+    User::Notification.unsent!
+    refute User::Notification.sent.any?
+  end
+
+  def test_sent!
+    refute unsent_user_notification.sent?
+
+    unsent_user_notification.sent!
+    assert unsent_user_notification.sent?
+  end
+
+  def test_unsent!
+    assert sent_user_notification.sent?
+
+    sent_user_notification.unsent!
+    refute sent_user_notification.sent?
   end
 end

--- a/test/services/user/notification_digest_agent_test.rb
+++ b/test/services/user/notification_digest_agent_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class User::NotificationDigestAgentTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = User::NotificationDigestAgent.new(frequency)
+  end
+
+  def user
+    @user ||= users(:dennis)
+  end
+
+  def frequency
+    @frequency ||= user.notification_frequency
+  end
+
+  def test_call
+    assert @subject.call
+  end
+
+  def test_call_with_invalid_frequency
+    assert_raises(User::InvalidNotificationFrequency) do
+      User::NotificationDigestAgent.new(:wadus).call
+    end
+  end
+
+  def test_call_response
+    assert_kind_of Array, @subject.call
+  end
+end

--- a/test/services/user/notification_digest_test.rb
+++ b/test/services/user/notification_digest_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class User::NotificationDigestTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = User::NotificationDigest.new(user.id, frequency)
+  end
+
+  def user
+    @user ||= users(:dennis)
+  end
+
+  def user_notifications
+    @user_notifications ||= user.notifications
+  end
+
+  def frequency
+    @frequency ||= user.notification_frequency
+  end
+
+  def test_call
+    assert @subject.call
+  end
+
+  def test_call_response
+    assert_equal [user.id, user_notifications.unsent.count], @subject.call
+  end
+
+  def test_notification_digest_deliveries
+    assert_difference "ActionMailer::Base.deliveries.size", 1 do
+      @subject.call
+    end
+  end
+end

--- a/test/services/user/subscription/notification_builder_test.rb
+++ b/test/services/user/subscription/notification_builder_test.rb
@@ -35,7 +35,9 @@ class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
     assert_difference "User::Notification.count", 1 do
       @subject.call
     end
+  end
 
+  def test_user_notification_format
     user_notifications = @subject.call
     first_user_notification = user_notifications.first
 


### PR DESCRIPTION
Connects to #167.

### What does this PR do?

Taking the User preferences from https://github.com/PopulateTools/gobierto-dev/pull/180 into account, this PR provides a common interface to reach the `User::NotificationDigestAgent` service, which is in charge of collecting all User Notifications ready to be sent in a determined period, and deliver them in form of a digest email.

The interface to access this service from outside the application is a Rake interface, and it is defined as follows:

```shell
rake user:notification_digest_agent:daily           # Delivers daily notifi...
rake user:notification_digest_agent:hourly          # Delivers hourly notif...
rake user:notification_digest_agent:weekly          # Delivers weekly notif...
```

So, it would be needed to schedule all these Rake tasks as cron tasks to be executed in the same frequency to keep working the User Notification delivery mechanism.

It also updates the current implementation to make use of the User notification frequency preferences in combination to the new User Notification sent flag.

### How should this be manually tested?

After seeding the database, just try the `hourly` Rake task and wait for a digest email to come:

```shell
$ bundle exec rake user:notification_digest_agent:hourly
```

Run it twice to check that the email is not being delivered this time.