### PR TITLE
Prevent user authentication in gobierto admin module + a bit of cleanup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_site
-    request.env['gobierto_site'] unless Site.reserved_domain?(domain)
+    request.env['gobierto_site']
   end
 
   private
@@ -64,9 +64,5 @@ class ApplicationController < ActionController::Base
 
   def remote_ip
     request.env['action_dispatch.remote_ip'].try(:calculate_ip) || request.remote_ip
-  end
-
-  def domain
-    @domain ||= (request.env['HTTP_HOST'] || request.env['SERVER_NAME'] || request.env['SERVER_ADDR']).split(':').first
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,15 +16,6 @@ class ApplicationController < ActionController::Base
     ActionController::Base.helpers
   end
 
-  # TODO: check if we still need this
-  def default_url_options(options={})
-    if params[:e].present?
-      { e: true }
-    else
-      {}
-    end
-  end
-
   def current_site
     request.env['gobierto_site'] unless Site.reserved_domain?(domain)
   end

--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -5,6 +5,7 @@ module GobiertoAdmin
     include LayoutPolicyHelper
     include ModuleHelper
 
+    skip_before_action :authenticate_user_in_site
     before_action :authenticate_admin!
 
     helper_method :current_admin, :admin_signed_in?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,6 @@
 class Site < ApplicationRecord
 
-  RESERVED_SUBDOMAINS = %W(presupuestos)
+  RESERVED_SUBDOMAINS = %W(presupuestos hosted)
 
   # GobiertoAdmin integrations
   has_many :admin_sites, dependent: :destroy, class_name: "GobiertoAdmin::AdminSite"
@@ -30,10 +30,10 @@ class Site < ApplicationRecord
 
   enum visibility_level: { draft: 0, active: 1 }
 
-  def self.reserved_domain?(domain)
-    RESERVED_SUBDOMAINS.map do |subdomain|
-      "#{subdomain}." + Settings.gobierto_host
-    end.any?{ |reserved_domain| domain == reserved_domain }
+  def self.find_by_allowed_domain(domain)
+    unless reserved_domains.include?(domain)
+      find_by(domain: domain)
+    end
   end
 
   def subdomain
@@ -55,6 +55,13 @@ class Site < ApplicationRecord
   end
 
   private
+
+  def self.reserved_domains
+    @reserved_domains ||= RESERVED_SUBDOMAINS.map do |subdomain|
+      "#{subdomain}." + Settings.gobierto_host
+    end
+  end
+  private_class_method :reserved_domains
 
   def store_configuration
     self.configuration_data = self.configuration.instance_values

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -36,12 +36,6 @@ class Site < ApplicationRecord
     end
   end
 
-  def subdomain
-    if domain.present? and domain.include?('.')
-      domain.split('.').first
-    end
-  end
-
   def place
     @place ||= INE::Places::Place.find self.municipality_id
   end

--- a/lib/constraints/gobierto_site_constraint.rb
+++ b/lib/constraints/gobierto_site_constraint.rb
@@ -5,7 +5,7 @@ class GobiertoSiteConstraint
   def matches?(request)
     full_domain = (request.env['HTTP_HOST'] || request.env['SERVER_NAME'] || request.env['SERVER_ADDR']).split(':').first
 
-    if site = Site.find_by(domain: full_domain)
+    if site = Site.find_by_allowed_domain(full_domain)
       request.env['gobierto_site'] = site
       return true
     end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -36,4 +36,10 @@ class SiteTest < ActiveSupport::TestCase
     assert_kind_of INE::Places::Place, site.place
     assert site.place.present?
   end
+
+  def test_find_by_allowed_domain
+    assert_equal site, Site.find_by_allowed_domain(site.domain)
+    refute Site.find_by_allowed_domain('presupuestos.' + Settings.gobierto_host)
+    refute Site.find_by_allowed_domain('foo')
+  end
 end


### PR DESCRIPTION
Connects to #108

### What does this PR do?

This PR fixes a problem in gobierto admin module when the current site has password protection enabled. To keep the simplicity and because most of the modules will be public, the preferred solution for the time being is to skip the filter in those modules that don't require http web authentication.

### How should this be manually tested?

1. Open a private browser session
2. Go to gobierto.dev/admin and login
3. Protect with password all the sites
4. Logout
5. Open a private browser session
6. Go to gobierto.dev/admin and login
7. You shouldn't be asked for a http password