### PR TITLE
Force password value to be included in the input

### DIFF
--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -124,7 +124,7 @@
                       </p>
                       <p>
                         <%= t(".password") %>
-                        <%= f.password_field :password %>
+                        <%= f.password_field :password, value: f.object.password %>
                       </p>
                     </div>
                   <% end %>

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -90,11 +90,18 @@ module GobiertoAdmin
           click_button "Update Site"
         end
 
+        assert has_message?("Site was successfully updated")
+
         within "form.edit_site" do
           within ".site-visibility-level-radio-buttons" do
             assert has_checked_field?("Draft")
           end
+
+          fill_in "site_title", with: "New Site Title"
+          click_button "Update Site"
         end
+
+        assert has_message?("Site was successfully updated")
       end
     end
 


### PR DESCRIPTION
Connects to #175

### What does this PR do?

This PR fixes a bug when updating a draft site, because site password wasn't present and it was returning validation error.

### How should this be manually tested?

In a draft site:

1. Edit any attribute
2. Click update
3. Site data should have been updated 
