### PR TITLE
ActiveNotifier service and common interface

### DIFF
--- a/app/models/gobierto_budget_consultations/consultation.rb
+++ b/app/models/gobierto_budget_consultations/consultation.rb
@@ -15,11 +15,15 @@ module GobiertoBudgetConsultations
 
     enum visibility_level: { draft: 0, active: 1 }
 
-    scope :sorted,    -> { order(created_at: :desc) }
-    scope :active,    -> { select(&:open?) }
-    scope :not_draft, -> { where.not(visibility_level: visibility_levels[:draft]) }
-    scope :past,      -> { not_draft.where("closes_on < ?", Date.current) }
-    scope :upcoming,  -> { not_draft.where("opens_on > ?", Date.current) }
+    scope :sorted,            -> { order(created_at: :desc) }
+    scope :active_visibility, -> { where(visibility_level: visibility_levels[:active]) }
+    scope :active,            -> { select(&:open?) }
+    scope :not_draft,         -> { where.not(visibility_level: visibility_levels[:draft]) }
+    scope :past,              -> { not_draft.where("closes_on < ?", Date.current) }
+    scope :upcoming,          -> { not_draft.where("opens_on > ?", Date.current) }
+    scope :opening_today,     -> { active_visibility.where(opens_on: Date.current) }
+    scope :closing_today,     -> { active_visibility.where(closes_on: Date.current) }
+    scope :about_to_close,    -> { active_visibility.where(closes_on: 2.days.from_now.to_date) }
 
     def open?
       visibility_level == "active" && opening_range.include?(Date.current)

--- a/app/services/gobierto_budget_consultations/active_notifier/events.rb
+++ b/app/services/gobierto_budget_consultations/active_notifier/events.rb
@@ -1,0 +1,32 @@
+module GobiertoBudgetConsultations
+  module ActiveNotifier
+    module Events
+      def notify_consultations_opening_today
+        event_name = "opened"
+
+        Consultation.opening_today.find_each do |consultation|
+          event_payload = { gid: consultation.to_gid, site_id: consultation.site_id }
+          Publishers::Trackable.broadcast_event(event_name, event_payload)
+        end
+      end
+
+      def notify_consultations_closing_today
+        event_name = "closed"
+
+        Consultation.closing_today.find_each do |consultation|
+          event_payload = { gid: consultation.to_gid, site_id: consultation.site_id }
+          Publishers::Trackable.broadcast_event(event_name, event_payload)
+        end
+      end
+
+      def notify_consultations_about_to_close
+        event_name = "about_to_close"
+
+        Consultation.about_to_close.find_each do |consultation|
+          event_payload = { gid: consultation.to_gid, site_id: consultation.site_id }
+          Publishers::Trackable.broadcast_event(event_name, event_payload)
+        end
+      end
+    end
+  end
+end

--- a/app/services/gobierto_common/active_notifier/daily.rb
+++ b/app/services/gobierto_common/active_notifier/daily.rb
@@ -1,0 +1,19 @@
+module GobiertoCommon
+  module ActiveNotifier
+    class Daily
+      extend GobiertoBudgetConsultations::ActiveNotifier::Events
+
+      EVENTS_TO_TRIGGER = %w(
+        notify_consultations_opening_today
+        notify_consultations_closing_today
+        notify_consultations_about_to_close
+      ).freeze
+
+      def self.call
+        EVENTS_TO_TRIGGER.each do |event_name|
+          send(event_name) if respond_to?(event_name)
+        end
+      end
+    end
+  end
+end

--- a/app/views/gobierto_budget_consultations/consultations/notifications/about_to_close.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/about_to_close.html.erb
@@ -1,0 +1,7 @@
+<p>
+  This Consultation is about to close:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/closed.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/closed.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been closed:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/app/views/gobierto_budget_consultations/consultations/notifications/opened.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/notifications/opened.html.erb
@@ -1,0 +1,7 @@
+<p>
+  A Consultation has been open:
+</p>
+
+<p>
+  <%= link_to @subject.title, polymorphic_url(@subject, domain: @site.domain) %>
+</p>

--- a/config/locales/gobierto_budget_consultations/notifications/ca.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/ca.yml
@@ -8,3 +8,6 @@ ca:
         title_changed: "S'ha actualitzat una consulta"
         opens_on_changed: "S'ha actualitzat una consulta"
         closes_on_changed: "S'ha actualitzat una consulta"
+        opened: "S'ha obert una consulta"
+        closed: "S'ha tancat una consulta"
+        about_to_close: "Aquesta consulta es tancarà aviat"

--- a/config/locales/gobierto_budget_consultations/notifications/en.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/en.yml
@@ -8,3 +8,6 @@ en:
         title_changed: "A consultation has been updated"
         opens_on_changed: "A consultation has been updated"
         closes_on_changed: "A consultation has been updated"
+        opened: "A consultation has been open"
+        closed: "A consultation has been closed"
+        about_to_close: "A consultation is about to close"

--- a/config/locales/gobierto_budget_consultations/notifications/es.yml
+++ b/config/locales/gobierto_budget_consultations/notifications/es.yml
@@ -8,3 +8,6 @@ es:
         title_changed: "Se ha actualizado una consulta"
         opens_on_changed: "Se ha actualizado una consulta"
         closes_on_changed: "Se ha actualizado una consulta"
+        opened: "Se ha abierto una consulta"
+        closed: "Se ha cerrado una consulta"
+        about_to_close: "Esta consulta se cerrará pronto"

--- a/lib/tasks/gobierto_common/active_notifier.rake
+++ b/lib/tasks/gobierto_common/active_notifier.rake
@@ -1,0 +1,8 @@
+namespace :common do
+  namespace :active_notifier do
+    desc "Actively seeks for events to notify"
+    task daily: :environment do
+      GobiertoCommon::ActiveNotifier::Daily.call
+    end
+  end
+end

--- a/test/models/gobierto_budget_consultations/consultation_test.rb
+++ b/test/models/gobierto_budget_consultations/consultation_test.rb
@@ -54,6 +54,30 @@ module GobiertoBudgetConsultations
       refute_includes subject, past_consultation
     end
 
+    def test_opening_today_scope
+      consultation.update_columns(opens_on: Date.today)
+      subject = Consultation.opening_today
+
+      assert_includes subject, consultation
+      refute_includes subject, past_consultation
+    end
+
+    def test_closing_today_scope
+      consultation.update_columns(closes_on: Date.today)
+      subject = Consultation.closing_today
+
+      assert_includes subject, consultation
+      refute_includes subject, past_consultation
+    end
+
+    def test_about_to_close_scope
+      consultation.update_columns(closes_on: 2.days.from_now.to_date)
+      subject = Consultation.about_to_close
+
+      assert_includes subject, consultation
+      refute_includes subject, past_consultation
+    end
+
     def test_open?
       assert consultation.open?
       refute past_consultation.open?

--- a/test/services/gobierto_common/active_notifier/daily_test.rb
+++ b/test/services/gobierto_common/active_notifier/daily_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class GobiertoCommon::ActiveNotifier::DailyTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = GobiertoCommon::ActiveNotifier::Daily
+  end
+
+  def test_call
+    assert @subject.call
+  end
+
+  def test_notifications
+    assert_difference "User::Notification.count", 1 do
+      @subject.call
+    end
+  end
+end


### PR DESCRIPTION
Connects to #167.

### What does this PR do?

This one implements a mechanism to seek for events that should be actively notified to the system, and wraps it within the `GobiertoCommon::ActiveNotifier` service. Those are events that can't be driven by the application workflow itself, so they need to be triggered explicitly.

Here we're integrating some `GobiertoBudgetConsultations::Consultation` events to continue with our sample case. These are: `opened`, `closed` and `about_to_close`. Messages and mailer templates have been added as well.

The interface to access this service from outside the application is a Rake interface too, and it is defined as follows:

```shell
rake common:active_notifier:daily
```

Due to the nature of the currently watched events, only a daily performed task is needed. It is expected to define interfaces in other kind of frequencies or contexts though.

### How should this be manually tested?

Just run the only rake task here to see how events are being published and consumed, so the corresponding `User::Notification` entries should be created in this case:

```shell
$ rake common:active_notifier:daily
```