### PR TITLE
User Notifications seen control

### DIFF
--- a/app/controllers/user/notifications_controller.rb
+++ b/app/controllers/user/notifications_controller.rb
@@ -1,5 +1,6 @@
 class User::NotificationsController < User::BaseController
   before_action :authenticate_user!
+  after_action :mark_as_seen, only: :index
 
   def index
     @user_notifications = find_user_notifications.sorted
@@ -8,9 +9,10 @@ class User::NotificationsController < User::BaseController
   private
 
   def find_user_notifications
-    User::Notification.where(
-      user: current_user,
-      site: current_site
-    )
+    User::Notification.unseen.where(user: current_user, site: current_site)
+  end
+
+  def mark_as_seen
+    @user_notifications.seen!
   end
 end

--- a/app/helpers/user/notifications_helper.rb
+++ b/app/helpers/user/notifications_helper.rb
@@ -13,13 +13,19 @@ module User::NotificationsHelper
         concat(
           link_to(
             user_notification.subject.subscribable_label,
-            polymorphic_url(
-              user_notification.subject,
-              domain: (user_notification.site.domain if absolute_url)
-            )
+            notification_subject_url(user_notification, absolute_url)
           )
         )
       end
     end
+  end
+
+  def notification_subject_url(user_notification, absolute_url = false)
+    return url_for(user_notification.subject) unless absolute_url
+
+    polymorphic_url(
+      user_notification.subject,
+      domain: (user_notification.site.domain if absolute_url)
+    )
   end
 end

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -6,6 +6,8 @@ class User::Notification < ApplicationRecord
   scope :sorted, -> { order(created_at: :desc) }
   scope :sent,   -> { where(sent: true) }
   scope :unsent, -> { where(sent: false) }
+  scope :seen,   -> { where(is_seen: true) }
+  scope :unseen, -> { where(is_seen: false) }
 
   def self.sent!
     update_all(sent: true)
@@ -15,11 +17,31 @@ class User::Notification < ApplicationRecord
     update_all(sent: false)
   end
 
+  def self.seen!
+    update_all(is_seen: true)
+  end
+
+  def self.unseen!
+    update_all(is_seen: false)
+  end
+
   def sent!
     update_columns(sent: true)
   end
 
   def unsent!
     update_columns(sent: false)
+  end
+
+  def seen?
+    is_seen
+  end
+
+  def seen!
+    update_columns(is_seen: true)
+  end
+
+  def unseen!
+    update_columns(is_seen: false)
   end
 end

--- a/app/models/user/notification.rb
+++ b/app/models/user/notification.rb
@@ -4,17 +4,17 @@ class User::Notification < ApplicationRecord
   belongs_to :subject, polymorphic: true
 
   scope :sorted, -> { order(created_at: :desc) }
-  scope :sent,   -> { where(sent: true) }
-  scope :unsent, -> { where(sent: false) }
+  scope :sent,   -> { where(is_sent: true) }
+  scope :unsent, -> { where(is_sent: false) }
   scope :seen,   -> { where(is_seen: true) }
   scope :unseen, -> { where(is_seen: false) }
 
   def self.sent!
-    update_all(sent: true)
+    update_all(is_sent: true)
   end
 
   def self.unsent!
-    update_all(sent: false)
+    update_all(is_sent: false)
   end
 
   def self.seen!
@@ -25,12 +25,16 @@ class User::Notification < ApplicationRecord
     update_all(is_seen: false)
   end
 
+  def sent?
+    is_sent
+  end
+
   def sent!
-    update_columns(sent: true)
+    update_columns(is_sent: true)
   end
 
   def unsent!
-    update_columns(sent: false)
+    update_columns(is_sent: false)
   end
 
   def seen?

--- a/app/views/user/notifications/index.html.erb
+++ b/app/views/user/notifications/index.html.erb
@@ -8,24 +8,32 @@
 
   <h3><%= title t(".title") %></h3>
 
-  <table class="user-notification-list">
-    <tr>
-      <th><%= t(".headers.created") %></th>
-      <th><%= t(".headers.subject") %></th>
-      <th></th>
-    </tr>
-    <tbody>
-      <% @user_notifications.each do |user_notification| %>
-        <tr id="user-notification-item-<%= user_notification.id %>">
-          <td>
-            <%= l(user_notification.created_at, format: :long) %>
-          </td>
-          <td>
-            <%= render_notification_item(user_notification) %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <% if @user_notifications.any? %>
+
+    <table class="user-notification-list">
+      <tr>
+        <th><%= t(".headers.created") %></th>
+        <th><%= t(".headers.subject") %></th>
+        <th></th>
+      </tr>
+      <tbody>
+        <% @user_notifications.each do |user_notification| %>
+          <tr id="user-notification-item-<%= user_notification.id %>">
+            <td>
+              <%= l(user_notification.created_at, format: :long) %>
+            </td>
+            <td>
+              <%= render_notification_item(user_notification) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  <% else %>
+
+    <%= t(".no_new_notifications") %>
+
+  <% end %>
 
 </div>

--- a/config/locales/user/views/notifications/ca.yml
+++ b/config/locales/user/views/notifications/ca.yml
@@ -4,6 +4,7 @@ ca:
     notifications:
       index:
         title: Activitat recent
+        no_new_notifications: No hi ha notificacions noves
         headers:
           created: Creat
           subject: Asumpte

--- a/config/locales/user/views/notifications/en.yml
+++ b/config/locales/user/views/notifications/en.yml
@@ -4,6 +4,7 @@ en:
     notifications:
       index:
         title: Recent activity
+        no_new_notifications: There are no new notifications
         headers:
           created: Created
           subject: Subject

--- a/config/locales/user/views/notifications/es.yml
+++ b/config/locales/user/views/notifications/es.yml
@@ -4,6 +4,7 @@ es:
     notifications:
       index:
         title: Actividad reciente
+        no_new_notifications: No hay notificaciones nuevas
         headers:
           created: Creado
           subject: Asunto

--- a/db/migrate/20161222054737_add_seen_flag_to_user_notifications.rb
+++ b/db/migrate/20161222054737_add_seen_flag_to_user_notifications.rb
@@ -1,0 +1,6 @@
+class AddSeenFlagToUserNotifications < ActiveRecord::Migration[5.0]
+  def change
+    add_column :user_notifications, :is_seen, :boolean, null: false, default: false
+    add_index :user_notifications, :is_seen
+  end
+end

--- a/db/migrate/20161222064115_rename_sent_flag_in_user_notifications.rb
+++ b/db/migrate/20161222064115_rename_sent_flag_in_user_notifications.rb
@@ -1,0 +1,5 @@
+class RenameSentFlagInUserNotifications < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :user_notifications, :sent, :is_sent
+  end
+end

--- a/db/migrate/20161222064233_add_sent_flag_index_in_user_notifications.rb
+++ b/db/migrate/20161222064233_add_sent_flag_index_in_user_notifications.rb
@@ -1,0 +1,5 @@
+class AddSentFlagIndexInUserNotifications < ActiveRecord::Migration[5.0]
+  def change
+    add_index :user_notifications, :is_sent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161222054737) do
+ActiveRecord::Schema.define(version: 20161222064233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,9 +166,10 @@ ActiveRecord::Schema.define(version: 20161222054737) do
     t.integer  "subject_id"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.boolean  "sent",         default: false, null: false
+    t.boolean  "is_sent",      default: false, null: false
     t.boolean  "is_seen",      default: false, null: false
     t.index ["is_seen"], name: "index_user_notifications_on_is_seen", using: :btree
+    t.index ["is_sent"], name: "index_user_notifications_on_is_sent", using: :btree
     t.index ["site_id"], name: "index_user_notifications_on_site_id", using: :btree
     t.index ["subject_type", "subject_id", "site_id", "user_id"], name: "index_user_notifications_on_subject_and_site_id_and_user_id", using: :btree
     t.index ["subject_type", "subject_id", "site_id"], name: "index_user_notifications_on_subject_and_site_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161221101641) do
+ActiveRecord::Schema.define(version: 20161222054737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,8 @@ ActiveRecord::Schema.define(version: 20161221101641) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.boolean  "sent",         default: false, null: false
+    t.boolean  "is_seen",      default: false, null: false
+    t.index ["is_seen"], name: "index_user_notifications_on_is_seen", using: :btree
     t.index ["site_id"], name: "index_user_notifications_on_site_id", using: :btree
     t.index ["subject_type", "subject_id", "site_id", "user_id"], name: "index_user_notifications_on_subject_and_site_id_and_user_id", using: :btree
     t.index ["subject_type", "subject_id", "site_id"], name: "index_user_notifications_on_subject_and_site_id", using: :btree

--- a/test/fixtures/user/notifications.yml
+++ b/test/fixtures/user/notifications.yml
@@ -3,7 +3,7 @@ dennis_consultation_created:
   site: madrid
   action: created
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
-  sent: true
+  is_sent: true
   is_seen: true
 
 dennis_consultation_title_changed:
@@ -11,7 +11,7 @@ dennis_consultation_title_changed:
   site: madrid
   action: title_changed
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
-  sent: false
+  is_sent: false
   is_seen: false
 
 dennis_consultation_visibility_level_changed:
@@ -19,5 +19,5 @@ dennis_consultation_visibility_level_changed:
   site: madrid
   action: visibility_level_changed
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
-  sent: false
+  is_sent: false
   is_seen: false

--- a/test/fixtures/user/notifications.yml
+++ b/test/fixtures/user/notifications.yml
@@ -4,6 +4,7 @@ dennis_consultation_created:
   action: created
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
   sent: true
+  is_seen: true
 
 dennis_consultation_title_changed:
   user: dennis
@@ -11,6 +12,7 @@ dennis_consultation_title_changed:
   action: title_changed
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
   sent: false
+  is_seen: false
 
 dennis_consultation_visibility_level_changed:
   user: dennis
@@ -18,3 +20,4 @@ dennis_consultation_visibility_level_changed:
   action: visibility_level_changed
   subject: madrid_open (GobiertoBudgetConsultations::Consultation)
   sent: false
+  is_seen: false

--- a/test/helpers/user/notifications_helper_test.rb
+++ b/test/helpers/user/notifications_helper_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class User::NotificationsHelperTest < ActionView::TestCase
+  def user_notification
+    @user_notification ||= user_notifications(:dennis_consultation_created)
+  end
+
+  def subject
+    @subject ||= user_notification.subject
+  end
+
+  def test_render_notification_item
+    notification_item_markup =
+      "<span>" \
+        "A consultation has been added: " \
+        "#{link_to(subject.subscribable_label, subject)}" \
+      "</span>"
+
+    assert_equal(
+      notification_item_markup,
+      render_notification_item(user_notification, false)
+    )
+  end
+
+  def test_render_notification_item_with_absolute_url
+    notification_item_markup =
+      "<span>" \
+        "A consultation has been added: " \
+        "#{link_to(subject.subscribable_label, polymorphic_url(subject, domain: subject.site.domain))}" \
+      "</span>"
+
+    assert_equal(
+      notification_item_markup,
+      render_notification_item(user_notification, true)
+    )
+  end
+end

--- a/test/integration/user/notification_index_test.rb
+++ b/test/integration/user/notification_index_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class User::NotificationIndexTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @path = user_notifications_path
+  end
+
+  def user
+    @user ||= users(:dennis)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_notification_index
+    with_current_site(site) do
+      with_signed_in_user(user) do
+        unseen_notifications = user.notifications.unseen
+        visit @path
+
+        within ".user-notification-list" do
+          unseen_notifications.each do |user_notification|
+            assert has_selector?(
+              "tr#user-notification-item-#{user_notification.id}",
+              text: user_notification.subject.subscribable_label
+            )
+          end
+        end
+      end
+    end
+  end
+
+  def test_notification_seen_flagging
+    with_current_site(site) do
+      with_signed_in_user(user) do
+        visit @path
+        assert has_selector?(".user-notification-list")
+        refute has_content?("There are no new notifications")
+
+        visit @path
+        refute has_selector?(".user-notification-list")
+        assert has_content?("There are no new notifications")
+      end
+    end
+  end
+end

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -63,18 +63,23 @@ class User::NotificationTest < ActiveSupport::TestCase
     refute User::Notification.seen.any?
   end
 
-  def test_sent!
+  def test_sent?
+    assert sent_user_notification.sent?
     refute unsent_user_notification.sent?
+  end
+
+  def test_sent!
+    refute unsent_user_notification.is_sent
 
     unsent_user_notification.sent!
-    assert unsent_user_notification.sent?
+    assert unsent_user_notification.is_sent
   end
 
   def test_unsent!
-    assert sent_user_notification.sent?
+    assert sent_user_notification.is_sent
 
     sent_user_notification.unsent!
-    refute sent_user_notification.sent?
+    refute sent_user_notification.is_sent
   end
 
   def test_seen?

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -13,6 +13,14 @@ class User::NotificationTest < ActiveSupport::TestCase
     @unsent_user_notification ||= user_notifications(:dennis_consultation_title_changed)
   end
 
+  def seen_user_notification
+    @seen_user_notification ||= user_notifications(:dennis_consultation_created)
+  end
+
+  def unseen_user_notification
+    @unseen_user_notification ||= user_notifications(:dennis_consultation_title_changed)
+  end
+
   def test_valid
     assert notification.valid?
   end
@@ -41,6 +49,20 @@ class User::NotificationTest < ActiveSupport::TestCase
     refute User::Notification.sent.any?
   end
 
+  def test_class_seen!
+    assert User::Notification.unseen.any?
+
+    User::Notification.seen!
+    refute User::Notification.unseen.any?
+  end
+
+  def test_class_unseen!
+    assert User::Notification.seen.any?
+
+    User::Notification.unseen!
+    refute User::Notification.seen.any?
+  end
+
   def test_sent!
     refute unsent_user_notification.sent?
 
@@ -53,5 +75,24 @@ class User::NotificationTest < ActiveSupport::TestCase
 
     sent_user_notification.unsent!
     refute sent_user_notification.sent?
+  end
+
+  def test_seen?
+    assert seen_user_notification.seen?
+    refute unseen_user_notification.seen?
+  end
+
+  def test_seen!
+    refute unseen_user_notification.is_seen
+
+    unseen_user_notification.seen!
+    assert unseen_user_notification.is_seen
+  end
+
+  def test_unseen!
+    assert seen_user_notification.is_seen
+
+    seen_user_notification.unseen!
+    refute seen_user_notification.is_seen
   end
 end


### PR DESCRIPTION
Connects to #167.

### What does this PR do?

This one adds a new status flag at `User::Notification` level to control which of them have been already seen by the User so that they aren't shown in coming requests.

To do so, we're implementing a simple API to deal with this state and a callback that is triggered just after retrieving the unseen Notifications list in the User UI.

In addition, we're refactoring a little other flags' implementation to be consistent in our code. Test coverage has been increased as well.

#### Reviewer notes

A new localisation string has been added in all three available languages, but it would be great if we could confirm that the Catalan translation is correct.

### How should this be manually tested?

After reseeding the database, just get into http://madrid.gobierto.dev/user/notifications to see a couple new notifications there, and refresh the page to check they are replaced by a proper message.
