### PR TITLE
Validate record creation through Admin Invitations UI

### DIFF
--- a/app/controllers/gobierto_admin/admin/invitations_controller.rb
+++ b/app/controllers/gobierto_admin/admin/invitations_controller.rb
@@ -10,9 +10,16 @@ module GobiertoAdmin
       @sites = get_sites
 
       if @admin_invitation_form.process
-        flash[:notice] = t(".success")
+        if @admin_invitation_form.not_delivered_email_addresses.any?
+          flash.now[:alert] = t(
+            ".success_with_errors",
+            email_addresses: @admin_invitation_form.not_delivered_email_addresses.to_sentence
+          )
+        else
+          flash.now[:notice] = t(".success")
+        end
       else
-        flash[:notice] = t(".error")
+        flash.now[:alert] = t(".error")
       end
 
       render :new

--- a/app/forms/gobierto_admin/admin_invitation_form.rb
+++ b/app/forms/gobierto_admin/admin_invitation_form.rb
@@ -16,6 +16,14 @@ module GobiertoAdmin
       @site_ids ||= []
     end
 
+    def delivered_email_addresses
+      @delivered_email_addresses ||= []
+    end
+
+    def not_delivered_email_addresses
+      Array(email_list) - delivered_email_addresses
+    end
+
     private
 
     def email_list
@@ -27,7 +35,11 @@ module GobiertoAdmin
 
     def build_invitations
       email_list.each do |email_address|
-        AdminInvitationBuilder.new(email_address, site_ids).call
+        invitation_builder = AdminInvitationBuilder.new(email_address, site_ids)
+
+        if invitation_builder.call
+          delivered_email_addresses.push(invitation_builder.email_address)
+        end
       end
     end
   end

--- a/app/services/gobierto_admin/admin_invitation_builder.rb
+++ b/app/services/gobierto_admin/admin_invitation_builder.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
     private
 
     def create_admin
-      @admin = Admin.create(
+      @admin = Admin.create!(
         email: email_address,
         name: get_username_from_email(email_address),
         password: generate_random_password,
@@ -24,6 +24,8 @@ module GobiertoAdmin
       @admin.sites = sites
 
       @admin
+    rescue ActiveRecord::RecordInvalid
+      false
     end
 
     def deliver_invitation_email

--- a/config/locales/gobierto_admin/controllers/admin_invitations/ca.yml
+++ b/config/locales/gobierto_admin/controllers/admin_invitations/ca.yml
@@ -5,4 +5,5 @@ ca:
       invitations:
         create:
           success: Les invitacions s'han enviat correctament
+          success_with_errors: "Algunes invitacions no han pogut ser enviades: %{email_addresses}."
           error: Hi hagué un problema al enviar les invitacions

--- a/config/locales/gobierto_admin/controllers/admin_invitations/en.yml
+++ b/config/locales/gobierto_admin/controllers/admin_invitations/en.yml
@@ -5,4 +5,5 @@ en:
       invitations:
         create:
           success: The invitations have been successfully sent
+          success_with_errors: "Some invitations could not be delivered: %{email_addresses}."
           error: There was a problem sending the invitations

--- a/config/locales/gobierto_admin/controllers/admin_invitations/es.yml
+++ b/config/locales/gobierto_admin/controllers/admin_invitations/es.yml
@@ -5,4 +5,5 @@ es:
       invitations:
         create:
           success: Las invitaciones se han enviado correctamente
+          success_with_errors: "Algunas invitaciones no han podido ser enviadas: %{email_addresses}."
           error: Hubo un problema al enviar las invitaciones

--- a/test/forms/gobierto_admin/admin_invitation_form_test.rb
+++ b/test/forms/gobierto_admin/admin_invitation_form_test.rb
@@ -9,8 +9,19 @@ module GobiertoAdmin
       )
     end
 
+    def invalid_admin_invitation_form
+      @invalid_admin_invitation_form ||= AdminInvitationForm.new(
+        emails: "one@gobierto.dev, #{admin.email}",
+        site_ids: [site.id]
+      )
+    end
+
     def site
       @site ||= sites(:madrid)
+    end
+
+    def admin
+      @admin ||= gobierto_admin_admins(:tony)
     end
 
     def test_validation
@@ -19,6 +30,12 @@ module GobiertoAdmin
 
     def test_process
       assert valid_admin_invitation_form.process
+      assert_equal 2, valid_admin_invitation_form.delivered_email_addresses.size
+    end
+
+    def test_invalid_process
+      assert invalid_admin_invitation_form.process
+      assert_equal 1, invalid_admin_invitation_form.delivered_email_addresses.size
     end
   end
 end

--- a/test/services/gobierto_admin/admin_invitation_builder_test.rb
+++ b/test/services/gobierto_admin/admin_invitation_builder_test.rb
@@ -12,6 +12,10 @@ module GobiertoAdmin
       @site ||= sites(:madrid)
     end
 
+    def admin
+      @admin ||= gobierto_admin_admins(:tony)
+    end
+
     def site_ids
       [site.id]
     end
@@ -23,6 +27,14 @@ module GobiertoAdmin
     def test_admin_creation
       assert_difference "Admin.count", 1 do
         admin_invitation_builder.call
+      end
+    end
+
+    def test_invalid_admin_creation
+      refute AdminInvitationBuilder.new(admin.email, site_ids).call
+
+      assert_no_difference "Admin.count" do
+        AdminInvitationBuilder.new(admin.email, site_ids).call
       end
     end
 


### PR DESCRIPTION
Connects to #202.

### What does this PR do?

This PR fixes a bug when requesting an Admin invitation with an invalid email address. That is when the email address is already present in database due to the uniqueness email constraint.

Also, we're improving the Admin invitations UI by displaying which of the email addresses couldn't be delivered for some reason.

### How should this be manually tested?

Get into the Admin invitations UI at http://gobierto.dev/admin/admin/invitations, and mix up valid and invalid email addresses in the form input. It is expected to work in a non transactional way, so any invitations with valid email addresses should be delivered, and process should return successfully by printing any not delivered email addresses in a flash message:

![screen shot 2016-12-27 at 6 45 38 pm](https://cloud.githubusercontent.com/assets/126392/21505116/b11c4038-cc64-11e6-9b2f-e485647e5f62.jpg)
