### PR TITLE
Deal with invalid requests and with missing budget lines

### DIFF
--- a/app/controllers/gobierto_budgets/application_controller.rb
+++ b/app/controllers/gobierto_budgets/application_controller.rb
@@ -1,5 +1,10 @@
 class GobiertoBudgets::ApplicationController < ApplicationController
   include User::SessionHelper
 
+  rescue_from GobiertoBudgets::BudgetLine::RecordNotFound, with: :render_404
+  rescue_from GobiertoBudgets::BudgetLine::InvalidSearchConditions do |exception|
+    head :bad_request
+  end
+
   layout "gobierto_budgets/layouts/application"
 end

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -35,4 +35,12 @@ class GobiertoBudgets::BudgetLineTest < ActionDispatch::IntegrationTest
       assert page.all(".metric_box .metric").all?{ |e| e.text =~ /\d{2}/}
     end
   end
+
+  def test_invalid_budget_line_url
+    with_current_site(site) do
+      visit gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::BudgetLine::ECONOMIC, 'foo')
+
+      assert_equal 400, status_code
+    end
+  end
 end


### PR DESCRIPTION
Connects to #203

### What does this PR do?

This PR avoids that invalid budget line URLs raise an exception. It also catches missing budget lines for a given year.

### How should this be manually tested?

http://madrid.gobify.net/presupuestos/partidas/420/2011/economic/gobierto.es should return 400 error

http://madrid.gobify.net/presupuestos/partidas/420/2011/economic/G should return 404 error
