### PR TITLE
Support rendering based on type and behavior in Dynamic content record fields

### DIFF
--- a/app/assets/javascripts/admin/app/components/dynamic_content_component.js
+++ b/app/assets/javascripts/admin/app/components/dynamic_content_component.js
@@ -2,6 +2,7 @@ this.GobiertoAdmin.DynamicContentComponent = (function() {
   function DynamicContentComponent() {}
 
   DynamicContentComponent.prototype.handle = function(wrapper, namespace) {
+    initializeRecordFields(wrapper);
     handleAddChild(wrapper, namespace);
     handleAddRecord();
     handleCancelRecord();
@@ -9,8 +10,18 @@ this.GobiertoAdmin.DynamicContentComponent = (function() {
     handleDeleteRecord();
   };
 
+  function initializeRecordFields(wrapper) {
+    var componentWrapper = $(wrapper || ".dynamic-content-wrapper");
+    var componentLocale = componentWrapper.data("locale");
+
+    _handleGeocompleteBehavior(componentWrapper.find("input[data-behavior=geocomplete]"));
+    _handleDateType(componentWrapper.find("input[data-type=date]"), componentLocale);
+    _handleCurrencyType(componentWrapper.find("input[data-type=currency]"));
+  }
+
   function handleAddChild(wrapper, namespace) {
     var componentWrapper = $(wrapper || ".dynamic-content-wrapper");
+    var componentLocale = componentWrapper.data("locale");
 
     componentWrapper.on("click", "[data-behavior=add_child]", function(e) {
       e.preventDefault();
@@ -53,18 +64,8 @@ this.GobiertoAdmin.DynamicContentComponent = (function() {
           $(this).attr("id", fieldId.replace(fieldIdRegExp, uniqueFieldId));
         }
 
-        if ($(this).attr("type") === "text") {
-          $(this).val("");
-        }
-
-        $(this).find("option:selected").prop("selected", false);
-
-        if ($(this).data("behavior") === "geocomplete") {
-          $(this).geocomplete({
-            details: ".content-block-field",
-            detailsAttribute: "data-geo"
-          });
-        }
+        _cleanupRecordField($(this));
+        _initializeRecordField($(this), componentLocale);
       });
 
       clonedField.find("label").each(function() {
@@ -131,6 +132,47 @@ this.GobiertoAdmin.DynamicContentComponent = (function() {
       _setRecordViewState(eventWrapper);
       _switchToRecordView(eventWrapper);
     });
+  }
+
+  function _cleanupRecordField(selector) {
+    if (selector.attr("type") === "text") {
+      selector.val("");
+    } else if (selector.attr("type") === "select") {
+      selector.find("option:selected").prop("selected", false);
+    }
+  }
+
+  function _initializeRecordField(selector, locale) {
+    if (selector.data("behavior") === "geocomplete") {
+      _handleGeocompleteBehavior(selector);
+    }
+
+    if (selector.data("type") === "date") {
+      _handleDateType(selector, locale);
+    }
+
+    if (selector.data("type") === "currency") {
+      _handleCurrencyType(selector);
+    }
+  }
+
+  function _handleGeocompleteBehavior(selector) {
+    selector.geocomplete({
+      details: ".content-block-field",
+      detailsAttribute: "data-geo",
+      componentRestrictions: { country: "es" }
+    });
+  }
+
+  function _handleDateType(selector, locale) {
+    selector.datepicker({
+      language: locale,
+      autoClose: true
+    });
+  }
+
+  function _handleCurrencyType(selector) {
+    selector.attr("type", "number");
   }
 
   function _switchToRecordForm(wrapper) {

--- a/app/assets/stylesheets/comp-dyna_block.scss
+++ b/app/assets/stylesheets/comp-dyna_block.scss
@@ -46,7 +46,7 @@ body.gobierto_admin {
           background: initial;
         }
       }
-      input[type=text], select {
+      input[type=text], input[type=number], select {
         width: 100%;
         padding: .5em;
         margin: 0 0 .5em 0;

--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -2,7 +2,7 @@
  * Forms
  *
  */
-input[type=text], input[type=email], input[type=submit], input[type=password], input[type=file], .button, button, .option, select, option, textarea {
+input[type=text], input[type=email], input[type=number], input[type=submit], input[type=password], input[type=file], .button, button, .option, select, option, textarea {
   box-sizing: border-box;
   height: 74px;
   padding: 0 1em;

--- a/app/views/gobierto_admin/gobierto_common/dynamic_content/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/dynamic_content/_form.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     </label>
 
-    <table id="content-block-<%= content_block.id %>" class="dynamic-content-wrapper">
+    <table id="content-block-<%= content_block.id %>" class="dynamic-content-wrapper" data-locale="<%= I18n.locale %>">
       <tr>
         <% content_block.header.each do |content_block_header| %>
           <th><%= content_block_header %></th>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/_locations_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/_locations_form.html.erb
@@ -67,13 +67,6 @@
 <% content_for :javascript_hook do %>
   <%= javascript_include_tag "http://maps.googleapis.com/maps/api/js?key=#{Rails.application.secrets.google_places_api_key}&libraries=places" %>
   <%= javascript_tag do %>
-    $("input[data-behavior=geocomplete]").geocomplete({
-      details: ".content-block-field",
-      detailsAttribute: "data-geo"
-    });
-  <% end %>
-
-  <%= javascript_tag do %>
     window.GobiertoAdmin.person_events_controller.edit("#person-event-locations", "locations_attributes");
   <% end %>
 <% end %>

--- a/test/support/integration/dynamic_content_helpers.rb
+++ b/test/support/integration/dynamic_content_helpers.rb
@@ -16,7 +16,11 @@ module Integration
 
                 content_block.fields.each do |content_block_field|
                   within ".content-block-field-#{content_block_field.name.parameterize}" do
-                    fill_in content_block_field.label[I18n.locale], with: "Value for #{content_block_field.name}"
+                    if content_block_field.currency?
+                      fill_in content_block_field.label[I18n.locale], with: "42.0"
+                    else
+                      fill_in content_block_field.label[I18n.locale], with: "Value for #{content_block_field.name}"
+                    end
                   end
                 end
 
@@ -29,7 +33,11 @@ module Integration
             within ".cloned-dynamic-content-record-wrapper" do
               content_block.fields.each do |content_block_field|
                 within ".content-block-field-#{content_block_field.name.parameterize}" do
-                  fill_in content_block_field.label[I18n.locale], with: "Value for #{content_block_field.name}"
+                  if content_block_field.currency?
+                    fill_in content_block_field.label[I18n.locale], with: "42.0"
+                  else
+                    fill_in content_block_field.label[I18n.locale], with: "Value for #{content_block_field.name}"
+                  end
                 end
               end
 
@@ -44,7 +52,11 @@ module Integration
       content_blocks.each do |content_block|
         within "#content-block-#{content_block.id} .dynamic-content-record-view" do
           content_block.fields.each do |content_block_field|
-            assert has_selector?(".content-block-record-value", text: "Value for #{content_block_field.name}")
+            if content_block_field.currency?
+              assert has_selector?(".content-block-record-value", text: "42.0")
+            else
+              assert has_selector?(".content-block-record-value", text: "Value for #{content_block_field.name}")
+            end
           end
         end
       end
@@ -68,14 +80,22 @@ module Integration
         within ".cloned-dynamic-content-record-wrapper" do
           content_block.fields.each do |content_block_field|
             within ".content-block-field-#{content_block_field.name.parameterize}" do
-              fill_in content_block_field.label[I18n.locale], with: "Added value for #{content_block_field.name}"
+              if content_block_field.currency?
+                fill_in content_block_field.label[I18n.locale], with: "43.0"
+              else
+                fill_in content_block_field.label[I18n.locale], with: "Added value for #{content_block_field.name}"
+              end
             end
           end
 
           find("a[data-behavior=add_record]").click
 
           content_block.fields.each do |content_block_field|
-            assert has_selector?(".content-block-record-value", text: "Added value for #{content_block_field.name}")
+            if content_block_field.currency?
+              assert has_selector?(".content-block-record-value", text: "43.0")
+            else
+              assert has_selector?(".content-block-record-value", text: "Added value for #{content_block_field.name}")
+            end
           end
         end
       end
@@ -93,14 +113,22 @@ module Integration
 
           content_block.fields.each do |content_block_field|
             within ".content-block-field-#{content_block_field.name.parameterize}" do
-              fill_in content_block_field.label[I18n.locale], with: "Updated value for #{content_block_field.name}"
+              if content_block_field.currency?
+                fill_in content_block_field.label[I18n.locale], with: "44.0"
+              else
+                fill_in content_block_field.label[I18n.locale], with: "Updated value for #{content_block_field.name}"
+              end
             end
           end
 
           find("a[data-behavior=add_record]").click
 
           content_block.fields.each do |content_block_field|
-            assert has_selector?(".content-block-record-value", text: "Updated value for #{content_block_field.name}")
+            if content_block_field.currency?
+              assert has_selector?(".content-block-record-value", text: "44.0")
+            else
+              assert has_selector?(".content-block-record-value", text: "Updated value for #{content_block_field.name}")
+            end
           end
         end
       end
@@ -118,14 +146,22 @@ module Integration
 
           content_block.fields.each do |content_block_field|
             within ".content-block-field-#{content_block_field.name.parameterize}" do
-              fill_in content_block_field.label[I18n.locale], with: "Discarded value for #{content_block_field.name}"
+              if content_block_field.currency?
+                fill_in content_block_field.label[I18n.locale], with: "45.0"
+              else
+                fill_in content_block_field.label[I18n.locale], with: "Discarded value for #{content_block_field.name}"
+              end
             end
           end
 
           find("a[data-behavior=cancel_record]").click
 
           content_block.fields.each do |content_block_field|
-            assert has_selector?(".content-block-record-value", text: "Updated value for #{content_block_field.name}")
+            if content_block_field.currency?
+              assert has_selector?(".content-block-record-value", text: "44.0")
+            else
+              assert has_selector?(".content-block-record-value", text: "Updated value for #{content_block_field.name}")
+            end
           end
         end
       end


### PR DESCRIPTION
Connects to #219.
Relates to #190.

### What does this PR do?

It implements a custom Record field initialization mechanism based on each field's type and behavior data attributes:

- A field with `data-type=“date”` will invoke a date picker UI component, taking the current user’s locale into account.
- A field with `data-type=“currency”` will replace the current input type with “numeric” since it behaves almost the same in modern browsers.
- Also, we're refactoring the way we handle the "geocomplete" behavior, for consistency.

### How should this be manually tested?

Getting into a section in which we have Currency and Date field formats, and check that:

- [x] A Date type field invokes the date picker UI control, but allows to enter any content. I would not make this input read only for the convenience of the user.
- [x] A Currency type field is shown as a number input, whatever it implies in different browsers.

Here is how it should look like:

![screen shot 2017-01-10 at 9 31 14 am](https://cloud.githubusercontent.com/assets/126392/21799008/ab9dfcf6-d717-11e6-9880-d11907cd87f6.jpg)

![screen shot 2017-01-10 at 9 31 36 am](https://cloud.githubusercontent.com/assets/126392/21799009/aba4ff74-d717-11e6-9992-7120c3dc0168.jpg)

