### PR TITLE
Add “All events” filtering option to Person Events index view

### DIFF
--- a/app/presenters/gobierto_admin/gobierto_people/person_events_presenter.rb
+++ b/app/presenters/gobierto_admin/gobierto_people/person_events_presenter.rb
@@ -5,6 +5,10 @@ module GobiertoAdmin
         @person = person
       end
 
+      def events_count
+        @events_count ||= @person.events.count
+      end
+
       def pending_events_count
         @pending_events_count ||= @person.events.pending.count
       end

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -13,6 +13,10 @@
 
   <div class="pure-u-1 pure-u-md-3-5 sub_filter">
     <ul>
+      <li class="all-events-filter <%= class_if("active", controller_name == "person_events") %>">
+        <%= link_to t(".all_events"), admin_people_person_events_path(@person) %>
+        (<%= @person_events_presenter.events_count %>)
+      </li>
       <li class="pending-events-filter <%= class_if("active", controller_name == "pending_person_events") %> <%= class_if("warn", @person_events_presenter.pending_events_count > 0) %>">
         <%= link_to t(".pending_events"), admin_people_person_pending_events_path(@person) %>
         (<%= @person_events_presenter.pending_events_count %>)

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/ca.yml
@@ -8,6 +8,7 @@ ca:
             title: Agenda
             new: Nou esdeveniment
             view_event: Veure esdeveniment
+            all_events: Tots
             pending_events: Pendents de moderar
             published_events: Esdeveniments publicats
             past_events: Esdeveniments passats

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/en.yml
@@ -8,6 +8,7 @@ en:
             title: Agenda
             new: New event
             view_event: View event
+            all_events: All
             pending_events: Moderation pending
             published_events: Published events
             past_events: Past events

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/es.yml
@@ -8,6 +8,7 @@ es:
             title: Agenda
             new: Nuevo evento
             view_event: Ver evento
+            all_events: Todos
             pending_events: Pendientes de moderar
             published_events: Eventos publicados
             past_events: Eventos pasados

--- a/test/integration/gobierto_admin/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_events_index_test.rb
@@ -94,6 +94,11 @@ module GobiertoAdmin
 
             within ".sub_filter ul", match: :first do
               assert has_selector?(
+                ".all-events-filter",
+                text: "All (#{person.events.count})"
+              )
+
+              assert has_selector?(
                 ".pending-events-filter",
                 text: "Moderation pending (#{person.events.pending.count})"
               )

--- a/test/presenters/gobierto_admin/gobierto_people/person_events_presenter_test.rb
+++ b/test/presenters/gobierto_admin/gobierto_people/person_events_presenter_test.rb
@@ -12,6 +12,10 @@ module GobiertoAdmin
         @person ||= gobierto_people_people(:richard)
       end
 
+      def test_events_count
+        assert_equal person.events.count, @subject.events_count
+      end
+
       def test_pending_events_count
         assert_equal person.events.pending.count, @subject.pending_events_count
       end


### PR DESCRIPTION
Connects to #232.

### What does this PR do?

As requested in #232, it adds a new filtering option to the Person Events index view to provide better feedback to the Users.

### How should this be manually tested?

Taking a URL like http://gobierto.dev/admin/people/people/933465536/events, check that:

- [x] The new "All" filtering option is active by default.
- [x] The counters are correct (here we are counting both published and pending events).

This is how it looks like:

![screen shot 2017-01-18 at 8 15 32 am](https://cloud.githubusercontent.com/assets/126392/22054528/4dbb5012-dd56-11e6-9df6-f066874e99e7.jpg)

