### PR TITLE
Drop the model name from all localised form submit tags

### DIFF
--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -135,9 +135,9 @@ ca:
     select:
       prompt: Si us plau tria
     submit:
-      create: Crear %{model}
-      submit: Guardar %{model}
-      update: Actualitzar %{model}
+      create: Crear
+      submit: Guardar
+      update: Actualitzar
   number:
     currency:
       format:

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -140,9 +140,9 @@ en:
     select:
       prompt: Please select
     submit:
-      create: Create %{model}
-      submit: Save %{model}
-      update: Update %{model}
+      create: Create
+      submit: Save
+      update: Update
   number:
     currency:
       format:

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -134,9 +134,9 @@ es:
     select:
       prompt: Por favor seleccione
     submit:
-      create: Crear %{model}
-      submit: Guardar %{model}
-      update: Actualizar %{model}
+      create: Crear
+      submit: Guardar
+      update: Actualizar
   number:
     currency:
       format:

--- a/test/integration/gobierto_admin/admin_create_test.rb
+++ b/test/integration/gobierto_admin/admin_create_test.rb
@@ -33,7 +33,7 @@ module GobiertoAdmin
             choose "Regular"
           end
 
-          click_button "Create Admin"
+          click_button "Create"
         end
 
         assert has_message?("Admin was successfully created")

--- a/test/integration/gobierto_admin/admin_update_test.rb
+++ b/test/integration/gobierto_admin/admin_update_test.rb
@@ -36,7 +36,7 @@ module GobiertoAdmin
             choose "Regular"
           end
 
-          click_button "Update Admin"
+          click_button "Update"
         end
 
         assert has_message?("Admin was successfully updated")
@@ -81,7 +81,7 @@ module GobiertoAdmin
             choose "Manager"
           end
 
-          click_button "Update Admin"
+          click_button "Update"
         end
 
         assert has_message?("Admin was successfully updated")
@@ -109,7 +109,7 @@ module GobiertoAdmin
           refute has_selector?(".site-check-boxes")
           refute has_selector?(".admin-authorization-level-radio-buttons")
 
-          assert has_button?("Update Admin", disabled: true)
+          assert has_button?("Update", disabled: true)
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_create_test.rb
@@ -30,7 +30,7 @@ module GobiertoAdmin
                 choose "Active"
               end
 
-              click_button "Create Consultation"
+              click_button "Create"
             end
 
             assert has_message?("Consultation was successfully created")

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_create_test.rb
@@ -38,7 +38,7 @@ module GobiertoAdmin
                 # Simulate Budget line selection in user control
                 find("#consultation_item_budget_line_id", visible: false).set(populate_data_budget_line_summary[:name])
 
-                click_button "Create Budget line"
+                click_button "Create"
               end
 
               assert has_message?("Consultation item was successfully created")

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_update_test.rb
@@ -42,7 +42,7 @@ module GobiertoAdmin
                 # Simulate Budget line selection in user control
                 find("#consultation_item_budget_line_id", visible: false).set(populate_data_budget_line_summary[:name])
 
-                click_button "Update Budget line"
+                click_button "Update"
               end
 
               assert has_message?("Consultation item was successfully updated")

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_update_test.rb
@@ -34,7 +34,7 @@ module GobiertoAdmin
                 choose "Draft"
               end
 
-              click_button "Update Consultation"
+              click_button "Update"
             end
 
             assert has_message?("Consultation was successfully updated")

--- a/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_create_test.rb
@@ -56,7 +56,7 @@ module GobiertoAdmin
                     end
                   end
 
-                  click_button "Create Content block"
+                  click_button "Create"
                 end
 
                 assert has_message?("Content block was successfully created")

--- a/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_update_test.rb
@@ -58,7 +58,7 @@ module GobiertoAdmin
                     end
                   end
 
-                  click_button "Update Content block"
+                  click_button "Update"
                 end
 
                 assert has_message?("Content block was successfully updated")

--- a/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
@@ -73,7 +73,7 @@ module GobiertoAdmin
                 fill_in_content_blocks
 
                 with_stubbed_s3_file_upload do
-                  click_button "Create Person"
+                  click_button "Create"
                 end
               end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_event_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_event_create_test.rb
@@ -68,7 +68,7 @@ module GobiertoAdmin
                 end
 
                 with_stubbed_s3_file_upload do
-                  click_button "Create Event"
+                  click_button "Create"
                 end
               end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_event_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_event_update_test.rb
@@ -78,7 +78,7 @@ module GobiertoAdmin
                 scroll_to_top
 
                 with_stubbed_s3_file_upload do
-                  click_button "Update Event"
+                  click_button "Update"
                 end
               end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_post_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_create_test.rb
@@ -38,7 +38,7 @@ module GobiertoAdmin
                   find("label", text: "Active").click
                 end
 
-                click_button "Create Post"
+                click_button "Create"
               end
 
               assert has_message?("Post was successfully created")

--- a/test/integration/gobierto_admin/gobierto_people/person_post_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_update_test.rb
@@ -42,7 +42,7 @@ module GobiertoAdmin
                   find("label", text: "Draft").click
                 end
 
-                click_button "Update Post"
+                click_button "Update"
               end
 
               assert has_message?("Post was successfully updated")

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_create_test.rb
@@ -51,7 +51,7 @@ module GobiertoAdmin
                 fill_in_content_blocks
 
                 with_stubbed_s3_file_upload do
-                  click_button "Create Statement"
+                  click_button "Create"
                 end
               end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_update_test.rb
@@ -52,7 +52,7 @@ module GobiertoAdmin
                 fill_in_content_blocks
 
                 with_stubbed_s3_file_upload do
-                  click_button "Update Statement"
+                  click_button "Update"
                 end
               end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_update_test.rb
@@ -68,7 +68,7 @@ module GobiertoAdmin
                 fill_in_content_blocks
 
                 with_stubbed_s3_file_upload do
-                  click_button "Update Person"
+                  click_button "Update"
                 end
               end
 

--- a/test/integration/gobierto_admin/gobierto_people/political_group_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/political_group_create_test.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
             within "form.new_political_group" do
               fill_in "political_group_name", with: "Political group name"
 
-              click_button "Create Political group"
+              click_button "Create"
             end
 
             assert has_message?("Political group was successfully created")

--- a/test/integration/gobierto_admin/gobierto_people/political_group_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/political_group_update_test.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
             within "form.edit_political_group" do
               fill_in "political_group_name", with: "Political group name"
 
-              click_button "Update Political group"
+              click_button "Update"
             end
 
             assert has_message?("Political group was successfully update")

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -42,7 +42,7 @@ module GobiertoAdmin
           end
 
           with_stubbed_s3_file_upload do
-            click_button "Create Site"
+            click_button "Create"
           end
         end
 

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -43,7 +43,7 @@ module GobiertoAdmin
           end
 
           with_stubbed_s3_file_upload do
-            click_button "Update Site"
+            click_button "Update"
           end
         end
 
@@ -87,7 +87,7 @@ module GobiertoAdmin
             fill_in "site_password", with: "wadus"
           end
 
-          click_button "Update Site"
+          click_button "Update"
         end
 
         assert has_message?("Site was successfully updated")
@@ -98,7 +98,7 @@ module GobiertoAdmin
           end
 
           fill_in "site_title", with: "New Site Title"
-          click_button "Update Site"
+          click_button "Update"
         end
 
         assert has_message?("Site was successfully updated")
@@ -120,7 +120,7 @@ module GobiertoAdmin
             choose "Draft"
           end
 
-          click_button "Update Site"
+          click_button "Update"
         end
 
         assert has_content?("Username can't be blank")

--- a/test/integration/gobierto_admin/user_update_test.rb
+++ b/test/integration/gobierto_admin/user_update_test.rb
@@ -23,7 +23,7 @@ module GobiertoAdmin
             fill_in "user_name", with: "User Name"
             fill_in "user_email", with: "user@email.dev"
 
-            click_button "Update User"
+            click_button "Update"
           end
 
           assert has_message?("User was successfully updated")


### PR DESCRIPTION
Connects to #234.

### What does this PR do?

Here we are changing the texts of all localised submit tags throughout the entire UI, affecting both Admin and User namespaces. We could have gone for a model-specific localisation process instead but, after checking some uses of the submit tag helper, it seemed that it can be applied at global level.

Integration tests are passing but let's check that there are no side effects in other namespaces.

### How should this be manually tested?

- [x] Just check that every submit button within the Admin UI displays only the corresponding verb.

![screen shot 2017-01-18 at 8 45 28 am](https://cloud.githubusercontent.com/assets/126392/22055249/8631c440-dd5a-11e6-8167-845e1d545a3e.jpg)
