### PR TITLE
Review models’ `visibility_level` attribute labels

### DIFF
--- a/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultations/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultations/ca.yml
@@ -18,7 +18,7 @@ ca:
             other: "%{count} participacions"
           visibility_level:
             draft: Borrador
-            active: Activa
+            active: Publicada
         edit:
           title: Editar consulta
           consultation_section: Consulta
@@ -36,4 +36,4 @@ ca:
             description: Te recomanem descriure clarament el tipus de consulta.
           visibility_level:
             draft: Borrador
-            active: Activa
+            active: Publicada

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultations/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultations/en.yml
@@ -18,7 +18,7 @@ en:
             other: "%{count} participations"
           visibility_level:
             draft: Draft
-            active: Active
+            active: Published
         edit:
           title: Edit consultation
           consultation_section: Consultation
@@ -36,4 +36,4 @@ en:
             description:
           visibility_level:
             draft: Draft
-            active: Active
+            active: Published

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultations/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultations/es.yml
@@ -18,7 +18,7 @@ es:
             other: "%{count} participaciones"
           visibility_level:
             draft: Borrador
-            active: Activa
+            active: Publicada
         edit:
           title: Editar consulta
           consultation_section: Consulta
@@ -36,4 +36,4 @@ es:
             description: Te recomendamos describir claramente el tipo de consulta.
           visibility_level:
             draft: Borrador
-            active: Activa
+            active: Publicada

--- a/config/locales/gobierto_admin/gobierto_people/views/people/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/ca.yml
@@ -40,7 +40,7 @@ ca:
             charge: Alcalde
           visibility_level:
             draft: Borrador
-            active: Activa
+            active: Publicada
           category:
             politician: Polític
             executive: Directiu

--- a/config/locales/gobierto_admin/gobierto_people/views/people/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/en.yml
@@ -40,7 +40,7 @@ en:
             charge: Alcalde
           visibility_level:
             draft: Draft
-            active: Active
+            active: Published
           category:
             politician: Politician
             executive: Executive

--- a/config/locales/gobierto_admin/gobierto_people/views/people/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/es.yml
@@ -40,7 +40,7 @@ es:
             charge: Alcalde
           visibility_level:
             draft: Borrador
-            active: Activa
+            active: Publicada
           category:
             politician: Político
             executive: Directivo

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/ca.yml
@@ -22,4 +22,4 @@ ca:
               tags: personal, la meva carrera, sobre mi
             visibility_level:
               draft: Borrador
-              active: Activa
+              active: Publicat

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/en.yml
@@ -22,4 +22,4 @@ en:
               tags: personal, about me, my career
             visibility_level:
               draft: Draft
-              active: Active
+              active: Published

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/es.yml
@@ -22,4 +22,4 @@ es:
               tags: personal, sobre mi, mi carrera
             visibility_level:
               draft: Borrador
-              active: Activa
+              active: Publicado

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/ca.yml
@@ -20,4 +20,4 @@ ca:
               title: Declaració de béns i activitats
             visibility_level:
               draft: Borrador
-              active: Activa
+              active: Publicada

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/en.yml
@@ -20,4 +20,4 @@ en:
               title: Statement of assets and activities
             visibility_level:
               draft: Draft
-              active: Active
+              active: Published

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/es.yml
@@ -20,4 +20,4 @@ es:
               title: Declaración de Bienes y Actividades
             visibility_level:
               draft: Borrador
-              active: Activa
+              active: Publicada

--- a/config/locales/gobierto_admin/views/sites/ca.yml
+++ b/config/locales/gobierto_admin/views/sites/ca.yml
@@ -35,4 +35,4 @@ ca:
         password: Contrasenya
         visibility_level:
           draft: Borrador
-          active: Actiu
+          active: Publicat

--- a/config/locales/gobierto_admin/views/sites/en.yml
+++ b/config/locales/gobierto_admin/views/sites/en.yml
@@ -35,4 +35,4 @@ en:
         password: Password
         visibility_level:
           draft: Draft
-          active: Active
+          active: Published

--- a/config/locales/gobierto_admin/views/sites/es.yml
+++ b/config/locales/gobierto_admin/views/sites/es.yml
@@ -35,4 +35,4 @@ es:
         password: Contraseña
         visibility_level:
           draft: Borrador
-          active: Activo
+          active: Publicado

--- a/test/helpers/gobierto_admin/site_helper_test.rb
+++ b/test/helpers/gobierto_admin/site_helper_test.rb
@@ -25,7 +25,7 @@ module GobiertoAdmin
       visibility_level_badge_markup =
         '<span>' \
           '<i class="fa fa-unlock"></i>' \
-          'Active' \
+          'Published' \
         '</span>'
 
       assert_equal visibility_level_badge_markup,

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_create_test.rb
@@ -27,7 +27,7 @@ module GobiertoAdmin
               fill_in "consultation_opening_date_range", with: "2016-01-01 - 2016-12-01"
 
               within ".consultation-visibility-level-radio-buttons" do
-                choose "Active"
+                choose "Published"
               end
 
               click_button "Create Consultation"

--- a/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
@@ -67,7 +67,7 @@ module GobiertoAdmin
                 end
 
                 within ".person-visibility-level-radio-buttons" do
-                  find("label", text: "Active").click
+                  find("label", text: "Published").click
                 end
 
                 fill_in_content_blocks
@@ -113,7 +113,7 @@ module GobiertoAdmin
 
                 within ".person-visibility-level-radio-buttons" do
                   with_hidden_elements do
-                    assert has_checked_field?("Active")
+                    assert has_checked_field?("Published")
                   end
                 end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_post_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_create_test.rb
@@ -35,7 +35,7 @@ module GobiertoAdmin
                 fill_in "person_post_tags", with: "one, two, three"
 
                 within ".person-post-visibility-level-radio-buttons" do
-                  find("label", text: "Active").click
+                  find("label", text: "Published").click
                 end
 
                 click_button "Create Post"
@@ -55,7 +55,7 @@ module GobiertoAdmin
 
                 within ".person-post-visibility-level-radio-buttons" do
                   with_hidden_elements do
-                    assert has_checked_field?("Active")
+                    assert has_checked_field?("Published")
                   end
                 end
               end

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_create_test.rb
@@ -45,7 +45,7 @@ module GobiertoAdmin
                 end
 
                 within ".person-statement-visibility-level-radio-buttons" do
-                  find("label", text: "Active").click
+                  find("label", text: "Published").click
                 end
 
                 fill_in_content_blocks
@@ -67,7 +67,7 @@ module GobiertoAdmin
 
                 within ".person-statement-visibility-level-radio-buttons" do
                   with_hidden_elements do
-                    assert has_checked_field?("Active")
+                    assert has_checked_field?("Published")
                   end
                 end
 

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -38,7 +38,7 @@ module GobiertoAdmin
           end
 
           within ".site-visibility-level-radio-buttons" do
-            choose "Active"
+            choose "Published"
           end
 
           with_stubbed_s3_file_upload do
@@ -51,7 +51,7 @@ module GobiertoAdmin
         within "table.site-list tbody tr", match: :first do
           assert has_content?("Site Title")
           assert has_content?("Site Name")
-          assert has_content?("Active")
+          assert has_content?("Published")
         end
       end
     end

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -39,7 +39,7 @@ module GobiertoAdmin
           end
 
           within ".site-visibility-level-radio-buttons" do
-            choose "Active"
+            choose "Published"
           end
 
           with_stubbed_s3_file_upload do
@@ -64,7 +64,7 @@ module GobiertoAdmin
           end
 
           within ".site-visibility-level-radio-buttons" do
-            assert has_checked_field?("Active")
+            assert has_checked_field?("Published")
           end
         end
       end
@@ -75,7 +75,7 @@ module GobiertoAdmin
         visit admin_sites_path
 
         within "table.site-list tbody tr#site-item-#{site.id}" do
-          assert has_content?("Active")
+          assert has_content?("Published")
         end
 
         visit @path
@@ -110,7 +110,7 @@ module GobiertoAdmin
         visit admin_sites_path
 
         within "table.site-list tbody tr#site-item-#{site.id}" do
-          assert has_content?("Active")
+          assert has_content?("Published")
         end
 
         visit @path


### PR DESCRIPTION
Connects to #236.

### What does this PR do?

As described in #236, this one just replaces all "Active" labels with "Published" for any `visibility_level` attributes around there.

### How should this be manually tested?

- [ ] Every user control to select a Resource's visibility level, generally as radio buttons, displays "Published" instead of "Active" for the `active` visibility level option, this way:

![screen shot 2017-01-18 at 9 29 41 am](https://cloud.githubusercontent.com/assets/126392/22056505/b0de8ccc-dd60-11e6-96f7-a53c2d26d3c6.jpg)

![screen shot 2017-01-18 at 9 29 50 am](https://cloud.githubusercontent.com/assets/126392/22056504/b0d7edcc-dd60-11e6-9740-2885d074505c.jpg)
