### PR TITLE
Implement Dirty forms component with Turbolinks and custom event support

### DIFF
--- a/app/assets/javascripts/admin/app/components/dirty_forms_component.js
+++ b/app/assets/javascripts/admin/app/components/dirty_forms_component.js
@@ -1,0 +1,40 @@
+this.GobiertoAdmin.DirtyFormsComponent = (function() {
+  var isDirty;
+
+  function DirtyFormsComponent() {}
+
+  DirtyFormsComponent.prototype.handle = function(message) {
+    $(document).on("turbolinks:load", _handleDirtyFlag);
+
+    $(document).on("turbolinks:before-visit", function() {
+      if (isDirty) { return confirm(message); }
+    });
+
+    $(window).on("beforeunload", function() {
+      if (isDirty) { return message; }
+    });
+  };
+
+  function _handleDirtyFlag() {
+    isDirty = false;
+
+    var checkingForm = $("form:not(.skip-dirty-check)");
+
+    checkingForm.on("submit", _unsetDirty);
+    checkingForm.on("change", "input, select, textarea", _setDirty);
+    checkingForm.on("trix-change", _setDirty);
+    checkingForm.on("datepicker-change", _setDirty);
+  }
+
+  function _setDirty() {
+    isDirty = true;
+  }
+
+  function _unsetDirty() {
+    isDirty = false;
+  }
+
+  return DirtyFormsComponent;
+})();
+
+this.GobiertoAdmin.dirty_forms_component = new GobiertoAdmin.DirtyFormsComponent;

--- a/app/assets/javascripts/admin/app/components/dynamic_content_component.js
+++ b/app/assets/javascripts/admin/app/components/dynamic_content_component.js
@@ -167,7 +167,10 @@ this.GobiertoAdmin.DynamicContentComponent = (function() {
   function _handleDateType(selector, locale) {
     selector.datepicker({
       language: locale,
-      autoClose: true
+      autoClose: true,
+      onSelect: function onSelect(_, _, instance) {
+        $(instance.el).trigger("datepicker-change");
+      }
     });
   }
 

--- a/app/assets/javascripts/admin/application.js
+++ b/app/assets/javascripts/admin/application.js
@@ -9,7 +9,10 @@ $(document).on('turbolinks:load', function() {
 
   // Datepicker
   $('.air-datepicker').datepicker({
-    autoClose: true
+    autoClose: true,
+    onSelect: function onSelect(_, _, instance) {
+      $(instance.el).trigger("datepicker-change");
+    }
   });
 
 });

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -160,6 +160,10 @@
     <%= render 'layouts/analytics_footer_site' %>
   <% end %>
 
+  <%= javascript_tag data: { "turbolinks-eval" => false } do %>
+    window.GobiertoAdmin.dirty_forms_component.handle("<%= t(".dirty_forms.message") %>");
+  <% end %>
+
   <%= yield :javascript_hook %>
 
 </body>

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -16,3 +16,5 @@ ca:
         admin_dropdown:
           account: El teu compte
           sign_out: Tancar sessió
+        dirty_forms:
+          message: Hi ha canvis sense desar. Estàs segur de voler continuar?

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -16,3 +16,5 @@ en:
         admin_dropdown:
           account: Account
           sign_out: Sign out
+        dirty_forms:
+          message: You have unsaved changes. Are you sure you want to leave this page?

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -16,3 +16,5 @@ es:
         admin_dropdown:
           account: Tu cuenta
           sign_out: Cerrar sesión
+        dirty_forms:
+          message: Hay cambios sin guardar. ¿Estás seguro de querer continuar?

--- a/test/integration/gobierto_admin/dirty_forms_test.rb
+++ b/test/integration/gobierto_admin/dirty_forms_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+module GobiertoAdmin
+  class DirtyFormsTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = edit_admin_user_path(user)
+    end
+
+    def admin
+      @admin ||= gobierto_admin_admins(:nick)
+    end
+
+    def user
+      @user ||= users(:reed)
+    end
+
+    def site
+      @site ||= user.source_site
+    end
+
+    def test_dirty_forms
+      with_javascript do
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "form.edit_user" do
+              fill_in "user_name", with: "User Name"
+
+              click_link "Change password"
+
+              assert_equal(
+                "You have unsaved changes. Are you sure you want to leave this page?",
+                page.driver.browser.modal_message
+              )
+
+              click_button "Update"
+
+              refute page.driver.browser.modal_message
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to #240.

### What does this PR do?

This PR implements a JS component which will be responsible for warning for unsaved changes when leaving a page. It is supporting Turbolinks and implements custom events that can be triggered by other UI components.

This behavior can be skipped by adding the `.skip-dirty-check` class at `form` tag level.

### How should this be manually tested?

We would need to check that changes are detected and the alert dialogs are shown as expected:

- [x] Detects changes any kind of form input controls (`<input>`, `<select>`, `<textarea>`).
- [x] Detects text changes in a WYSIWYG control (Trix).
- [x] Detects file attachments in a WYSIWYG control (Trix).
- [x] Detects changes in a date picker control.
- [x] It can intercept a Turbolinks event, or leave it to the `beforeunload` window event.
- [x] The confirm/alert dialogs are displayed when forms are dirty 🙌 

Confirm dialog triggered while listening to Turbolinks events:

![screen shot 2017-01-19 at 9 14 52 am](https://cloud.githubusercontent.com/assets/126392/22099306/1c19f920-de2b-11e6-9acb-b69cb216f301.jpg)

Native `beforeunload` event dialogs (leave and reload):

![screen shot 2017-01-19 at 9 15 18 am](https://cloud.githubusercontent.com/assets/126392/22099305/1c177538-de2b-11e6-8d4e-15dd95e4ca45.jpg)

![screen shot 2017-01-19 at 9 14 58 am](https://cloud.githubusercontent.com/assets/126392/22099307/1c1b4dde-de2b-11e6-835f-5f0ccd879933.jpg)