### PR TITLE
Implement a specific redirect behavior when switching Sites in Admin

### DIFF
--- a/app/controllers/gobierto_admin/sites/sessions_controller.rb
+++ b/app/controllers/gobierto_admin/sites/sessions_controller.rb
@@ -3,7 +3,7 @@ module GobiertoAdmin
     def create
       if allowed_site?(params[:site_id])
         enter_site(params[:site_id])
-        redirect_to(request.referrer)
+        redirect_to(redirect_path)
       else
         raise_admin_not_authorized
       end
@@ -15,6 +15,14 @@ module GobiertoAdmin
     end
 
     private
+
+    def redirect_path
+      if URI(request.referrer).path == edit_admin_site_path(current_site)
+        return edit_admin_site_path(id: params[:site_id])
+      end
+
+      request.referrer
+    end
 
     def allowed_site?(site_id)
       site_id.to_i.in?(managed_sites.map(&:id))

--- a/test/controllers/gobierto_admin/sites/sessions_controller_test.rb
+++ b/test/controllers/gobierto_admin/sites/sessions_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module GobiertoAdmin
+  class Sites::SessionsControllerTest < GobiertoControllerTest
+    def setup
+      super
+      sign_in_admin(admin)
+    end
+
+    def teardown
+      super
+      sign_out_admin
+    end
+
+    def admin
+      @admin ||= gobierto_admin_admins(:nick)
+    end
+
+    def site_madrid
+      @site_madrid ||= sites(:madrid)
+    end
+
+    def site_santander
+      @site_santander ||= sites(:santander)
+    end
+
+    def test_create
+      with_current_site(site_madrid) do
+        post(
+          admin_sites_sessions_path,
+          params: { site_id: site_santander.id },
+          headers: { "HTTP_REFERER" => admin_root_url }
+        )
+        assert_redirected_to admin_root_url
+      end
+    end
+
+    def test_create_from_edit_admin_site_path
+      with_current_site(site_madrid) do
+        post(
+          admin_sites_sessions_path,
+          params: { site_id: site_santander.id },
+          headers: { "HTTP_REFERER" => edit_admin_site_url(site_madrid) }
+        )
+        assert_redirected_to edit_admin_site_path(site_santander)
+      end
+
+      with_current_site(site_santander) do
+        post(
+          admin_sites_sessions_path,
+          params: { site_id: site_madrid.id },
+          headers: { "HTTP_REFERER" => edit_admin_site_url(site_santander) }
+        )
+        assert_redirected_to edit_admin_site_path(site_madrid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to #250.

### What does this PR do?

This one implements a specific redirection behavior when switching Sites from a specific path.

This path is `edit_admin_site_path(<site>)` (e.g. http://gobierto.dev/admin/sites/1009469985/edit). In brief, when the request comes from `edit_admin_site_path`, we should be redirecting to the same path for the recently created Site session. Otherwise, we keep redirecting to `HTTP_REFERER` URL as we do already.

### How should this be manually tested?

Taking the Site seeds available right now, let's check that:

- [x] Switching from "Santander" to "Madrid" when in an Santander's Site edit path (e.g. http://gobierto.dev/admin/sites/782762298/edit), the user gets redirected to Madrid's edit path (e.g. http://gobierto.dev/admin/sites/1009469985/edit) instead of to the actual referrer URL (e.g. http://gobierto.dev/admin/sites/782762298/edit).
- [x] Vice versa 😛 
