### PR TITLE
Implement a Service class to handle uploads across multiple adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ config/deploy/production.rb
 
 # Coverage reports
 /coverage
+
+# Uploaded files
+/public/attachments

--- a/app/controllers/gobierto_admin/gobierto_people/file_attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/file_attachments_controller.rb
@@ -5,7 +5,10 @@ module GobiertoAdmin
 
       def create
         @file_attachment_form = FileAttachmentForm.new(
-          file_attachment_params.merge(base_path: "gobierto_people")
+          file_attachment_params.merge(
+            site: current_site,
+            collection: "gobierto_people"
+          )
         )
 
         if @file_attachment_form.save

--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -1,31 +1,34 @@
-require "file_uploader/s3"
-
 module GobiertoAdmin
   class FileAttachmentForm
     include ActiveModel::Model
 
     attr_accessor(
+      :site,
       :file,
-      :base_path
+      :collection
     )
 
     validates :file, presence: true
+    validates :site, presence: true
 
     def save
       valid?
     end
 
     def file_url
-      @file_url ||= FileUploader::S3.new(
-        file: file,
-        file_name: "#{base_path}/attachment-#{SecureRandom.uuid}"
+      @file_url ||= FileUploadService.new(
+        adapter: :s3,
+        site: site,
+        collection: collection,
+        attribute_name: :attachment,
+        file: file
       ).call
     end
 
     private
 
-    def base_path
-      @base_path ||= "file_attachments"
+    def collection
+      @collection ||= "file_attachments"
     end
   end
 end

--- a/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
@@ -1,5 +1,3 @@
-require "file_uploader/s3"
-
 module GobiertoAdmin
   module GobiertoPeople
     class PersonEventForm
@@ -44,9 +42,12 @@ module GobiertoAdmin
         @attachment_url ||= begin
           return person_event.attachment_url unless attachment_file.present?
 
-          FileUploader::S3.new(
-            file: attachment_file,
-            file_name: "gobierto_people/people/#{person_id}/events/attachment-#{SecureRandom.uuid}"
+          FileUploadService.new(
+            adapter: :s3,
+            site: person.site,
+            collection: person_event.model_name.collection,
+            attribute_name: :attachment,
+            file: attachment_file
           ).call
         end
       end

--- a/app/forms/gobierto_admin/gobierto_people/person_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_form.rb
@@ -1,5 +1,3 @@
-require "file_uploader/s3"
-
 module GobiertoAdmin
   module GobiertoPeople
     class PersonForm
@@ -77,9 +75,12 @@ module GobiertoAdmin
         @bio_url ||= begin
           return person.bio_url unless bio_file.present?
 
-          FileUploader::S3.new(
-            file: bio_file,
-            file_name: "gobierto_people/people/bio-#{SecureRandom.uuid}"
+          FileUploadService.new(
+            adapter: :s3,
+            site: site,
+            collection: person.model_name.collection,
+            attribute_name: :bio,
+            file: bio_file
           ).call
         end
       end
@@ -88,9 +89,12 @@ module GobiertoAdmin
         @avatar_url ||= begin
           return person.avatar_url unless avatar_file.present?
 
-          FileUploader::S3.new(
-            file: avatar_file,
-            file_name: "gobierto_people/people/avatar-#{SecureRandom.uuid}"
+          FileUploadService.new(
+            adapter: :s3,
+            site: site,
+            collection: person.model_name.collection,
+            attribute_name: :avatar,
+            file: avatar_file
           ).call
         end
       end

--- a/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
@@ -54,9 +54,12 @@ module GobiertoAdmin
         @attachment_url ||= begin
           return person_statement.attachment_url unless attachment_file.present?
 
-          FileUploader::S3.new(
-            file: attachment_file,
-            file_name: "gobierto_people/people/#{person_id}/statements/attachment-#{SecureRandom.uuid}"
+          FileUploadService.new(
+            adapter: :s3,
+            site: person.site,
+            collection: person_statement.model_name.collection,
+            attribute_name: :attachment,
+            file: attachment_file
           ).call
         end
       end

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -1,5 +1,3 @@
-require "file_uploader/s3"
-
 module GobiertoAdmin
   class SiteForm
     include ActiveModel::Model
@@ -94,9 +92,12 @@ module GobiertoAdmin
       @logo_url ||= begin
         return site.configuration.logo unless logo_file.present?
 
-        FileUploader::S3.new(
-          file: logo_file,
-          file_name: "sites/logo-#{SecureRandom.uuid}"
+        FileUploadService.new(
+          adapter: :s3,
+          site: site,
+          collection: site.model_name.collection,
+          attribute_name: :logo,
+          file: logo_file
         ).call
       end
     end

--- a/app/services/gobierto_admin/file_upload_service.rb
+++ b/app/services/gobierto_admin/file_upload_service.rb
@@ -1,0 +1,45 @@
+require "file_uploader"
+
+module GobiertoAdmin
+  class FileUploadService
+    attr_reader :file, :site, :collection
+
+    def initialize(adapter:, site:, collection:, attribute_name:, file:)
+      @adapter = adapter
+      @site = site
+      @collection = collection
+      @attribute_name = attribute_name
+      @file = file
+    end
+
+    delegate :call, to: :adapter
+
+    def adapter
+      if Rails.env.development?
+        return FileUploader::Local.new(file: file, file_name: file_name)
+      end
+
+      case @adapter
+      when :s3 then FileUploader::S3.new(file: file, file_name: file_name)
+      end
+    end
+
+    private
+
+    def file_name
+      @file_name ||= begin
+        [site_id, collection, attribute_name].join("/")
+      end
+    end
+
+    protected
+
+    def site_id
+      site.present? ? "site-#{site.id}" : "site-unknown"
+    end
+
+    def attribute_name
+      "#{@attribute_name}-#{SecureRandom.uuid}"
+    end
+  end
+end

--- a/lib/file_uploader/local.rb
+++ b/lib/file_uploader/local.rb
@@ -1,0 +1,48 @@
+module FileUploader
+  class Local
+    FILE_PATH_PREFIX = "attachments".freeze
+
+    attr_reader :file, :file_name
+
+    def initialize(file:, file_name:)
+      @file = file
+      @file_name = file_name
+    end
+
+    def call
+      FileUtils.mkdir_p(file_base_path) unless File.exists?(file_base_path)
+      FileUtils.mv(file.tempfile.path, file_path)
+      ObjectSpace.undefine_finalizer(file.tempfile)
+
+      file_uri
+    end
+
+    private
+
+    def file_uri
+      File.join("/", FILE_PATH_PREFIX, file_name)
+    end
+
+    def file_path
+      File.join(file_base_path, file_basename)
+    end
+
+    def file_base_path
+      File.join(
+        defined?(Rails) ? Rails.public_path : "",
+        FILE_PATH_PREFIX,
+        file_dirname
+      )
+    end
+
+    protected
+
+    def file_dirname
+      Pathname.new(file_name).dirname
+    end
+
+    def file_basename
+      Pathname.new(file_name).basename
+    end
+  end
+end

--- a/test/forms/gobierto_admin/file_attachment_form_test.rb
+++ b/test/forms/gobierto_admin/file_attachment_form_test.rb
@@ -10,7 +10,8 @@ module GobiertoAdmin
         file: Rack::Test::UploadedFile.new(
           Rails.root.join("test/fixtures/files/sites/logo-madrid.png")
         ),
-        base_path: "wadus"
+        site: site,
+        collection: "wadus"
       )
     end
 
@@ -18,6 +19,10 @@ module GobiertoAdmin
       @invalid_file_attachment_form ||= FileAttachmentForm.new(
         file: nil
       )
+    end
+
+    def site
+      @site ||= sites(:madrid)
     end
 
     def test_validation

--- a/test/lib/file_uploader/local_test.rb
+++ b/test/lib/file_uploader/local_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+module FileUploader
+  class LocalTest < Minitest::Test
+    def local_file_uploader
+      @local_file_uploader ||= FileUploader::Local.new(
+        file: file,
+        file_name: "people/person/avatar.jpg"
+      )
+    end
+
+    def file
+      @file ||= Rack::Test::UploadedFile.new(
+        File.join(
+          ActionDispatch::IntegrationTest.fixture_path,
+          "files/gobierto_people/people/avatar.jpg"
+        )
+      )
+    end
+
+    def test_call
+      assert_equal "/attachments/people/person/avatar.jpg", local_file_uploader.call
+    end
+  end
+end

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -6,15 +6,13 @@ module GobiertoAdmin
     include FileUploaderHelpers
 
     def file_upload_service
-      @file_upload_service ||= begin
-        FileUploadService.new(
-          adapter: :s3,
-          site: site,
-          collection: :test_collection,
-          attribute_name: :test_attribute,
-          file: file
-        )
-      end
+      @file_upload_service ||= FileUploadService.new(
+        adapter: :s3,
+        site: site,
+        collection: :test_collection,
+        attribute_name: :test_attribute,
+        file: file
+      )
     end
 
     def site

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+require "support/file_uploader_helpers"
+
+module GobiertoAdmin
+  class FileUploadServiceTest < ActiveSupport::TestCase
+    include FileUploaderHelpers
+
+    def file_upload_service
+      @file_upload_service ||= begin
+        FileUploadService.new(
+          adapter: :s3,
+          site: site,
+          collection: :test_collection,
+          attribute_name: :test_attribute,
+          file: file
+        )
+      end
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def file
+      @file ||= Rack::Test::UploadedFile.new(
+        File.join(
+          ActionDispatch::IntegrationTest.fixture_path,
+          "files/gobierto_people/people/avatar.jpg"
+        )
+      )
+    end
+
+    def test_adapter
+      assert_kind_of FileUploader::S3, file_upload_service.adapter
+      assert_equal file, file_upload_service.adapter.file
+      assert_includes file_upload_service.adapter.file_name, "site-#{site.id}/test_collection/test_attribute"
+    end
+
+    def test_adapter_in_development
+      Rails.env.stub(:development?, true) do
+        assert_kind_of FileUploader::Local, file_upload_service.adapter
+        assert_equal file, file_upload_service.adapter.file
+        assert_includes file_upload_service.adapter.file_name, "site-#{site.id}/test_collection/test_attribute"
+      end
+    end
+
+    def test_call
+      with_stubbed_s3_file_upload do
+        assert file_upload_service.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to #212.
Connects to #213.

### What does this PR do?

In this PR we are refactoring the current `FileUploader` kinda service-library by splitting it into a simpler library and a service class. The new service class is called `FileUploadService` and it should be always implemented to deal with file uploads through attachment behaviors (#212).

We are taking advantage of this refactor to implement an alternative file upload adapter (#213) for ease and portability in development environment. In these cases, the adapter is automatically switched and all files are stored locally instead of hitting external services such as AWS S3.

### How should this be manually tested?

- [x] The `FileUploader::S3` adapter is still working fine.
- [x] The `FileUploader` adapter is automatically switched to `Local` when in development environment.
- [x] By using the `FileUploader::Local` adapter, all files are stored locally under `/public/attachments`, and everything regarding the UI still works as before.