### PR TITLE
Add public references to every Person resource in the Admin UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "ruby_px"
 gem "responders"
 gem "dalli"
 gem "cookies_eu"
-gem "actionpack-action_caching", git: "git@github.com:rails/actionpack-action_caching.git", ref: "9044141824650138bf27741e8f0ed95ccd9ef26d"
+gem "actionpack-action_caching", git: "https://github.com/rails/actionpack-action_caching.git", ref: "9044141824650138bf27741e8f0ed95ccd9ef26d"
 
 # Frontend
 gem "sass-rails", "~> 5.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:rails/actionpack-action_caching.git
+  remote: https://github.com/rails/actionpack-action_caching.git
   revision: 9044141824650138bf27741e8f0ed95ccd9ef26d
   ref: 9044141824650138bf27741e8f0ed95ccd9ef26d
   specs:

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -50,9 +50,16 @@
         <%= t(".posts_count", count: person.posts_count) %>
       </td>
       <td>
-        <%= link_to "#", class: "view_item" do %>
-          <i class="fa fa-eye"></i>
-          <%= t(".view_person") %>
+        <% if person.active? %>
+          <%= link_to gobierto_people_person_url(person, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view_person") %>
+          <% end %>
+        <% else %>
+          <div class="view_item">
+            <i class="fa fa-eye"></i>
+            <%= t(".view_person") %>
+          </div>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -68,9 +68,16 @@
       <td>
       </td>
       <td>
-        <%= link_to "#", class: "view_item" do %>
-          <i class="fa fa-eye"></i>
-          <%= t(".view_event") %>
+        <% if person_event.published? %>
+          <%= link_to gobierto_people_person_event_url(@person, person_event, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view_event") %>
+          <% end %>
+        <% else %>
+          <div class="view_item">
+            <i class="fa fa-eye"></i>
+            <%= t(".view_event") %>
+          </div>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
@@ -44,9 +44,16 @@
         <% end %>
       </td>
       <td>
-        <%= link_to "#", class: "view_item" do %>
-          <i class="fa fa-eye"></i>
-          <%= t(".view_post") %>
+        <% if person_post.active? %>
+          <%= link_to gobierto_people_person_post_url(@person, person_post, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view_post") %>
+          <% end %>
+        <% else %>
+          <div class="view_item">
+            <i class="fa fa-eye"></i>
+            <%= t(".view_post") %>
+          </div>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
@@ -38,9 +38,16 @@
         <%= l(person_statement.published_on, format: :short) %>
       </td>
       <td>
-        <%= link_to "#", class: "view_item" do %>
-          <i class="fa fa-eye"></i>
-          <%= t(".view_statement") %>
+        <% if person_statement.active? %>
+          <%= link_to gobierto_people_person_statement_url(@person, person_statement, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view_statement") %>
+          <% end %>
+        <% else %>
+          <div class="view_item">
+            <i class="fa fa-eye"></i>
+            <%= t(".view_statement") %>
+          </div>
         <% end %>
       </td>
     </tr>

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/en.yml
@@ -7,7 +7,7 @@ en:
           index:
             title: Blog
             new: New post
-            view_post: view post
+            view_post: View post
             header:
               title: Title
               date: Date

--- a/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PeopleIndexTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = admin_people_people_path
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def people
+        @people ||= ::GobiertoPeople::Person.all
+      end
+
+      def test_people_index
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "table.people-list tbody" do
+              assert has_selector?("tr", count: people.size)
+
+              people.each do |person|
+                assert has_selector?("tr#person-item-#{person.id}")
+
+                within "tr#person-item-#{person.id}" do
+                  if person.active?
+                    assert has_link?("View person")
+                  else
+                    assert has_selector?(".view_item", text: "View person")
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_events_index_test.rb
@@ -65,6 +65,14 @@ module GobiertoAdmin
 
               person.events.published.each do |event|
                 assert has_selector?("tr#person-event-item-#{event.id}")
+
+                within "tr#person-event-item-#{event.id}" do
+                  if event.published?
+                    assert has_link?("View event")
+                  else
+                    assert has_selector?(".view_item", text: "View event")
+                  end
+                end
               end
             end
           end

--- a/test/integration/gobierto_admin/gobierto_people/person_posts_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_posts_index_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PersonPostsIndexTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = admin_people_person_posts_path(person)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def person
+        @person ||= gobierto_people_people(:richard)
+      end
+
+      def test_person_posts_index
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "table.person-posts-list tbody" do
+              assert has_selector?("tr", count: person.posts.count)
+
+              person.posts.each do |person_post|
+                assert has_selector?("tr#person-post-item-#{person_post.id}")
+
+                within "tr#person-post-item-#{person_post.id}" do
+                  if person_post.active?
+                    assert has_link?("View post")
+                  else
+                    assert has_selector?(".view_item", text: "View post")
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/person_statements_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statements_index_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PersonStatementsIndexTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = admin_people_person_statements_path(person)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def person
+        @person ||= gobierto_people_people(:richard)
+      end
+
+      def test_person_statements_index
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "table.person-statements-list tbody" do
+              assert has_selector?("tr", count: person.statements.count)
+
+              person.statements.each do |statement|
+                assert has_selector?("tr#person-statement-item-#{statement.id}")
+
+                within "tr#person-statement-item-#{statement.id}" do
+                  if statement.active?
+                    assert has_link?("View statement")
+                  else
+                    assert has_selector?(".view_item", text: "View statement")
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to #266.

### What does this PR do?

This PR replaces some placeholders we left intentionally in the Admin UI until having the [User's part of this Module](https://github.com/PopulateTools/gobierto/pull/225) merged. Those placeholders were links to refer the User namespace UI (public) from the Admin UI.

#### Extra 🎱 

Here we are also changing the way we install the recently added `rails/actionpack-action_caching` gem. As we can read in [GitHub help docs](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended), it is recommended to clone repos with HTTPs URL. Also, there may be issues when installing gems within the Docker-based environment. So, since `bundler` can handle both formats, I would go for the most compatible one.

### How should this be manually tested?

In every index page, we should be rendering a link to the specific resource in the User's namespace when it is publicly available. Otherwise, that link should look kind of disabled.

The pages in which we would need to check this behavior are:

- [x] People index: http://gobierto.dev/admin/people/people
- [x] Person Events index: http://gobierto.dev/admin/people/people/933465536/events
- [x] Person Statements index: http://gobierto.dev/admin/people/people/933465536/statements
- [x] Person Posts index: http://gobierto.dev/admin/people/people/933465536/posts

This is how those links should look like:

![screen shot 2017-01-20 at 5 27 07 pm](https://cloud.githubusercontent.com/assets/126392/22157723/233ab140-df39-11e6-8923-2d8466ae7c8a.jpg)