### PR TITLE
Show resource status in the list

### DIFF
--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -21,6 +21,7 @@
   <th><%= t(".header.events") %></th>
   <th><%= t(".header.statements") %></th>
   <th><%= t(".header.posts") %></th>
+  <th><%= t(".header.status") %></th>
   <th></th>
 </tr>
 
@@ -50,16 +51,17 @@
         <%= t(".posts_count", count: person.posts_count) %>
       </td>
       <td>
-        <% if person.active? %>
-          <%= link_to gobierto_people_person_url(person, domain: current_site.domain), target: "_blank", class: "view_item" do %>
-            <i class="fa fa-eye"></i>
-            <%= t(".view_person") %>
-          <% end %>
+        <% if person.draft? %>
+          <i class="fa fa-lock"></i>
         <% else %>
-          <div class="view_item">
-            <i class="fa fa-eye"></i>
-            <%= t(".view_person") %>
-          </div>
+          <i class="fa fa-check"></i>
+        <% end %>
+        <%= t(".visibility_level.#{person.visibility_level}") %>
+      </td>
+      <td>
+        <%= link_to gobierto_people_person_url(person, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+          <i class="fa fa-eye"></i>
+          <%= t(".view_person") %>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -46,6 +46,7 @@
   <th><%= t(".header.event") %></th>
   <th><%= t(".header.date") %></th>
   <th><%= t(".header.location") %></th>
+  <th><%= t(".header.status") %></th>
   <th></th>
 </tr>
 
@@ -68,16 +69,17 @@
       <td>
       </td>
       <td>
-        <% if person_event.published? %>
-          <%= link_to gobierto_people_person_event_url(@person, person_event, domain: current_site.domain), target: "_blank", class: "view_item" do %>
-            <i class="fa fa-eye"></i>
-            <%= t(".view_event") %>
-          <% end %>
+        <% if person_event.pending? %>
+          <i class="fa fa-lock"></i>
         <% else %>
-          <div class="view_item">
-            <i class="fa fa-eye"></i>
-            <%= t(".view_event") %>
-          </div>
+          <i class="fa fa-check"></i>
+        <% end %>
+        <%= t(".visibility_level.#{person_event.state}") %>
+      </td>
+      <td>
+        <%= link_to gobierto_people_person_event_url(@person, person_event, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+          <i class="fa fa-eye"></i>
+          <%= t(".view_event") %>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
@@ -19,6 +19,7 @@
   <th><%= t(".header.title") %></th>
   <th><%= t(".header.date") %></th>
   <th><%= t(".header.tags") %></th>
+  <th><%= t(".header.status") %></th>
   <th></th>
 </tr>
 
@@ -44,16 +45,17 @@
         <% end %>
       </td>
       <td>
-        <% if person_post.active? %>
-          <%= link_to gobierto_people_person_post_url(@person, person_post, domain: current_site.domain), target: "_blank", class: "view_item" do %>
-            <i class="fa fa-eye"></i>
-            <%= t(".view_post") %>
-          <% end %>
+        <% if person_post.draft? %>
+          <i class="fa fa-lock"></i>
         <% else %>
-          <div class="view_item">
-            <i class="fa fa-eye"></i>
-            <%= t(".view_post") %>
-          </div>
+          <i class="fa fa-check"></i>
+        <% end %>
+        <%= t(".visibility_level.#{person_post.visibility_level}") %>
+      </td>
+      <td>
+        <%= link_to gobierto_people_person_post_url(@person, person_post, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+          <i class="fa fa-eye"></i>
+          <%= t(".view_post") %>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
@@ -18,6 +18,7 @@
   <th></th>
   <th><%= t(".header.statement") %></th>
   <th><%= t(".header.date") %></th>
+  <th><%= t(".header.status") %></th>
   <th></th>
 </tr>
 
@@ -38,16 +39,17 @@
         <%= l(person_statement.published_on, format: :short) %>
       </td>
       <td>
-        <% if person_statement.active? %>
-          <%= link_to gobierto_people_person_statement_url(@person, person_statement, domain: current_site.domain), target: "_blank", class: "view_item" do %>
-            <i class="fa fa-eye"></i>
-            <%= t(".view_statement") %>
-          <% end %>
+        <% if person_statement.draft? %>
+          <i class="fa fa-lock"></i>
         <% else %>
-          <div class="view_item">
-            <i class="fa fa-eye"></i>
-            <%= t(".view_statement") %>
-          </div>
+          <i class="fa fa-check"></i>
+        <% end %>
+        <%= t(".visibility_level.#{person_statement.visibility_level}") %>
+      </td>
+      <td>
+        <%= link_to gobierto_people_person_statement_url(@person, person_statement, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+          <i class="fa fa-eye"></i>
+          <%= t(".view_statement") %>
         <% end %>
       </td>
     </tr>

--- a/config/locales/gobierto_admin/gobierto_people/views/people/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/ca.yml
@@ -31,6 +31,7 @@ ca:
             person: Persona
             posts: Posts
             statements: Declaracions
+            status: Estat
           new: Nova persona
           posts_count:
             one: Un post
@@ -40,6 +41,9 @@ ca:
             other: "%{count} declaracions"
           title: Persones
           view_person: Veure persona
+          visibility_level: 
+            draft: Borrador
+            active: Publicat
         navigation:
           agenda: Agenda
           person: Persona

--- a/config/locales/gobierto_admin/gobierto_people/views/people/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/en.yml
@@ -31,6 +31,7 @@ en:
             person: Person
             posts: Posts
             statements: Statements
+            status: Status
           new: New person
           posts_count:
             one: One post
@@ -40,6 +41,9 @@ en:
             other: "%{count} statements"
           title: Persons
           view_person: View person
+          visibility_level:
+            draft: Draft
+            active: Published
         navigation:
           agenda: Agenda
           person: Person

--- a/config/locales/gobierto_admin/gobierto_people/views/people/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/es.yml
@@ -31,6 +31,7 @@ es:
             person: Persona
             posts: Posts
             statements: Declaraciones
+            status: Estado
           new: Nueva persona
           posts_count:
             one: Un post
@@ -40,6 +41,9 @@ es:
             other: "%{count} declaraciones"
           title: Personas
           view_person: Ver persona
+          visibility_level:
+            draft: Borrador
+            active: Publicada
         navigation:
           agenda: Agenda
           person: Persona

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/ca.yml
@@ -26,12 +26,16 @@ ca:
               date: Data
               event: Dsdeveniment
               location: Localització
+              status: Estat
             new: Nou esdeveniment
             past_events: Esdeveniments passats
             pending_events: Pendents de moderar
             published_events: Esdeveniments publicats
             title: Agenda
             view_event: Veure esdeveniment
+            visibility_level:
+              pending: Borrador
+              published: Publicat
           locations_form:
             header:
               address: Direcció

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/en.yml
@@ -26,12 +26,16 @@ en:
               date: Date
               event: Event
               location: Location
+              status: Status
             new: New event
             past_events: Past events
             pending_events: Moderation pending
             published_events: Published events
             title: Agenda
             view_event: View event
+            visibility_level:
+              pending: Draft
+              published: Published
           locations_form:
             header:
               address: Address

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/es.yml
@@ -26,12 +26,16 @@ es:
               date: Fecha
               event: Evento
               location: Localización
+              status: Estado
             new: Nuevo evento
             past_events: Eventos pasados
             pending_events: Pendientes de moderar
             published_events: Eventos publicados
             title: Agenda
             view_event: Ver evento
+            visibility_level:
+              pending: Borrador
+              published: Publicado
           locations_form:
             header:
               address: Dirección

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/ca.yml
@@ -18,8 +18,12 @@ ca:
               date: Data
               tags: Tags
               title: Títol
+              status: Estat
             new: Nou post
             title: Blog
             view_post: Veure post
+            visibility_level:
+              draft: Borrador
+              active: Publicat
           new:
             title: Nou post

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/en.yml
@@ -18,8 +18,12 @@ en:
               date: Date
               tags: Tags
               title: Title
+              status: Status
             new: New post
             title: Blog
             view_post: View post
+            visibility_level:
+              draft: Draft
+              active: Published
           new:
             title: New post

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_posts/es.yml
@@ -18,8 +18,12 @@ es:
               date: Fecha
               tags: Tags
               title: Título
+              status: Estado
             new: Nuevo post
             title: Blog
             view_post: Ver post
+            visibility_level:
+              draft: Borrador
+              active: Publicado
           new:
             title: Nuevo post

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/ca.yml
@@ -16,8 +16,12 @@ ca:
             header:
               date: Data
               statement: Declaració
+              status: Estat
             new: Nova declaració
             title: Declaracions
             view_statement: Veure declaració
+            visibility_level:
+              draft: Borrador
+              active: Publicada
           new:
             title: Nou declaració

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/en.yml
@@ -16,8 +16,13 @@ en:
             header:
               date: Date
               statement: Statement
+              status: Status
+              status: Estat
             new: New statement
             title: Statements
             view_statement: View statement
+            visibility_level:
+              draft: Draft
+              active: Published
           new:
             title: New statement

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_statements/es.yml
@@ -16,8 +16,12 @@ es:
             header:
               date: Fecha
               statement: Declaración
+              status: Estado
             new: Nueva declaración
             title: Declaraciones
             view_statement: Ver declaración
+            visibility_level:
+              draft: Borrador
+              active: Publicada
           new:
             title: Nueva declaración

--- a/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
@@ -33,10 +33,11 @@ module GobiertoAdmin
 
                 within "tr#person-item-#{person.id}" do
                   if person.active?
-                    assert has_link?("View person")
+                    assert has_content?("Published")
                   else
-                    assert has_selector?(".view_item", text: "View person")
+                    assert has_content?("Draft")
                   end
+                  assert has_link?("View person")
                 end
               end
             end

--- a/test/integration/gobierto_admin/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_events_index_test.rb
@@ -68,10 +68,11 @@ module GobiertoAdmin
 
                 within "tr#person-event-item-#{event.id}" do
                   if event.published?
-                    assert has_link?("View event")
+                    assert has_content?("Published")
                   else
-                    assert has_selector?(".view_item", text: "View event")
+                    assert has_content?("Draft")
                   end
+                  assert has_link?("View event")
                 end
               end
             end

--- a/test/integration/gobierto_admin/gobierto_people/person_posts_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_posts_index_test.rb
@@ -33,10 +33,11 @@ module GobiertoAdmin
 
                 within "tr#person-post-item-#{person_post.id}" do
                   if person_post.active?
-                    assert has_link?("View post")
+                    assert has_content?("Published")
                   else
-                    assert has_selector?(".view_item", text: "View post")
+                    assert has_content?("Draft")
                   end
+                  assert has_link?("View post")
                 end
               end
             end

--- a/test/integration/gobierto_admin/gobierto_people/person_statements_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statements_index_test.rb
@@ -33,10 +33,11 @@ module GobiertoAdmin
 
                 within "tr#person-statement-item-#{statement.id}" do
                   if statement.active?
-                    assert has_link?("View statement")
+                    assert has_content?("Published")
                   else
-                    assert has_selector?(".view_item", text: "View statement")
+                    assert has_content?("Draft")
                   end
+                  assert has_link?("View statement")
                 end
               end
             end


### PR DESCRIPTION
Connects to #286

### What does this PR do?

This PR enables a new status column in all the resources of Gobierto People.

### How should this be manually tested?

- [x] Check the column presence in all the lists

