### PR TITLE
New settings section with a configuration entry for the home page

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_people/configuration/settings_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/configuration/settings_controller.rb
@@ -1,0 +1,36 @@
+module GobiertoAdmin
+  module GobiertoPeople
+    module Configuration
+      class SettingsController < BaseController
+        before_action { module_enabled!(current_site, "GobiertoPeople") }
+
+        def index
+          @settings = current_site.gobierto_people_settings.all
+        end
+
+        def update
+          @setting = find_setting
+          @setting_form = SettingForm.new(
+            setting_params.merge(id: params[:id])
+          )
+
+          @setting_form.save
+          redirect_to(
+            admin_people_configuration_settings_path,
+            notice: t(".success")
+          )
+        end
+
+        private
+
+        def find_setting
+          current_site.gobierto_people_settings.find(params[:id])
+        end
+
+        def setting_params
+          params.require(:gobierto_people_setting).permit(:value)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -7,6 +7,13 @@ module GobiertoPeople
       @events = current_site.person_events.upcoming.sorted.first(10)
       @posts  = current_site.person_posts.active.sorted.last(10)
       @political_groups = get_political_groups
+      @home_text = load_home_text
+    end
+
+    private
+
+    def load_home_text
+      current_site.gobierto_people_settings.find_by(key: "home_text_#{I18n.locale}").try(:value)
     end
   end
 end

--- a/app/forms/gobierto_admin/gobierto_people/setting_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/setting_form.rb
@@ -1,0 +1,56 @@
+module GobiertoAdmin
+  module GobiertoPeople
+    class SettingForm
+      include ActiveModel::Model
+
+      attr_accessor(
+        :id,
+        :value
+      )
+
+      delegate :persisted?, to: :setting
+
+      def save
+        save_setting if valid?
+      end
+
+      def setting
+        @setting ||= setting_class.find_by(id: id).presence || build_setting
+      end
+
+      private
+
+      def build_setting
+        setting_class.new
+      end
+
+      def setting_class
+        ::GobiertoPeople::Setting
+      end
+
+      def save_setting
+        @setting = setting.tap do |setting_attributes|
+          setting_attributes.value = value
+        end
+
+        if @setting.valid?
+          @setting.save
+
+          @setting
+        else
+          promote_errors(@setting.errors)
+
+          false
+        end
+      end
+
+      protected
+
+      def promote_errors(errors_hash)
+        errors_hash.each do |attribute, message|
+          errors.add(attribute, message)
+        end
+      end
+    end
+  end
+end

--- a/app/models/gobierto_people/setting.rb
+++ b/app/models/gobierto_people/setting.rb
@@ -1,0 +1,12 @@
+require_dependency "gobierto_people"
+
+module GobiertoPeople
+  class Setting < ApplicationRecord
+    validates :key, :site_id, presence: true
+    validates :key, uniqueness: { scope: :site_id }
+
+    belongs_to :site
+
+    default_scope { order(id: :asc) }
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -23,6 +23,7 @@ class Site < ApplicationRecord
   has_many :person_events, through: :people, source: :events, class_name: "GobiertoPeople::PersonEvent"
   has_many :person_posts, through: :people, source: :posts, class_name: "GobiertoPeople::PersonPost"
   has_many :person_statements, through: :people, source: :statements, class_name: "GobiertoPeople::PersonStatement"
+  has_many :gobierto_people_settings, class_name: "GobiertoPeople::Setting"
 
   serialize :configuration_data
 

--- a/app/views/gobierto_admin/gobierto_people/configuration/_navigation.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/configuration/_navigation.html.erb
@@ -1,0 +1,23 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_people.people.index.title"), admin_people_people_path %> »
+  <%= link_to t("gobierto_admin.gobierto_people.configuration.title"), admin_people_configuration_political_groups_path %> »
+  <% if controller_name == 'political_groups' %>
+    <%= t("gobierto_admin.gobierto_people.political_groups.title") %>
+  <% elsif controller_name == 'settings' %>
+    <%= t("gobierto_admin.gobierto_people.settings.title") %>
+  <% end %>
+</div>
+
+<h1><%= t("gobierto_admin.gobierto_people.configuration.title") %></h1>
+
+<div class="tabs">
+  <ul>
+    <li <%= %Q{class="active"}.html_safe if controller_name == 'political_groups'%>>
+      <%= link_to t("gobierto_admin.gobierto_people.political_groups.title"), admin_people_configuration_political_groups_path %>
+    </li>
+    <li <%= %Q{class="active"}.html_safe if controller_name == 'settings'%>>
+      <%= link_to t("gobierto_admin.gobierto_people.settings.title"), admin_people_configuration_settings_path %>
+    </li>
+  </ul>
+</div>

--- a/app/views/gobierto_admin/gobierto_people/configuration/political_groups/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/configuration/political_groups/index.html.erb
@@ -1,18 +1,4 @@
-<div class="admin_breadcrumb">
-  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
-  <%= link_to t("gobierto_admin.gobierto_people.people.index.title"), admin_people_people_path %> »
-  <%= link_to t("gobierto_admin.gobierto_people.configuration.title"), admin_people_configuration_political_groups_path %>
-</div>
-
-<h1><%= t("gobierto_admin.gobierto_people.configuration.title") %></h1>
-
-<div class="tabs">
-  <ul>
-    <li class="active">
-      <%= link_to t(".title"), "#" %>
-    </li>
-  </ul>
-</div>
+<%= render 'gobierto_admin/gobierto_people/configuration/navigation' %>
 
 <div class="admin_tools right">
   <%= link_to t(".new"), new_admin_people_configuration_political_group_path, class: "button" %>

--- a/app/views/gobierto_admin/gobierto_people/configuration/settings/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/configuration/settings/index.html.erb
@@ -1,0 +1,27 @@
+<%= render 'gobierto_admin/gobierto_people/configuration/navigation' %>
+
+<table class="people-list">
+  <tr>
+    <th><%= t(".header.key") %></th>
+    <th><%= t(".header.value") %></th>
+    <th></th>
+  </tr>
+
+  <tbody>
+    <% @settings.each do |setting| %>
+      <%= form_for setting, url: admin_people_configuration_setting_path(setting), method: :patch do |f| %>
+        <tr id="setting-item-<%= setting.id %>" class="<%= cycle("odd", "even") %>">
+          <td>
+            <%= t(".settings.#{f.object.key}") %>
+          </td>
+          <td>
+            <%= f.text_area :value, cols: 50 %>
+          </td>
+          <td>
+            <%= f.submit t(".update") %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/gobierto_people/welcome/index.html.erb
+++ b/app/views/gobierto_people/welcome/index.html.erb
@@ -6,7 +6,7 @@
 
       <div class="p_h_2">
 
-        <h1><%= t(".title") %></h1>
+        <h1><%= @home_text || t(".title") %></h1>
 
         <h2><%= t(".people_summary.title", site_name: current_site.name) %></h2>
 

--- a/config/locales/gobierto_admin/gobierto_people/controllers/configuration/settings/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/configuration/settings/ca.yml
@@ -1,0 +1,8 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_people:
+      configuration:
+        settings:
+          update:
+            success: Preferencia actualitzada correctament

--- a/config/locales/gobierto_admin/gobierto_people/controllers/configuration/settings/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/configuration/settings/en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  gobierto_admin:
+    gobierto_people:
+      configuration:
+        settings:
+          update:
+            success: Setting updated successfully

--- a/config/locales/gobierto_admin/gobierto_people/controllers/configuration/settings/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/configuration/settings/es.yml
@@ -1,0 +1,8 @@
+---
+es:
+  gobierto_admin:
+    gobierto_people:
+      configuration:
+        settings:
+          update:
+            success: Preferencia actualizada correctamente

--- a/config/locales/gobierto_admin/gobierto_people/views/configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/configuration/ca.yml
@@ -11,7 +11,15 @@ ca:
               created: Creada
               political_group: Agrupació
             new: Nova agrupació
-            title: Agrupacions polítiques
           new:
             title: Nova agrupación
+        settings:
+          index:
+            update: Actualitzar
+            header:
+              key: Nom
+              value: Valor
+            settings:
+              home_text_es: Text home espanyol
+              home_text_ca: Text home català
         title: Configuració

--- a/config/locales/gobierto_admin/gobierto_people/views/configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/configuration/en.yml
@@ -11,7 +11,15 @@ en:
               created: Created
               political_group: Group
             new: New group
-            title: Political groups
           new:
             title: New group
+        settings:
+          index:
+            update: Update
+            header:
+              key: Name
+              value: Value
+            settings:
+              home_text_es: Home text Spanish
+              home_text_ca: Home text Catalan
         title: Configuration

--- a/config/locales/gobierto_admin/gobierto_people/views/configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/configuration/es.yml
@@ -11,7 +11,15 @@ es:
               created: Creada
               political_group: Agrupación
             new: Nueva agrupación
-            title: Agrupaciones políticas
           new:
             title: Nueva agrupación
+        settings:
+          index:
+            update: Actualizar
+            header:
+              key: Nombre
+              value: Valor
+            settings:
+              home_text_es: Texto home español
+              home_text_ca: Texto home catalán
         title: Configuración

--- a/config/locales/gobierto_admin/gobierto_people/views/political_groups/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/political_groups/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_people:
+      political_groups:
+        title: Grups polítics
+

--- a/config/locales/gobierto_admin/gobierto_people/views/political_groups/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/political_groups/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  gobierto_admin:
+    gobierto_people:
+      political_groups:
+        title: Political groups
+

--- a/config/locales/gobierto_admin/gobierto_people/views/political_groups/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/political_groups/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  gobierto_admin:
+    gobierto_people:
+      political_groups:
+        title: Grupos políticos
+

--- a/config/locales/gobierto_admin/gobierto_people/views/settings/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/settings/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_people:
+      settings:
+        title: Preferencies
+

--- a/config/locales/gobierto_admin/gobierto_people/views/settings/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/settings/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  gobierto_admin:
+    gobierto_people:
+      settings:
+        title: Settings
+

--- a/config/locales/gobierto_admin/gobierto_people/views/settings/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/settings/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  gobierto_admin:
+    gobierto_people:
+      settings:
+        title: Preferencias
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
       end
 
       namespace :configuration do
+        resources :settings, only: [:index, :update], path: :settings
         resources :political_groups, only: [:index, :new, :create, :edit, :update], path: :groups
       end
 

--- a/db/migrate/20170131144344_create_gobierto_people_settings.rb
+++ b/db/migrate/20170131144344_create_gobierto_people_settings.rb
@@ -1,0 +1,11 @@
+class CreateGobiertoPeopleSettings < ActiveRecord::Migration[5.0]
+  def change
+    create_table :gp_settings do |t|
+      t.references :site
+      t.string :key, null: false, default: ""
+      t.string :value, null: false, default: ""
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170116072555) do
+ActiveRecord::Schema.define(version: 20170131144344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -260,6 +260,15 @@ ActiveRecord::Schema.define(version: 20170116072555) do
     t.datetime "updated_at",              null: false
     t.index ["admin_id"], name: "index_gp_political_groups_on_admin_id", using: :btree
     t.index ["site_id"], name: "index_gp_political_groups_on_site_id", using: :btree
+  end
+
+  create_table "gp_settings", force: :cascade do |t|
+    t.integer  "site_id"
+    t.string   "key",        default: "", null: false
+    t.string   "value",      default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.index ["site_id"], name: "index_gp_settings_on_site_id", using: :btree
   end
 
   create_table "sites", force: :cascade do |t|

--- a/db/seeds/gobierto_people/seeds.rb
+++ b/db/seeds/gobierto_people/seeds.rb
@@ -1,0 +1,4 @@
+Site.all.each do |site|
+  GobiertoPeople::Setting.create! site: site, key: "home_text_ca"
+  GobiertoPeople::Setting.create! site: site, key: "home_text_es"
+end

--- a/test/fixtures/gobierto_people/settings.yml
+++ b/test/fixtures/gobierto_people/settings.yml
@@ -1,0 +1,4 @@
+home_text:
+  key: home_text
+  value: this is the home text
+  site: madrid

--- a/test/forms/gobierto_admin/gobierto_people/setting_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/setting_form_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class SettingFormTest < ActiveSupport::TestCase
+      def valid_setting_form
+        @valid_setting_form ||= SettingForm.new(
+          id: setting.id,
+          value: "new value"
+        )
+      end
+
+      def setting
+        @setting ||= gobierto_people_settings(:home_text)
+      end
+
+      def test_save_with_valid_attributes
+        assert valid_setting_form.save
+        setting.reload
+        assert_equal "new value", setting.value
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/settings_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/settings_update_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class SettingsUpdateTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = admin_people_configuration_settings_path
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def setting
+        @setting ||= gobierto_people_settings(:home_text)
+      end
+
+      def test_setting_update
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "#edit_gobierto_people_setting_#{setting.id}" do
+              fill_in "gobierto_people_setting_value", with: "New value"
+
+              click_button "Update"
+            end
+
+            assert has_message?("Setting updated successfully")
+
+            within "#edit_gobierto_people_setting_#{setting.id}" do
+              assert has_field?("gobierto_people_setting_value", with: "New value")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_people/welcome_index_test.rb
+++ b/test/integration/gobierto_people/welcome_index_test.rb
@@ -39,10 +39,13 @@ module GobiertoPeople
     end
 
     def test_welcome_index
+      home_text = "This is the welcome message"
+      site.gobierto_people_settings.create! key: "home_text_#{I18n.locale}", value: home_text
+
       with_current_site(site) do
         visit @path
 
-        assert has_selector?("h1", text: "Know the people who work to make your city a better place to live.")
+        assert has_selector?("h1", text: home_text)
       end
     end
 


### PR DESCRIPTION
Connects to #292

### What does this PR do?

This PR adds a new section settings into Gobierto People module and a new setting for the text in the home page.

### How should this be manually tested?

- [x] You should be able to see the new settings section in the configuration page
- [x] You should be able to update the settings
- [x] You should be able to see the value of the settings in the front page

