### PR TITLE
Introduce sorting for people

### DIFF
--- a/app/assets/javascripts/admin/app/controllers/consultation_items_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/consultation_items_controller.js
@@ -28,7 +28,7 @@ this.GobiertoAdmin.ConsultationItemsController = (function() {
   }
 
   function _handleSortableList() {
-    var wrapper = "ul[data-behavior=sortable]"
+    var wrapper = "ul[data-behavior=sortable]";
     var positions = [];
 
     sortable(wrapper);

--- a/app/assets/javascripts/admin/app/controllers/people_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/people_controller.js
@@ -1,0 +1,53 @@
+this.GobiertoAdmin.PeopleController = (function() {
+  function PeopleController() {}
+
+  PeopleController.prototype.index = function() {
+    _handleSortableList();
+  };
+
+  function _handleSortableList() {
+    var wrapper = "tbody[data-behavior=sortable]";
+    var positions = [];
+
+    sortable(wrapper, {
+      items: 'tr',
+      forcePlaceholderSize: true
+    });
+
+    $(wrapper).on("sortupdate", function(e) {
+      _refreshPositions(wrapper);
+      _requestUpdate(wrapper, _buildPositions(wrapper));
+    });
+  }
+
+  function _refreshPositions(wrapper) {
+    $(wrapper).find("tr").each(function(index) {
+      $(this).attr("data-pos", index + 1);
+    });
+  };
+
+  function _buildPositions(wrapper) {
+    var positions = [];
+
+    $(wrapper).find("tr").each(function(index) {
+      positions.push({
+        id: $(this).data("id"),
+        position: index + 1
+      });
+    });
+
+    return positions;
+  };
+
+  function _requestUpdate(wrapper, positions) {
+    $.ajax({
+      url: $(wrapper).data("sortable-target"),
+      method: "POST",
+      data: { positions: positions }
+    });
+  };
+
+  return PeopleController;
+})();
+
+this.GobiertoAdmin.people_controller = new GobiertoAdmin.PeopleController;

--- a/app/assets/stylesheets/comp-tables.scss
+++ b/app/assets/stylesheets/comp-tables.scss
@@ -141,3 +141,7 @@ th.icon_col {
 	width: 15px;
 }
 
+[data-behavior="sortable"] tr {
+  display: block;
+  width: 100%;
+}

--- a/app/controllers/gobierto_admin/gobierto_people/people/people_sort_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/people_sort_controller.rb
@@ -1,0 +1,24 @@
+module GobiertoAdmin
+  module GobiertoPeople
+    module People
+      class PeopleSortController < GobiertoAdmin::BaseController
+        before_action { module_enabled!(current_site, "GobiertoPeople") }
+
+        def create
+          params[:positions].each do |_, item_attributes|
+            if person = current_site.people.find_by(id: item_attributes['id'])
+              person.update_column :position, item_attributes['position']
+            end
+          end
+          head :no_content
+        end
+
+        private
+
+        def people_sort_params
+          params.require(:positions).permit!
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
@@ -112,6 +112,7 @@ module GobiertoAdmin
         %w(
         created_at updated_at
         events_count statements_count posts_count
+        position
         )
       end
     end

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -4,6 +4,7 @@ module GobiertoPeople
   class Person < ApplicationRecord
     include ::GobiertoCommon::DynamicContent
     include User::Subscribable
+    include GobiertoCommon::Sortable
 
     belongs_to :admin, class_name: "GobiertoAdmin::Admin"
     belongs_to :site
@@ -13,7 +14,7 @@ module GobiertoPeople
     has_many :statements, class_name: "PersonStatement", dependent: :destroy
     has_many :posts, class_name: "PersonPost", dependent: :destroy
 
-    scope :sorted, -> { order(created_at: :desc) }
+    scope :sorted, -> { order(position: :asc, created_at: :desc) }
     scope :by_site, ->(site) { where(site_id: site.id) }
 
     enum visibility_level: { draft: 0, active: 1 }

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -25,9 +25,9 @@
   <th></th>
 </tr>
 
-<tbody>
+<tbody data-behavior="sortable" data-sortable-target="<%= admin_people_people_sort_path %>">
   <% @people.each do |person| %>
-    <tr id="person-item-<%= person.id %>" class="<%= cycle("odd", "even") %>">
+    <tr id="person-item-<%= person.id %>" data-id="<%= person.id %>" class="<%= cycle("odd", "even") %>">
       <td>
         <%= link_to edit_admin_people_person_path(person) do %>
           <i class="fa fa-edit"></i>
@@ -63,8 +63,13 @@
           <i class="fa fa-eye"></i>
           <%= t(".view_person") %>
         <% end %>
+        <i class="sort-handler fa fa-bars f_right"></i>
       </td>
     </tr>
   <% end %>
 </tbody>
 </table>
+
+<%= javascript_tag do %>
+  window.GobiertoAdmin.people_controller.index();
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
 
     namespace :gobierto_people, as: :people, path: :people do
       resources :people, only: [:index, :new, :create, :edit, :update] do
+        collection do
+          resource :people_sort, only: [:create], controller: "people/people_sort", path: :people_sort
+        end
         resources :person_events, only: [:index, :new, :create, :edit, :update], controller: "people/person_events", as: :events, path: :events
         resources :published_person_events, only: [:index], controller: "people/published_person_events", as: :published_events, path: "events/published"
         resources :pending_person_events, only: [:index], controller: "people/pending_person_events", as: :pending_events, path: "events/pending"

--- a/db/migrate/20170201120912_add_position_to_gobierto_people_people.rb
+++ b/db/migrate/20170201120912_add_position_to_gobierto_people_people.rb
@@ -1,5 +1,5 @@
 class AddPositionToGobiertoPeoplePeople < ActiveRecord::Migration[5.0]
   def change
-    add_column :gp_people, :position, :integer, default: 0, null: false
+    add_column :gp_people, :position, :integer, default: 999999, null: false
   end
 end

--- a/db/migrate/20170201120912_add_position_to_gobierto_people_people.rb
+++ b/db/migrate/20170201120912_add_position_to_gobierto_people_people.rb
@@ -1,0 +1,5 @@
+class AddPositionToGobiertoPeoplePeople < ActiveRecord::Migration[5.0]
+  def change
+    add_column :gp_people, :position, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131144344) do
+ActiveRecord::Schema.define(version: 20170201120912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 20170131144344) do
     t.integer  "political_group_id"
     t.integer  "category",           default: 0,  null: false
     t.integer  "party"
+    t.integer  "position",           default: 0,  null: false
     t.index ["admin_id"], name: "index_gp_people_on_admin_id", using: :btree
     t.index ["category", "party"], name: "index_gp_people_on_category_and_party", using: :btree
     t.index ["category"], name: "index_gp_people_on_category", using: :btree

--- a/test/controllers/gobierto_admin/gobierto_people/people/people_sort_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_people/people/people_sort_controller_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    module People
+      class PeopleSortControllerTest < GobiertoControllerTest
+        def admin
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def person1
+          @person1 ||= gobierto_people_people(:richard)
+        end
+
+        def person2
+          @person2 ||= gobierto_people_people(:tamara)
+        end
+
+        def setup
+          super
+          sign_in_admin(admin)
+        end
+
+        def teardown
+          super
+          sign_out_admin
+        end
+
+        def valid_sort_params
+          {
+            positions: {
+              '0' => { id: person1.id, position: 2 },
+              '1' => { id: person2.id, position: 1 }
+            }
+          }
+        end
+
+        def test_create
+          assert_equal 1, person1.position
+          assert_equal 2, person2.position
+
+          post admin_people_people_sort_url, params: valid_sort_params
+          assert_response :no_content
+
+          person1.reload
+          person2.reload
+          assert_equal 1, person2.position
+          assert_equal 2, person1.position
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/gobierto_people/people.yml
+++ b/test/fixtures/gobierto_people/people.yml
@@ -10,6 +10,7 @@ richard:
   category: <%= GobiertoPeople::Person.categories["politician"] %>
   party: <%= GobiertoPeople::Person.parties["government"] %>
   political_group: marvel
+  position: 1
 
 tamara:
   site: madrid
@@ -23,3 +24,4 @@ tamara:
   category: <%= GobiertoPeople::Person.categories["executive"] %>
   party:
   political_group:
+  position: 2


### PR DESCRIPTION
Connects to #280 

### What does this PR do?

This PR introduces a new attribute `position` in Person model. People can be sorted by an admin in the UI. All the people lists use the `sorted` scope which uses the new `position` attribute.

### How should this be manually tested?

- [x] check you can reorde people
- [ ] check the order is applied in the front
