### PR TITLE
Consider events only from the first second

### DIFF
--- a/app/assets/javascripts/admin/app/components/dirty_forms_component.js
+++ b/app/assets/javascripts/admin/app/components/dirty_forms_component.js
@@ -1,5 +1,6 @@
 this.GobiertoAdmin.DirtyFormsComponent = (function() {
   var isDirty;
+  var t1, t2;
 
   function DirtyFormsComponent() {}
 
@@ -17,6 +18,8 @@ this.GobiertoAdmin.DirtyFormsComponent = (function() {
 
   function _handleDirtyFlag() {
     isDirty = false;
+    var date = new Date();
+    t1 = date.getTime();
 
     var checkingForm = $("form:not(.skip-dirty-check)");
 
@@ -27,8 +30,13 @@ this.GobiertoAdmin.DirtyFormsComponent = (function() {
   }
 
   function _setDirty(e) {
-    console.log('_setDirty', e);
-    isDirty = true;
+    var date = new Date();
+    t2 = date.getTime();
+    // For some reason, when the WYSIWYG has an image, it triggers a trix-change event.
+    // Here, we check if the time difference between the load and the event is big than 1 sec.
+    if(t2 - t1 > 1000) {
+      isDirty = true;
+    }
   }
 
   function _unsetDirty() {

--- a/test/integration/gobierto_admin/dirty_forms_test.rb
+++ b/test/integration/gobierto_admin/dirty_forms_test.rb
@@ -28,6 +28,8 @@ module GobiertoAdmin
             within "form.edit_user" do
               fill_in "user_name", with: "User Name"
 
+              sleep 2
+
               click_link "Change password"
 
               assert_equal(

--- a/test/integration/gobierto_admin/dirty_forms_test.rb
+++ b/test/integration/gobierto_admin/dirty_forms_test.rb
@@ -26,9 +26,9 @@ module GobiertoAdmin
             visit @path
 
             within "form.edit_user" do
-              fill_in "user_name", with: "User Name"
-
               sleep 2
+
+              fill_in "user_name", with: "User Name"
 
               click_link "Change password"
 


### PR DESCRIPTION
Connects to #290

### What does this PR do?

This PR solves the issue with the alerts. The problem was an event `trix-change` triggered by Trix when it had a picture in its content.
