### PR TITLE
Don't require password confirmation if the password hasn't changed

### DIFF
--- a/app/forms/gobierto_admin/admin_form.rb
+++ b/app/forms/gobierto_admin/admin_form.rb
@@ -2,8 +2,6 @@ module GobiertoAdmin
   class AdminForm
     include ActiveModel::Model
 
-    EMAIL_ADDRESS_REGEXP = /\A(.+)@(.+\..+)\z/
-
     attr_accessor(
       :id,
       :name,

--- a/app/forms/gobierto_admin/admin_form.rb
+++ b/app/forms/gobierto_admin/admin_form.rb
@@ -23,13 +23,12 @@ module GobiertoAdmin
 
     validates :name, :email, presence: true
     validates :email, format: { with: Admin::EMAIL_ADDRESS_REGEXP }
-    validates :password, presence: true, if: Proc.new { |f| f.admin.new_record? }
-    validates :password, confirmation: true, if: Proc.new { |f|  f.password != f.admin.password }
+    validates :password, presence: { if: :new_record? }, confirmation: true
 
     def save
-      return false unless valid?
-
       @new_record = admin.new_record?
+
+      return false unless valid?
 
       if save_admin
         send_confirmation_instructions if send_confirmation_instructions?

--- a/app/forms/gobierto_admin/admin_form.rb
+++ b/app/forms/gobierto_admin/admin_form.rb
@@ -23,7 +23,8 @@ module GobiertoAdmin
 
     validates :name, :email, presence: true
     validates :email, format: { with: Admin::EMAIL_ADDRESS_REGEXP }
-    validates :password, presence: true, confirmation: true
+    validates :password, presence: true, if: Proc.new { |f| f.admin.new_record? }
+    validates :password, confirmation: true, if: Proc.new { |f|  f.password != f.admin.password }
 
     def save
       return false unless valid?

--- a/test/forms/gobierto_admin/admin_form_test.rb
+++ b/test/forms/gobierto_admin/admin_form_test.rb
@@ -6,7 +6,8 @@ module GobiertoAdmin
       @valid_admin_form ||= AdminForm.new(
         name: admin.name,
         email: new_admin_email, # To ensure uniqueness
-        password: "gobierto"
+        password: "gobierto",
+        password_confirmation: "gobierto"
       )
     end
 
@@ -14,7 +15,8 @@ module GobiertoAdmin
       @invalid_admin_form ||= AdminForm.new(
         name: nil,
         email: nil,
-        password: nil
+        password: nil,
+        password_confirmation: nil
       )
     end
 
@@ -30,10 +32,20 @@ module GobiertoAdmin
       assert valid_admin_form.save
     end
 
+    def test_error_messages_with_valid_attributes_and_not_matching_passwords
+      valid_admin_form.password_confirmation = "wadus"
+
+      valid_admin_form.save
+
+      assert_equal 0, valid_admin_form.errors.messages[:password].size
+      assert_equal 1, valid_admin_form.errors.messages[:password_confirmation].size
+    end
+
     def test_error_messages_with_invalid_attributes
       invalid_admin_form.save
 
       assert_equal 1, invalid_admin_form.errors.messages[:password].size
+      assert_equal 0, invalid_admin_form.errors.messages[:password_confirmation].size
       assert_equal 1, invalid_admin_form.errors.messages[:name].size
       assert_equal 2, invalid_admin_form.errors.messages[:email].size
     end

--- a/test/integration/gobierto_admin/admin_update_test.rb
+++ b/test/integration/gobierto_admin/admin_update_test.rb
@@ -111,5 +111,62 @@ module GobiertoAdmin
         end
       end
     end
+
+    def test_admin_update_with_not_matching_passwords
+      with_signed_in_admin(manager_admin) do
+        visit edit_admin_admin_path(regular_admin)
+
+        within "form.edit_admin" do
+          fill_in "admin_name", with: "Admin Name"
+          fill_in "admin_email", with: "wadus@gobierto.dev"
+          fill_in "admin_password", with: "wadus"
+          fill_in "admin_password_confirmation", with: "foo"
+
+          within ".site-module-check-boxes" do
+            check "Gobierto Development"
+          end
+
+          within ".site-check-boxes" do
+            check "madrid.gobierto.dev"
+          end
+
+          within ".admin-authorization-level-radio-buttons" do
+            choose "Regular"
+          end
+
+          click_button "Update"
+        end
+
+        assert has_alert?("Password confirmation doesn't match Password")
+      end
+    end
+
+    def test_admin_update_with_no_password_confirmation
+      with_signed_in_admin(manager_admin) do
+        visit edit_admin_admin_path(regular_admin)
+
+        within "form.edit_admin" do
+          fill_in "admin_name", with: "Admin Name"
+          fill_in "admin_email", with: "wadus@gobierto.dev"
+          fill_in "admin_password", with: "wadus"
+
+          within ".site-module-check-boxes" do
+            check "Gobierto Development"
+          end
+
+          within ".site-check-boxes" do
+            check "madrid.gobierto.dev"
+          end
+
+          within ".admin-authorization-level-radio-buttons" do
+            choose "Regular"
+          end
+
+          click_button "Update"
+        end
+
+        assert has_alert?("Password confirmation doesn't match Password")
+      end
+    end
   end
 end

--- a/test/integration/gobierto_admin/admin_update_test.rb
+++ b/test/integration/gobierto_admin/admin_update_test.rb
@@ -21,8 +21,6 @@ module GobiertoAdmin
         within "form.edit_admin" do
           fill_in "admin_name", with: "Admin Name"
           fill_in "admin_email", with: "wadus@gobierto.dev"
-          fill_in "admin_password", with: "adminpassword"
-          fill_in "admin_password_confirmation", with: "adminpassword"
 
           within ".site-module-check-boxes" do
             check "Gobierto Development"

--- a/test/support/integration/matcher_helpers.rb
+++ b/test/support/integration/matcher_helpers.rb
@@ -5,5 +5,11 @@ module Integration
         has_content?(text)
       end
     end
+
+    def has_alert?(text)
+      within ".alert" do
+        has_content?(text)
+      end
+    end
   end
 end


### PR DESCRIPTION
Connects to #305

### What does this PR do?

This PR fixes admin update error that required to introduce a new password each time.
