### PR TITLE
Run seeds hooked on module activation

### DIFF
--- a/app/models/gobierto_seeds.rb
+++ b/app/models/gobierto_seeds.rb
@@ -1,0 +1,4 @@
+module GobiertoSeeds
+  class Recipe
+  end
+end

--- a/app/services/gobierto_common/gobierto_seeder/module_seeder.rb
+++ b/app/services/gobierto_common/gobierto_seeder/module_seeder.rb
@@ -1,0 +1,16 @@
+module GobiertoCommon
+  module GobiertoSeeder
+    class ModuleSeeder
+      def self.seed(module_name, site)
+        module_path = module_name.underscore
+        module_seeds_path = Rails.root.join("db/seeds/modules/#{module_path}")
+        return unless Dir.exists?(module_seeds_path)
+
+        return unless site.configuration.modules.include?(module_name)
+
+        require "#{module_seeds_path}/seeds"
+        GobiertoSeeds::Recipe.run(site)
+      end
+    end
+  end
+end

--- a/app/services/gobierto_common/gobierto_seeder/module_site_seeder.rb
+++ b/app/services/gobierto_common/gobierto_seeder/module_site_seeder.rb
@@ -1,0 +1,19 @@
+module GobiertoCommon
+  module GobiertoSeeder
+    class ModuleSiteSeeder
+      def self.seed(gobierto_site, module_name, site)
+        module_path = module_name.underscore
+        site_seeds_path = Rails.root.join("db/seeds/sites/#{gobierto_site}")
+        return unless Dir.exists?(site_seeds_path)
+
+        site_module_seeds_path = Rails.root.join("db/seeds/sites/#{gobierto_site}/#{module_path}")
+        return unless Dir.exists?(site_module_seeds_path)
+
+        return unless site.configuration.modules.include?(module_name)
+
+        require "#{site_module_seeds_path}/seeds"
+        GobiertoSeeds::Recipe.run(site)
+      end
+    end
+  end
+end

--- a/db/seeds/gobierto_people/seeds.rb
+++ b/db/seeds/gobierto_people/seeds.rb
@@ -1,5 +1,0 @@
-Site.all.each do |site|
-  # Site settings
-  GobiertoPeople::Setting.find_or_create_by! site: site, key: "home_text_ca"
-  GobiertoPeople::Setting.find_or_create_by! site: site, key: "home_text_es"
-end

--- a/db/seeds/modules/gobierto_people/seeds.rb
+++ b/db/seeds/modules/gobierto_people/seeds.rb
@@ -1,0 +1,8 @@
+module GobiertoSeeds
+  class Recipe
+    def self.run(site)
+      GobiertoPeople::Setting.find_or_create_by! site: site, key: "home_text_ca"
+      GobiertoPeople::Setting.find_or_create_by! site: site, key: "home_text_es"
+    end
+  end
+end

--- a/db/seeds/sites/gobierto_dival/gobierto_people/seeds.rb
+++ b/db/seeds/sites/gobierto_dival/gobierto_people/seeds.rb
@@ -1,0 +1,6 @@
+module GobiertoSeeds
+  class Recipe
+    def self.run(site)
+    end
+  end
+end

--- a/db/seeds/sites/gobierto_populate/gobierto_people/seeds.rb
+++ b/db/seeds/sites/gobierto_populate/gobierto_people/seeds.rb
@@ -1,0 +1,6 @@
+module GobiertoSeeds
+  class Recipe
+    def self.run(site)
+    end
+  end
+end

--- a/docs/developing-module.md
+++ b/docs/developing-module.md
@@ -213,3 +213,27 @@ module GobiertoAdmin
   end
 end
 ```
+
+## Seeds
+
+Sometimes module need some database data to exist. For example, a configuratio entry, a list of `DynamicContentBlocks` preconfigured. For that reason, we have created a seeds structure and two seeds runner classes:
+
+- `ModuleSeeder`: seeds a module
+- `ModuleSiteSeeder`: seeds a module for a specific Gobierto installation. It uses the attribute `site.name` from `config/application.yml`
+
+Both seed types can be found in `db/seeds/modules` and `db/seeds/sites`.
+
+These seeds are executed when a module is **activated** in a site. De-activating the module doesn't run the seeder. Keep this in mind in order to write idempotent scripts.
+
+Here's a template of the seed class:
+
+```ruby
+module GobiertoSeeds
+  class Recipe
+    def self.run(site)
+      # Your code goes here
+    end
+  end
+end
+```
+

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -1,6 +1,18 @@
 require "test_helper"
 
 class SiteTest < ActiveSupport::TestCase
+  def setup
+    super
+    @module_seeder_spy = Spy.on(GobiertoCommon::GobiertoSeeder::ModuleSeeder, :seed)
+    @module_site_seeder_spy = Spy.on(GobiertoCommon::GobiertoSeeder::ModuleSiteSeeder, :seed)
+  end
+
+  attr_reader :module_seeder_spy, :module_site_seeder_spy
+
+  def first_call_arguments
+    recipe_spy.calls.first.args
+  end
+
   def site
     @site ||= sites(:madrid)
   end
@@ -42,4 +54,36 @@ class SiteTest < ActiveSupport::TestCase
     refute Site.find_by_allowed_domain('presupuestos.' + ENV.fetch("HOST"))
     refute Site.find_by_allowed_domain('foo')
   end
+
+  def test_seeder_called_after_create
+    site = Site.new title: "Transparencia", name: "Albacete", domain: "albacete.gobierto.dev",
+                    location_name: "Albacete", municipality_id: INE::Places::Place.find_by_slug("albacete").id,
+                    location_type: INE::Places::Place, external_id: INE::Places::Place.find_by_slug("albacete").id
+
+    site.configuration_data = {
+      "links_markup" => %Q{<a href="http://madrid.es">Ayuntamiento de Madrid</a>},
+      "logo" => "http://www.madrid.es/assets/images/logo-madrid.png",
+      "modules" => ["GobiertoBudgets", "GobiertoBudgetConsultations", "GobiertoPeople"],
+      "locale" => "en",
+      "google_analytics_id" => "UA-000000-01"
+    }
+    site.save!
+    assert module_seeder_spy.has_been_called?
+    assert module_site_seeder_spy.has_been_called?
+    assert_equal ["GobiertoBudgets", site], module_seeder_spy.calls.first.args
+    assert_equal ["gobierto_populate", "GobiertoBudgets", site], module_site_seeder_spy.calls.first.args
+
+  end
+
+  def test_seeder_called_after_modules_updated
+    configuration_data = site.configuration_data
+    configuration_data['modules'].push "GobiertoIndicators"
+    site.configuration_data = configuration_data
+    site.save!
+    assert module_seeder_spy.has_been_called?
+    assert module_site_seeder_spy.has_been_called?
+    assert_equal ["GobiertoIndicators", site], module_seeder_spy.calls.first.args
+    assert_equal ["gobierto_populate", "GobiertoIndicators", site], module_site_seeder_spy.calls.first.args
+  end
+
 end

--- a/test/services/gobierto_common/gobierto_seeder/module_seeder_test.rb
+++ b/test/services/gobierto_common/gobierto_seeder/module_seeder_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class GobiertoCommon::GobiertoSeeder::ModuleSeederTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = GobiertoCommon::GobiertoSeeder::ModuleSeeder
+    require seeds_path
+    @recipe_spy = Spy.on(::GobiertoSeeds::Recipe, :run)
+  end
+
+  attr_reader :recipe_spy
+
+  def first_call_arguments
+    recipe_spy.calls.first.args
+  end
+
+  def seeds_path
+    @seeds_path ||= Rails.root.join("db/seeds/modules/gobierto_people/seeds")
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_seed_a_site_with_that_module
+    @subject.seed("GobiertoPeople", site)
+    assert recipe_spy.has_been_called?
+    args = first_call_arguments
+    assert_equal site, args.first
+  end
+end

--- a/test/services/gobierto_common/gobierto_seeder/module_site_seeder_test.rb
+++ b/test/services/gobierto_common/gobierto_seeder/module_site_seeder_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class GobiertoCommon::GobiertoSeeder::ModuleSiteSeederTest < ActiveSupport::TestCase
+  def setup
+    super
+    @subject = GobiertoCommon::GobiertoSeeder::ModuleSiteSeeder
+    require seeds_path
+    @recipe_spy = Spy.on(::GobiertoSeeds::Recipe, :run)
+  end
+
+  attr_reader :recipe_spy
+
+  def first_call_arguments
+    recipe_spy.calls.first.args
+  end
+
+  def seeds_path
+    @seeds_path ||= Rails.root.join("db/seeds/sites/gobierto_populate/gobierto_people/seeds")
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_seed_a_site_with_that_module
+    @subject.seed("gobierto_populate", "GobiertoPeople", site)
+    assert recipe_spy.has_been_called?
+    args = first_call_arguments
+    assert_equal site, args.first
+  end
+end


### PR DESCRIPTION
Connects to #300

### What does this PR do?

This PR introduces a way of running specific seeds when a module is enabled.

This allows to implement #316 in an easy way.

### How should this be manually tested?

When creating a new site with the GobiertoPeople module enabled, the settings should be created by default.