### PR TITLE
Dont show box if subscribed

### DIFF
--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -1,13 +1,12 @@
 <% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
 
+<% unless user_signed_in? & current_user.subscribed_to?(subscribable, current_site) %>
+
 <div class="subscribable-box slim_box box">
   <div class="inner">
     <h3><%= title %>
     <% if defined?(subtitle) %>
       · <%= subtitle %>
-    <% end %>
-    <% if defined?(placeholder) %>
-      · <%= placeholder %>
     <% end %>
     </h3>
 
@@ -41,3 +40,5 @@
 
   </div>
 </div>
+
+<% end %>

--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -1,6 +1,6 @@
 <% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
 
-<% unless user_signed_in? & current_user.subscribed_to?(subscribable, current_site) %>
+<% if !user_signed_in? || !current_user.subscribed_to?(subscribable, current_site) %>
 
 <div class="subscribable-box slim_box box">
   <div class="inner">


### PR DESCRIPTION
Connects to #331 

### What does this PR do?

Doesn't show the subscribe box to a logged in user that is already subscribed to an item. 

### How should this be manually tested?

Go to People home; subscribe to events; come back: you should not seen the box. If you unsubscribe from your control panel, you should see the box again. 


