### PR TITLE
Allow municipality id to be nil

### DIFF
--- a/app/assets/javascripts/admin/app/controllers/sites_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/sites_controller.js
@@ -15,6 +15,7 @@ this.GobiertoAdmin.SitesController = (function() {
           method: "GET",
           data: { query: request.term },
           success: function(data) {
+            $(municipalityFieldHandler).val('');
             response(data["suggestions"])
           },
         });

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -45,8 +45,6 @@ module GobiertoAdmin
     validates :username, :password, presence: true, if: :draft_visibility?
     validates :title, presence: true
     validates :name, presence: true
-    validates :location_name, presence: true
-    validates :municipality_id, presence: true
 
     def save
       save_site if valid?

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -132,6 +132,7 @@ ca:
       too_long: és massa llarg (%{count} caràcters màxim)
       too_short: és massa curt (%{count} caràcters mínim)
       wrong_length: no té la longitud correcta (%{count} caràcters exactament)
+      blank_for_modules: ha de ser un municipi per a que els moduls actius funcionen
     template:
       body: 'Hi ha hagut problemes amb els següents camps:'
       header:

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -138,6 +138,7 @@ en:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      blank_for_modules: must be a municipality for the current modules to work
     template:
       body: 'There were problems with the following fields:'
       header:

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -132,6 +132,7 @@ es:
       too_long: es demasiado largo (%{count} caracteres máximo)
       too_short: es demasiado corto (%{count} caracteres mínimo)
       wrong_length: no tiene la longitud correcta (%{count} caracteres exactos)
+      blank_for_modules: tiene que ser un municipio para que los módulos activos funcionen
     template:
       body: 'Se encontraron problemas con los siguientes campos:'
       header:

--- a/config/locales/gobierto_admin/models/ca.yml
+++ b/config/locales/gobierto_admin/models/ca.yml
@@ -22,10 +22,11 @@ ca:
         google_analytics_id: Codi de Google Analytics
         head_markup: HTML de Capçalera
         links_markup: HTML de Enllaços
-        location_name: Entitat relacionada
+        location_name: Municipi
         logo_file: Logotip
         name: Nom de l'entitat
         title: Nom del site
+        municipality_id: Municipi
       gobierto_admin/user_form:
         email: Email
         name: Nom

--- a/config/locales/gobierto_admin/models/en.yml
+++ b/config/locales/gobierto_admin/models/en.yml
@@ -22,10 +22,11 @@ en:
         google_analytics_id: Google Analytics code
         head_markup: Head HTML
         links_markup: Links HTML
-        location_name: Associated entity
+        location_name: Municipality
         logo_file: Logo
         name: Entity ame
         title: Site name
+        municipality_id: Municipality
       gobierto_admin/user_form:
         email: Email
         name: Name

--- a/config/locales/gobierto_admin/models/es.yml
+++ b/config/locales/gobierto_admin/models/es.yml
@@ -22,10 +22,11 @@ es:
         google_analytics_id: Código de Google Analytics
         head_markup: HTML de Cabecera
         links_markup: HTML de Enlaces
-        location_name: Entidad relacionada
+        location_name: Municipio
         logo_file: Logotipo
         name: Nombre de la entidad
         title: Nombre del site
+        municipality_id: Municipio
       gobierto_admin/user_form:
         email: Email
         name: Nombre

--- a/test/forms/gobierto_admin/site_form_test.rb
+++ b/test/forms/gobierto_admin/site_form_test.rb
@@ -19,7 +19,6 @@ module GobiertoAdmin
         name: nil,
         domain: site.domain,
         location_name: site.location_name,
-        municipality_id: nil,
         visibility_level: "active"
       )
     end
@@ -70,7 +69,6 @@ module GobiertoAdmin
 
       assert invalid_site_form.errors.messages[:title].one?
       assert invalid_site_form.errors.messages[:name].one?
-      assert invalid_site_form.errors.messages[:municipality_id].one?
     end
   end
 end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -86,4 +86,10 @@ class SiteTest < ActiveSupport::TestCase
     assert_equal ["gobierto_populate", "GobiertoIndicators", site], module_site_seeder_spy.calls.first.args
   end
 
+  def test_invalid_if_municipality_blank
+    site.municipality_id = nil
+    site.location_name = nil
+    site.save
+    assert site.errors.messages[:location_name].one?
+  end
 end


### PR DESCRIPTION
Connects to #324

### What does this PR do?

This PR adds a validation error for municipality only if some modules that use the municipality are active (GobiertoBudgets, BudgetsConsultations and Indicators).

### How should this be manually tested?

Check the DipVal site in staging!