### PR TITLE
Don't register activity if previous activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "rails-html-sanitizer"
 # Pagination
 gem "kaminari", "~> 1.0"
 
+# Redis
+gem "redis", "~> 3.3"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,7 @@ DEPENDENCIES
   rails (~> 5.0, >= 5.0.1)
   rails-html-sanitizer
   redcarpet
+  redis (~> 3.3)
   responders
   rollbar
   ruby_px

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -11,7 +11,7 @@ module GobiertoPeople
       @person = PersonDecorator.new(find_person)
       @upcoming_events = @person.events.upcoming.sorted.first(3)
 
-      @latest_activity = ActivityCollectionDecorator.new(Activity.for_recipient(@person).limit(30))
+      @latest_activity = ActivityCollectionDecorator.new(Activity.for_recipient(@person).limit(30).sorted)
     end
 
     private

--- a/app/decorators/activity_decorator.rb
+++ b/app/decorators/activity_decorator.rb
@@ -21,8 +21,8 @@ class ActivityDecorator < BaseDecorator
     ["#{object_module}.activities.#{@object.action.tr('.', '_')}", { subject_name: subject_name }]
   end
 
-  def visible?
-    @object.subject.present? && @object.subject.respond_to?(:visible?) && @object.subject.visible?
+  def active?
+    @object.subject.present? && @object.subject.respond_to?(:active?) && @object.subject.active?
   end
 
   private

--- a/app/extensions/gobierto_common/trackable.rb
+++ b/app/extensions/gobierto_common/trackable.rb
@@ -50,7 +50,7 @@ module GobiertoCommon
         return true
       end
 
-      self.class.send(:changed_attributes_to_notify).each do |attribute_name|
+      (self.class.send(:changed_attributes_to_notify) & @changed).each do |attribute_name|
         publish_changed(attribute_name)
         return true
       end

--- a/app/extensions/gobierto_common/trackable.rb
+++ b/app/extensions/gobierto_common/trackable.rb
@@ -52,9 +52,10 @@ module GobiertoCommon
 
       self.class.send(:changed_attributes_to_notify).each do |attribute_name|
         publish_changed(attribute_name)
+        return true
       end
 
-      if (@changed - self.class.send(:changed_attributes_to_notify)).any?
+      if updated? && (@changed - self.class.send(:changed_attributes_to_notify)).any?
         publish_updated
       end
 

--- a/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
@@ -140,7 +140,7 @@ module GobiertoAdmin
       end
 
       def notify?
-        person_event.published?
+        person_event.active?
       end
 
       private

--- a/app/models/concerns/gobierto_common/searchable.rb
+++ b/app/models/concerns/gobierto_common/searchable.rb
@@ -10,7 +10,7 @@ module GobiertoCommon
       end
 
       def self.algoliasearch_gobierto(&block)
-        algoliasearch(enqueue: true, disable_indexing: Rails.env.test?, index_name: search_index_name, if: :visible?, sanitize: true, &block)
+        algoliasearch(enqueue: true, disable_indexing: Rails.env.test?, index_name: search_index_name, if: :active?, sanitize: true, &block)
       end
     end
 

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -28,9 +28,5 @@ module GobiertoPeople
     enum visibility_level: { draft: 0, active: 1 }
     enum category: { politician: 0, executive: 1 }
     enum party: { government: 0, opposition: 1 }
-
-    def visible?
-      active?
-    end
   end
 end

--- a/app/models/gobierto_people/person_event.rb
+++ b/app/models/gobierto_people/person_event.rb
@@ -51,7 +51,7 @@ module GobiertoPeople
       starts_at > Time.zone.now
     end
 
-    def visible?
+    def active?
       published?
     end
   end

--- a/app/models/gobierto_people/person_post.rb
+++ b/app/models/gobierto_people/person_post.rb
@@ -22,10 +22,6 @@ module GobiertoPeople
 
     enum visibility_level: { draft: 0, active: 1 }
 
-    def visible?
-      active?
-    end
-
     def parameterize
       { person_id: person, id: self }
     end

--- a/app/models/gobierto_people/person_statement.rb
+++ b/app/models/gobierto_people/person_statement.rb
@@ -22,10 +22,6 @@ module GobiertoPeople
     delegate :site_id, to: :person
     delegate :admin_id, to: :person
 
-    def visible?
-      active?
-    end
-
     def parameterize
       { person_id: person, id: self }
     end

--- a/app/pub_sub/subscribers/admin_activity.rb
+++ b/app/pub_sub/subscribers/admin_activity.rb
@@ -31,7 +31,6 @@ module Subscribers
                        subject_ip: event.payload[:ip],
                        action: action,
                        admin_activity: true
-
     end
   end
 end

--- a/app/pub_sub/subscribers/census_activity.rb
+++ b/app/pub_sub/subscribers/census_activity.rb
@@ -12,7 +12,6 @@ module Subscribers
                        subject_ip: event.payload[:ip],
                        action: action,
                        admin_activity: true
-
     end
   end
 end

--- a/app/pub_sub/subscribers/site_activity.rb
+++ b/app/pub_sub/subscribers/site_activity.rb
@@ -35,7 +35,6 @@ module Subscribers
                        subject_ip: event.payload[:ip],
                        action: action,
                        admin_activity: true
-
     end
   end
 end

--- a/app/views/gobierto_people/people/_latest_activity.html.erb
+++ b/app/views/gobierto_people/people/_latest_activity.html.erb
@@ -7,7 +7,7 @@
     <ul>
       <% @latest_activity.each do |activity| %>
         <li>
-          <%= link_to_if activity.visible?, t(*activity.i18n_key), activity.subject.to_url(domain: @site.domain) %>
+          <%= link_to_if activity.active?, t(*activity.i18n_key), activity.subject.to_url(domain: @site.domain) %>
           <span class="soft">
             <%= l(activity.created_at.to_date, format: :short) %>
           </span>

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  services:
+    - redis
   environment:
     CI: true
     HOST: gobierto.dev

--- a/config/initializers/redis_client.rb
+++ b/config/initializers/redis_client.rb
@@ -1,0 +1,4 @@
+$redis = Redis.new({
+  url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/0" },
+  namespace: APP_CONFIG["site"]["name"]
+})

--- a/test/services/gobierto_common/active_notifier/daily_test.rb
+++ b/test/services/gobierto_common/active_notifier/daily_test.rb
@@ -6,13 +6,9 @@ class GobiertoCommon::ActiveNotifier::DailyTest < ActiveSupport::TestCase
     @subject = GobiertoCommon::ActiveNotifier::Daily
   end
 
-  def test_call
-    assert @subject.call
-  end
-
   def test_notifications
     assert_difference "User::Notification.count", 1 do
-      @subject.call
+      assert @subject.call
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -98,6 +98,7 @@ class ActionDispatch::IntegrationTest
   DatabaseCleaner.clean_with :truncation
 
   def setup
+    $redis.flushdb
     DatabaseCleaner.start
     Capybara.current_driver = Capybara.default_driver
   end


### PR DESCRIPTION
Connects to #334

### What does this PR do?

This PR creates a debouncing limit to block event publication if the same event has been published in the previous 60 minutes.

It also:

- sorts events in the person event page
- refactors the visible method
- if published event has been ingested, blocks the updated event.

### How should this be manually tested?

1. Check that repeting an action multiple times doesn't publishes multiple events
2. Check that creating a public event, or post or person or statement produces a single event