### PR TITLE
Notifications hierarchy

### DIFF
--- a/app/models/user/subscription.rb
+++ b/app/models/user/subscription.rb
@@ -25,4 +25,29 @@ class User::Subscription < ApplicationRecord
   def subscribable
     generic? ? subscribable_type.constantize : super
   end
+
+  def self.find_users_for(subject_type, subject_id, site_id)
+    conditions = [{subscribable_type: subject_type, subscribable_id: subject_id, site_id: site_id}]
+
+    if subject_id.present?
+      conditions.push({subscribable_type: subject_type, subscribable_id: nil, site_id: site_id})
+    end
+
+    if subject_type.include?("::")
+      module_name = subject_type.split("::").first
+      conditions.push({subscribable_type: module_name, subscribable_id: nil, site_id: site_id})
+
+      main_class = subject_type.split("::").last
+      classes = main_class.underscore.split('_')
+      if classes.length > 1
+        conditions.push({subscribable_type: "#{module_name}::#{classes.first.classify}", site_id: site_id})
+      end
+    end
+
+    scoped = self.where(conditions.pop)
+    while conditions.any?
+      scoped = scoped.or(self.where(conditions.pop))
+    end
+    scoped.pluck(:user_id).uniq
+  end
 end

--- a/test/models/user/subscription_test.rb
+++ b/test/models/user/subscription_test.rb
@@ -5,6 +5,26 @@ class User::SubscriptionTest < ActiveSupport::TestCase
     @user_subscription ||= user_subscriptions(:dennis_consultation_madrid_open)
   end
 
+  def user
+    @user ||= users(:dennis)
+  end
+
+  def other_user
+    @other_user ||= users(:reed)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def person
+    @person ||= gobierto_people_people(:richard)
+  end
+
+  def person_event
+    @person_event ||= gobierto_people_person_events(:richard_published)
+  end
+
   def generic_user_subscription
     @generic_user_subscription ||= user_subscriptions(:dennis_consultations)
   end
@@ -28,5 +48,74 @@ class User::SubscriptionTest < ActiveSupport::TestCase
     assert user_subscription.subscribable.is_a?(GobiertoBudgetConsultations::Consultation)
 
     assert_equal GobiertoBudgetConsultations::Consultation, generic_user_subscription.subscribable
+  end
+
+  def test_find_subscriptions_when_subscribed_to_module
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople"
+    User::Subscription.create! user: other_user, site: site, subscribable_type: "GobiertoBudgetConsultations"
+
+    [
+      ["GobiertoPeople::PersonEvent", person_event.id],
+      ["GobiertoPeople::PersonEvent", nil],
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil]
+    ].each do |subject|
+      subject_type, subject_id = subject
+      assert_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), user.id
+      assert_not_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), other_user.id
+    end
+  end
+
+  def test_find_subscriptions_when_subscribed_to_class
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::Person"
+    User::Subscription.create! user: other_user, site: site, subscribable_type: "GobiertoPeople"
+
+    [
+      ["GobiertoPeople::PersonEvent", person_event.id],
+      ["GobiertoPeople::PersonEvent", nil],
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+    ].each do |subject|
+      subject_type, subject_id = subject
+      assert_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), user.id
+      assert_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), other_user.id
+    end
+  end
+
+  def test_find_subscriptions_when_subscribed_to_class_instance
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::Person", subscribable_id: person.id
+
+    [
+      ["GobiertoPeople::PersonEvent", person_event.id],
+      ["GobiertoPeople::PersonEvent", nil],
+      ["GobiertoPeople::Person", person.id],
+    ].each do |subject|
+      subject_type, subject_id = subject
+      assert_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), user.id
+    end
+  end
+
+  def test_find_subscriptions_when_subscribed_to_subclass
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::PersonEvent"
+
+    [
+      ["GobiertoPeople::PersonEvent", person_event.id],
+      ["GobiertoPeople::PersonEvent", nil],
+    ].each do |subject|
+      subject_type, subject_id = subject
+      assert_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), user.id
+    end
+  end
+
+  def test_find_subscriptions_when_subscribed_to_subclass_instance
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::PersonEvent", subscribable_id: person_event.id
+
+    [
+      ["GobiertoPeople::PersonEvent", person_event.id],
+    ].each do |subject|
+      subject_type, subject_id = subject
+      assert_includes User::Subscription.find_users_for(subject_type, subject_id, site.id), user.id
+    end
   end
 end

--- a/test/services/gobierto_common/active_notifier/daily_test.rb
+++ b/test/services/gobierto_common/active_notifier/daily_test.rb
@@ -7,7 +7,7 @@ class GobiertoCommon::ActiveNotifier::DailyTest < ActiveSupport::TestCase
   end
 
   def test_notifications
-    assert_difference "User::Notification.count", 1 do
+    assert_difference "User::Notification.count", 2 do
       assert @subject.call
     end
   end


### PR DESCRIPTION
Connects to #348

### What does this PR do?

Given the following module and classes hierarchy:

- GobiertoPeople::PersonEvent#748131510 (person event)
- GobiertoPeople::PersonEvent from a person **not supported**
- GobiertoPeople::PersonEvent
- GobiertoPeople::Person#933465536 (richard)
- GobiertoPeople::Person
- GobiertoPeople

A subscription from an item in the list includes the subscriptions to the elements above. Example: if I'm subscribed to a person I receive alerts for person events, person posts and person statements.

### How should this be manually tested?

Reproduce this behaviour.