### PR TITLE
Add Redis to docker compose test environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,13 @@ test:
     - ELASTICSEARCH_URL=http://elasticsearch:9200
     - BUNDLE_PATH=/bundle
     - PYTHONUNBUFFERED=1
+    - REDIS_URL=redis://redis:6379
   volumes_from:
     - web
   links:
     - postgres
     - elasticsearch
+    - redis
 
 sidekiq:
   image: gobierto_web


### PR DESCRIPTION
Connects to #363

### What does this PR do?

This PR adds Redis to the Docker compose test environment. We totally forgot to add it as a dependency.

### How should this be manually tested?

Run the tests using Docker, and you shouldn't see the connection error.