### PR TITLE
Update deprecated methods, remove duplicated method, fix typos

### DIFF
--- a/app/forms/gobierto_admin/gobierto_people/person_post_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_post_form.rb
@@ -58,10 +58,6 @@ module GobiertoAdmin
         @person ||= person_class.find_by(id: person_id)
       end
 
-      def site_id
-        @site_id ||= person.site_id
-      end
-
       def visibility_level
         @visibility_level ||= "draft"
       end

--- a/app/services/gobierto_common/gobierto_seeder/module_seeder.rb
+++ b/app/services/gobierto_common/gobierto_seeder/module_seeder.rb
@@ -4,7 +4,7 @@ module GobiertoCommon
       def self.seed(module_name, site)
         module_path = module_name.underscore
         module_seeds_path = Rails.root.join("db/seeds/modules/#{module_path}")
-        return unless Dir.exists?(module_seeds_path)
+        return unless Dir.exist?(module_seeds_path)
 
         return unless site.configuration.modules.include?(module_name)
 

--- a/app/services/gobierto_common/gobierto_seeder/module_site_seeder.rb
+++ b/app/services/gobierto_common/gobierto_seeder/module_site_seeder.rb
@@ -4,10 +4,10 @@ module GobiertoCommon
       def self.seed(gobierto_site, module_name, site)
         module_path = module_name.underscore
         site_seeds_path = Rails.root.join("db/seeds/sites/#{gobierto_site}")
-        return unless Dir.exists?(site_seeds_path)
+        return unless Dir.exist?(site_seeds_path)
 
         site_module_seeds_path = Rails.root.join("db/seeds/sites/#{gobierto_site}/#{module_path}")
-        return unless Dir.exists?(site_module_seeds_path)
+        return unless Dir.exist?(site_module_seeds_path)
 
         return unless site.configuration.modules.include?(module_name)
 

--- a/docs/developing-module.md
+++ b/docs/developing-module.md
@@ -63,7 +63,7 @@ module GobiertoPeople
 ...
 ```
 
-In case your model implements a relationship with other model outside the module, you shouldn't include the module name in the name of the relationship for readibility reasons, unless there is a name conflict.
+In case your model implements a relationship with other model outside the module, you shouldn't include the module name in the name of the relationship for readability reasons, unless there is a name conflict.
 
 Example:
 
@@ -216,7 +216,7 @@ end
 
 ## Seeds
 
-Sometimes module need some database data to exist. For example, a configuratio entry, a list of `DynamicContentBlocks` preconfigured. For that reason, we have created a seeds structure and two seeds runner classes:
+Sometimes modules need some database data to exist. For example, a configuration entry, a list of `DynamicContentBlocks` preconfigured. For that reason, we have created a seeds structure and two seeds runner classes:
 
 - `ModuleSeeder`: seeds a module
 - `ModuleSiteSeeder`: seeds a module for a specific Gobierto installation. It uses the attribute `site.name` from `config/application.yml`
@@ -236,4 +236,3 @@ module GobiertoSeeds
   end
 end
 ```
-

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -88,4 +88,4 @@ To use `MailCatcher`, make sure the `mailcatcher` container is up and running:
 $ docker-compose up -d mailcatcher
 ```
 
-Having do this, the server should be available at `http://<your_docker_host>:1080`.
+Having done this, the server should be available at `http://<your_docker_host>:1080`.

--- a/lib/file_uploader/local.rb
+++ b/lib/file_uploader/local.rb
@@ -10,7 +10,7 @@ module FileUploader
     end
 
     def call
-      FileUtils.mkdir_p(file_base_path) unless File.exists?(file_base_path)
+      FileUtils.mkdir_p(file_base_path) unless File.exist?(file_base_path)
       FileUtils.mv(file.tempfile.path, file_path)
       ObjectSpace.undefine_finalizer(file.tempfile)
 


### PR DESCRIPTION
### What does this PR do?

* Replaces `File::exists?` and `Dir::exists?` deprecated methods in favor of `File::exist?` and `Dir::exist?`
  * https://ruby-doc.org/core-2.3.1/File.html#method-c-exists-3F
  * https://ruby-doc.org/core-2.3.1/Dir.html#method-c-exists-3F
* Removes the duplicated `site_id` method from `person_post_form.rb`
* Corrects a couple of typos in the documentation
