### PR TITLE
Fix input form display on Firefox

### DIFF
--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -234,7 +234,7 @@ option, select {
     font-weight: 700;
   }
   input, textarea {
-    padding: 2.75rem 1rem 1.35rem .95rem;
+    padding: 1.75rem 1rem 0.5rem .95rem;
     width: 100%;
     outline: none;
   }


### PR DESCRIPTION
Connects to #369.

### What does this PR do?
This PR changes the padding in the input forms to fix their display in Firefox. 

### Before
![](https://cloud.githubusercontent.com/assets/1236790/23121725/cac1456a-f761-11e6-85fb-5c4c70ce2a40.png)

### After
![screen shot 2017-02-21 at 16 35 28](https://cloud.githubusercontent.com/assets/1236790/23171777/c9ba2cac-f853-11e6-8b97-9aafa8399d48.png)
