### PR TITLE
[WIP] Refactor suggestions for BudgetLine, FunctionalArea and EconomicArea

### DIFF
--- a/app/controllers/gobierto_budgets/api/categories_controller.rb
+++ b/app/controllers/gobierto_budgets/api/categories_controller.rb
@@ -5,7 +5,7 @@ module GobiertoBudgets
 
       def index
         kind = params[:kind]
-        area = area_klass_for(params[:area])
+        area = GobiertoBudgets::BudgetLine.budget_area_klass_for params[:area]
 
         if !valid_area_filter(params[:area]) || ( area && !area.valid_kinds.include?(kind) )
           render_404 and return
@@ -31,13 +31,6 @@ module GobiertoBudgets
       end
 
       private
-
-        def area_klass_for(area_name)
-          GobiertoBudgets::BudgetLine.budget_areas.each do |area|
-            return area if area.area_name == area_name
-          end
-          nil
-        end
 
         def valid_area_filter(area_name)
           are_name.nil? || area_klass_for(area_name)

--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -159,7 +159,7 @@ module GobiertoBudgets
                 bool: {
                   must: [
                     {term: { year: year }},
-                    {term: { kind: GobiertoBudgets::BudgetLine::EXPENSE }}
+                    {term: { kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense] }}
                   ]
                 }
               }
@@ -169,7 +169,7 @@ module GobiertoBudgets
           _source: false
         }
 
-        id = "#{params[:ine_code]}/#{year}/#{GobiertoBudgets::BudgetLine::EXPENSE}"
+        id = "#{params[:ine_code]}/#{year}/#{GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]}"
 
         if ranking
           response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_forecast, type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, body: query
@@ -195,7 +195,7 @@ module GobiertoBudgets
       end
 
       def total_budget_data_executed(year, field)
-        id = "#{params[:ine_code]}/#{year}/#{GobiertoBudgets::BudgetLine::EXPENSE}"
+        id = "#{params[:ine_code]}/#{year}/#{GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]}"
 
         begin
           value = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_executed, type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: id
@@ -217,7 +217,7 @@ module GobiertoBudgets
       def deviation_message(kind, up_or_down, percentage, diff)
         percentage = percentage.to_s.gsub('-', '')
         diff = format_currency(diff, true)
-        final_message = if (kind == GobiertoBudgets::BudgetLine::INCOME)
+        final_message = if (kind == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income])
           up_or_down == "sign-up" ? I18n.t("controllers.gobierto_budgets.api.data.income_up", percentage: percentage, diff: diff) : I18n.t("controllers.gobierto_budgets.api.data.income_down", percentage: percentage, diff: diff)
         else
           up_or_down == "sign-up" ? I18n.t("controllers.gobierto_budgets.api.data.expense_up", percentage: percentage, diff: diff) : I18n.t("controllers.gobierto_budgets.api.data.expense_down", percentage: percentage, diff: diff)

--- a/app/controllers/gobierto_budgets/budget_line_descendants_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_line_descendants_controller.rb
@@ -24,8 +24,8 @@ class GobiertoBudgets::BudgetLineDescendantsController < GobiertoBudgets::Applic
     render_404 and return if @place.nil?
 
     @year = params[:year]
-    @kind = params[:kind] || GobiertoBudgets::BudgetLine::EXPENSE
-    @area_name = params[:area_name] || GobiertoBudgets::BudgetLine::FUNCTIONAL
+    @kind = params[:kind] || GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]
+    @area_name = params[:area_name] || GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name
     @parent_code = params[:parent_code]
   end
 

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -17,12 +17,8 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
       @parent_budget_line = GobiertoBudgets::BudgetLine.where(code: @budget_line.parent_code, place: @place, year: @year, kind: @kind, area_name: @area_name).first
     end
     @budget_line_stats = GobiertoBudgets::BudgetLineStats.new site: @site, budget_line: @budget_line
-    @budget_line_descendants = GobiertoBudgets::BudgetLine.where(place: @place, parent_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-    @budget_line_composition = if @area_name == GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name
-                                 GobiertoBudgets::BudgetLine.where(place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-                               else
-                                 GobiertoBudgets::BudgetLine.where(place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-                               end
+    @budget_line_descendants = GobiertoBudgets::BudgetLine.where(place: @place, parent_code:     @code, year: @year, kind: @kind, area_name: @area_name).all
+    @budget_line_composition = GobiertoBudgets::BudgetLine.where(place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
 
     respond_to do |format|
       format.html

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -18,7 +18,7 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     end
     @budget_line_stats = GobiertoBudgets::BudgetLineStats.new site: @site, budget_line: @budget_line
     @budget_line_descendants = GobiertoBudgets::BudgetLine.where(place: @place, parent_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-    @budget_line_composition = if @area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL
+    @budget_line_composition = if @area_name == GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name
                                  GobiertoBudgets::BudgetLine.where(place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
                                else
                                  GobiertoBudgets::BudgetLine.where(place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
@@ -47,8 +47,8 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     render_404 and return if @place.nil?
 
     @year = params[:year].to_i
-    @kind = params[:kind] || GobiertoBudgets::BudgetLine::EXPENSE
-    @area_name = params[:area_name] || GobiertoBudgets::BudgetLine::FUNCTIONAL
+    @kind = params[:kind] || GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]
+    @area_name = params[:area_name] || GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name
     @level = params[:level].present? ? params[:level].to_i : 1
     @code = params[:id]
   end

--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -2,16 +2,16 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
   before_action :load_place, :load_year
 
   def index
-    @kind = GobiertoBudgets::BudgetLine::INCOME
-    @area_name = GobiertoBudgets::BudgetLine::ECONOMIC
-    @interesting_area = GobiertoBudgets::BudgetLine::FUNCTIONAL
+    @kind = GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]
+    @area_name = GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name
+    @interesting_area = GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name
 
     @site_stats = GobiertoBudgets::SiteStats.new site: @site, year: @year
 
-    @top_income_budget_lines = GobiertoBudgets::TopBudgetLine.limit(5).where(year: @year, place: @site.place, kind: GobiertoBudgets::BudgetLine::INCOME).all
-    @top_expense_budget_lines = GobiertoBudgets::TopBudgetLine.limit(5).where(year: @year, place: @site.place, kind: GobiertoBudgets::BudgetLine::EXPENSE).all
+    @top_income_budget_lines = GobiertoBudgets::TopBudgetLine.limit(5).where(year: @year, place: @site.place, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]).all
+    @top_expense_budget_lines = GobiertoBudgets::TopBudgetLine.limit(5).where(year: @year, place: @site.place, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]).all
     @place_budget_lines = GobiertoBudgets::BudgetLine.where(place: @place, level: 1, year: @year, kind: @kind, area_name: @area_name).all
-    @interesting_expenses = GobiertoBudgets::BudgetLine.where(place: @place, level: 2, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: @interesting_area).all
+    @interesting_expenses = GobiertoBudgets::BudgetLine.where(place: @place, level: 2, year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: @interesting_area).all
 
     @sample_budget_lines = (@top_income_budget_lines + @top_expense_budget_lines).sample(3)
   end

--- a/app/controllers/gobierto_budgets/budgets_execution_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_execution_controller.rb
@@ -2,15 +2,15 @@ class GobiertoBudgets::BudgetsExecutionController < GobiertoBudgets::Application
   before_action :load_place, :load_year
 
   def index
-    @top_possitive_difference_income, @top_negative_difference_income = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, type: 'economic')
+    @top_possitive_difference_income, @top_negative_difference_income = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], type: 'economic')
 
     if @top_possitive_difference_income.empty?
       flash[:alert] = t('controllers.gobierto_budgets.budgets_execution.index.alert', year: @year)
       redirect_to gobierto_budgets_budgets_execution_path(@year -1) and return
     end
 
-    @top_possitive_difference_expending_economic, @top_negative_difference_expending_economic = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, type: 'economic')
-    @top_possitive_difference_expending_functional, @top_negative_difference_expending_functional = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, type: 'functional')
+    @top_possitive_difference_expending_economic, @top_negative_difference_expending_economic = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], type: 'economic')
+    @top_possitive_difference_expending_functional, @top_negative_difference_expending_functional = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], type: 'functional')
   end
 
   private

--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -5,7 +5,7 @@ module GobiertoBudgets
       @year = params[:year].to_i
       @area_name = 'functional'
 
-      @kind = GobiertoBudgets::BudgetLine::EXPENSE
+      @kind = GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]
       results = GobiertoBudgets::BudgetLine.search({
           kind: @kind, year: @year, ine_code: @place.id,
           type: @area_name, range_hash: {

--- a/app/controllers/gobierto_budgets/search_controller.rb
+++ b/app/controllers/gobierto_budgets/search_controller.rb
@@ -7,9 +7,9 @@ module GobiertoBudgets
 
       query = params[:query].downcase
       suggestions = []
-      [GobiertoBudgets::BudgetLine::ECONOMIC, GobiertoBudgets::BudgetLine::FUNCTIONAL].each do |area|
-        [GobiertoBudgets::BudgetLine::EXPENSE, GobiertoBudgets::BudgetLine::INCOME].each do |kind|
-          next if area == GobiertoBudgets::BudgetLine::FUNCTIONAL and kind == GobiertoBudgets::BudgetLine::INCOME
+      [GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name].each do |area|
+        [GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]].each do |kind|
+          next if area == GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name and kind == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]
 
           this_year_codes = get_year_codes(place, area, kind, year)
           klass_name = area == 'economic' ? GobiertoBudgets::EconomicArea : GobiertoBudgets::FunctionalArea

--- a/app/helpers/gobierto_budgets/application_helper.rb
+++ b/app/helpers/gobierto_budgets/application_helper.rb
@@ -66,7 +66,7 @@ module GobiertoBudgets
     end
 
     def kind_literal(kind, plural = true)
-      if kind == GobiertoBudgets::BudgetLine::INCOME
+      if kind == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]
         plural ? I18n.t('gobierto_budgets.common.incomes') : I18n.t('gobierto_budgets.common.income')
       else
         plural ? I18n.t('gobierto_budgets.common.expenses') : I18n.t('gobierto_budgets.common.expense')

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -3,10 +3,15 @@ module GobiertoBudgets
     class RecordNotFound < StandardError; end
     class InvalidSearchConditions < StandardError; end
 
-    INCOME = 'I'
-    EXPENSE = 'G'
-    ECONOMIC = 'economic'
-    FUNCTIONAL = 'functional'
+    BUDGET_KINDS = {
+      income:  'I',
+      expense: 'G'
+    }
+
+    BUDGET_AREAS = {
+      functional: GobiertoBudgets::FunctionalArea,
+      economic:   GobiertoBudgets::EconomicArea
+    }
 
     @sort_attribute ||= 'code'
     @sort_order ||= 'asc'
@@ -273,7 +278,6 @@ module GobiertoBudgets
       GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: options[:area_name], body: query
     end
 
-
     def self.find(options)
       return self.search(options)['hits'].detect{|h| h['code'] == options[:code] }
     end
@@ -353,6 +357,22 @@ module GobiertoBudgets
       end
 
       return results.sort{ |b, a| a[1][2] <=> b[1][2] }[0..15], results.sort{ |a, b| a[1][2] <=> b[1][2] }[0..15]
+    end
+
+    def self.budget_areas
+      BUDGET_AREAS.values
+    end
+
+    def self.budget_areas_names
+      budget_areas.map { |area| area.area_name }
+    end
+
+    def self.budget_kinds
+      BUDGET_KINDS.keys
+    end
+
+    def self.budget_kinds_names
+      BUDGET_KINDS.values
     end
 
     def to_param

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -367,12 +367,20 @@ module GobiertoBudgets
       budget_areas.map { |area| area.area_name }
     end
 
+    def self.budget_area_klass_for(area_name)
+      BUDGET_AREAS[area_name.to_sym]
+    end
+
     def self.budget_kinds
       BUDGET_KINDS.keys
     end
 
     def self.budget_kinds_names
       BUDGET_KINDS.values
+    end
+
+    def self.budget_kind_for(budget_kind_name)
+      BUDGET_KINDS[budget_kind_name.to_sym]
     end
 
     def to_param

--- a/app/models/gobierto_budgets/budget_total.rb
+++ b/app/models/gobierto_budgets/budget_total.rb
@@ -7,15 +7,15 @@ module GobiertoBudgets
     BUDGETED = 'B'
     EXECUTED = 'E'
 
-    def self.budgeted_for(ine_code, year, kind = BudgetLine::EXPENSE)
+    def self.budgeted_for(ine_code, year, kind = BudgetLine::BUDGET_KINDS[:expense])
       return BudgetTotal.for(ine_code, year, BudgetTotal::BUDGETED, kind)
     end
 
-    def self.execution_for(ine_code, year, kind = BudgetLine::EXPENSE)
+    def self.execution_for(ine_code, year, kind = BudgetLine::BUDGET_KINDS[:expense])
       return BudgetTotal.for(ine_code, year, BudgetTotal::EXECUTED, kind)
     end
 
-    def self.for(ine_code, year, b_or_e = BudgetTotal::BUDGETED, kind = BudgetLine::EXPENSE)
+    def self.for(ine_code, year, b_or_e = BudgetTotal::BUDGETED, kind = BudgetLine::BUDGET_KINDS[:expense])
       return for_places(ine_code, year) if ine_code.is_a?(Array)
       index = (b_or_e == BudgetTotal::EXECUTED) ? SearchEngineConfiguration::TotalBudget.index_executed : SearchEngineConfiguration::TotalBudget.index_forecast
 
@@ -23,7 +23,7 @@ module GobiertoBudgets
       result['_source']['total_budget'].to_f
     end
 
-    def self.budget_evolution_for(ine_code, b_or_e = BudgetTotal::BUDGETED, kind = BudgetLine::EXPENSE)
+    def self.budget_evolution_for(ine_code, b_or_e = BudgetTotal::BUDGETED, kind = BudgetLine::BUDGET_KINDS[:expense])
       query = {
         sort: [
           { year: { order: 'asc' } }

--- a/app/models/gobierto_budgets/economic_area.rb
+++ b/app/models/gobierto_budgets/economic_area.rb
@@ -27,7 +27,7 @@ module GobiertoBudgets
 
         response['hits']['hits'].each do |h|
           source = h['_source']
-          source['kind'] = GobiertoBudgets::BudgetLine::BUDGET_KINDS[source['kind'].to_sym]
+          source['kind'] = GobiertoBudgets::BudgetLine.budget_kind_for source['kind']
           all_items[source['kind']][source['code']] = source['name']
         end
 

--- a/app/models/gobierto_budgets/economic_area.rb
+++ b/app/models/gobierto_budgets/economic_area.rb
@@ -5,8 +5,8 @@ module GobiertoBudgets
     def self.all_items
       @all_items ||= begin
         all_items = {
-          EXPENSE => {},
-          INCOME => {}
+          GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense] => {},
+          GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income] => {}
         }
 
         query = {

--- a/app/models/gobierto_budgets/economic_area.rb
+++ b/app/models/gobierto_budgets/economic_area.rb
@@ -2,9 +2,6 @@ module GobiertoBudgets
   class EconomicArea
     include Describable
 
-    EXPENSE = 'G'
-    INCOME  = 'I'
-
     def self.all_items
       @all_items ||= begin
         all_items = {
@@ -30,12 +27,21 @@ module GobiertoBudgets
 
         response['hits']['hits'].each do |h|
           source = h['_source']
-          source['kind'] = source['kind'] == 'income' ? 'I' : 'G'
+          source['kind'] = GobiertoBudgets::BudgetLine::BUDGET_KINDS[source['kind'].to_sym]
           all_items[source['kind']][source['code']] = source['name']
         end
 
         all_items
       end
     end
+
+    def self.area_name
+      'economic'
+    end
+
+    def self.valid_kinds
+      [GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]]
+    end
+
   end
 end

--- a/app/models/gobierto_budgets/functional_area.rb
+++ b/app/models/gobierto_budgets/functional_area.rb
@@ -26,7 +26,7 @@ module GobiertoBudgets
 
         response['hits']['hits'].each do |h|
           source = h['_source']
-          source['kind'] = GobiertoBudgets::BudgetLine::BUDGET_KINDS[source['kind'].to_sym]
+          source['kind'] = GobiertoBudgets::BudgetLine.budget_kind_for source['kind']
           all_items[source['kind']][source['code']] = source['name']
         end
 

--- a/app/models/gobierto_budgets/functional_area.rb
+++ b/app/models/gobierto_budgets/functional_area.rb
@@ -2,8 +2,6 @@ module GobiertoBudgets
   class FunctionalArea
     include Describable
 
-    EXPENSE = 'G'
-
     def self.all_items
       @all_items ||= begin
         all_items = {
@@ -28,12 +26,21 @@ module GobiertoBudgets
 
         response['hits']['hits'].each do |h|
           source = h['_source']
-          source['kind'] = source['kind'] == 'income' ? 'I' : 'G'
+          source['kind'] = GobiertoBudgets::BudgetLine::BUDGET_KINDS[source['kind'].to_sym]
           all_items[source['kind']][source['code']] = source['name']
         end
 
         all_items
       end
     end
+
+    def self.area_name
+      'functional'
+    end
+
+    def self.valid_kinds
+      [GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]]
+    end
+
   end
 end

--- a/app/models/gobierto_budgets/functional_area.rb
+++ b/app/models/gobierto_budgets/functional_area.rb
@@ -5,7 +5,7 @@ module GobiertoBudgets
     def self.all_items
       @all_items ||= begin
         all_items = {
-          EXPENSE => {}
+          GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense] => {}
         }
 
         query = {

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -99,21 +99,21 @@ module GobiertoBudgets
 
     def total_budget_planned_query(year)
       GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_forecast,
-        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, GobiertoBudgets::BudgetLine::EXPENSE].join('/')
+        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]].join('/')
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
     end
 
     def total_budget_executed_query(year)
       GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_executed,
-        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, GobiertoBudgets::BudgetLine::EXPENSE].join('/')
+        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]].join('/')
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
     end
 
     def total_budget_planned_income_query(year)
       GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_forecast,
-        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, GobiertoBudgets::BudgetLine::INCOME].join('/')
+        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]].join('/')
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
     end

--- a/app/models/gobierto_budgets/top_budget_line.rb
+++ b/app/models/gobierto_budgets/top_budget_line.rb
@@ -34,11 +34,11 @@ module GobiertoBudgets
         size: @limit
       }
 
-      if @conditions[:kind] == GobiertoBudgets::BudgetLine::INCOME
-        type = GobiertoBudgets::BudgetLine::ECONOMIC
+      if @conditions[:kind] == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]
+        type = GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name
         area = GobiertoBudgets::EconomicArea
       else
-        type = GobiertoBudgets::BudgetLine::FUNCTIONAL
+        type = GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name
         area = GobiertoBudgets::FunctionalArea
       end
 

--- a/app/views/gobierto_budget_consultations/layouts/_menu_subsections.html.erb
+++ b/app/views/gobierto_budget_consultations/layouts/_menu_subsections.html.erb
@@ -3,7 +3,7 @@
     <ul>
       <% if @site.configuration.gobierto_budgets_enabled? %>
         <li><%= link_to t('gobierto_budgets.layouts.menu_subsections.summary'), gobierto_budgets_budgets_path, class: class_if('active', controller_name == 'budgets') %></li>
-        <li><%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1), class: class_if('active', controller_name == 'budget_lines') %></li>
+        <li><%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, level: 1), class: class_if('active', controller_name == 'budget_lines') %></li>
         <li><%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), class: class_if('active', controller_name == 'budgets_execution')  %></li>
       <% end %>
 

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -4,11 +4,11 @@
 
   <div class="tabs m_v_2">
     <ul>
-      <li class="<%= class_if('active', @kind == GobiertoBudgets::BudgetLine::INCOME) %>">
-        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true } %>
+      <li class="<%= class_if('active', @kind == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income]) %>">
+        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], remote: true } %>
       </li>
-      <li class="<%= class_if('active', @kind == GobiertoBudgets::BudgetLine::EXPENSE) %>">
-        <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::EXPENSE, remote: true } %>
+      <li class="<%= class_if('active', @kind == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense]) %>">
+        <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], remote: true } %>
       </li>
     </ul>
   </div>

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -1,9 +1,9 @@
 <p class="m_2"></p>
 
 <div class="filter m_2">
-  <% if kind == GobiertoBudgets::BudgetLine::EXPENSE %>
-    <%= link_to t('.expense_in_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: {remote: true}, class: class_if('active', area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL) %>
-    <%= link_to t('.expense_to_do_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: {remote: true}, class: class_if('active', area_name == GobiertoBudgets::BudgetLine::ECONOMIC) %>
+  <% if kind == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense] %>
+    <%= link_to t('.expense_in_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name), data: {remote: true}, class: class_if('active', area_name == GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name) %>
+    <%= link_to t('.expense_to_do_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name), data: {remote: true}, class: class_if('active', area_name == GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name) %>
   <% else %>
     <%= link_to t('.income_from_what'), '', class:'active' %>
   <% end %>

--- a/app/views/gobierto_budgets/budget_lines/index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :breadcrumb_current_item do %>
   <strong>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1) %>
+    <%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, level: 1) %>
   </strong>
 <% end %>
 

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -52,7 +52,7 @@
     <header data-share>
       <h1><%= title @budget_line.name %></h1>
 
-      <div class="social_links_container" data-share-text="<%= t(@area_name == GobiertoBudgets::BudgetLine::EXPENSE ? '.twitter_text_expense' : '.twitter_text_income', name: @site.place.name, budget_line_name: @budget_line.name, year: @year) %>">
+      <div class="social_links_container" data-share-text="<%= t(@area_name == GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense] ? '.twitter_text_expense' : '.twitter_text_income', name: @site.place.name, budget_line_name: @budget_line.name, year: @year) %>">
         <a href="#" class="social_share twitter" data-share-network="twitter" data-track-event="Social Share|Click Twitter|XXX"><i class="fa fa-twitter"></i></a>
         <a href="#" class="social_share facebook" data-share-network="facebook" data-track-event="Social Share|Click Facebook|XXX"><i class="fa fa-facebook"></i></a>
         <% pending do %>
@@ -144,7 +144,7 @@
 
         <% end %>
 
-        <% if @kind != GobiertoBudgets::BudgetLine::INCOME %>
+        <% if @kind != GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income] %>
           <h2><%= t('.budget_lines_distribution') %></h2>
           <% if @budget_line_composition.any? %>
             <table>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -125,7 +125,7 @@
         </table>
 
         <div class="small center m_v_2">
-          <%= link_to t('.see_all'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1) %>
+          <%= link_to t('.see_all'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, level: 1) %>
         </div>
       </div>
 
@@ -144,7 +144,7 @@
         </table>
 
         <div class="small center m_v_2">
-          <%= link_to t('.see_all'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL, level: 1) %>
+          <%= link_to t('.see_all'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:functional].area_name, level: 1) %>
         </div>
       </div>
 
@@ -159,15 +159,15 @@
     <p class="description"><%= t('.most_interesting_budget_lines_description') %></p>
 
     <div class="graph" id="expense-treemap"
-                       data-functional-url="<%= gobierto_budgets_budget_lines_treemap_path(@year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: 'functional', level: 2, format: :json) %>"
-                       data-economic-url="<%= gobierto_budgets_budget_lines_treemap_path(@year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: 'economic', level: 2, format: :json) %>">
+                       data-functional-url="<%= gobierto_budgets_budget_lines_treemap_path(@year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: 'functional', level: 2, format: :json) %>"
+                       data-economic-url="<%= gobierto_budgets_budget_lines_treemap_path(@year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area_name: 'economic', level: 2, format: :json) %>">
     </div>
 
     <table class="explore_slow">
       <% @interesting_expenses.group_by(&:parent_code).each do |parent_code, bls| %>
         <tr class="group">
           <td class="level_1" rowspan="<%= bls.count %>">
-            <%= budget_line_denomination @interesting_area, parent_code, GobiertoBudgets::BudgetLine::EXPENSE %>
+            <%= budget_line_denomination @interesting_area, parent_code, GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense] %>
           </td>
           <%= render partial: "gobierto_budgets/budgets/sub_budget_line",
                 locals: {sub_budget_line: bls.first } %>

--- a/app/views/gobierto_budgets/budgets_execution/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_execution/index.html.erb
@@ -24,7 +24,7 @@
 				<div class="deviation_widget"
 					data-widget-template="#widget-template-deviation"
 	    		data-widget-type="budget_execution_deviation"
-	    		data-widget-data-url="<%= gobierto_budgets_api_data_budget_execution_deviation_path(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, format: :json) %>"
+	    		data-widget-data-url="<%= gobierto_budgets_api_data_budget_execution_deviation_path(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], format: :json) %>"
 	    		data-callback="render_evo_line">
 				</div>
 			</div>
@@ -33,7 +33,7 @@
 				<div class="deviation_widget"
 					data-widget-template="#widget-template-deviation"
 	    		data-widget-type="budget_execution_deviation"
-	    		data-widget-data-url="<%= gobierto_budgets_api_data_budget_execution_deviation_path(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, format: :json) %>"
+	    		data-widget-data-url="<%= gobierto_budgets_api_data_budget_execution_deviation_path(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], format: :json) %>"
 	    		data-callback="render_evo_line">
 				</div>
 			</div>
@@ -53,13 +53,13 @@
 
         <h2 class="lite"><%= t('.budget_lines_income_higher') %></h2>
 
-				<%= render partial: 'execution_table', locals: {data: @top_possitive_difference_income, kind: GobiertoBudgets::BudgetLine::INCOME, area: 'economic'} %>
+				<%= render partial: 'execution_table', locals: {data: @top_possitive_difference_income, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area: 'economic'} %>
 
 				<div class="separator"></div>
 
         <h2 class="lite"><%= t('.budget_lines_income_lower') %></h2>
 
-				<%= render partial: 'execution_table', locals: {data: @top_negative_difference_income, kind: GobiertoBudgets::BudgetLine::INCOME, area: 'economic'} %>
+				<%= render partial: 'execution_table', locals: {data: @top_negative_difference_income, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area: 'economic'} %>
 
 			</div>
 			<div class="pure-u-1 pure-u-lg-2-24"></div>
@@ -76,25 +76,25 @@
 
 				<div class="tab_content" data-tab="economic" style="display: none">
 
-					<%= render partial: 'execution_table', locals: {data: @top_possitive_difference_expending_economic, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: 'economic'} %>
+					<%= render partial: 'execution_table', locals: {data: @top_possitive_difference_expending_economic, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area: 'economic'} %>
 
 					<div class="separator"></div>
 
           <h2 class="lite"><%= t('.budget_lines_expense_lower') %></h2>
 
-					<%= render partial: 'execution_table', locals: {data: @top_negative_difference_expending_economic, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: 'economic'} %>
+					<%= render partial: 'execution_table', locals: {data: @top_negative_difference_expending_economic, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area: 'economic'} %>
 
 				</div>
 
 				<div class="tab_content" data-tab="functional">
 
-					<%= render partial: 'execution_table', locals: {data: @top_possitive_difference_expending_functional, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: 'functional'} %>
+					<%= render partial: 'execution_table', locals: {data: @top_possitive_difference_expending_functional, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area: 'functional'} %>
 
 					<div class="separator"></div>
 
           <h2 class="lite"><%= t('.budget_lines_expense_lower') %></h2>
 
-					<%= render partial: 'execution_table', locals: {data: @top_negative_difference_expending_functional, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: 'functional'} %>
+					<%= render partial: 'execution_table', locals: {data: @top_negative_difference_expending_functional, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense], area: 'functional'} %>
 				</div>
 
 			</div>

--- a/app/views/gobierto_budgets/layouts/_menu_subsections.html.erb
+++ b/app/views/gobierto_budgets/layouts/_menu_subsections.html.erb
@@ -2,7 +2,7 @@
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
     <ul>
       <li><%= link_to t('.summary'), gobierto_budgets_budgets_path, class: class_if('active', controller_name == 'budgets') %></li>
-      <li><%= link_to t('.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1), class: class_if('active', controller_name == 'budget_lines') %></li>
+      <li><%= link_to t('.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, level: 1), class: class_if('active', controller_name == 'budget_lines') %></li>
       <li><%= link_to t('.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), class: class_if('active', controller_name == 'budgets_execution')  %></li>
 
       <% if @site.configuration.gobierto_budget_consultations_enabled? %>

--- a/app/views/gobierto_budgets/layouts/_navigation.html.erb
+++ b/app/views/gobierto_budgets/layouts/_navigation.html.erb
@@ -1,7 +1,7 @@
 <div class="pure-u-1 pure-u-md-1-4 section">
   <h2><%= link_to t("gobierto_budgets.layouts.application.budgets"), gobierto_budgets_budgets_path, data: { turbolinks: false } %></h2>
 
-  <%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1), data: { turbolinks: false } %>
+  <%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, level: 1), data: { turbolinks: false } %>
   <%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), data: { turbolinks: false } %>
 
   <% if @site.configuration.gobierto_budget_consultations_enabled? %>

--- a/app/views/sandbox/layouts/_menu_subsections.html.erb
+++ b/app/views/sandbox/layouts/_menu_subsections.html.erb
@@ -2,7 +2,7 @@
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable" >
     <ul>
       <li><%= link_to t('.summary'), gobierto_budgets_budgets_path, class: class_if('active', controller_name == 'budgets') %></li>
-      <li><%= link_to t('.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1), class: class_if('active', controller_name == 'budget_lines') %></li>
+      <li><%= link_to t('.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income], area_name: GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, level: 1), class: class_if('active', controller_name == 'budget_lines') %></li>
       <li><%= link_to t('.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), class: class_if('active', controller_name == 'budgets_execution')  %></li>
       <% pending do %>
         <li><%= link_to 'Consultas', 'consultation' %></li>

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class GobiertoBudgets::BudgetLineTest < ActionDispatch::IntegrationTest
   def setup
     super
-    @path = gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::BudgetLine::ECONOMIC, GobiertoBudgets::BudgetLine::EXPENSE)
+    @path = gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, GobiertoBudgets::BudgetLine::BUDGET_KINDS[:expense])
   end
 
   def site
@@ -38,7 +38,7 @@ class GobiertoBudgets::BudgetLineTest < ActionDispatch::IntegrationTest
 
   def test_invalid_budget_line_url
     with_current_site(site) do
-      visit gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::BudgetLine::ECONOMIC, 'foo')
+      visit gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, 'foo')
 
       assert_equal 400, status_code
     end

--- a/test/integration/gobierto_budgets/budget_lines_test.rb
+++ b/test/integration/gobierto_budgets/budget_lines_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class GobiertoBudgets::BudgetLinesTest < ActionDispatch::IntegrationTest
   def setup
     super
-    @path = gobierto_budgets_budget_lines_path(last_year, GobiertoBudgets::BudgetLine::ECONOMIC, GobiertoBudgets::BudgetLine::INCOME)
+    @path = gobierto_budgets_budget_lines_path(last_year, GobiertoBudgets::BudgetLine::BUDGET_AREAS[:economic].area_name, GobiertoBudgets::BudgetLine::BUDGET_KINDS[:income])
   end
 
   def site


### PR DESCRIPTION

Hello!

I was taking a look around for some refactoring opportunities and I found one which I think can be useful. It's mainly focused around the `GobiertoBudgets::BudgetLine`, `GobiertoBudgets::FunctionalArea` and `GobiertoBudgets::EconomicArea` classes.

I think the *functional*, *economic*, *income* and *expense* concepts are duplicated several times between these three classes.

I also found some constructs used quite often which I think can be clarified by using the approach suggested in this PR.

1. The first one is the use of the ternary operator to check if a budget line area is of type *economic* or *functional*, or if a budget kind is of type *income* or *expense*:

  ```ruby
  area_klass = area_name == 'economic' ? GobiertoBudgets::EconomicArea : GobiertoBudgets::FunctionalArea
  kind = source['kind'] == 'income' ? 'I' : 'G'
  ```

  which can be substituded by something like this:

  ```ruby
  area_klass = BudgetLine.budget_area_klass_for area_name
  kind = BudgetLine.budget_kind_for source['kind']
  ```
 
2. The second one is referrencing the 'hardcoded' list of the available budget areas like this:

  ```ruby
  [GobiertoBudgets::EconomicArea, GobiertoBudgets::FunctionalArea]
  ```
 
 This can be avoided by providing this array from the `BudgetLine::budget_areas` method.

One good example of the effects of this refactoring would be inside the `CategoriesController#index` method, which transforms from this:

```ruby
if kind.nil? && area.nil?
  categories = {}
  [GobiertoBudgets::EconomicArea, GobiertoBudgets::FunctionalArea].each do |klass|
    area_name = (klass == GobiertoBudgets::EconomicArea) ? GobiertoBudgets::BudgetLine::ECONOMIC : GobiertoBudgets::BudgetLine::FUNCTIONAL
    [GobiertoBudgets::BudgetLine::INCOME, GobiertoBudgets::BudgetLine::EXPENSE].each do |kind|
      next if kind == GobiertoBudgets::BudgetLine::INCOME and klass == GobiertoBudgets::FunctionalArea

      categories[area_name] ||= {}
      categories[area_name][kind] = Hash[klass.all_items[kind].sort_by{ |k,v| k.to_f }]
    end
  end
else
  klass = area == 'economic' ? GobiertoBudgets::EconomicArea : GobiertoBudgets::FunctionalArea
  categories = Hash[klass.all_items[kind].sort_by{ |k,v| k.to_f }]
end
```

Into something like this:

```ruby
if kind.nil? && area.nil?
  categories = {}
  GobiertoBudgets::BudgetLine.budget_areas.each do |area|
    area.valid_kinds.each do |kind|
      categories[area.area_name] ||= {}
      categories[area.area_name][kind] = Hash[area.all_items[kind].sort_by { |k, v| k.to_f } ]
    end
  end
else
  categories = Hash[area.all_items[kind].sort_by { |k, v| k.to_f } ]
end
```

Maybe it'll be useful to create a `BudgetLineArea` abstraction for the `FunctionalArea` and `EconomicArea` classes, but since for the moment there are only two areas this might sound like *'overkilling'*.

**Tests are sure going to fail right now since I haven't tried to do the necessary consistent renaming of the affected code accross all the application**, but if you think this refactoring can be useful I can work on that. 🙂

Thanks for your time! Any critics or suggestions are welcome!

Alberto