### PR TITLE
Regular admins can't access the admins controller

### DIFF
--- a/app/controllers/gobierto_admin/admins_controller.rb
+++ b/app/controllers/gobierto_admin/admins_controller.rb
@@ -1,5 +1,7 @@
 module GobiertoAdmin
   class AdminsController < BaseController
+    before_action :managing_user
+
     def index
       @admins = Admin.sorted.all
     end
@@ -131,6 +133,10 @@ module GobiertoAdmin
 
     def default_activity_params
       { ip: remote_ip, author: current_admin }
+    end
+
+    def managing_user
+      redirect_to admin_users_path and return false unless current_admin.managing_user?
     end
   end
 end

--- a/app/views/gobierto_admin/users/index.html.erb
+++ b/app/views/gobierto_admin/users/index.html.erb
@@ -7,11 +7,13 @@
         <%= t(".title") %>
       <% end %>
     </li>
-    <li>
-      <%= link_to admin_admins_path do %>
-        <%= t(".admins_section") %>
-      <% end %>
-    </li>
+    <% if current_admin.managing_user? %>
+      <li>
+        <%= link_to admin_admins_path do %>
+          <%= t(".admins_section") %>
+        <% end %>
+      </li>
+    <% end %>
   </ul>
 </div>
 

--- a/test/integration/gobierto_admin/admin_create_test.rb
+++ b/test/integration/gobierto_admin/admin_create_test.rb
@@ -11,6 +11,18 @@ module GobiertoAdmin
       @admin ||= gobierto_admin_admins(:nick)
     end
 
+    def regular_admin
+      @regular_admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def test_regular_admin_create
+      with_signed_in_admin(regular_admin) do
+        visit @path
+
+        refute has_selector?("form.new_admin")
+      end
+    end
+
     def test_admin_create
       with_signed_in_admin(admin) do
         visit @path


### PR DESCRIPTION
Connects to #379

### What does this PR do?

This PR blocks regular admins to visit AdminsController, so they can't see admins, create new ones or edit them.
