### PR TITLE
Fix const reloading in development

### DIFF
--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -1,10 +1,10 @@
 # Common subscribers (`Subscribers::Base` pattern)
-Subscribers::SiteActivity.attach_to('activities/sites')
-Subscribers::AdminActivity.attach_to('activities/admins')
-Subscribers::CensusActivity.attach_to('activities/census')
-Subscribers::UserActivity.attach_to('activities/users')
-Subscribers::GobiertoPeopleActivity.attach_to('trackable')
-Subscribers::GobiertoCmsPageActivity.attach_to('activities/gobierto_cms_pages')
+::Subscribers::SiteActivity.attach_to('activities/sites')
+::Subscribers::AdminActivity.attach_to('activities/admins')
+::Subscribers::CensusActivity.attach_to('activities/census')
+::Subscribers::UserActivity.attach_to('activities/users')
+::Subscribers::GobiertoPeopleActivity.attach_to('trackable')
+::Subscribers::GobiertoCmsPageActivity.attach_to('activities/gobierto_cms_pages')
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|


### PR DESCRIPTION
Unexpected

### What does this PR do?

Fixes an issue in developemnt with subscribers, becauses subscriber classes where reloaded all the time. It seems like the `::` in the module name does the trick.
