### PR TITLE
Add events missing translations

### DIFF
--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -18,7 +18,7 @@ ca:
       admins_admin_updated: Admin actualitzat
   users:
     events:
-      users.user_updated: Usuari actualitzat
+      users_user_updated: Usuari actualitzat
   based_on: Web basat en
   invisible_captcha:
     sentence_for_humans: "Si ets humà, per favor, ignora este camp."

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -1,5 +1,24 @@
 ---
 ca:
+  census:
+    events:
+      census_census_imported: Cens importat
+  sites:
+    events:
+      sites_site_visibility_updated: Site publicat
+      sites_site_created: Site creat
+      sites_site_updated: Site actualitzat
+      sites_site_destroyed: Site eliminat
+  admins:
+    events:
+      admins_admin_authorization_level_updated: Nivel autorització admin actualitzat
+      admins_invitation_created: Admin invitat
+      admins_invitation_accepted: Invitació admin aceptada
+      admins_admin_created: Admin creat
+      admins_admin_updated: Admin actualitzat
+  users:
+    events:
+      users.user_updated: Usuari actualitzat
   based_on: Web basat en
   invisible_captcha:
     sentence_for_humans: "Si ets humà, per favor, ignora este camp."

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -18,7 +18,7 @@ en:
       admins_admin_updated: Admin updated
   users:
     events:
-      users.user_updated: User updated
+      users_user_updated: User updated
   based_on: Web based on
   invisible_captcha:
     sentence_for_humans: "If you are human, ignore this field"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,5 +1,24 @@
 ---
 en:
+  census:
+    events:
+      census_census_imported: Census imported
+  sites:
+    events:
+      sites_site_visibility_updated: Site published
+      sites_site_created: Site created
+      sites_site_updated: Site updated
+      sites_site_destroyed: Site deleted
+  admins:
+    events:
+      admins_admin_authorization_level_updated: Admin authorization level updated
+      admins_invitation_created: Admin invited
+      admins_invitation_accepted: Admin invitation accepted
+      admins_admin_created: Admin created
+      admins_admin_updated: Admin updated
+  users:
+    events:
+      users.user_updated: User updated
   based_on: Web based on
   invisible_captcha:
     sentence_for_humans: "If you are human, ignore this field"

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -1,5 +1,24 @@
 ---
 es:
+  census:
+    events:
+      census_census_imported: Censo importado
+  sites:
+    events:
+      sites_site_visibility_updated: Site publicado
+      sites_site_created: Site creado
+      sites_site_updated: Site actualizado
+      sites_site_destroyed: Site eliminado
+  admins:
+    events:
+      admins_admin_authorization_level_updated: Nivel autorización admin actualizado
+      admins_invitation_created: Admin invitado
+      admins_invitation_accepted: Invitación admin aceptada
+      admins_admin_created: Admin creado
+      admins_admin_updated: Admin actualizado
+  users:
+    events:
+      users.user_updated: Usuario actualizado
   based_on: Web basada en 
   invisible_captcha:
     sentence_for_humans: "Si eres humano, por favor ignora este campo."

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -18,7 +18,7 @@ es:
       admins_admin_updated: Admin actualizado
   users:
     events:
-      users.user_updated: Usuario actualizado
+      users_user_updated: Usuario actualizado
   based_on: Web basada en 
   invisible_captcha:
     sentence_for_humans: "Si eres humano, por favor ignora este campo."


### PR DESCRIPTION
Connects to #358

### What does this PR do?

This PR adds the translations of activities for admins missing and reported in #358
