### PR TITLE
Align consultation status icon

### DIFF
--- a/app/assets/stylesheets/module-consultations.scss
+++ b/app/assets/stylesheets/module-consultations.scss
@@ -303,6 +303,10 @@ img.side_50 {
 .consultation-figure {
   font-weight: 300;
   float: right;
+  width: 5rem;
+}
+.consultation-figure span {
+  float: right;
 }
 .consultation-figure .fa-arrow-up {
   color: $color_success;

--- a/app/views/gobierto_budget_consultations/consultations/consultation_responses/new.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/consultation_responses/new.html.erb
@@ -55,7 +55,7 @@
   <div class="consultation-card" :class="{ active: card.toggleDesc }" :data-card-id="card.id">
     <div class="card-title" @click="setActive(card, $event)">
       <div class="consultation-title">{{card.title}}</div>
-      <div class="consultation-figure"><i class="fa" :class="iconForChoice" aria-hidden="true"></i> {{card.figure}}</div>
+      <div class="consultation-figure"><i class="fa" :class="iconForChoice" aria-hidden="true"></i> <span>{{card.figure}}</span></div>
     </div>
 
     <card-description :card="card" :figures="figures"></card-description>
@@ -66,7 +66,7 @@
   <div class="consultation-card" :class="{ active: card.toggleDesc }" :data-card-id="card.id">
     <div class="card-title" @click="setActive(card, $event)">
       <div class="consultation-title">{{card.title}}</div>
-      <div class="consultation-figure"><i class="fa" :class="iconForChoice" aria-hidden="true"></i> {{card.figure}}</div>
+      <div class="consultation-figure"><i class="fa" :class="iconForChoice" aria-hidden="true"></i> <span>{{card.figure}}</span></div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Connects to #429.

### What does this PR do?
This PR aligns the icons in the consultation UI, improving the parsing and the comparison between the status of each card.