### PR TITLE
Store socio-demographic data into consultation responses

### DIFF
--- a/app/controllers/gobierto_budget_consultations/consultations/consultation_responses_controller.rb
+++ b/app/controllers/gobierto_budget_consultations/consultations/consultation_responses_controller.rb
@@ -8,7 +8,8 @@ module GobiertoBudgetConsultations
       def new
         @consultation_response_form = ConsultationResponseForm.new(
           document_number_digest: document_number_digest,
-          consultation_id: @consultation.id
+          consultation_id: @consultation.id,
+          user: current_user
         )
 
         @consultation_items = @consultation.consultation_items.sorted
@@ -18,7 +19,8 @@ module GobiertoBudgetConsultations
         @consultation_response_form = ConsultationResponseForm.new(
           consultation_response_params.merge(
             document_number_digest: document_number_digest,
-            consultation_id: @consultation.id
+            consultation_id: @consultation.id,
+            user: current_user
           )
         )
 

--- a/app/forms/concerns/gobierto_common/custom_user_fields_helper.rb
+++ b/app/forms/concerns/gobierto_common/custom_user_fields_helper.rb
@@ -7,7 +7,9 @@ module GobiertoCommon
     end
 
     def custom_records
-      @custom_records ||= if user.nil? || user.custom_records.empty?
+      @custom_records ||= if user.nil?
+                            site.presence ? site.custom_user_fields.map{|custom_user_field| custom_user_field.records.new } : []
+                          elsif user.custom_records.empty?
                             site.presence ? site.custom_user_fields.map{|custom_user_field| user.custom_records.build(custom_user_field: custom_user_field) } : []
                           else
                             user.custom_records

--- a/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form.rb
+++ b/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form.rb
@@ -65,13 +65,9 @@ module GobiertoAdmin
       def custom_records=(attributes)
         @custom_records_attributes ||= Hash[Array(attributes).map do |name, field_attributes|
           custom_user_field = site.custom_user_fields.find(field_attributes["custom_user_field_id"])
-          raw_value = field_attributes["value"]
-          localized_value = if custom_user_field.options.present? && custom_user_field.options[raw_value].present?
-                              custom_user_field.options[raw_value][I18n.locale.to_s]
-                            else
-                              raw_value
-                            end
-          [name, {"raw_value" => raw_value, "localized_value" => localized_value}]
+          custom_record = custom_user_field.records.new
+          custom_record.value = field_attributes["value"]
+          [name, {"raw_value" => custom_record.raw_value, "localized_value" => custom_record.value}]
         end]
       end
 
@@ -79,6 +75,7 @@ module GobiertoAdmin
 
       def valid_custom_records
         return if custom_records_attributes.nil? || custom_records_attributes.empty?
+
         custom_records_attributes.each do |name, attributes|
           custom_user_field = site.custom_user_fields.find_by(name: name)
           if custom_user_field.mandatory? && attributes["raw_value"].blank?

--- a/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form.rb
+++ b/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form.rb
@@ -2,16 +2,23 @@ module GobiertoAdmin
   module GobiertoBudgetConsultations
     class ConsultationResponseForm
       include ActiveModel::Model
+      include ::GobiertoCommon::CustomUserFieldsHelper
 
       attr_accessor(
         :consultation_id,
         :document_number_digest,
-        :selected_options
+        :selected_options,
+        :date_of_birth_year,
+        :date_of_birth_month,
+        :date_of_birth_day,
+        :gender,
+        :custom_records_attributes
       )
 
       delegate :to_model, :persisted?, to: :consultation_response
 
-      validates :document_number_digest, :consultation, :selected_options, :site, :census_item, presence: true
+      validates :document_number_digest, :consultation, :selected_options,
+                :site, :census_item, :date_of_birth, :gender, presence: true
 
       def save
         save_consultation_response if valid?
@@ -39,7 +46,46 @@ module GobiertoAdmin
         @site ||= consultation.site if consultation
       end
 
+      def user
+        nil
+      end
+
+      def date_of_birth
+        @date_of_birth ||= if date_of_birth_year && date_of_birth_month && date_of_birth_day
+          Date.new(
+            date_of_birth_year.to_i,
+            date_of_birth_month.to_i,
+            date_of_birth_day.to_i
+          )
+        end
+      rescue ArgumentError
+        nil
+      end
+
+      def custom_records=(attributes)
+        @custom_records_attributes ||= Hash[Array(attributes).map do |name, field_attributes|
+          custom_user_field = site.custom_user_fields.find(field_attributes["custom_user_field_id"])
+          raw_value = field_attributes["value"]
+          localized_value = if custom_user_field.options.present? && custom_user_field.options[raw_value].present?
+                              custom_user_field.options[raw_value][I18n.locale.to_s]
+                            else
+                              raw_value
+                            end
+          [name, {"raw_value" => raw_value, "localized_value" => localized_value}]
+        end]
+      end
+
       private
+
+      def valid_custom_records
+        return if custom_records_attributes.nil? || custom_records_attributes.empty?
+        custom_records_attributes.each do |name, attributes|
+          custom_user_field = site.custom_user_fields.find_by(name: name)
+          if custom_user_field.mandatory? && attributes["raw_value"].blank?
+            errors[:base] << "#{custom_user_field.localized_title} #{I18n.t('errors.messages.blank')}"
+          end
+        end
+      end
 
       def consultation_class
         ::GobiertoBudgetConsultations::Consultation
@@ -79,6 +125,10 @@ module GobiertoAdmin
           consultation_response_attributes.budget_amount = consultation_items.sum(&:budget_line_amount)
           consultation_response_attributes.sharing_token ||= consultation_response_class.generate_unique_secure_token
           consultation_response_attributes.visibility_level = consultation_class.visibility_levels[:active]
+          consultation_response_attributes.user_information = {
+            gender: gender,
+            date_of_birth: date_of_birth.to_s
+          }.merge(custom_records_attributes || {})
         end
 
         if @consultation_response.valid?

--- a/app/models/gobierto_common/custom_user_field_record.rb
+++ b/app/models/gobierto_common/custom_user_field_record.rb
@@ -3,23 +3,27 @@ module GobiertoCommon
     belongs_to :user
     belongs_to :custom_user_field
 
+    validates :custom_user_field, :user, presence: true
+
     def value
       if custom_user_field && payload.present?
         if custom_user_field.string? || custom_user_field.paragraph?
-          payload[custom_user_field.name]
+          raw_value
         elsif custom_user_field.single_option?
-          if payload[custom_user_field.name].present? && custom_user_field.options[payload[custom_user_field.name]].present?
-            custom_user_field.options[payload[custom_user_field.name]][I18n.locale.to_s]
+          if raw_value.present? && custom_user_field.options[raw_value].present?
+            custom_user_field.options[raw_value][I18n.locale.to_s]
           end
         elsif custom_user_field.multiple_options?
-          if payload[custom_user_field.name]
-            payload[custom_user_field.name].map do |v|
-              custom_user_field.options[v][I18n.locale.to_s]
-            end
-          else
-            []
+          Array(raw_value).map do |v|
+            custom_user_field.options[v][I18n.locale.to_s]
           end
         end
+      end
+    end
+
+    def raw_value
+      @raw_value ||= if custom_user_field && payload.present?
+        payload[custom_user_field.name]
       end
     end
 

--- a/app/views/gobierto_admin/gobierto_budget_consultations/consultations/consultation_responses/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_budget_consultations/consultations/consultation_responses/new.html.erb
@@ -38,6 +38,41 @@
       </table>
     </div>
 
+    <div class="pure-u-1 pure-u-md-16-24">
+      <h3><%= t('.user_information') %></h3>
+
+      <div class="form_item select_control selects_inline">
+        <%= f.label :date_of_birth, f.object.class.human_attribute_name(:date_of_birth) %>
+        <%= f.date_select(
+          :date_of_birth,
+          prompt: true,
+          end_year: 100.years.ago.year,
+          start_year: Date.current.year) %>
+      </div>
+
+        <div class="form_item">
+          <div class="options options_cont">
+            <%= f.label :gender, f.object.class.human_attribute_name(:gender) %>
+
+            <div class="pure-g">
+              <%= f.collection_radio_buttons(:gender, @user_genders, :first, :first) do |b| %>
+                <div class="pure-u-md-1-2">
+                  <div class="option ">
+                    <%= b.radio_button %>
+                    <%= b.label do %>
+                      <span></span>
+                      <%= t(".gender.#{b.text}") %>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+      <%= render partial: 'user/shared/custom_fields', locals: {custom_records: f.object.custom_records, form_name: "consultation_response"} %>
+    </div>
+
     <div class="pure-u-1 pure-u-md-2-24"></div>
 
     <div class="pure-u-1 pure-u-md-1-4 stick_in_parent" id="stick_in_parent">

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/models/ca.yml
@@ -14,6 +14,10 @@ ca:
         description: Descripción
         title: Título
         block_reduction: Bloquear reducció
+      gobierto_admin/gobierto_budget_consultations/consultation_response_form:
+        date_of_birth: Data de naiximent
+        gender: Gènere
     models:
       gobierto_admin/gobierto_budget_consultations/consultation_form: Consulta
       gobierto_admin/gobierto_budget_consultations/consultation_item_form: Partida
+      gobierto_admin/gobierto_budget_consultations/consultation_response_form: Resposta

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/models/en.yml
@@ -14,6 +14,10 @@ en:
         description: Description
         title: Title
         block_reduction: Block reduction
+      gobierto_admin/gobierto_budget_consultations/consultation_response_form:
+        date_of_birth: Date of birth
+        gender: Gender
     models:
       gobierto_admin/gobierto_budget_consultations/consultation_form: Consultation
       gobierto_admin/gobierto_budget_consultations/consultation_item_form: Budget line
+      gobierto_admin/gobierto_budget_consultations/consultation_response_form: Response

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/models/es.yml
@@ -14,6 +14,10 @@ es:
         description: Descripción
         title: Título
         block_reduction: Bloquear reducción
+      gobierto_admin/gobierto_budget_consultations/consultation_response_form:
+        date_of_birth: Fecha de nacimiento
+        gender: Género
     models:
       gobierto_admin/gobierto_budget_consultations/consultation_form: Consulta
       gobierto_admin/gobierto_budget_consultations/consultation_item_form: Partida
+      gobierto_admin/gobierto_budget_consultations/consultation_response_form: Respuesta

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultation_responses/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultation_responses/ca.yml
@@ -11,3 +11,8 @@ ca:
               date: Data
             title: Participacions
             view_response: Vore Particpiació
+          new:
+            gender:
+              male: Hombre
+              female: Mujer
+            user_information: Informació personal

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultation_responses/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultation_responses/en.yml
@@ -11,3 +11,8 @@ en:
               date: Date
             title: Participations
             view_response: View participation
+          new:
+            gender:
+              male: Male
+              female: Female
+            user_information: User information

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultation_responses/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/views/consultation_responses/es.yml
@@ -11,3 +11,8 @@ es:
               date: Fecha
             title: Participaciones
             view_response: Ver Particpiación
+          new:
+            gender:
+              male: Hombre
+              female: Mujer
+            user_information: Información personal

--- a/db/migrate/20170302154209_add_user_information_to_consultation_responses.rb
+++ b/db/migrate/20170302154209_add_user_information_to_consultation_responses.rb
@@ -1,0 +1,6 @@
+class AddUserInformationToConsultationResponses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :gbc_consultation_responses, :user_information, :jsonb
+    add_index :gbc_consultation_responses, :user_information, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302100518) do
+ActiveRecord::Schema.define(version: 20170302154209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -175,9 +175,11 @@ ActiveRecord::Schema.define(version: 20170302100518) do
     t.datetime "updated_at",                                                      null: false
     t.string   "sharing_token"
     t.string   "document_number_digest"
+    t.jsonb    "user_information"
     t.index ["consultation_id", "document_number_digest"], name: "index_gbc_consultation_responses_on_document_number_digest", unique: true, using: :btree
     t.index ["consultation_id"], name: "index_gbc_consultation_responses_on_consultation_id", using: :btree
     t.index ["sharing_token"], name: "index_gbc_consultation_responses_on_sharing_token", unique: true, using: :btree
+    t.index ["user_information"], name: "index_gbc_consultation_responses_on_user_information", using: :gin
   end
 
   create_table "gbc_consultations", force: :cascade do |t|

--- a/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form_test.rb
@@ -13,7 +13,11 @@ module GobiertoAdmin
           date_of_birth_year: 1992,
           date_of_birth_month: 1,
           date_of_birth_day: 1,
-          gender: User.genders["male"]
+          gender: "male",
+          custom_records: {
+            madrid_custom_user_field_district.name => { "custom_user_field_id" => madrid_custom_user_field_district.id, "value" => madrid_custom_user_field_district.options.keys.first },
+            madrid_custom_user_field_association.name => { "custom_user_field_id" => madrid_custom_user_field_association.id, "value" => "Foo" }
+          }
         )
       end
 
@@ -45,8 +49,26 @@ module GobiertoAdmin
         @consultation_items ||= consultation.consultation_items
       end
 
+      def madrid_custom_user_field_district
+        @madrid_custom_user_field_district ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_district)
+      end
+
+      def madrid_custom_user_field_association
+        @madrid_custom_user_field_association ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_association)
+      end
+
       def test_valid_with_valid_attributes
         assert valid_consultation_response_form.save
+      end
+
+      def test_user_information
+        valid_consultation_response_form.save
+
+        user_information = valid_consultation_response_form.consultation_response.user_information
+        assert_equal "male", user_information["gender"]
+        assert_equal "1992-01-01", user_information["date_of_birth"]
+        assert_equal user_information["district"], {"raw_value"=>"randomstring1", "localized_value"=>"Center"}
+        assert_equal user_information["association"], {"raw_value"=>"Foo", "localized_value"=>"Foo"}
       end
 
       def test_error_messages_with_invalid_attributes

--- a/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form_test.rb
@@ -9,7 +9,11 @@ module GobiertoAdmin
           consultation_id: consultation.id,
           selected_options: Hash[consultation_items.map do |item|
             [item.id.to_s, nil]
-          end]
+          end],
+          date_of_birth_year: 1992,
+          date_of_birth_month: 1,
+          date_of_birth_day: 1,
+          gender: User.genders["male"]
         )
       end
 

--- a/test/forms/gobierto_budget_consultations/consultation_response_form_test.rb
+++ b/test/forms/gobierto_budget_consultations/consultation_response_form_test.rb
@@ -6,7 +6,8 @@ module GobiertoBudgetConsultations
       @valid_consultation_response_form ||= ConsultationResponseForm.new(
         document_number_digest: SecretAttribute.digest("00000000D"),
         consultation_id: consultation.id,
-        selected_options: selected_options_params
+        selected_options: selected_options_params,
+        user: user
       )
     end
 
@@ -14,7 +15,8 @@ module GobiertoBudgetConsultations
       @invalid_consultation_response_form ||= ConsultationResponseForm.new(
         document_number_digest: nil,
         consultation_id: nil,
-        selected_options: {}
+        selected_options: {},
+        user: nil
       )
     end
 
@@ -33,6 +35,10 @@ module GobiertoBudgetConsultations
 
     def selected_option
       @selected_option ||= consultation_item.response_options.first
+    end
+
+    def user
+      @user ||= users(:dennis)
     end
 
     def consultation
@@ -110,6 +116,16 @@ module GobiertoBudgetConsultations
       consultation_response = valid_consultation_response_form.save
 
       assert_equal sharing_token, consultation_response.sharing_token
+    end
+
+    def test_user_information
+      valid_consultation_response_form.save
+
+      user_information = valid_consultation_response_form.consultation_response.user_information
+      assert_equal "female", user_information["gender"]
+      assert_equal "1990-01-01", user_information["date_of_birth"]
+      assert_equal user_information["district"], {"raw_value"=>"randomstring1", "localized_value"=>"Center"}
+      assert_equal user_information["association"], {"raw_value"=>"Asociación amigos perros", "localized_value"=>"Asociación amigos perros"}
     end
   end
 end

--- a/test/forms/user/confirmation_form_test.rb
+++ b/test/forms/user/confirmation_form_test.rb
@@ -34,11 +34,11 @@ class User::ConfirmationFormTest < ActiveSupport::TestCase
   end
 
   def madrid_custom_user_field_district
-    madrid_custom_user_field_district ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_district)
+    @madrid_custom_user_field_district ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_district)
   end
 
   def madrid_custom_user_field_association
-    madrid_custom_user_field_association ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_association)
+    @madrid_custom_user_field_association ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_association)
   end
 
   def unconfirmed_user

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_responses_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_responses_test.rb
@@ -98,6 +98,15 @@ module GobiertoAdmin
               item1 = gobierto_budget_consultations_consultation_items(:madrid_sports_facilities)
               item2 = gobierto_budget_consultations_consultation_items(:madrid_civil_protection)
 
+              # User information fields
+              select "1992", from: :consultation_response_date_of_birth_1i
+              select "January", from: :consultation_response_date_of_birth_2i
+              select "1", from: :consultation_response_date_of_birth_3i
+              page.find("#consultation_response_gender_male", visible: false).trigger('click')
+              select "Center", from: "Districts"
+              fill_in "Association", with: "Asociación Vecinos Arganzuela"
+              fill_in "Bio", with: "My short bio"
+
               page.find("#consultation_response_selected_options_#{item1.id}_5", visible: false).trigger('click')
               page.find("#consultation_response_selected_options_#{item2.id}_5", visible: false).trigger('click')
               click_button "Create"
@@ -106,11 +115,14 @@ module GobiertoAdmin
 
               page.find("#consultation_response_selected_options_#{item1.id}_0", visible: false).trigger('click')
               page.find("#consultation_response_selected_options_#{item2.id}_-5", visible: false).trigger('click')
+              select "Center", from: "Districts"
+              fill_in "Association", with: "Asociación Vecinos Arganzuela"
+              fill_in "Bio", with: "My short bio"
+
               click_button "Create"
 
               assert has_message?("Response created successfully")
               assert has_content?("Responses until now: 3")
-
 
               activity = Activity.last
               assert_equal consultation, activity.recipient

--- a/test/models/gobierto_common/custom_user_field_record_test.rb
+++ b/test/models/gobierto_common/custom_user_field_record_test.rb
@@ -17,29 +17,52 @@ class GobiertoCommon::CustomUserFieldRecordTest < ActiveSupport::TestCase
     @custom_user_field_multiple_options ||= gobierto_common_custom_user_fields(:madrid_custom_user_field_interests)
   end
 
-  def subject
-    @subject ||= GobiertoCommon::CustomUserFieldRecord.new
-  end
-
   def test_value_assignment
+    subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_single_option
     subject.value = 'foo'
     assert_equal 'foo', subject.payload[custom_user_field_single_option.name]
   end
 
+  def test_raw_value
+    subject = GobiertoCommon::CustomUserFieldRecord.new
+    subject.custom_user_field = custom_user_field_single_option
+    subject.value = 'randomstring1'
+    assert_equal 'randomstring1', subject.raw_value
+
+    subject = GobiertoCommon::CustomUserFieldRecord.new
+    subject.custom_user_field = custom_user_field_string
+    subject.value = 'randomstring1'
+    assert_equal 'randomstring1', subject.raw_value
+
+    subject = GobiertoCommon::CustomUserFieldRecord.new
+    subject.custom_user_field = custom_user_field_paragraph
+    subject.value = 'randomstring1'
+    assert_equal 'randomstring1', subject.raw_value
+
+    subject = GobiertoCommon::CustomUserFieldRecord.new
+    subject.custom_user_field = custom_user_field_multiple_options
+    subject.value = ['randomstring1', 'random2']
+    assert_equal ['randomstring1', 'random2'], subject.raw_value
+  end
+
   def test_values
+    subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_single_option
     subject.value = 'randomstring1'
     assert_equal 'Center', subject.value
 
+    subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_string
     subject.value = 'randomstring1'
     assert_equal 'randomstring1', subject.value
 
+    subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_paragraph
     subject.value = 'randomstring1'
     assert_equal 'randomstring1', subject.value
 
+    subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_multiple_options
     subject.value = ['randomstring1']
     assert_equal ['Sports'], subject.value


### PR DESCRIPTION
Connects to #377 

### What does this PR do?

This PR stores sociodemographic and custom user fields data in consultation responses, no matter if they have been created by an user or by an admin.
