### PR TITLE
Download attachments

### DIFF
--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -21,7 +21,8 @@ module GobiertoAdmin
         site: site,
         collection: collection,
         attribute_name: :attachment,
-        file: file
+        file: file,
+        content_disposition: "attachment"
       ).call
     end
 

--- a/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
@@ -71,7 +71,8 @@ module GobiertoAdmin
             site: person.site,
             collection: person_event.model_name.collection,
             attribute_name: :attachment,
-            file: attachment_file
+            file: attachment_file,
+            content_disposition: "attachment"
           ).call
         end
       end

--- a/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
@@ -78,7 +78,8 @@ module GobiertoAdmin
             site: person.site,
             collection: person_statement.model_name.collection,
             attribute_name: :attachment,
-            file: attachment_file
+            file: attachment_file,
+            content_disposition: "attachment"
           ).call
         end
       end

--- a/app/services/gobierto_admin/file_upload_service.rb
+++ b/app/services/gobierto_admin/file_upload_service.rb
@@ -29,7 +29,7 @@ module GobiertoAdmin
 
     def file_name
       @file_name ||= begin
-        [site_id, collection, attribute_name].join("/")
+        [site_id, collection, attribute_name, file.original_filename].join("/")
       end
     end
 

--- a/app/services/gobierto_admin/file_upload_service.rb
+++ b/app/services/gobierto_admin/file_upload_service.rb
@@ -4,12 +4,13 @@ module GobiertoAdmin
   class FileUploadService
     attr_reader :file, :site, :collection
 
-    def initialize(adapter:, site:, collection:, attribute_name:, file:)
+    def initialize(adapter:, site:, collection:, attribute_name:, file:, content_disposition: nil)
       @adapter = adapter
       @site = site
       @collection = collection
       @attribute_name = attribute_name
       @file = file
+      @content_disposition = content_disposition
     end
 
     delegate :call, to: :adapter
@@ -20,7 +21,7 @@ module GobiertoAdmin
       end
 
       case @adapter
-      when :s3 then FileUploader::S3.new(file: file, file_name: file_name)
+      when :s3 then FileUploader::S3.new(file: file, file_name: file_name, content_disposition: @content_disposition)
       end
     end
 

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/_form.html.erb
@@ -56,7 +56,7 @@
         <%= f.label :attachment_file, t(".attachment_file_constraints") %>
 
         <% if f.object.attachment_url.present? %>
-          <%= link_to f.object.attachment_url, f.object.attachment_url %>
+          <%= link_to f.object.attachment_url, f.object.attachment_url, download: "" %>
         <% end %>
 
         <%= f.file_field :attachment_file %>

--- a/app/views/gobierto_people/people/person_bio/show.html.erb
+++ b/app/views/gobierto_people/people/person_bio/show.html.erb
@@ -14,7 +14,7 @@
   <% if @person.bio_url.present? %>
     <div class="download_file f_right">
       <i class="fa fa-file-pdf-o"></i>
-      <strong><%= link_to t(".download"), @person.bio_url %></strong>
+      <strong><%= link_to t(".download"), @person.bio_url, download: "" %></strong>
     </div>
   <% end %>
 

--- a/app/views/gobierto_people/people/person_statements/show.html.erb
+++ b/app/views/gobierto_people/people/person_statements/show.html.erb
@@ -15,7 +15,7 @@
   <% if @statement.attachment_url.present? %>
     <div class="download_file f_right">
       <i class="fa fa-file-pdf-o"></i>
-      <%= link_to @statement.attachment_url do %>
+      <%= link_to @statement.attachment_url, download: "" do %>
         <%= t(".download", file_size: number_to_human_size(@statement.attachment_size || 0)) %>
       <% end %>
     </div>

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -4,17 +4,21 @@ module FileUploader
   class S3
     attr_reader :file, :file_name
 
-    def initialize(file:, file_name:, bucket_name: nil)
+    def initialize(file:, file_name:, content_disposition: nil, bucket_name: nil)
       @file = file
       @file_name = file_name
       @bucket_name = bucket_name
+      @content_disposition = content_disposition
     end
 
     def call
       object = resource.bucket(bucket_name).object(file_name)
 
       File.open(file.tempfile, "rb") do |file_body|
-        object.put(body: file_body)
+        options = { body: file_body }
+        options[:content_disposition] = @content_disposition if @content_disposition.present?
+
+        object.put(options)
       end
 
       object.public_url

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -32,6 +32,7 @@ module GobiertoAdmin
       assert_kind_of FileUploader::S3, file_upload_service.adapter
       assert_equal file, file_upload_service.adapter.file
       assert_includes file_upload_service.adapter.file_name, "site-#{site.id}/test_collection/test_attribute"
+      assert_includes file_upload_service.adapter.file_name, file.original_filename
     end
 
     def test_adapter_in_development
@@ -39,6 +40,7 @@ module GobiertoAdmin
         assert_kind_of FileUploader::Local, file_upload_service.adapter
         assert_equal file, file_upload_service.adapter.file
         assert_includes file_upload_service.adapter.file_name, "site-#{site.id}/test_collection/test_attribute"
+        assert_includes file_upload_service.adapter.file_name, file.original_filename
       end
     end
 


### PR DESCRIPTION
Connects to #282

### What does this PR do?

Adds the original filename of the uploaded file to the file url (I've kept the uuid part of the filename to avoid name collisions).

Adds a `download`html5 attribute to links to attached files, so the browser downloads them instead of rendering them inline.

It also sets the `content_disposition` property to `attachment` for S3 uploads of files.


### How should this be manually tested?

Check that the files are downloaded instead of rendered inline when clicking in the download links (in people's cv for example).

Check also that newly uploaded files are stored with the original filename after the uuid that there was before.