### PR TITLE
Hide social links in user namespace

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,8 @@ module ApplicationHelper
     end
   end
 
+  def show_social_links?
+    !params[:controller].include?('user/')
+  end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -168,13 +168,15 @@
 
           <div id="search_results" class="search_result_list"></div>
 
-          <div class="social_links_container" data-share-text="" data-share>
-            <a href="#" class="social_share twitter" data-share-network="twitter" data-track-event="Social Share|Click Twitter|Header"><i class="fa fa-twitter"></i></a>
-            <a href="#" class="social_share facebook" data-share-network="facebook" data-track-event="Social Share|Click Facebook|Header"><i class="fa fa-facebook"></i></a>
-            <% pending do %>
-              <a href="#embed-graph-code" class="code open_modal"><i class="fa fa-code"></i></a>
-            <% end %>
-          </div>
+          <% if show_social_links? %>
+            <div class="social_links_container" data-share-text="" data-share>
+              <a href="#" class="social_share twitter" data-share-network="twitter" data-track-event="Social Share|Click Twitter|Header"><i class="fa fa-twitter"></i></a>
+              <a href="#" class="social_share facebook" data-share-network="facebook" data-track-event="Social Share|Click Facebook|Header"><i class="fa fa-facebook"></i></a>
+              <% pending do %>
+                <a href="#embed-graph-code" class="code open_modal"><i class="fa fa-code"></i></a>
+              <% end %>
+            </div>
+          <% end %>
 
         </menu>
       </div>


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR removes share links in user namespace (login, signup, reset password, private area...).
