### PR TITLE
Accesible tabs

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -6,6 +6,7 @@
 //= require jquery.visible
 //= require sticky-kit.min
 //= require jquery-ui
+//= require tabs
 //= require tipsy
 //= require mustache.min
 //= require velocity.min

--- a/app/assets/javascripts/gobierto_budgets/application.js
+++ b/app/assets/javascripts/gobierto_budgets/application.js
@@ -45,8 +45,10 @@ $(document).on('turbolinks:load', function() {
     });
 
   $('.bread_hover').hover(function(e) {
+    $('.bread_links a').attr('aria-expanded', true);
     $('.line_browser').velocity("fadeIn", { duration: 50 });
   }, function(e) {
+    $('.bread_links a').attr('aria-expanded', false);
     $('.line_browser').velocity("fadeOut", { duration: 50 });
   });
 

--- a/app/assets/javascripts/gobierto_budgets/components/visLine.js
+++ b/app/assets/javascripts/gobierto_budgets/components/visLine.js
@@ -16,7 +16,16 @@
         visLineasJ.measure = $(this).data('line-widget-type');
         visLineasJ.render($(this).data('line-widget-url'));
         $('[data-line-widget-url]').removeClass('active');
+        $('[data-line-widget-url]').attr({
+          'tabindex': -1,
+          'aria-selected': false
+        });
+
         $(this).addClass('active');
+        $(this).attr({
+          'tabindex': 0,
+          'aria-selected': true
+        });
       });
     });
   });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
   
   def tab_attributes(condition)
     {
-      role:'tab', 'tab-index' => condition ? 0 : -1, 'aria-selected' => condition
+      role:'tab', 'tabindex' => condition ? 0 : -1, 'aria-selected' => condition
     }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,5 +27,11 @@ module ApplicationHelper
       link_to t('layouts.accept_privacy_policy_signup'), current_site.configuration.privacy_page
     end
   end
+  
+  def tab_attributes(condition)
+    {
+      role:'tab', 'tab-index' => condition ? 0 : -1, 'aria-selected' => condition
+    }
+  end
 
 end

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -6,7 +6,7 @@
     <ul role="tablist" aria-label="Explora el detalle de ingresos y gastos">
       
       <li role="presentation" class="active">
-        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true }, id:"ingresos", "aria-controls" => "gastos-tab", role:"tab", tabindex:"0", "aria-selected" => "true"%>
+        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true }, id:"ingresos", "aria-controls" => "ingresos-tab", role:"tab", tabindex:"0", "aria-selected" => "true"%>
       </li>
       <li role="presentation">
         <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::EXPENSE, remote: true }, id:"gastos", "aria-controls" => "gastos-tab", role:"tab", tabindex:"-1", "aria-selected" => "false" %>

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -3,19 +3,20 @@
   <h2><%= t('.explore_the_detail') %></h2>
 
   <div class="tabs m_v_2">
-    <ul>
-      <li class="<%= class_if('active', @kind == GobiertoBudgets::BudgetLine::INCOME) %>">
-        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true } %>
+    <ul role="tablist" aria-label="Explora el detalle de ingresos y gastos">
+      
+      <li role="presentation" class="active">
+        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true }, id:"ingresos", "aria-controls" => "gastos-tab", role:"tab", tabindex:"0", "aria-selected" => "true"%>
       </li>
-      <li class="<%= class_if('active', @kind == GobiertoBudgets::BudgetLine::EXPENSE) %>">
-        <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::EXPENSE, remote: true } %>
+      <li role="presentation">
+        <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::EXPENSE, remote: true }, id:"gastos", "aria-controls" => "gastos-tab", role:"tab", tabindex:"-1", "aria-selected" => "false" %>
       </li>
     </ul>
   </div>
 
   <div class="pure-g">
 
-    <div class="pure-u-1 pure-u-md-2-3 table p_h_r_3" data-budget-lines>
+    <div role="tabpanel" class="pure-u-1 pure-u-md-2-3 table p_h_r_3" data-budget-lines>
       <%= render partial: 'gobierto_budgets/budget_lines/index', locals: { place_budget_lines: @place_budget_lines, kind: @kind, area_name: @area_name, year: @year, place: @place }  %>
     </div>
 
@@ -42,4 +43,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -6,17 +6,17 @@
     <ul role="tablist" aria-label="Explora el detalle de ingresos y gastos">
       
       <li role="presentation" class="active">
-        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true }, id:"ingresos", "aria-controls" => "ingresos-tab", role:"tab", tabindex:"0", "aria-selected" => "true"%>
+        <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true }, id:"ingresos", "aria-controls" => "detail_tab", role:"tab", tabindex:"0", "aria-selected" => "true"%>
       </li>
       <li role="presentation">
-        <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::EXPENSE, remote: true }, id:"gastos", "aria-controls" => "gastos-tab", role:"tab", tabindex:"-1", "aria-selected" => "false" %>
+        <%= link_to t('.expenses'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::EXPENSE, remote: true }, id:"gastos", "aria-controls" => "detail_tab", role:"tab", tabindex:"-1", "aria-selected" => "false" %>
       </li>
     </ul>
   </div>
 
   <div class="pure-g">
 
-    <div role="tabpanel" class="pure-u-1 pure-u-md-2-3 table p_h_r_3" data-budget-lines>
+    <div role="tabpanel" id="detail_tab" class="pure-u-1 pure-u-md-2-3 table p_h_r_3" data-budget-lines>
       <%= render partial: 'gobierto_budgets/budget_lines/index', locals: { place_budget_lines: @place_budget_lines, kind: @kind, area_name: @area_name, year: @year, place: @place }  %>
     </div>
 

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -3,8 +3,7 @@
   <h2><%= t('.explore_the_detail') %></h2>
 
   <div class="tabs m_v_2">
-    <ul role="tablist" aria-label="Explora el detalle de ingresos y gastos">
-      
+    <ul role="tablist" aria-label="<%= t('.explore_the_detail') %>">
       <li role="presentation" class="active">
         <%= link_to t('.income'), gobierto_budgets_budget_lines_path(year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: { "budget-lines-tab": GobiertoBudgets::BudgetLine::INCOME, remote: true }, id:"ingresos", "aria-controls" => "detail_tab", role:"tab", tabindex:"0", "aria-selected" => "true"%>
       </li>

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -1,30 +1,23 @@
 <div <%= @kind == GobiertoBudgets::BudgetLine::INCOME ? 'aria-labelledby="ingresos" id="ingresos-tab"'.html_safe : 'aria-labelledby="gastos" id="gastos-tab"'.html_safe %> >
   <p class="m_2"></p>
 
-  <div class="filter m_2" role="tablist" aria-label="Categorías presupuestarias">
+  <div class="filter m_2" role="tablist" aria-label="<%= t('.categories') %>">
     <% if kind == GobiertoBudgets::BudgetLine::EXPENSE %>
       <%= link_to t('.expense_in_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: {remote: true},
           class: class_if('active', area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL),
-          id:'functional-G',
-          role:'tab',
-          tabindex: area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL ? '0' : '-1',
+          id: 'functional-G', role: 'tab', tabindex: area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL ? '0' : '-1',
           'aria-selected' => area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL ? 'true' : 'false',
           'aria-controls' => 'functional-G-table' %>
       <%= link_to t('.expense_to_do_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: {remote: true},
           class: class_if('active', area_name == GobiertoBudgets::BudgetLine::ECONOMIC),
-          id:'economic-G',
-          role:'tab',
-          tabindex: area_name == GobiertoBudgets::BudgetLine::ECONOMIC ? '0' : '-1',
+          id: 'economic-G', role: 'tab', tabindex: area_name == GobiertoBudgets::BudgetLine::ECONOMIC ? '0' : '-1',
           'aria-selected' => area_name == GobiertoBudgets::BudgetLine::ECONOMIC ? 'true' : 'false',
           'aria-controls' => 'economic-G-table' %>
     <% else %>
       <%= link_to t('.income_from_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC),
-          class:'active',
-          id:'economic-I',
-          role:'tab',
-          tabindex:'0',
-          'aria-selected' => 'true',
-          'aria-controls' => 'economic-I-table' %>
+          class: 'active',
+          id: 'economic-I', role: 'tab', tabindex: '0',
+          'aria-selected' => 'true', 'aria-controls' => 'economic-I-table' %>
     <% end %>
     <%= link_to '?', '', class:'help tipsit', title: t('.help') %>
   </div>

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -1,25 +1,45 @@
-<p class="m_2"></p>
+<div <%= @kind == GobiertoBudgets::BudgetLine::INCOME ? 'aria-labelledby="ingresos" id="ingresos-tab"'.html_safe : 'aria-labelledby="gastos" id="gastos-tab"'.html_safe %> >
+  <p class="m_2"></p>
 
-<div class="filter m_2">
-  <% if kind == GobiertoBudgets::BudgetLine::EXPENSE %>
-    <%= link_to t('.expense_in_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: {remote: true}, class: class_if('active', area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL) %>
-    <%= link_to t('.expense_to_do_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: {remote: true}, class: class_if('active', area_name == GobiertoBudgets::BudgetLine::ECONOMIC) %>
-  <% else %>
-    <%= link_to t('.income_from_what'), '', class:'active' %>
-  <% end %>
-  <%= link_to '?', '', class:'help tipsit', title: t('.help') %>
-</div>
+  <div class="filter m_2" role="tablist" aria-label="Categorías presupuestarias">
+    <% if kind == GobiertoBudgets::BudgetLine::EXPENSE %>
+      <%= link_to t('.expense_in_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::FUNCTIONAL), data: {remote: true},
+          class: class_if('active', area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL),
+          id:'functional-G',
+          role:'tab',
+          tabindex: area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL ? '0' : '-1',
+          'aria-selected' => area_name == GobiertoBudgets::BudgetLine::FUNCTIONAL ? 'true' : 'false',
+          'aria-controls' => 'functional-G-table' %>
+      <%= link_to t('.expense_to_do_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::BudgetLine::ECONOMIC), data: {remote: true},
+          class: class_if('active', area_name == GobiertoBudgets::BudgetLine::ECONOMIC),
+          id:'economic-G',
+          role:'tab',
+          tabindex: area_name == GobiertoBudgets::BudgetLine::ECONOMIC ? '0' : '-1',
+          'aria-selected' => area_name == GobiertoBudgets::BudgetLine::ECONOMIC ? 'true' : 'false',
+          'aria-controls' => 'economic-G-table' %>
+    <% else %>
+      <%= link_to t('.income_from_what'), gobierto_budgets_budget_lines_path(year: year, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC),
+          class:'active',
+          id:'economic-I',
+          role:'tab',
+          tabindex:'0',
+          'aria-selected' => 'true',
+          'aria-controls' => 'economic-I-table' %>
+    <% end %>
+    <%= link_to '?', '', class:'help tipsit', title: t('.help') %>
+  </div>
 
-<div class="table_cont_round">
-  <table class="med_bg">
-    <tr>
-      <th class="budget_line"><span><%= t('.budget_line') %></span></th>
-      <th class="qty big_qty"><%= t('.amount') %></th>
-      <th class="qty"><%= t('.per_inhabitant') %></th>
-      <th class="qty">%</th>
-      <th class="qty bar"></th>
-    </tr>
+  <div class="table_cont_round" role="tabpanel" id="<%= area_name %>-<%= kind %>-table" aria-labelledby="<%= area_name %>-<%= kind %>">
+    <table class="med_bg">
+      <tr>
+        <th class="budget_line"><span><%= t('.budget_line') %></span></th>
+        <th class="qty big_qty"><%= t('.amount') %></th>
+        <th class="qty"><%= t('.per_inhabitant') %></th>
+        <th class="qty">%</th>
+        <th class="qty bar"></th>
+      </tr>
 
-    <%= render partial: 'gobierto_budgets/budget_lines/budget_line_row', collection: place_budget_lines, as: :budget_line, locals: { year: year, place: place, area_name: area_name, kind: kind } %>
-  </table>
+      <%= render partial: 'gobierto_budgets/budget_lines/budget_line_row', collection: place_budget_lines, as: :budget_line, locals: { year: year, place: place, area_name: area_name, kind: kind } %>
+    </table>
+  </div>
 </div>

--- a/app/views/gobierto_budgets/budget_lines/index.js.erb
+++ b/app/views/gobierto_budgets/budget_lines/index.js.erb
@@ -1,4 +1,4 @@
 $('[data-budget-lines]').html('<%=j render partial: 'gobierto_budgets/budget_lines/index', locals: { place_budget_lines: @place_budget_lines, kind: @kind, area_name: @area_name, place: @place, year: @year } %>');
-$('[data-budget-lines-tab]').parent().removeClass('active');
-$('[data-budget-lines-tab="<%= @kind %>"]').parent().addClass('active');
+$('[data-budget-lines-tab]').attr({'tabindex': -1, 'aria-selected': 'false'}).parent().removeClass('active');
+$('[data-budget-lines-tab="<%= @kind %>"]').attr({'tabindex': 0, 'aria-selected': 'true'}).parent().addClass('active');
 rebindAll();

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -166,7 +166,7 @@
 
     <div class="separator"></div>
 
-    <div class="pure-g block" data-vis-lines>
+    <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
       <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
         <h2><%= t('.evolution') %></h2>
         <div id="lines_chart"></div>
@@ -181,9 +181,9 @@
       </div>
 
       <div class="pure-u-1">
-        <div class="filter m_v_2">
-          <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" } %>
-          <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" } %>
+        <div class="filter m_v_2" role="tablist" aria-label="Visualiza los <%= @budget_line.name %> por habitante o el total">
+          <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person','aria-controls' => 'lines_chart_wrapper' %>
+          <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" },  role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
         </div>
       </div>
     </div>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -190,7 +190,7 @@
       </div>
 
       <div class="pure-u-1">
-        <div class="filter m_v_2" role="tablist" aria-label="Visualiza los <%= @budget_line.name %> por habitante o el total">
+        <div class="filter m_v_2" role="tablist" aria-label="<%= t('gobierto_budgets.budgets.index.visualize') %>">
           <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person','aria-controls' => 'lines_chart_wrapper' %>
           <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" },  role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
         </div>

--- a/app/views/gobierto_budgets/budgets/_year_breadcrumb.html.erb
+++ b/app/views/gobierto_budgets/budgets/_year_breadcrumb.html.erb
@@ -1,11 +1,11 @@
 <div class="breadcrumb year_only">
   <div class="bread_hover">
     <div class="bread_links">
-      <%= link_to @year, send(path_calculation_method, @year) %>
+      <%= link_to @year, send(path_calculation_method, @year), id: @year, 'aria-haspopup' => 'true', 'aria-label' => 'Escoge el año de los datos', 'aria-owns' => 'popup-year', 'aria-controls' => 'popup-year', 'aria-expanded' => 'false' %>
       <i class="fa fa-sort-down"></i>
     </div>
 
-    <div class="line_browser clearfix">
+    <div id="popup-year" class="line_browser clearfix" role="group">
       <div class="bread_links clearfix">
         <%= link_to @year, send(path_calculation_method, @year) %>
         <i class="fa fa-sort-down"></i>
@@ -14,7 +14,7 @@
       <div class="col" data-level="0">
         <table  class="med_bg">
           <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
-            <tr >
+            <tr role="presentation" >
               <td data-code="<%= year %>"><%= link_to year, url_for(current_parameters_with_year(year)) %></td>
             </tr>
           <% end %>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -205,7 +205,7 @@
     </div>
 
     <div class="pure-u-1">
-      <div class="filter m_v_2" role="tablist" aria-label="Visualiza los gastos por habitante o el total">
+      <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
         <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
         <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
 

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -205,9 +205,9 @@
     </div>
 
     <div class="pure-u-1">
-      <div class="filter m_v_2">
-        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" } %>
-        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" } %>
+      <div class="filter m_v_2" role="tablist" aria-label="Visualiza los gastos por habitante o el total">
+        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true' %>
+        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false' %>
 
         <% pending do %>
           <span class="separator_v"></span>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -188,8 +188,8 @@
 
   <div class="separator"></div>
 
-  <div class="pure-g" data-vis-lines>
-    <div class="pure-u-1 pure-u-md-1-2 block">
+  <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+    <div class=" pure-u-1 pure-u-md-1-2 block" >
       <h2><%= t('.at_a_glance') %></h2>
 
       <div id="lines_chart"></div>
@@ -206,8 +206,8 @@
 
     <div class="pure-u-1">
       <div class="filter m_v_2" role="tablist" aria-label="Visualiza los gastos por habitante o el total">
-        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true' %>
-        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false' %>
+        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
+        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: @place.id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
 
         <% pending do %>
           <span class="separator_v"></span>

--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -3,20 +3,20 @@
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
     <ul role="tablist" aria-label="Organigrama del <%= @site.name %>">
       <li role="presentation" class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>">
-        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path, tab_attributes(controller_name == 'government_party_people' || controller_name == 'welcome') %>
+        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path, tab_attributes(controller_name == 'government_party_people' || controller_name == 'welcome').merge('aria-controls' => 'people-list') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name == 'opposition_party_people') %>">
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_people_path, tab_attributes(controller_name == 'opposition_party_people') %>
+        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_people_path, tab_attributes(controller_name == 'opposition_party_people').merge('aria-controls' => 'people-list') %>
       </li>
       <li role="presentation" class="<%= class_if('active', @political_group.present?) %>">
-        <%= link_to t("gobierto_people.people_filter.political_groups.title"), gobierto_people_political_group_people_path(@political_groups.first), tab_attributes(@political_group.present?) %>
+        <%= link_to t("gobierto_people.people_filter.political_groups.title"), gobierto_people_political_group_people_path(@political_groups.first), tab_attributes(@political_group.present?).merge('aria-controls' => 'people-list') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name == 'executive_category_people') %>">
-        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_people_path, tab_attributes(controller_name == 'executive_category_people') %>
+        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_people_path, tab_attributes(controller_name == 'executive_category_people').merge('aria-controls' => 'people-list') %>
       </li>
       <% if controller_name != 'welcome' %>
         <li role="presentation" class="<%= class_if('active', @political_group.nil? && controller_name == 'people') %>">
-          <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_people_path, tab_attributes(@political_group.nil? && controller_name == 'people') %>
+          <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_people_path, tab_attributes(@political_group.nil? && controller_name == 'people').merge('aria-controls' => 'people-list') %>
         </li>
       <% end %>
     </ul>
@@ -26,7 +26,7 @@
         <ul role="tablist" aria-label="Grupos políticos del <%= @site.name %>">
           <% @political_groups.each do |political_group| %>
             <li role="presentation" class="<%= class_if('active', @political_group == political_group) %>">
-              <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group), tab_attributes(@political_group == political_group) %>
+              <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group), tab_attributes(@political_group == political_group).merge('aria-controls' => 'people-list').merge('aria-controls' => 'people-list') %>
             </li>
           <% end %>
         </ul>

--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -22,7 +22,7 @@
 
     <% if @political_group %>
       <div>
-        <ul role="tablist" aria-label="<%= t('.political_group', name: @site.name) %>">
+        <ul role="tablist" aria-label="<%= t('.political_groups', name: @site.name) %>">
           <% @political_groups.each do |political_group| %>
             <li role="presentation" class="<%= class_if('active', @political_group == political_group) %>">
               <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group), tab_attributes(@political_group == political_group).merge('aria-controls' => 'people-list').merge('aria-controls' => 'people-list') %>

--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -2,20 +2,20 @@
 
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
     <ul role="tablist" aria-label="Organigrama del <%= @site.name %>">
-      <li class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>">
+      <li role="presentation" class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>">
         <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path, tab_attributes(controller_name == 'government_party_people' || controller_name == 'welcome') %>
       </li>
-      <li class="<%= class_if('active', controller_name == 'opposition_party_people') %>">
+      <li role="presentation" class="<%= class_if('active', controller_name == 'opposition_party_people') %>">
         <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_people_path, tab_attributes(controller_name == 'opposition_party_people') %>
       </li>
-      <li class="<%= class_if('active', @political_group.present?) %>">
+      <li role="presentation" class="<%= class_if('active', @political_group.present?) %>">
         <%= link_to t("gobierto_people.people_filter.political_groups.title"), gobierto_people_political_group_people_path(@political_groups.first), tab_attributes(@political_group.present?) %>
       </li>
-      <li class="<%= class_if('active', controller_name == 'executive_category_people') %>">
+      <li role="presentation" class="<%= class_if('active', controller_name == 'executive_category_people') %>">
         <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_people_path, tab_attributes(controller_name == 'executive_category_people') %>
       </li>
       <% if controller_name != 'welcome' %>
-        <li class="<%= class_if('active', @political_group.nil? && controller_name == 'people') %>">
+        <li role="presentation" class="<%= class_if('active', @political_group.nil? && controller_name == 'people') %>">
           <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_people_path, tab_attributes(@political_group.nil? && controller_name == 'people') %>
         </li>
       <% end %>
@@ -25,7 +25,7 @@
       <div>
         <ul role="tablist" aria-label="Grupos políticos del <%= @site.name %>">
           <% @political_groups.each do |political_group| %>
-            <li class="<%= class_if('active', @political_group == political_group) %>">
+            <li role="presentation" class="<%= class_if('active', @political_group == political_group) %>">
               <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group), tab_attributes(@political_group == political_group) %>
             </li>
           <% end %>

--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -1,7 +1,6 @@
 <menu class="filter_boxed">
-
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
-    <ul role="tablist" aria-label="Organigrama del <%= @site.name %>">
+    <ul role="tablist" aria-label="<%= t('.organigram', name: @site.name) %>">
       <li role="presentation" class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>">
         <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path, tab_attributes(controller_name == 'government_party_people' || controller_name == 'welcome').merge('aria-controls' => 'people-list') %>
       </li>
@@ -23,7 +22,7 @@
 
     <% if @political_group %>
       <div>
-        <ul role="tablist" aria-label="Grupos políticos del <%= @site.name %>">
+        <ul role="tablist" aria-label="<%= t('.political_group', name: @site.name) %>">
           <% @political_groups.each do |political_group| %>
             <li role="presentation" class="<%= class_if('active', @political_group == political_group) %>">
               <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group), tab_attributes(@political_group == political_group).merge('aria-controls' => 'people-list').merge('aria-controls' => 'people-list') %>
@@ -32,7 +31,5 @@
         </ul>
       </div>
     <% end %>
-
   </div>
-
 </menu>

--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -1,32 +1,32 @@
 <menu class="filter_boxed">
 
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
-    <ul>
-      <li class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>" >
-        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path %>
+    <ul role="tablist" aria-label="Organigrama del <%= @site.name %>">
+      <li class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>">
+        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path, tab_attributes(controller_name == 'government_party_people' || controller_name == 'welcome') %>
       </li>
       <li class="<%= class_if('active', controller_name == 'opposition_party_people') %>">
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_people_path %>
+        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_people_path, tab_attributes(controller_name == 'opposition_party_people') %>
       </li>
       <li class="<%= class_if('active', @political_group.present?) %>">
-        <%= link_to t("gobierto_people.people_filter.political_groups.title"), gobierto_people_political_group_people_path(@political_groups.first) %>
+        <%= link_to t("gobierto_people.people_filter.political_groups.title"), gobierto_people_political_group_people_path(@political_groups.first), tab_attributes(@political_group.present?) %>
       </li>
       <li class="<%= class_if('active', controller_name == 'executive_category_people') %>">
-        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_people_path %>
+        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_people_path, tab_attributes(controller_name == 'executive_category_people') %>
       </li>
       <% if controller_name != 'welcome' %>
         <li class="<%= class_if('active', @political_group.nil? && controller_name == 'people') %>">
-          <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_people_path %>
+          <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_people_path, tab_attributes(@political_group.nil? && controller_name == 'people') %>
         </li>
       <% end %>
     </ul>
 
     <% if @political_group %>
       <div>
-        <ul>
+        <ul role="tablist" aria-label="Grupos políticos del <%= @site.name %>">
           <% @political_groups.each do |political_group| %>
             <li class="<%= class_if('active', @political_group == political_group) %>">
-              <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group) %>
+              <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group), tab_attributes(@political_group == political_group) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_people/people/index.html.erb
@@ -12,7 +12,7 @@
 
   <%= render "gobierto_people/people/people_filter"  %>
 
-  <div class="people-summary people-grid pure-g">
+  <div class="people-summary people-grid pure-g" id="people-list">
 
     <% @people.each do |person| %>
 

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -3,16 +3,16 @@
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
 
     <ul role="tablist" aria-label="Agenda de los miembros del <%= @site.name %>">
-      <li class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
+      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
         <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>
       </li>
-      <li class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
+      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
         <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_events_path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>
       </li>
-      <li class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
+      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
         <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_events_path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>
       </li>
-      <li class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
+      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
         <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_events_path, tab_attributes(controller_name.in?(%w(person_events past_person_events))) %>
       </li>
     </ul>
@@ -28,7 +28,7 @@
 
   <ul role="tablist" aria-label="Listado de partidos políticos">
     <% @political_groups.each do |political_group| %>
-      <li class="<%= class_if('active', @political_group.try(:name) == political_group.name) %>">
+      <li role="presentation" class="<%= class_if('active', @political_group.try(:name) == political_group.name) %>">
         <%= link_to political_group.name, gobierto_people_political_group_events_path(political_group), tab_attributes(@political_group.try(:name) == political_group.name) %>
       </li>
     <% end %>

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -2,18 +2,18 @@
 
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
 
-    <ul>
+    <ul role="tablist" aria-label="Agenda de los miembros del <%= @site.name %>">
       <li class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path %>
+        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>
       </li>
       <li class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_events_path %>
+        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_events_path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>
       </li>
       <li class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_events_path %>
+        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_events_path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>
       </li>
       <li class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_events_path %>
+        <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_events_path, tab_attributes(controller_name.in?(%w(person_events past_person_events))) %>
       </li>
     </ul>
 
@@ -26,10 +26,10 @@
 
   <%= t("gobierto_people.people_filter.political_groups.title") %>
 
-  <ul>
+  <ul role="tablist" aria-label="Listado de partidos políticos">
     <% @political_groups.each do |political_group| %>
       <li class="<%= class_if('active', @political_group.try(:name) == political_group.name) %>">
-        <%= link_to political_group.name, gobierto_people_political_group_events_path(political_group) %>
+        <%= link_to political_group.name, gobierto_people_political_group_events_path(political_group), tab_attributes(@political_group.try(:name) == political_group.name) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -4,16 +4,16 @@
 
     <ul role="tablist" aria-label="Agenda de los miembros del <%= @site.name %>">
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>
+        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_events_path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>
+        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_events_path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_events_path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>
+        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_events_path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_events_path, tab_attributes(controller_name.in?(%w(person_events past_person_events))) %>
+        <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_events_path, tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
     </ul>
 

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -1,8 +1,7 @@
 <menu class="filter_boxed">
-
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
 
-    <ul role="tablist" aria-label="Agenda de los miembros del <%= @site.name %>">
+    <ul role="tablist" aria-label="<%= t('.agenda', name: @site.name) %>">
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
         <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
@@ -18,7 +17,6 @@
     </ul>
 
   </div>
-
 </menu>
 
 <% pending do %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -52,7 +52,7 @@
 
     </div>
 
-    <div class="pure-u-1 pure-u-md-17-24 main_people_content">
+    <div id="person-agenda" class="pure-u-1 pure-u-md-17-24 main_people_content">
 
       <div class="events-filter">
 

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -14,11 +14,11 @@ ca:
         budget_line: Partida
         expense_in_what: En què es gasta
         expense_to_do_what: Per a què es gasta
-        help: El pressupuest organitza les despeses en dues categories. Consulta la
-          nostra guia.
+        help: El pressupuest organitza les despeses en dues categories. Consulta la nostra guia.
         income_from_what: En què s'ingressa
         per_inhabitant: Per habitant
         title: Pressupostos municipals en %{year}
+        categories: Categories pressupostàries
       show:
         about_this_line: Sobre aquesta partida
         avg_province: Mitjana %{kind} provincial
@@ -41,6 +41,7 @@ ca:
           al %{year}'
     budgets:
       index:
+        visualize: Visualitza les despeses per habitant o el total
         at_a_glance: Evolució de la despesa i comparació
         at_years_end: "* a final del %{year}"
         context: Contexte

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -110,9 +110,7 @@ en:
         planned: planned
         real: real
     common:
-      budget_line_description_html: 'This budget line is composed of %{kind_what}
-        in %{description}. If you want to understand more about it, check its parent
-        budget line: %{link}'
+      budget_line_description_html: 'This budget line is composed of %{kind_what} in %{description}. If you want to understand more about it, check its parent budget line: %{link}'
       expense: expense
       expenses: expenses
       income: income

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -18,6 +18,7 @@ en:
         income_from_what: Where does the income come from
         per_inhabitant: Per inhabitant
         title: Local municipality budgets in %{year}
+        categories: Categories
       show:
         about_this_line: About this budget line
         avg_province: Avg. %{kind} in the province
@@ -40,6 +41,7 @@ en:
           for year %{year}'
     budgets:
       index:
+        visualize: Visualize expenses per inhabitant or the total
         at_a_glance: At a glance
         at_years_end: "* at the end of %{year}"
         context: Context

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -14,11 +14,11 @@ es:
         budget_line: Partida
         expense_in_what: En qué se gasta
         expense_to_do_what: Para qué se gasta
-        help: El presupuesto organiza los gastos en dos categorías. Consulta nuestra
-          guía
+        help: El presupuesto organiza los gastos en dos categorías. Consulta nuestra guía
         income_from_what: En qué se ingresa
         per_inhabitant: Por habitante
         title: Presupuestos municipales en %{year}
+        categories: Categorías presupuestarias
       show:
         about_this_line: Acerca de esta partida
         avg_province: Media %{kind} provincial
@@ -41,6 +41,7 @@ es:
           para el %{year}'
     budgets:
       index:
+        visualize: Visualiza los gastos por habitante o el total
         at_a_glance: Evolución del gasto y comparación
         at_years_end: "* a cierre del %{year}"
         context: Contexto

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -117,6 +117,8 @@ ca:
         title: Agenda
         view_all: Veure tots
     people_filter:
+      organigram: Organigrama de %{name}
+      political_groups: Grups polítics de %{name}
       all: tots
       categories:
         executive: Directiu
@@ -126,6 +128,8 @@ ca:
       political_groups:
         title: Grup polític
     person_events:
+      person_events_filter:
+        agenda: Agenda dels membres del %{name}
       index:
         agenda_switcher:
           subtitle: Filtra per membres de la comunitat

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -35,6 +35,9 @@ ca:
           title: Declaracions
           description: Llistat de les declaracions de béns i activitats i tots els seus elements.
     people:
+      people_filter:
+        organigram: Organigrama de %{name}
+        political_groups: Grups polítics de %{name}
       contact_methods:
         send_email: Envia un correu-e
       index:
@@ -117,8 +120,6 @@ ca:
         title: Agenda
         view_all: Veure tots
     people_filter:
-      organigram: Organigrama de %{name}
-      political_groups: Grups polítics de %{name}
       all: tots
       categories:
         executive: Directiu

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -35,6 +35,9 @@ en:
           title: Statements
           description: Listing of all statements and it elements.
     people:
+      people_filter:
+        organigram: "%{name} organigram"
+        political_groups: "%{name} political groups"
       contact_methods:
         send_email: Send an email
       index:
@@ -117,8 +120,6 @@ en:
         title: Agenda
         view_all: View all
     people_filter:
-      organigram: %{name} organigram
-      political_groups: %{name} political groups
       all: All
       categories:
         executive: Executive
@@ -129,12 +130,12 @@ en:
         title: Political groups
     person_events:
       person_events_filter:
-        agenda: %{name} members agenda
+        agenda: "%{name} members agenda"
       index:
         agenda_switcher:
           subtitle: Filter by community members
           title: Check the agenda of...
-        displaying_events_of: Displaying events of %{date}
+        displaying_events_of: "Displaying events of %{date}"
         go_back: Go back
         past_events: Past events
         subscribable_box:

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -117,6 +117,8 @@ en:
         title: Agenda
         view_all: View all
     people_filter:
+      organigram: %{name} organigram
+      political_groups: %{name} political groups
       all: All
       categories:
         executive: Executive
@@ -126,6 +128,8 @@ en:
       political_groups:
         title: Political groups
     person_events:
+      person_events_filter:
+        agenda: %{name} members agenda
       index:
         agenda_switcher:
           subtitle: Filter by community members

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -118,6 +118,8 @@ es:
         title: Agenda
         view_all: Ver todos
     people_filter:
+      organigram: Organigrama de %{name}
+      political_groups: Grupos políticos de %{name}
       all: Todos
       categories:
         executive: Directivos
@@ -127,6 +129,8 @@ es:
       political_groups:
         title: Grupos políticos
     person_events:
+      person_events_filter:
+        agenda: Agenda de los miembros del %{name}
       index:
         agenda_switcher:
           subtitle: Filtra por miembros de la comunidad

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -35,6 +35,9 @@ es:
           title: Declaraciones de bienes y actividades
           description: Listado de las declaraciones de bienes y actividades y todos sus elementos.
     people:
+      people_filter:
+        organigram: Organigrama de %{name}
+        political_groups: Grupos políticos de %{name}
       contact_methods:
         send_email: Envía un correo-e
       index:
@@ -118,8 +121,6 @@ es:
         title: Agenda
         view_all: Ver todos
     people_filter:
-      organigram: Organigrama de %{name}
-      political_groups: Grupos políticos de %{name}
       all: Todos
       categories:
         executive: Directivos
@@ -130,17 +131,17 @@ es:
         title: Grupos políticos
     person_events:
       person_events_filter:
-        agenda: Agenda de los miembros del %{name}
+        agenda: "Agenda de los miembros del %{name}"
       index:
         agenda_switcher:
           subtitle: Filtra por miembros de la comunidad
           title: Consulta la agenda de...
-        displaying_events_of: Mostrando eventos del %{date}
+        displaying_events_of: "Mostrando eventos del %{date}"
         go_back: Volver
         past_events: Eventos pasados
         subscribable_box:
           title: Recibe un resumen de las agendas de tus representantes
-        title: Agendas de los miembros de %{site_name}
+        title: "Agendas de los miembros de %{site_name}"
         upcoming_events: Agenda
     person_post_tags:
       show:

--- a/vendor/assets/javascripts/tabs.js
+++ b/vendor/assets/javascripts/tabs.js
@@ -1,0 +1,209 @@
+$(document).on('turbolinks:load', function() {
+  (function () {
+    var tablist = document.querySelectorAll('[role="tablist"]')[0];
+    var tabs;
+    var panels;
+
+    console.log(tablist);
+
+    generateArrays();
+
+    function generateArrays () {
+      tabs = document.querySelectorAll('[role="tab"]');
+      panels = document.querySelectorAll('[role="tabpanel"]');
+    };
+
+    // For easy reference
+    var keys = {
+      end: 35,
+      home: 36,
+      left: 37,
+      up: 38,
+      right: 39,
+      down: 40,
+      enter: 13,
+      space: 32
+    };
+
+    // Add or substract depenign on key pressed
+    var direction = {
+      37: -1,
+      38: -1,
+      39: 1,
+      40: 1
+    };
+
+    // Bind listeners
+    for (i = 0; i < tabs.length; ++i) {
+      addListeners(i);
+    };
+
+    function addListeners (index) {
+      tabs[index].addEventListener('click', clickEventListener);
+      tabs[index].addEventListener('keydown', keydownEventListener);
+      tabs[index].addEventListener('keyup', keyupEventListener);
+
+      // Build an array with all tabs (<button>s) in it
+      tabs[index].index = index;
+    };
+
+    // When a tab is clicked, activateTab is fired to activate it
+    function clickEventListener (event) {
+      var tab = event.target;
+      activateTab(tab, false);
+    };
+
+    // Handle keydown on tabs
+    function keydownEventListener (event) {
+      var key = event.keyCode;
+
+      switch (key) {
+        case keys.end:
+          event.preventDefault();
+          // Activate last tab
+          focusLastTab();
+          break;
+        case keys.home:
+          event.preventDefault();
+          // Activate first tab
+          focusFirstTab();
+          break;
+
+        // Up and down are in keydown
+        // because we need to prevent page scroll >:)
+        case keys.up:
+        case keys.down:
+          determineOrientation(event);
+          break;
+      };
+    };
+
+    // Handle keyup on tabs
+    function keyupEventListener (event) {
+      var key = event.keyCode;
+
+      switch (key) {
+        case keys.left:
+        case keys.right:
+          determineOrientation(event);
+          break;
+        case keys.enter:
+        case keys.space:
+          activateTab(event.target);
+          break;
+      };
+    };
+
+    // When a tablist’s aria-orientation is set to vertical,
+    // only up and down arrow should function.
+    // In all other cases only left and right arrow function.
+    function determineOrientation (event) {
+      var key = event.keyCode;
+      var vertical = tablist.getAttribute('aria-orientation') == 'vertical';
+      var proceed = false;
+
+      if (vertical) {
+        if (key === keys.up || key === keys.down) {
+          event.preventDefault();
+          proceed = true;
+        };
+      }
+      else {
+        if (key === keys.left || key === keys.right) {
+          proceed = true;
+        };
+      };
+
+      if (proceed) {
+        switchTabOnArrowPress(event);
+      };
+    };
+
+    // Either focus the next, previous, first, or last tab
+    // depening on key pressed
+    function switchTabOnArrowPress (event) {
+      var pressed = event.keyCode;
+
+      if (direction[pressed]) {
+        var target = event.target;
+        if (target.index !== undefined) {
+          if (tabs[target.index + direction[pressed]]) {
+            tabs[target.index + direction[pressed]].focus();
+          }
+          else if (pressed === keys.left || pressed === keys.up) {
+            focusLastTab();
+          }
+          else if (pressed === keys.right || pressed == keys.down) {
+            focusFirstTab();
+          };
+        };
+      };
+    };
+
+    // Activates any given tab panel
+    function activateTab (tab, setFocus) {
+      setFocus = setFocus || true;
+      // Deactivate all other tabs
+      deactivateTabs();
+
+      // Remove tabindex attribute
+      tab.removeAttribute('tabindex');
+
+      // Set the tab as selected
+      tab.setAttribute('aria-selected', 'true');
+
+      // Get the value of aria-controls (which is an ID)
+      var controls = tab.getAttribute('aria-controls');
+
+      // Remove hidden attribute from tab panel to make it visible
+      document.getElementById(controls).removeAttribute('hidden');
+
+      // Set focus when required
+      if (setFocus) {
+        tab.focus();
+      };
+    };
+
+    // Deactivate all tabs and tab panels
+    function deactivateTabs () {
+      for (t = 0; t < tabs.length; t++) {
+        tabs[t].setAttribute('tabindex', '-1');
+        tabs[t].setAttribute('aria-selected', 'false');
+      };
+
+      for (p = 0; p < panels.length; p++) {
+        panels[p].setAttribute('hidden', 'hidden');
+      };
+    };
+
+    // Make a guess
+    function focusFirstTab () {
+      tabs[0].focus();
+    };
+
+    // Make a guess
+    function focusLastTab () {
+      tabs[tabs.length - 1].focus();
+    };
+
+    // Determine whether there should be a delay
+    // when user navigates with the arrow keys
+    function determineDelay () {
+      var hasDelay = tablist.hasAttribute('data-delay');
+      var delay = 0;
+
+      if (hasDelay) {
+        var delayValue = tablist.getAttribute('data-delay');
+        if (delayValue) {
+          delay = delayValue;
+        }
+        else {
+          // If no value is specified, default to 300ms
+          delay = 300;
+        };
+      };
+
+      return delay;
+    };
+  })();
+});

--- a/vendor/assets/javascripts/tabs.js
+++ b/vendor/assets/javascripts/tabs.js
@@ -4,8 +4,6 @@ $(document).on('turbolinks:load', function() {
     var tabs;
     var panels;
 
-    console.log(tablist);
-
     generateArrays();
 
     function generateArrays () {


### PR DESCRIPTION
Connects to #463.

### What does this PR do?
Improve the tab implementation in all the modules, using ARIA.
- JavaScript helper to improve keyboard navigation
- Ruby helper to control tab attributes.
- Add ids to certain HTML tags to implement `aria-controls`, `aria-labelledby`.

### How should this be manually tested?
Using a screen reader utility, as VoiceOver on macOS, the tabs and the tabpanels should have better accesibility and keyboard navigation.

