### PR TITLE
Hide Trix captions just for images

### DIFF
--- a/app/assets/stylesheets/comp-text_content.scss
+++ b/app/assets/stylesheets/comp-text_content.scss
@@ -15,7 +15,7 @@
 .article {
 	
 }
-figure {
+figure.png, figure.jpg, figure.gif {
 	margin: 1em 0;
 	img {
 		max-width: 100%;


### PR DESCRIPTION
Connects to #497

### What does this PR do?

This PR updates styles to hide captions in attachments uploaded in Trix just for images.
