### PR TITLE
Use <a> tag for links in mailer

### DIFF
--- a/app/views/gobierto_admin/admin_mailer/confirmation_instructions.html.erb
+++ b/app/views/gobierto_admin/admin_mailer/confirmation_instructions.html.erb
@@ -7,7 +7,8 @@
 </p>
 
 <p>
-  <%= admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, domain: @site.try(:domain)) %>
+  <%= link_to admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, domain: @site.try(:domain)),
+              admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, domain: @site.try(:domain)) %>
 </p>
 
 <p>

--- a/app/views/gobierto_admin/admin_mailer/invitation_instructions.html.erb
+++ b/app/views/gobierto_admin/admin_mailer/invitation_instructions.html.erb
@@ -7,7 +7,8 @@
 </p>
 
 <p>
-  <%= admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, domain: @site.try(:domain)) %>
+  <%= link_to admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, domain: @site.try(:domain)),
+              admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, domain: @site.try(:domain)) %>
 </p>
 
 <p>

--- a/app/views/gobierto_admin/admin_mailer/reset_password_instructions.html.erb
+++ b/app/views/gobierto_admin/admin_mailer/reset_password_instructions.html.erb
@@ -7,7 +7,8 @@
 </p>
 
 <p>
-  <%= edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, domain: @site.try(:domain)) %>
+  <%= link_to edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, domain: @site.try(:domain)),
+              edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, domain: @site.try(:domain)) %>
 </p>
 
 <p>

--- a/app/views/user/user_mailer/confirmation_instructions.html.erb
+++ b/app/views/user/user_mailer/confirmation_instructions.html.erb
@@ -7,7 +7,8 @@
 </p>
 
 <p>
-  <%= new_user_confirmations_url(confirmation_token: @user.confirmation_token, domain: @site.domain) %>
+  <%= link_to new_user_confirmations_url(confirmation_token: @user.confirmation_token, domain: @site.domain),
+              new_user_confirmations_url(confirmation_token: @user.confirmation_token, domain: @site.domain) %>
 </p>
 
 <p>

--- a/app/views/user/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user/user_mailer/reset_password_instructions.html.erb
@@ -7,7 +7,8 @@
 </p>
 
 <p>
-  <%= edit_user_passwords_url(reset_password_token: @user.reset_password_token, domain: @site.domain) %>
+  <%= link_to edit_user_passwords_url(reset_password_token: @user.reset_password_token, domain: @site.domain),
+              edit_user_passwords_url(reset_password_token: @user.reset_password_token, domain: @site.domain) %>
 </p>
 
 <p>


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR uses a `<a>` tag in HTML emails where just the URL was used.
