### PR TITLE
Allow census item search with alternative representations of the number

### DIFF
--- a/test/fixtures/census_items.yml
+++ b/test/fixtures/census_items.yml
@@ -18,3 +18,17 @@ madrid_93:
   date_of_birth: 1993-01-01
   verified: false
   import_reference: 0
+
+madrid_98:
+  site: madrid
+  document_number_digest: <%= SecretAttribute.digest("12345678") %>
+  date_of_birth: 1998-01-01
+  verified: false
+  import_reference: 0
+
+madrid_00:
+  site: madrid
+  document_number_digest: <%= SecretAttribute.digest("X05104959") %>
+  date_of_birth: 2000-01-01
+  verified: false
+  import_reference: 0

--- a/test/forms/gobierto_admin/census_import_form_test.rb
+++ b/test/forms/gobierto_admin/census_import_form_test.rb
@@ -53,7 +53,7 @@ module GobiertoAdmin
     end
 
     def test_items_creation
-      assert_difference "CensusItem.count", 1 do
+      assert_difference "CensusItem.count", -1 do
         valid_user_census_import_form.save
       end
     end

--- a/test/repositories/census_repository_test.rb
+++ b/test/repositories/census_repository_test.rb
@@ -25,7 +25,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
   def test_destroy_previous_by_reference
     census_repository.create
 
-    assert_difference "CensusItem.count", -3 do
+    assert_difference "CensusItem.count", -5 do
       CensusRepository.destroy_previous_by_reference(
         site_id: census_repository.site_id,
         import_reference: 1
@@ -54,6 +54,50 @@ class CensusRepositoryTest < ActiveSupport::TestCase
       site_id: census_item.site_id,
       document_number: "00000000A",
       date_of_birth: census_item.date_of_birth
+    )
+
+    assert existing_census_repository.exists?
+  end
+
+  def test_exists_with_no_letter?
+    existing_census_repository =  CensusRepository.new(
+      site_id: census_item.site_id,
+      document_number: "12345678",
+      date_of_birth: Date.parse("1998-01-01")
+    )
+
+    assert existing_census_repository.exists?
+
+    existing_census_repository =  CensusRepository.new(
+      site_id: census_item.site_id,
+      document_number: "12345678A",
+      date_of_birth: Date.parse("1998-01-01")
+    )
+
+    assert existing_census_repository.exists?
+  end
+
+  def test_exists_with_special_letters
+    existing_census_repository =  CensusRepository.new(
+      site_id: census_item.site_id,
+      document_number: "x5104959v",
+      date_of_birth: Date.parse("1998-01-01")
+    )
+
+    assert existing_census_repository.exists?
+
+    existing_census_repository =  CensusRepository.new(
+      site_id: census_item.site_id,
+      document_number: "x05104959v",
+      date_of_birth: Date.parse("1998-01-01")
+    )
+
+    assert existing_census_repository.exists?
+
+    existing_census_repository =  CensusRepository.new(
+      site_id: census_item.site_id,
+      document_number: "05104959v",
+      date_of_birth: Date.parse("1998-01-01")
     )
 
     assert existing_census_repository.exists?


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR helps users verifications by allowing different versions of a document number. Examples:

- stored number: 12345678, and the user tries that number with a letter
- stored number: X0123456, and the user tries: X0123456V, X123456V, X123456 or X123456V

All these scenarios work now.