### PR TITLE
Census item alternatives + Fix consultation response

### DIFF
--- a/app/forms/gobierto_budget_consultations/consultation_response_form.rb
+++ b/app/forms/gobierto_budget_consultations/consultation_response_form.rb
@@ -16,7 +16,7 @@ module GobiertoBudgetConsultations
 
     delegate :to_model, :persisted?, to: :consultation_response
 
-    validates :selected_options, :document_number_digest, :census_item, :consultation, :user, presence: true
+    validates :selected_options, :document_number_digest, :consultation, :user, presence: true
 
     def save
       save_consultation_response if valid?
@@ -32,10 +32,6 @@ module GobiertoBudgetConsultations
 
     def site
       @site ||= consultation.site if consultation
-    end
-
-    def census_item
-      @census_item ||= CensusItem.find_by(site_id: site.id, document_number_digest: document_number_digest) if site
     end
 
     def budget_amount

--- a/app/repositories/census_repository.rb
+++ b/app/repositories/census_repository.rb
@@ -115,6 +115,18 @@ class CensusRepository
       alternatives.push(document_number.tr(letter, '').tr('X', ''))
     end
 
+    if document_number =~ /\AX0\d+\z/i
+      alternatives.push(document_number.tr('X0', 'X'))
+      alternatives.push(document_number.tr('X0', '0'))
+      alternatives.push(document_number.tr('X0', ''))
+    end
+
+    if document_number =~ /\AX\d+\z/i
+      alternatives.push(document_number.gsub('X', 'X0'))
+      alternatives.push(document_number.tr('X', '0'))
+      alternatives.push(document_number.tr('X', ''))
+    end
+
     return alternatives
   end
 

--- a/test/forms/gobierto_budget_consultations/consultation_response_form_test.rb
+++ b/test/forms/gobierto_budget_consultations/consultation_response_form_test.rb
@@ -60,7 +60,6 @@ module GobiertoBudgetConsultations
     def test_error_messages_with_invalid_attributes
       invalid_consultation_response_form.save
 
-      assert_equal 1, invalid_consultation_response_form.errors.messages[:census_item].size
       assert_equal 1, invalid_consultation_response_form.errors.messages[:document_number_digest].size
       assert_equal 1, invalid_consultation_response_form.errors.messages[:consultation].size
       assert_equal 1, invalid_consultation_response_form.errors.messages[:selected_options].size

--- a/test/repositories/census_repository_test.rb
+++ b/test/repositories/census_repository_test.rb
@@ -110,6 +110,13 @@ class CensusRepositoryTest < ActiveSupport::TestCase
 
     assert existing_census_repository.exists?
 
+    existing_census_repository =  CensusRepository.new(
+      site_id: census_item.site_id,
+      document_number: "X5104959",
+      date_of_birth: Date.parse("1998-01-01")
+    )
+
+    assert existing_census_repository.exists?
   end
 
   def test_create


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR adds a new census item check alternative scenario.

It also fixes how consultation responses fetch the document number.