### PR TITLE
Load site from url in admin pages

### DIFF
--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -7,6 +7,7 @@ module GobiertoAdmin
 
     skip_before_action :authenticate_user_in_site
     before_action :authenticate_admin!
+    before_action :set_admin_site
 
     helper_method :current_admin, :admin_signed_in?
     helper_method :current_site, :managing_site?
@@ -34,6 +35,17 @@ module GobiertoAdmin
       preferred_locale = (locale_param || locale_cookie || I18n.default_locale).to_s
 
       I18n.locale = cookies.permanent.signed[:locale] = preferred_locale.to_sym
+    end
+
+    def set_admin_site
+      return unless current_site
+
+      if request.host != current_site.domain
+        if site = managed_sites.find_by(domain: request.host)
+          enter_site(site.id)
+          redirect_to admin_root_path
+        end
+      end
     end
   end
 end

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -38,10 +38,9 @@
           <ul id="managed-sites-list" class="pure-menu-children">
             <% managed_sites.each do |site| %>
               <li class="pure-menu-item">
-                <%= button_to(
+                <%= link_to(
                   site.name,
-                  admin_sites_sessions_path,
-                  params: { site_id: site.id },
+                  admin_root_url(domain: site.domain),
                   class: "pure-menu-link") %>
               </li>
             <% end %>

--- a/test/controllers/gobierto_admin/census/imports_controller_test.rb
+++ b/test/controllers/gobierto_admin/census/imports_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module GobiertoAdmin
-  class Census::ImporsControllerTest < GobiertoControllerTest
+  class Census::ImportsControllerTest < GobiertoControllerTest
     def admin
       @admin ||= gobierto_admin_admins(:nick)
     end

--- a/test/support/integration/site_session_helpers.rb
+++ b/test/support/integration/site_session_helpers.rb
@@ -11,7 +11,7 @@ module Integration
       visit admin_root_path
 
       within("#managed-sites-list") do
-        click_button site.name
+        click_link site.name
       end
     end
   end


### PR DESCRIPTION
Connects to #388

### What does this PR do?

If the subdomain in the url is different than the current site it loads the site from the subdomain and redirects to the root admin page with that subdomain in the url. 

### How should this be manually tested?

Paste an admin url with a site different from the current one and check that the site is changed in the admin page.
Check also if there are any weird redirections or inconsistent site from the page and the url.
