### PR TITLE
Add more search labels

### DIFF
--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -27,8 +27,8 @@
       </div>
 
       <h3><%= t('.search_budget_line') %></h3>
-
-      <input type="text" placeholder="<%= t('.search') %>..." data-autocomplete="<%= gobierto_budgets_search_all_categories_path(@place.slug, @year, format: :json) %>">
+      <label class="screen-hidden" for="budget_line_search"><%= t('.search_budget_line') %></label>
+      <input id="budget_line_search" type="text" placeholder="<%= t('.search') %>..." data-autocomplete="<%= gobierto_budgets_search_all_categories_path(@place.slug, @year, format: :json) %>">
 
       <div class="small m_v_3">
         <p><%= t('.examples') %>:</p>
@@ -42,4 +42,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -163,6 +163,7 @@
           <%= content_for?(:module_sub_sections) ? yield(:module_sub_sections) : load_module_sub_sections(current_module) %>
 
           <div class="search_box slim_search desktop_only">
+            <label for="gobierto_search" class="screen-hidden"><%= t('.search') %></label>
             <input type="text" placeholder="<%= t('.search') %>" name="q" id="gobierto_search" />
           </div>
 

--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -29,6 +29,7 @@
       <%= form_for(user_subscription_form, as: :user_subscription, url: :user_subscriptions) do |f| %>
         <%= f.hidden_field :subscribable_type %>
         <%= f.hidden_field :subscribable_id %>
+        <label class="screen-hidden" for="user_subscription_user_email"><%= defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %></label>
         <%= f.email_field :user_email, placeholder: defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %>
 
         <%= f.submit t(".form.submit") %>

--- a/vendor/assets/stylesheets/populities.scss
+++ b/vendor/assets/stylesheets/populities.scss
@@ -61,6 +61,14 @@
 .hidden, .soft_hidden {
   display: none;
 }
+/* From https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css#L128 */
+.screen-hidden {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px; width: 1px;
+  margin: -1px; padding: 0; border: 0;
+}
 .fixed {
   position: fixed;
 }


### PR DESCRIPTION
Connects to #464.

### What does this PR do?
This PR adds labels tag in the header's Search bar, the Budget module and the email box.

It also adds [a way](https://css-tricks.com/places-its-tempting-to-use-display-none-but-dont/) to hide content from the viewer, but not from a screen reader, inside Populities.