### PR TITLE
Improve button declarations

### DIFF
--- a/app/assets/stylesheets/module-consultations.scss
+++ b/app/assets/stylesheets/module-consultations.scss
@@ -513,6 +513,11 @@ img.side_50 {
     padding: 0.75rem 1rem;
   }
 }
+.pct:focus {
+  border-color: inherit;
+  box-shadow: none;
+  background: #00626b;
+}
 .border .active {
   border-radius: 6px;
   background: #00626b;

--- a/app/views/gobierto_budget_consultations/consultations/consultation_items/index.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/consultation_items/index.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="consultation-step">
-        <%= link_to [@consultation, :new_response], class: "consultation-link" do %>
+        <%= link_to [@consultation, :new_response], class: "consultation-link", role: "button" do %>
           <div class="bottom-info-small">
             <div class="teaser">
               <h2 class="consultation-q inline-block"><%= t('.start') %></h2>

--- a/app/views/gobierto_budget_consultations/consultations/consultation_responses/new.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/consultation_responses/new.html.erb
@@ -188,11 +188,11 @@
         </div>
       </div>
       <div class="pure-u-1-6">
-        <a href="#" class="budget-next" @click="nextScreen" v-if="!next"><i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+        <a href="#" role="button" class="budget-next" @click="nextScreen" v-if="!next"><i class="fa fa-arrow-right" aria-hidden="true"></i></a>
         <% if @consultation.force_responses_balance? %>
-          <a href="#" class="budget-next consultation-status-error" @click="showConsultationStatusError" v-else-if="status=='deficit'" title="<p><%= I18n.t('gobierto_budget_consultations.consultation_status_error') %></p><button class='tip-button' data-tipsy-close>OK</button>"><i class="fa fa-times" aria-hidden="true"></i></a>
+          <a href="#" role="button" class="budget-next consultation-status-error" @click="showConsultationStatusError" v-else-if="status=='deficit'" title="<p><%= I18n.t('gobierto_budget_consultations.consultation_status_error') %></p><button class='tip-button' data-tipsy-close>OK</button>"><i class="fa fa-times" aria-hidden="true"></i></a>
         <% end %>
-        <a href="#" class="budget-next" @click="submitConsultation" v-else><i class="fa fa-check" aria-hidden="true"></i></a>
+        <a href="#" role="button" class="budget-next" @click="submitConsultation" v-else><i class="fa fa-check" aria-hidden="true"></i></a>
       </div>
     </div>
 

--- a/app/views/gobierto_budget_consultations/consultations/show.html.erb
+++ b/app/views/gobierto_budget_consultations/consultations/show.html.erb
@@ -3,7 +3,7 @@
     <%= raw @consultation.description %>
   </div>
   <% if @consultation.open? %>
-    <%= link_to gobierto_budget_consultations_consultation_item_summary_path(@consultation), class: "consultation-link", data:{ consultation_link: true } do %>
+    <%= link_to gobierto_budget_consultations_consultation_item_summary_path(@consultation), class: "consultation-link", data:{ consultation_link: true }, role: "button" do %>
       <div class="bottom-info">
         <div class="teaser">
           <h2 class="consultation-q inline-block"><%= t('.want_to_opinate') %></h2>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -182,8 +182,8 @@
 
       <div class="pure-u-1">
         <div class="filter m_v_2">
-          <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" } %>
-          <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" } %>
+          <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" }, role: "button" %>
+          <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(@place.id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" }, role: "button" %>
         </div>
       </div>
     </div>

--- a/app/views/gobierto_budgets/budgets_execution/_execution_table.html.erb
+++ b/app/views/gobierto_budgets/budgets_execution/_execution_table.html.erb
@@ -19,4 +19,4 @@
   </tbody>
 </table>
 
-<%= link_to t('.view_more'), '', class:'button_light more', data: {more_literal: t('.view_more'), less_literal: t('.view_less')} %>
+<%= link_to t('.view_more'), '', class:'button_light more', data: {more_literal: t('.view_more'), less_literal: t('.view_less'), role: "button"} %>

--- a/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
+++ b/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <div class="show_me_another">
-  <%= link_to %Q{<i class="fa fa-refresh"></i> #{t('.show_me_another')}}.html_safe, '#', class: 'show_me_another', data: { 'featured-budget-line-load-more' => true }%>
+  <%= link_to %Q{<i class="fa fa-refresh"></i> #{t('.show_me_another')}}.html_safe, '#', class: 'show_me_another', data: { 'featured-budget-line-load-more' => true }, role: "button" %>
 </div>
 
 <script type="text/html" id="widget-template">

--- a/app/views/gobierto_people/exports/_index.html.erb
+++ b/app/views/gobierto_people/exports/_index.html.erb
@@ -9,28 +9,28 @@
 
     <div class="data_item">
       <h3><%= t("gobierto_people.exports.index.people.title") %></h3>
-      <%= link_to 'CSV', gobierto_people_people_path(format: :csv), class: 'button small' %>
-      <%= link_to 'JSON', gobierto_people_people_path(format: :json), class: 'button small' %>
+      <%= link_to 'CSV', gobierto_people_people_path(format: :csv), class: 'button small', role: "button" %>
+      <%= link_to 'JSON', gobierto_people_people_path(format: :json), class: 'button small', role: "button" %>
       <p><%= t("gobierto_people.exports.index.people.description") %></p>
     </div>
 
     <div class="data_item">
       <h3><%= t("gobierto_people.exports.index.events.title") %></h3>
-      <%= link_to 'CSV', gobierto_people_events_path(format: :csv), class: 'button small' %>
-      <%= link_to 'JSON', gobierto_people_events_path(format: :json), class: 'button small' %>
+      <%= link_to 'CSV', gobierto_people_events_path(format: :csv), class: 'button small', role: "button" %>
+      <%= link_to 'JSON', gobierto_people_events_path(format: :json), class: 'button small', role: "button" %>
       <p><%= t("gobierto_people.exports.index.events.description") %></p>
     </div>
 
     <div class="data_item">
       <h3><%= t("gobierto_people.exports.index.statements.title") %></h3>
-      <%= link_to 'CSV', gobierto_people_statements_path(format: :csv), class: 'button small' %>
-      <%= link_to 'JSON', gobierto_people_statements_path(format: :json), class: 'button small' %>
+      <%= link_to 'CSV', gobierto_people_statements_path(format: :csv), class: 'button small', role: "button" %>
+      <%= link_to 'JSON', gobierto_people_statements_path(format: :json), class: 'button small', role: "button" %>
       <p><%= t("gobierto_people.exports.index.statements.description") %></p>
     </div>
 
     <div class="data_item">
       <h3><%= t("gobierto_people.exports.index.posts.title") %></h3>
-      <%= link_to 'RSS', gobierto_people_posts_path(format: :rss), class: 'button small' %>
+      <%= link_to 'RSS', gobierto_people_posts_path(format: :rss), class: 'button small', role: "button" %>
       <p><%= t("gobierto_people.exports.index.posts.description") %></p>
     </div>
 

--- a/app/views/gobierto_people/people/_subscription_button.html.erb
+++ b/app/views/gobierto_people/people/_subscription_button.html.erb
@@ -11,7 +11,7 @@
               subscribable_id: user_subscription_form.subscribable_id
             }
           },
-          class: "button outline")
+          class: "button outline", role: "button")
         %>
     </div>
   <% end %>

--- a/app/views/gobierto_people/people/person_statements/show.html.erb
+++ b/app/views/gobierto_people/people/person_statements/show.html.erb
@@ -15,7 +15,7 @@
   <% if @statement.attachment_url.present? %>
     <div class="download_file f_right">
       <i class="fa fa-file-pdf-o"></i>
-      <%= link_to @statement.attachment_url, download: "" do %>
+      <%= link_to @statement.attachment_url, download: "", role:"button" do %>
         <%= t(".download", file_size: number_to_human_size(@statement.attachment_size || 0)) %>
       <% end %>
     </div>

--- a/app/views/gobierto_people/welcome/index.html.erb
+++ b/app/views/gobierto_people/welcome/index.html.erb
@@ -32,7 +32,7 @@
         <%= render "gobierto_people/people/people_filter" %>
         <%= render @people %>
 
-        <%= link_to t(".people_summary.view_all"), gobierto_people_people_path, class: "see_more" %>
+        <%= link_to t(".people_summary.view_all"), gobierto_people_people_path, class: "see_more", role: "button" %>
 
       </div>
 
@@ -49,7 +49,7 @@
 
         <%= render @events %>
 
-        <%= link_to t(".events_summary.view_all"), gobierto_people_events_path, class: "see_more" %>
+        <%= link_to t(".events_summary.view_all"), gobierto_people_events_path, class: "see_more", role: "button" %>
 
       </div>
 
@@ -66,7 +66,7 @@
     <div class="pure-u-1 pure-u-md-1-2 site-references p_h_r_2">
 
       <div class="box fully_linked">
-        <%= link_to gobierto_people_statements_path do %>
+        <%= link_to gobierto_people_statements_path, role: "button" do %>
           <h2 class="linked_headline">
             <i class="fa fa-money"></i>
             <%= t(".statements") %>
@@ -75,7 +75,7 @@
       </div>
 
       <div class="box fully_linked">
-        <%= link_to gobierto_people_gifts_path do %>
+        <%= link_to gobierto_people_gifts_path, role: "button" do %>
           <h2 class="linked_headline">
             <i class="fa fa-gift"></i>
             <%= t(".gifts") %>
@@ -84,7 +84,7 @@
       </div>
 
       <div class="box fully_linked">
-        <%= link_to gobierto_people_travels_path do %>
+        <%= link_to gobierto_people_travels_path, role: "button" do %>
           <h2 class="linked_headline">
             <i class="fa fa-plane"></i>
             <%= t(".travels") %>
@@ -104,7 +104,7 @@
 
         <%= render @posts %>
 
-        <%= link_to t(".posts_summary.view_all"), gobierto_people_posts_path, class: "see_more" %>
+        <%= link_to t(".posts_summary.view_all"), gobierto_people_posts_path, class: "see_more", role: "button" %>
 
       </div>
 

--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -21,7 +21,7 @@
             subscribable_id: user_subscription_form.subscribable_id
           }
         },
-        class: "pure-menu-link")
+        class: "pure-menu-link", role: "button")
       %>
 
     <% else %>
@@ -31,7 +31,7 @@
         <%= f.hidden_field :subscribable_id %>
         <%= f.email_field :user_email, placeholder: defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %>
 
-        <%= f.submit t(".form.submit") %>
+        <%= f.submit t(".form.submit"), role: "button" %>
         <div class="disclaimer"><%= privacy_policy_page_link %></div>
       <% end %>
 


### PR DESCRIPTION
Connects to #466.

### What does this PR do?
This PR changes the markup of nearly all the modules (and the subscription box) to add ARIA roles to the links which act as buttons.

### More info
It would be better to implement most of them as proper `<button>`'s. Unfortunately adding an anchor before of inside a button [isn't valid HTML5](https://stackoverflow.com/questions/6393827/can-i-nest-a-button-element-inside-an-a-using-html5).

At the end it's easier to take this approach (also [used by Bootstrap](https://getbootstrap.com/css/#buttons)).

Extra: improves the focus style on the Budget Consultations options.