### PR TITLE
GobiertoCms::Page content translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "invisible_captcha"
 # Redis
 gem "redis", "~> 3.3"
 
+# Translations
+gem "json_translate", "~> 3.0"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
     js_cookie_rails (2.1.3)
       railties (>= 3.1)
     json (2.0.3)
+    json_translate (3.0.1)
+      activerecord (>= 4.2.0)
     jsonapi-renderer (0.1.2)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
@@ -370,6 +372,7 @@ DEPENDENCIES
   invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails
+  json_translate (~> 3.0)
   kaminari (~> 1.0)
   launchy
   meta-tags

--- a/app/assets/javascripts/admin/app/components/globalized_forms_component.js
+++ b/app/assets/javascripts/admin/app/components/globalized_forms_component.js
@@ -1,0 +1,66 @@
+this.GobiertoAdmin.GlobalizedFormsComponent = (function() {
+  function GlobalizedFormsComponent() {}
+
+  GlobalizedFormsComponent.prototype.handle = function(message) {
+    $(document).on("turbolinks:load", _handleGlobalizedForm);
+  };
+
+  function _handleGlobalizedForm() {
+    var $globalizedForm = _findGlobalizedForm();
+    if(!$globalizedForm.length) return;
+
+    $globalizedForm.find('[data-toggle-edit-locale]').on("click", _toggleLocaleClickHandler);
+    $globalizedForm.on("change", "input, select, textarea", _changeHandler);
+
+    var currentLocale = $globalizedForm.find('[data-loaded-locale]').data('loaded-locale');
+    if(currentLocale === undefined)
+      currentLocale = I18n.defaultLocale;
+    _activateLocale(currentLocale);
+    _checkCompleted($globalizedForm);
+  }
+
+  function _toggleLocaleClickHandler(e){
+    e.preventDefault();
+    _activateLocale($(this).data('toggle-edit-locale'));
+  }
+
+  function _changeHandler(e){
+    _checkCompleted(_findGlobalizedForm());
+  }
+
+  function _activateLocale(currentLocale){
+    var $globalizedForm = _findGlobalizedForm();
+
+    $globalizedForm.find('[data-toggle-edit-locale]').removeClass('selected');
+    $globalizedForm.find('[data-toggle-edit-locale='+currentLocale+']').addClass('selected');
+
+    $globalizedForm.find('[data-locale]').each(function(){
+      $(this).data('locale') !== currentLocale ? $(this).hide() : $(this).show();
+    });
+  }
+
+  function _checkCompleted($globalizedForm){
+    $globalizedForm.find('[data-toggle-edit-locale]').each(function(){
+      var locale = $(this).data('toggle-edit-locale');
+      var completed = true;
+      var $el = $globalizedForm.find('[data-locale='+locale+']');
+
+      $el.find("input, select, textarea").each(function(){
+        if($(this).attr('id') !== undefined && $(this).val() === ""){
+          completed = false;
+        }
+      });
+
+      $el = $globalizedForm.find('[data-toggle-edit-locale='+locale+']');
+      completed ? $el.addClass('completed') : $el.removeClass('completed');
+    });
+  }
+
+  function _findGlobalizedForm(){
+    return $("form[data-globalized-form-container]");
+  }
+
+  return GlobalizedFormsComponent;
+})();
+
+this.GobiertoAdmin.globalized_forms_component = new GobiertoAdmin.GlobalizedFormsComponent;

--- a/app/assets/javascripts/module-search.js
+++ b/app/assets/javascripts/module-search.js
@@ -21,7 +21,7 @@ $(document).on('turbolinks:load', function() {
 
   function itemDescription(d){
     var maxLenght = 200;
-    var description = (d['bio'] || d['description'] || d['body'] || '');
+    var description = (d['bio'] || d['description'] || d['body'] || d['bio_' + I18n.locale] || d['description_' + I18n.locale] || d['body_' + I18n.locale] || '');
     if(description === '' || description.length < maxLenght)
       return description;
     return truncateOnWord(description, maxLenght) + '...';
@@ -56,7 +56,7 @@ $(document).on('turbolinks:load', function() {
     content.results.forEach(function(indexResults){
       indexResults.hits.forEach(function(d){
         var result = '<div class="result">' +
-					'<h2><a href="'+d.resource_path+'">' + (d['title'] || d['name']) + '</a></h2>' +
+					'<h2><a href="'+d.resource_path+'">' + (d['title'] || d['name'] || d['title_' + I18n.locale] || d['name_' + I18n.locale]) + '</a></h2>' +
 					'<div class="description">' +
             '<div>' + itemDescription(d) + '</div>' +
 						'<span class="soft item_type">' + itemType(d) + '</span> · ' +

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -85,15 +85,15 @@ module GobiertoAdmin
 
       def page_params
         params.require(:page).permit(
-          :title,
-          :body,
-          :slug,
-          :visibility_level
+          :visibility_level,
+          title_translations: [*I18n.available_locales],
+          body_translations:  [*I18n.available_locales],
+          slug_translations:  [*I18n.available_locales],
         )
       end
 
       def ignored_page_attributes
-        %w( created_at updated_at )
+        %w( created_at updated_at title body slug )
       end
 
       def find_page

--- a/app/controllers/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_cms/pages_controller.rb
@@ -17,7 +17,7 @@ module GobiertoCms
     end
 
     def find_page
-      current_site.pages.active.find_by!(slug: params[:id])
+      current_site.pages.active.find_by_slug!(params[:id])
     end
   end
 end

--- a/app/controllers/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_cms/pages_controller.rb
@@ -12,7 +12,7 @@ module GobiertoCms
     def find_page_by_id_and_redirect
       if params[:id].present? && params[:id] =~ /\A\d+\z/
         page = current_site.pages.active.find(params[:id])
-        redirect_to gobierto_cms_page_path(page) and return false
+        redirect_to gobierto_cms_page_path(page.slug) and return false
       end
     end
 

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -6,15 +6,15 @@ module GobiertoAdmin
       attr_accessor(
         :id,
         :site_id,
-        :title,
-        :body,
-        :slug,
         :visibility_level,
+        :title_translations,
+        :body_translations,
+        :slug_translations
       )
 
       delegate :persisted?, to: :page
 
-      validates :site, :title, :body, :slug, :visibility_level, presence: true
+      validates :site, :visibility_level, presence: true
 
       def save
         save_page if valid?
@@ -49,9 +49,9 @@ module GobiertoAdmin
       def save_page
         @page = page.tap do |page_attributes|
           page_attributes.site_id = site_id
-          page_attributes.title = title
-          page_attributes.body = body
-          page_attributes.slug = slug
+          page_attributes.title_translations = title_translations
+          page_attributes.body_translations = body_translations
+          page_attributes.slug_translations = slug_translations
           page_attributes.visibility_level = visibility_level
         end
 

--- a/app/helpers/gobierto_admin/form_helper.rb
+++ b/app/helpers/gobierto_admin/form_helper.rb
@@ -5,6 +5,26 @@ module GobiertoAdmin
         include FormBuilderMethods
       end
     end
+
+    def rich_text_area_tag(method, value, options = {})
+      content_tag(:div, class: "rich-text-area", id: "#{method}_rich") do
+        [
+          hidden_field_tag(method, value),
+          content_tag(
+            "trix-editor",
+            nil,
+            input: sanitize_to_id(method),
+            data: { attachment_path: options[:attachment_path] }
+          ),
+          content_tag(
+            "div",
+            content_tag("i", nil, class: "fa fa-info") +
+              I18n.t("gobierto_admin.form_helpers.rich_text_area.hints"),
+            class: "inline_help"
+          )
+        ].join.html_safe
+      end
+    end
   end
 
   module FormBuilderMethods

--- a/app/models/concerns/gobierto_common/localized_content.rb
+++ b/app/models/concerns/gobierto_common/localized_content.rb
@@ -1,0 +1,13 @@
+module GobiertoCommon
+  module LocalizedContent
+    extend ActiveSupport::Concern
+
+    included do
+      translated_attribute_names.each do |attr_name|
+        define_method "#{attr_name}_with_fallback" do
+          return send("#{attr_name}_translations").values.detect{|v| v.present? }
+        end
+      end
+    end
+  end
+end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -6,22 +6,39 @@ module GobiertoCms
     include GobiertoCommon::Searchable
 
     algoliasearch_gobierto do
-      attribute :site_id, :title, :body, :updated_at
-      searchableAttributes ['title', 'body']
+      attribute :site_id, :updated_at, :title_en, :title_es, :title_ca, :body_en, :body_es, :body_ca
+      searchableAttributes ['title_en', 'title_es', 'title_ca', 'body_en', 'body_es', 'body_ca']
       attributesForFaceting [:site_id]
       add_attribute :resource_path, :class_name
     end
+
+    translates :title, :body, :slug
+    include GobiertoCommon::LocalizedContent
 
     belongs_to :site
 
     enum visibility_level: { draft: 0, active: 1 }
 
-    validates :site, :title, :body, :slug, presence: true
+    # TODO: title, body, slug validations?
+    validates :site, presence: true
+    validate :uniqueness_of_slug
 
     scope :sorted, -> { order(id: :desc) }
 
-    def to_param
-      self.slug
+    def self.find_by_slug!(slug)
+      if slug.present?
+        self.with_slug_translation(slug).first || raise(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    private
+
+    def uniqueness_of_slug
+      if slug_translations.present?
+        if slug_translations.any?{ |_, slug| self.class.where(site_id: self.site_id).with_slug_translation(slug).exists? }
+          errors.add(:slug, I18n.t('errors.messages.taken'))
+        end
+      end
     end
   end
 end

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -4,20 +4,22 @@
 
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
-      <div class="form_item input_text">
-        <%= f.label :title %>
-        <%= f.text_field :title, placeholder: t(".placeholders.title") %>
-      </div>
+      <% Site.first.configuration.available_locales.each do |locale| %>
+        <div class="form_item input_text">
+          <%= label_tag "page[title_translations][#{locale}]", "#{f.object.class.human_attribute_name(:title)} (#{locale})" %>
+          <%= text_field_tag "page[title_translations][#{locale}]", f.object.title_translations[locale], placeholder: t(".placeholders.title") %>
+        </div>
 
-      <div class="form_item input_text">
-        <%= f.label :slug %>
-        <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
-      </div>
+        <div class="form_item input_text">
+          <%= label_tag "page[slug_translations][#{locale}]", "#{f.object.class.human_attribute_name(:slug)} (#{locale})" %>
+          <%= text_field_tag "page[slug_translations][#{locale}]", f.object.slug_translations[locale], placeholder: t(".placeholders.slug") %>
+        </div>
 
-      <div class="form_item textarea">
-        <%= f.label :body %>
-        <%= f.rich_text_area :body, attachment_path: admin_cms_file_attachments_path %>
-      </div>
+        <div class="form_item textarea">
+          <%= label_tag "page[body_translations][#{locale}]", "#{f.object.class.human_attribute_name(:body)} (#{locale})" %>
+          <%= rich_text_area_tag "page[body_translations][#{locale}]", f.object.body_translations[locale], attachment_path: admin_cms_file_attachments_path %>
+        </div>
+      <% end %>
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -4,31 +4,21 @@
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
       <div class="globalized_fields">
-        <% if current_site.configuration.available_locales.length > 1 %>
-          <div class="globalize_tool">
-            <label>Traducir</label>
-            <% current_site.configuration.available_locales.each do |locale| %>
-              <a href="#" data-toggle-edit-locale="<%= locale %>" class="locale_option tipsit" title="Define el contenido en su versión en Español" <%= %Q{data-loaded-locale="#{locale}"}.html_safe if locale == current_site.configuration.default_locale %>>
-                <span class="locale"><%= locale.upcase %></span>
-                <span class="status"></span>
-              </a>
-            <% end %>
-          </div>
-        <% end %>
+        <%= render "gobierto_admin/shared/form_locale_switchers" %>
 
         <% I18n.available_locales.map(&:to_s).each do |locale| %>
           <div class="form_item input_text" data-locale="<%= locale %>">
-            <%= label_tag "page[title_translations][#{locale}]", "#{f.object.class.human_attribute_name(:title)} (#{locale})" %>
+            <%= label_tag "page[title_translations][#{locale}]", f.object.class.human_attribute_name(:title) %>
             <%= text_field_tag "page[title_translations][#{locale}]", f.object.title_translations && f.object.title_translations[locale], placeholder: t(".placeholders.title") %>
           </div>
 
           <div class="form_item input_text" data-locale="<%= locale %>">
-            <%= label_tag "page[slug_translations][#{locale}]", "#{f.object.class.human_attribute_name(:slug)} (#{locale})" %>
+            <%= label_tag "page[slug_translations][#{locale}]", f.object.class.human_attribute_name(:slug) %>
             <%= text_field_tag "page[slug_translations][#{locale}]", f.object.slug_translations && f.object.slug_translations[locale], placeholder: t(".placeholders.slug") %>
           </div>
 
           <div class="form_item textarea" data-locale="<%= locale %>">
-            <%= label_tag "page[body_translations][#{locale}]", "#{f.object.class.human_attribute_name(:body)} (#{locale})" %>
+            <%= label_tag "page[body_translations][#{locale}]", f.object.class.human_attribute_name(:body) %>
             <%= rich_text_area_tag "page[body_translations][#{locale}]", f.object.body_translations && f.object.body_translations[locale], attachment_path: admin_cms_file_attachments_path %>
           </div>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -1,25 +1,38 @@
 <%= render "gobierto_admin/shared/validation_errors", resource: @page_form %>
 
-<%= form_for(@page_form, as: :page, url: @page_form.persisted? ? admin_cms_page_path(@page_form) : :admin_cms_pages) do |f| %>
-
+<%= form_for(@page_form, as: :page, url: @page_form.persisted? ? admin_cms_page_path(@page_form) : :admin_cms_pages, data: { "globalized-form-container" => true }) do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
-      <% Site.first.configuration.available_locales.each do |locale| %>
-        <div class="form_item input_text">
-          <%= label_tag "page[title_translations][#{locale}]", "#{f.object.class.human_attribute_name(:title)} (#{locale})" %>
-          <%= text_field_tag "page[title_translations][#{locale}]", f.object.title_translations[locale], placeholder: t(".placeholders.title") %>
-        </div>
+      <div class="globalized_fields">
+        <% if current_site.configuration.available_locales.length > 1 %>
+          <div class="globalize_tool">
+            <label>Traducir</label>
+            <% current_site.configuration.available_locales.each do |locale| %>
+              <a href="#" data-toggle-edit-locale="<%= locale %>" class="locale_option tipsit" title="Define el contenido en su versión en Español" <%= %Q{data-loaded-locale="#{locale}"}.html_safe if locale == current_site.configuration.default_locale %>>
+                <span class="locale"><%= locale.upcase %></span>
+                <span class="status"></span>
+              </a>
+            <% end %>
+          </div>
+        <% end %>
 
-        <div class="form_item input_text">
-          <%= label_tag "page[slug_translations][#{locale}]", "#{f.object.class.human_attribute_name(:slug)} (#{locale})" %>
-          <%= text_field_tag "page[slug_translations][#{locale}]", f.object.slug_translations[locale], placeholder: t(".placeholders.slug") %>
-        </div>
+        <% I18n.available_locales.map(&:to_s).each do |locale| %>
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "page[title_translations][#{locale}]", "#{f.object.class.human_attribute_name(:title)} (#{locale})" %>
+            <%= text_field_tag "page[title_translations][#{locale}]", f.object.title_translations && f.object.title_translations[locale], placeholder: t(".placeholders.title") %>
+          </div>
 
-        <div class="form_item textarea">
-          <%= label_tag "page[body_translations][#{locale}]", "#{f.object.class.human_attribute_name(:body)} (#{locale})" %>
-          <%= rich_text_area_tag "page[body_translations][#{locale}]", f.object.body_translations[locale], attachment_path: admin_cms_file_attachments_path %>
-        </div>
-      <% end %>
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "page[slug_translations][#{locale}]", "#{f.object.class.human_attribute_name(:slug)} (#{locale})" %>
+            <%= text_field_tag "page[slug_translations][#{locale}]", f.object.slug_translations && f.object.slug_translations[locale], placeholder: t(".placeholders.slug") %>
+          </div>
+
+          <div class="form_item textarea" data-locale="<%= locale %>">
+            <%= label_tag "page[body_translations][#{locale}]", "#{f.object.class.human_attribute_name(:body)} (#{locale})" %>
+            <%= rich_text_area_tag "page[body_translations][#{locale}]", f.object.body_translations && f.object.body_translations[locale], attachment_path: admin_cms_file_attachments_path %>
+          </div>
+        <% end %>
+      </div>
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
@@ -23,7 +23,7 @@
     <% @pages.each do |page| %>
       <tr id="page-item-<%= page.id %>">
         <td><%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_cms_page_path(page.id) %></td>
-        <td><%= link_to page.title, edit_admin_cms_page_path(page.id) %></td>
+        <td><%= link_to page.title_with_fallback, edit_admin_cms_page_path(page.id) %></td>
         <td><%= time_ago_in_words(page.created_at) %></td>
         <td><%= time_ago_in_words(page.updated_at) %></td>
         <td class="visibility_level">

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -173,6 +173,7 @@
 
   <%= javascript_tag data: { "turbolinks-eval" => false } do %>
     window.GobiertoAdmin.dirty_forms_component.handle("<%= t(".dirty_forms.message") %>");
+    window.GobiertoAdmin.globalized_forms_component.handle();
   <% end %>
 
   <%= yield :javascript_hook %>

--- a/app/views/gobierto_admin/shared/_form_locale_switchers.html.erb
+++ b/app/views/gobierto_admin/shared/_form_locale_switchers.html.erb
@@ -1,0 +1,11 @@
+<% if current_site.configuration.available_locales.length > 1 %>
+  <div class="globalize_tool">
+    <label><%= t('.translate') %></label>
+    <% current_site.configuration.available_locales.each do |locale| %>
+      <a href="#" data-toggle-edit-locale="<%= locale %>" class="locale_option tipsit" title="<%= t('.define_content_in_locale', locale_name: t("locales.#{locale}")) %>" <%= %Q{data-loaded-locale="#{locale}"}.html_safe if locale == current_site.configuration.default_locale %>>
+        <span class="locale"><%= locale.upcase %></span>
+        <span class="status"></span>
+      </a>
+    <% end %>
+  </div>
+<% end %>

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  gobierto_admin:
+    shared:
+      form_locale_switchers:
+        translate: Traduxir
+        define_content_in_locale: Defineix el contingut en la versió en %{locale_name}

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  gobierto_admin:
+    shared:
+      form_locale_switchers:
+        translate: Translate
+        define_content_in_locale: Define the content in %{locale_name} version

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  gobierto_admin:
+    shared:
+      form_locale_switchers:
+        translate: Traducir
+        define_content_in_locale: Define el contenido en su versión %{locale_name}

--- a/db/migrate/20170322144939_add_gcms_pages_translations.rb
+++ b/db/migrate/20170322144939_add_gcms_pages_translations.rb
@@ -1,0 +1,13 @@
+class AddGcmsPagesTranslations < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :gcms_pages, name: "index_gcms_pages_on_slug_and_site_id", unique: true
+
+    add_column :gcms_pages, :title_translations, :jsonb
+    add_column :gcms_pages, :body_translations, :jsonb
+    add_column :gcms_pages, :slug_translations, :jsonb
+
+    add_index :gcms_pages, :title_translations, using: :gin
+    add_index :gcms_pages, :body_translations, using: :gin
+    add_index :gcms_pages, :slug_translations, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170312182331) do
+ActiveRecord::Schema.define(version: 20170322144939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -200,15 +200,20 @@ ActiveRecord::Schema.define(version: 20170312182331) do
   end
 
   create_table "gcms_pages", force: :cascade do |t|
-    t.string   "title",            default: "", null: false
-    t.text     "body",             default: "", null: false
-    t.string   "slug",             default: "", null: false
+    t.string   "title",              default: "", null: false
+    t.text     "body",               default: "", null: false
+    t.string   "slug",               default: "", null: false
     t.integer  "site_id"
-    t.integer  "visibility_level", default: 0,  null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.integer  "visibility_level",   default: 0,  null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.jsonb    "title_translations"
+    t.jsonb    "body_translations"
+    t.jsonb    "slug_translations"
+    t.index ["body_translations"], name: "index_gcms_pages_on_body_translations", using: :gin
     t.index ["site_id"], name: "index_gcms_pages_on_site_id", using: :btree
-    t.index ["slug", "site_id"], name: "index_gcms_pages_on_slug_and_site_id", unique: true, using: :btree
+    t.index ["slug_translations"], name: "index_gcms_pages_on_slug_translations", using: :gin
+    t.index ["title_translations"], name: "index_gcms_pages_on_title_translations", using: :gin
   end
 
   create_table "gp_people", force: :cascade do |t|

--- a/lib/tasks/gobierto_cms/migrate_pages_to_globalize.rake
+++ b/lib/tasks/gobierto_cms/migrate_pages_to_globalize.rake
@@ -3,7 +3,7 @@ namespace :gobierto_cms do
     desc "Migrates pages fields to globalize"
     task migrate: :environment do
       GobiertoCms::Page.find_each do |page|
-        puts "* Migrating #{page.id} content"
+        puts "* Migrating page id=#{page.id}"
 
         I18n.available_locales.map(&:to_s).each do |locale|
           page.send "title_#{locale}=", page.read_attribute(:title)

--- a/lib/tasks/gobierto_cms/migrate_pages_to_globalize.rake
+++ b/lib/tasks/gobierto_cms/migrate_pages_to_globalize.rake
@@ -1,0 +1,18 @@
+namespace :gobierto_cms do
+  namespace :globalize do
+    desc "Migrates pages fields to globalize"
+    task migrate: :environment do
+      GobiertoCms::Page.find_each do |page|
+        puts "* Migrating #{page.id} content"
+
+        I18n.available_locales.map(&:to_s).each do |locale|
+          page.send "title_#{locale}=", page.read_attribute(:title)
+          page.send "body_#{locale}=", page.read_attribute(:body)
+          page.send "slug_#{locale}=", page.read_attribute(:slug)
+        end
+
+        page.save!
+      end
+    end
+  end
+end

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -1,14 +1,14 @@
 consultation_faq:
-  title_translations: <%= { 'en' => 'Consultation page FAQ' }.to_json %>
-  body_translations: <%= { 'en' => 'This is the body of the page' }.to_json %>
-  slug_translations: <%= { 'en' => 'consultation-faq' }.to_json %>
+  title_translations: <%= { 'en' => 'Consultation page FAQ', 'es' => 'FAQ consultas' }.to_json %>
+  body_translations: <%= { 'en' => 'This is the body of the page', 'es' => 'Cuerpo página consultas' }.to_json %>
+  slug_translations: <%= { 'en' => 'consultation-faq', 'es' => 'faq-consultas' }.to_json %>
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
 
 privacy:
-  title_translations: <%= {'en' => 'Privacy' }.to_json %>
-  body_translations: <%= {'en' => 'These are the privacy terms' }.to_json %>
-  slug_translations: <%= {'en' => 'privacy' }.to_json %>
+  title_translations: <%= {'en' => 'Privacy', 'es' => 'Privacidad' }.to_json %>
+  body_translations: <%= {'en' => 'These are the privacy terms', 'es' => 'Privacidad' }.to_json %>
+  slug_translations: <%= {'en' => 'privacy', 'es' => 'privacidad' }.to_json %>
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
 

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -1,27 +1,27 @@
 consultation_faq:
-  title: 'Consultation page FAQ'
-  body: 'This is the body of the page'
-  slug: 'consultation-faq'
+  title_translations: <%= { 'en' => 'Consultation page FAQ' }.to_json %>
+  body_translations: <%= { 'en' => 'This is the body of the page' }.to_json %>
+  slug_translations: <%= { 'en' => 'consultation-faq' }.to_json %>
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
 
 privacy:
-  title: 'Privacy'
-  body: 'These are the privacy terms'
-  slug: 'privacy'
+  title_translations: <%= {'en' => 'Privacy' }.to_json %>
+  body_translations: <%= {'en' => 'These are the privacy terms' }.to_json %>
+  slug_translations: <%= {'en' => 'privacy' }.to_json %>
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
 
 cookies:
-  title: 'Cookies'
-  body: 'These are the cookies terms'
-  slug: 'cookies'
+  title_translations: <%= {'en' => 'Cookies' }.to_json %>
+  body_translations: <%= {'en' => 'These are the cookies terms' }.to_json %>
+  slug_translations: <%= {'en' => 'cookies' }.to_json %>
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
 
 about:
-  title: 'About'
-  body: 'About santander'
-  slug: 'about'
+  title_translations: <%= {'en' => 'About' }.to_json %>
+  body_translations: <%= {'en' => 'About santander' }.to_json %>
+  slug_translations: <%= {'en' => 'about' }.to_json %>
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: santander

--- a/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
@@ -6,9 +6,9 @@ module GobiertoAdmin
       def valid_page_form
         @valid_page_form ||= PageForm.new(
           site_id: site.id,
-          title: page.title,
-          body: page.body,
-          slug: page.slug,
+          title_translations: {I18n.locale => page.title},
+          body_translations: {I18n.locale => page.body},
+          slug_translations: {I18n.locale => page.slug},
           visibility_level: page.visibility_level
         )
       end
@@ -16,9 +16,9 @@ module GobiertoAdmin
       def invalid_page_form
         @invalid_page_form ||= PageForm.new(
           site_id: nil,
-          title: nil,
-          body: nil,
-          slug: nil,
+          title_translations: nil,
+          body_translations: nil,
+          slug_translations: nil,
           visibility_level: nil
         )
       end
@@ -39,9 +39,6 @@ module GobiertoAdmin
         invalid_page_form.save
 
         assert_equal 1, invalid_page_form.errors.messages[:site].size
-        assert_equal 1, invalid_page_form.errors.messages[:title].size
-        assert_equal 1, invalid_page_form.errors.messages[:body].size
-        assert_equal 1, invalid_page_form.errors.messages[:slug].size
       end
     end
   end

--- a/test/integration/gobierto_admin/gobierto_cms/create_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/create_page_test.rb
@@ -16,6 +16,23 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def test_create_page_errors
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              click_link "New"
+              click_button "Create"
+
+              assert has_alert?("Title can't be blank")
+              assert has_alert?("Body can't be blank")
+              assert has_alert?("URL can't be blank")
+            end
+          end
+        end
+      end
+
       def test_create_page
         with_javascript do
           with_signed_in_admin(admin) do
@@ -24,20 +41,34 @@ module GobiertoAdmin
 
               click_link "New"
 
-              fill_in "Title", with: "My page"
-              find("#page_body", visible: false).set("The content of the page")
-              fill_in "URL", with: "new-page"
+              fill_in "page_title_translations_en", with: "My page"
+              find("#page_body_translations_en", visible: false).set("The content of the page")
+              fill_in "page_slug_translations_en", with: "new-page"
+
+              click_link "ES"
+              fill_in "page_title_translations_es", with: "Mi página"
+              find("#page_body_translations_es", visible: false).set("Contenido de la página")
+              fill_in "page_slug_translations_es", with: "nueva-pagina"
 
               click_button "Create"
 
               assert has_message?("Page created successfully")
               assert has_selector?("h1", text: "My page")
-              assert has_field?("page_slug", with: "new-page")
+              assert has_field?("page_slug_translations_en", with: "new-page")
 
               assert_equal(
                 "<div>The content of the page</div>",
-                find("#page_body", visible: false).value
+                find("#page_body_translations_en", visible: false).value
               )
+
+              click_link "ES"
+
+              assert_equal(
+                "<div>Contenido de la página</div>",
+                find("#page_body_translations_es", visible: false).value
+              )
+
+             assert has_field?("page_slug_translations_es", with: "nueva-pagina")
 
               page = site.pages.last
               activity = Activity.last

--- a/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
@@ -28,18 +28,19 @@ module GobiertoAdmin
 
               click_link "Consultation page FAQ"
 
-              fill_in "Title", with: "Consultation page FAQ updated"
-              fill_in "URL", with: "consultation-faq-updated"
+              fill_in "page_title_translations_en", with: "Consultation page FAQ updated"
+              fill_in "page_slug_translations_en", with: "consultation-faq-updated"
 
               click_button "Update"
 
               assert has_message?("Page updated successfully")
               assert has_selector?("h1", text: "Consultation page FAQ updated")
-              assert has_field?("page_slug", with: "consultation-faq-updated")
+              assert has_field?("page_slug_translations_en", with: "consultation-faq-updated")
+              assert_equal("faq-consultas", find("#page_slug_translations_es", visible: false).value)
 
               assert_equal(
                 "<div>This is the body of the page</div>",
-                find("#page_body", visible: false).value
+                find("#page_body_translations_en", visible: false).value
               )
 
               activity = Activity.last

--- a/test/integration/gobierto_cms/visit_page_test.rb
+++ b/test/integration/gobierto_cms/visit_page_test.rb
@@ -4,7 +4,7 @@ module GobiertoCms
   class VisitPageTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = gobierto_cms_page_path(cms_page)
+      @path = gobierto_cms_page_path(cms_page.slug)
     end
 
     def site

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -18,7 +18,7 @@ module GobiertoCms
         GobiertoCms::Page.find_by_slug! "foo"
       end
 
-      assert_nil GobiertoCms::Page.find_by_slug!(page.slug_es)
+      assert_equal page, GobiertoCms::Page.find_by_slug!(page.slug_es)
       assert_equal page, GobiertoCms::Page.find_by_slug!(page.slug_en)
     end
   end

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -10,5 +10,16 @@ module GobiertoCms
     def test_valid
       assert page.valid?
     end
+
+    def test_find_by_slug
+      assert_nil GobiertoCms::Page.find_by_slug! nil
+      assert_nil GobiertoCms::Page.find_by_slug! ""
+      assert_raises(ActiveRecord::RecordNotFound) do
+        GobiertoCms::Page.find_by_slug! "foo"
+      end
+
+      assert_nil GobiertoCms::Page.find_by_slug!(page.slug_es)
+      assert_equal page, GobiertoCms::Page.find_by_slug!(page.slug_en)
+    end
   end
 end


### PR DESCRIPTION
Connects to #545 

### What does this PR do?

This PR adds globalization capabilities to GobiertoCms module, specifically to the Page model.

A few comments:

- we are using [json_translate](https://github.com/cfabianski/json_translate) instad of Globalize
- the UI implements the changes described in #562 
- at least the admin should fill the values in the current language

After releasing, you should run `bin/rails gobierto_cms:globalize:migrate` to migrate current content.

### How should this be manually tested?