### PR TITLE
Review header levels

### DIFF
--- a/app/assets/stylesheets/comp-site_header.scss
+++ b/app/assets/stylesheets/comp-site_header.scss
@@ -144,6 +144,12 @@ header.meta {
         strong {
           font-weight: 600;
         }
+        h1 {
+          font-size: 1em;
+          font-weight: 600;
+          display: inline-block;
+          margin: 0;
+        }
       }
       menu.sub_sections {
         padding: 0;

--- a/app/views/gobierto_budget_consultations/layouts/application.html.erb
+++ b/app/views/gobierto_budget_consultations/layouts/application.html.erb
@@ -7,9 +7,9 @@
     <%= link_to t("gobierto_budget_consultations.layouts.application.participation"), gobierto_budget_consultations_consultations_path, data: { turbolinks: false } %>
   </strong>
   <span>/</span>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_budget_consultations.layouts.menu_subsections.consultations'), gobierto_budget_consultations_consultations_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <%= render template: "layouts/application" %>

--- a/app/views/gobierto_budgets/budget_lines/index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/index.html.erb
@@ -1,9 +1,9 @@
 <% title t('.title', year: @year) %>
 
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::BudgetLine::ECONOMIC, level: 1) %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -1,9 +1,9 @@
 <% title t('.title', year: @year) %>
 
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_budgets.layouts.menu_subsections.summary'), gobierto_budgets_budgets_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">
@@ -143,7 +143,7 @@
         <h3><%= t('.expenses') %></h3>
 
         <table class="med_bg">
-          <thead>
+          <thead class="screen-hidden">
             <tr>
               <th><%= t('.top_expense_category') %></th>
               <th><%= t('.top_expense_value') %></th>

--- a/app/views/gobierto_budgets/budgets_execution/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_execution/index.html.erb
@@ -4,9 +4,9 @@
 %>
 
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last) %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/gobierto_exports/layouts/application.html.erb
+++ b/app/views/gobierto_exports/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_items do %>
-  <strong>
+  <h1>
     <%= link_to t('.exports'), gobierto_exports_root_path %>
-  </strong>
+  </h1>
   <strong data-breadcrumb-sub-item></strong>
 <% end %>
 

--- a/app/views/gobierto_indicators/layouts/application.html.erb
+++ b/app/views/gobierto_indicators/layouts/application.html.erb
@@ -12,9 +12,9 @@
 <% end %>
 
 <% content_for :breadcrumb_items do %>
-  <strong>
+  <h1>
     <%= link_to t('.indicators'), gobierto_indicators_root_path %>
-  </strong>
+  </h1>
   <strong data-breadcrumb-sub-item></strong>
 <% end %>
 

--- a/app/views/gobierto_people/layouts/application.html.erb
+++ b/app/views/gobierto_people/layouts/application.html.erb
@@ -3,12 +3,16 @@
 <% end %>
 
 <% content_for :breadcrumb_items do %>
-  <strong>
-    <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
-  </strong>
   <% if content_for?(:breadcrumb_current_item) %>
+    <strong>
+      <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
+    </strong>
     <span>/</span>
     <%= yield(:breadcrumb_current_item) %>
+  <% else %>
+    <h1>
+      <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
+    </h1>
   <% end %>
 <% end %>
 

--- a/app/views/gobierto_people/people/_content_for_breadcrumb.html.erb
+++ b/app/views/gobierto_people/people/_content_for_breadcrumb.html.erb
@@ -1,5 +1,5 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.people'), gobierto_people_people_path %>
-  </strong>
+  </h1>
 <% end %>

--- a/app/views/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_people/people/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.people'), gobierto_people_people_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/gobierto_people/people/person_events/show.html.erb
+++ b/app/views/gobierto_people/people/person_events/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.agendas'), gobierto_people_events_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="person_event-item">

--- a/app/views/gobierto_people/people/person_posts/show.html.erb
+++ b/app/views/gobierto_people/people/person_posts/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="blog_header">

--- a/app/views/gobierto_people/people/person_statements/show.html.erb
+++ b/app/views/gobierto_people/people/person_statements/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.statements'), gobierto_people_statements_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="person_header">

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.agendas'), gobierto_people_events_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/gobierto_people/person_post_tags/show.html.erb
+++ b/app/views/gobierto_people/person_post_tags/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/gobierto_people/person_posts/index.html.erb
+++ b/app/views/gobierto_people/person_posts/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column pure-g">

--- a/app/views/gobierto_people/person_statements/index.html.erb
+++ b/app/views/gobierto_people/person_statements/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t('gobierto_people.layouts.menu_subsections.statements'), gobierto_people_statements_path %>
-  </strong>
+  </h1>
 <% end %>
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -149,9 +149,9 @@
     <div class="site_header">
 
       <div class="column">
-        <h1 class="logo">
+        <div class="logo">
           <%= link_to(image_tag(@site.configuration.logo_with_fallback, alt: @site.name), root_url) %>
-        </h1>
+        </div>
       </div>
 
       <%= render "layouts/main_menu" %>

--- a/app/views/user/notifications/index.html.erb
+++ b/app/views/user/notifications/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t("user.layouts.menu_subsections.notifications"), user_notifications_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/user/settings/show.html.erb
+++ b/app/views/user/settings/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t("user.layouts.menu_subsections.admin"), user_settings_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumb_current_item do %>
-  <strong>
+  <h1>
     <%= link_to t("user.layouts.menu_subsections.alerts"), user_subscriptions_path %>
-  </strong>
+  </h1>
 <% end %>
 
 <div class="column">


### PR DESCRIPTION
Connects to #544.

### What does this PR do?
This PR switches the first heading level from the city name to each section title (featured in the breadcrumb).

Extra: adds a missing hidden class to a table heading.

### How should this be manually tested?
The header levels are section-focused now. You can check the structure using the [tota11y bookmarklet](https://khan.github.io/tota11y/) on each page.