### PR TITLE
Preprocess CensusRepository document number when initializing

### DIFF
--- a/app/repositories/census_repository.rb
+++ b/app/repositories/census_repository.rb
@@ -19,7 +19,7 @@ class CensusRepository
   def initialize(site_id:, document_number:, date_of_birth:, import_reference: nil)
     @site_id = site_id
 
-    @document_number = document_number.to_s
+    @document_number = parse_document_number(document_number.to_s)
     @document_number_alternatives = build_alternatives(@document_number)
     @document_number_digest = ::SecretAttribute.digest(@document_number)
 
@@ -80,6 +80,16 @@ class CensusRepository
     end
   rescue ArgumentError
     nil
+  end
+
+  def parse_document_number(document_number)
+    parsed_document_number = document_number
+
+    parsed_document_number.gsub!(' ', '')
+    parsed_document_number.gsub!(/\W/, '')
+    parsed_document_number.upcase!
+
+    parsed_document_number
   end
 
   def build_alternatives(document_number)

--- a/test/integration/user/census_verification_test.rb
+++ b/test/integration/user/census_verification_test.rb
@@ -23,7 +23,7 @@ class User::CensusVerificationTest < ActionDispatch::IntegrationTest
       with_signed_in_user(unverified_user) do
         visit @verification_path
 
-        fill_in :user_verification_document_number, with: "00000000A"
+        fill_in :user_verification_document_number, with: " 00*00 00ñ00 a "
 
         click_on "Verify"
 

--- a/test/repositories/census_repository_test.rb
+++ b/test/repositories/census_repository_test.rb
@@ -47,6 +47,21 @@ class CensusRepositoryTest < ActiveSupport::TestCase
     end
   end
 
+  def test_parse_document_number
+
+    document_numbers = ["12345678A", " 1234 5678 a ", "ñ1?23 45*6¿78--a"]
+
+    document_numbers.each do |document_number|
+      census_repository = CensusRepository.new(
+        site_id: site.id,
+        document_number: document_number,
+        date_of_birth: "2000-01-02"
+      )
+
+      assert_equal census_repository.document_number, "12345678A"
+    end
+  end
+
   def test_exists?
     refute census_repository.exists?
 


### PR DESCRIPTION
Connects to #518 

### What does this PR do?

Perform a series of transformations to census items document numbers to
correct possible misspellings in user inputs, both when importing
census items from a CSV and when a user tries to verify its profile
trough the corresponding form.

The applied transformations are:

 * Remove white spaces
 * Convert all letters to uppercase
 * Remove non-alphanumeric characters

### How should this be manually tested?

As an unverified user, try to perform verification with a document number containing non alphanumeric characters, whitespaces and lowercase letters.

### Does this PR changes any configuration file?

No