### PR TITLE
Add gobierto_indicators_permissions association to admin

### DIFF
--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -21,6 +21,7 @@ module GobiertoAdmin
     has_many :gobierto_budget_consultations_permissions, class_name: "Permission::GobiertoBudgetConsultations"
     has_many :gobierto_people_permissions, class_name: "Permission::GobiertoPeople"
     has_many :gobierto_cms_permissions, class_name: "Permission::GobiertoCms"
+    has_many :gobierto_indicators_permissions, class_name: "Permission::GobiertoIndicators"
 
     has_many :census_imports
 


### PR DESCRIPTION
There was an error when selecting Indicators module in the admin form because the permissions method wasn’t defined, this fixes that error.

Connects to this rollbar https://rollbar.com/fernando/gobierto/items/349/