### PR TITLE
Reduce padding on People groups filter

### DIFF
--- a/app/assets/stylesheets/comp-tabs.scss
+++ b/app/assets/stylesheets/comp-tabs.scss
@@ -82,6 +82,7 @@
   ul {
     list-style-type: none;
     padding-left: 0;
+    margin-bottom: .5rem;
 
     li {
     	position: relative;
@@ -91,7 +92,7 @@
       a {
         text-transform: uppercase;
         text-decoration: none;
-        padding: .75em 3em .6em;
+        padding: .4em .6em .4em;
         display: inline-block;
         border: 1px solid $color_separator;
         color: $text_soft;
@@ -127,8 +128,8 @@
 			pointer-events: none;
 			border-color: white;
 			border-top-color: $color_1_soft;
-			border-width: 20px;
-			margin-left: -20px;
+			border-width: 10px;
+			margin-left: -10px;
 			@include border-radius(2px);
 		}
   }
@@ -143,5 +144,3 @@
 		}
 	}
 }
-
-


### PR DESCRIPTION
Connects to #515.

### What does this PR do?
This PR reduces the padding in the People groups filter.

### Before
![screen shot 2017-03-29 at 11 45 34](https://cloud.githubusercontent.com/assets/1236790/24448696/484da4bc-1475-11e7-946e-72923550746c.png)

### After
![screen shot 2017-03-29 at 11 46 46](https://cloud.githubusercontent.com/assets/1236790/24448763/6b43db4e-1475-11e7-98ae-feb77a56ab27.png)

