### PR TITLE
Link calendar events - 557

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "dalli"
 gem "cookies_eu"
 gem "actionpack-action_caching", git: "https://github.com/rails/actionpack-action_caching.git", ref: "9044141824650138bf27741e8f0ed95ccd9ef26d"
 gem "active_model_serializers"
+gem "timecop"
 
 # Frontend
 gem "sass-rails", "~> 5.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,6 +320,7 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.6)
+    timecop (0.8.1)
     tins (1.13.2)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
@@ -394,9 +395,10 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   spy
   therubyracer
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -3,14 +3,8 @@ module GobiertoPeople
     include PoliticalGroupsHelper
 
     def index
-      if params[:date]
-        @events = filter_by_date_param
-        calendar_date_range = (Date.parse(params[:date]).at_beginning_of_month - 1.week)..(Date.parse(params[:date]).at_end_of_month + 1.week)
-      else
-        @events = current_site.person_events.upcoming.sorted
-        calendar_date_range = (Time.zone.now.at_beginning_of_month - 1.week)..(Time.zone.now.at_end_of_month + 1.week)
-      end
-      
+      @events = current_site.person_events.upcoming.sorted
+      @events = filter_by_date_param if params[:date]
       @calendar_events = current_site.person_events.for_month_calendar(calendar_date_range)
       @people = current_site.people.active.sorted
       @political_groups = get_political_groups
@@ -31,5 +25,14 @@ module GobiertoPeople
     rescue ArgumentError
       @events
     end
+
+    def calendar_date_range
+      if params[:start_date]
+        (Date.parse(params[:start_date]).at_beginning_of_month.at_beginning_of_week)..(Date.parse(params[:start_date]).at_end_of_month.at_end_of_week)
+      else
+        (Time.zone.now.at_beginning_of_month.at_beginning_of_week)..(Time.zone.now.at_end_of_month.at_end_of_week)
+      end
+    end
+    
   end
 end

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -3,8 +3,15 @@ module GobiertoPeople
     include PoliticalGroupsHelper
 
     def index
-      @events = current_site.person_events.upcoming.sorted
-      @events = filter_by_date_param if params[:date]
+      if params[:date]
+        @events = filter_by_date_param
+        calendar_date_range = (Date.parse(params[:date]).at_beginning_of_month - 1.week)..(Date.parse(params[:date]).at_end_of_month + 1.week)
+      else
+        @events = current_site.person_events.upcoming.sorted
+        calendar_date_range = (Time.zone.now.at_beginning_of_month - 1.week)..(Time.zone.now.at_end_of_month + 1.week)
+      end
+      
+      @calendar_events = current_site.person_events.for_month_calendar(calendar_date_range)
       @people = current_site.people.active.sorted
       @political_groups = get_political_groups
 

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -5,7 +5,7 @@ module GobiertoPeople
     def index
       @events = current_site.person_events.upcoming.sorted
       @events = filter_by_date_param if params[:date]
-      @calendar_events = current_site.person_events.for_month_calendar(calendar_date_range)
+      @calendar_events = current_site.person_events.within_range(calendar_date_range)
       @people = current_site.people.active.sorted
       @political_groups = get_political_groups
 
@@ -33,6 +33,6 @@ module GobiertoPeople
         (Time.zone.now.at_beginning_of_month.at_beginning_of_week)..(Time.zone.now.at_end_of_month.at_end_of_week)
       end
     end
-    
+
   end
 end

--- a/app/models/gobierto_people/person_event.rb
+++ b/app/models/gobierto_people/person_event.rb
@@ -20,7 +20,7 @@ module GobiertoPeople
     scope :past,     -> { published.where("starts_at <= ?", Time.zone.now) }
     scope :upcoming, -> { published.where("starts_at > ?", Time.zone.now) }
     scope :sorted,   -> { order(starts_at: :asc) }
-    scope :for_month_calendar, -> (date_range) { published.where(starts_at: date_range) }
+    scope :within_range, -> (date_range) { published.where(starts_at: date_range) }
     scope :by_date,  ->(date) { where("starts_at::date = ?", date) }
 
     scope :by_site, ->(site) do

--- a/app/models/gobierto_people/person_event.rb
+++ b/app/models/gobierto_people/person_event.rb
@@ -20,6 +20,7 @@ module GobiertoPeople
     scope :past,     -> { published.where("starts_at <= ?", Time.zone.now) }
     scope :upcoming, -> { published.where("starts_at > ?", Time.zone.now) }
     scope :sorted,   -> { order(starts_at: :asc) }
+    scope :for_month_calendar, -> (date_range) { published.where(starts_at: date_range) }
     scope :by_date,  ->(date) { where("starts_at::date = ?", date) }
 
     scope :by_site, ->(site) do

--- a/app/views/gobierto_people/person_events/_calendar_template.html.erb
+++ b/app/views/gobierto_people/person_events/_calendar_template.html.erb
@@ -1,10 +1,10 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <%= link_to calendar.url_for_previous_view do %>
+    <%= link_to calendar.url_for_previous_view, id: "previous-month-link" do %>
       <i class="fa fa-chevron-left f_left"></i>
     <% end %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month].capitalize %>, <%= start_date.year %></span>
-    <%= link_to calendar.url_for_next_view do %>
+    <%= link_to calendar.url_for_next_view, id: "next-month-link" do %>
       <i class="fa fa-chevron-right f_right"></i>
     <% end %>
   </div>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -34,7 +34,7 @@
       <div class="calendar-component m_v_2">
         <%= month_calendar(
           partial: "gobierto_people/person_events/calendar_template",
-          events: @events,
+          events: @calendar_events,
           attribute: :starts_at,
           start_date: @filtering_date || params[:start_date] || Date.current
         ) do |date, events| %>

--- a/test/fixtures/gobierto_people/person_events.yml
+++ b/test/fixtures/gobierto_people/person_events.yml
@@ -24,3 +24,21 @@ richard_published_past:
   ends_at: <%= 1.month.ago + 1.hour %>
   attachment_url: https://bit.ly/67890
   state: <%= GobiertoPeople::PersonEvent.states["published"] %>
+
+richard_published_tomorrow:
+  person: richard
+  title: Junta de Gobierno
+  description: El Presidente analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.
+  starts_at: <%= 1.day.from_now %>
+  ends_at: <%= 1.day.from_now + 1.hour %>
+  attachment_url: https://bit.ly/67890
+  state: <%= GobiertoPeople::PersonEvent.states["published"] %>
+
+richard_published_yesterday:
+  person: richard
+  title: Junta de Gobierno
+  description: El Presidente analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.
+  starts_at: <%= 1.day.ago %>
+  ends_at: <%= 1.day.ago + 1.hour %>
+  attachment_url: https://bit.ly/67890
+  state: <%= GobiertoPeople::PersonEvent.states["published"] %>

--- a/test/fixtures/gobierto_people/person_events.yml
+++ b/test/fixtures/gobierto_people/person_events.yml
@@ -24,21 +24,3 @@ richard_published_past:
   ends_at: <%= 1.month.ago + 1.hour %>
   attachment_url: https://bit.ly/67890
   state: <%= GobiertoPeople::PersonEvent.states["published"] %>
-
-richard_published_tomorrow:
-  person: richard
-  title: Junta de Gobierno
-  description: El Presidente analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.
-  starts_at: <%= 1.day.from_now %>
-  ends_at: <%= 1.day.from_now + 1.hour %>
-  attachment_url: https://bit.ly/67890
-  state: <%= GobiertoPeople::PersonEvent.states["published"] %>
-
-richard_published_yesterday:
-  person: richard
-  title: Junta de Gobierno
-  description: El Presidente analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.
-  starts_at: <%= 1.day.ago %>
-  ends_at: <%= 1.day.ago + 1.hour %>
-  attachment_url: https://bit.ly/67890
-  state: <%= GobiertoPeople::PersonEvent.states["published"] %>

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -15,12 +15,20 @@ module GobiertoPeople
 
     def upcoming_events
       @upcoming_events ||= [
-        gobierto_people_person_events(:richard_published)
+        gobierto_people_person_events(:richard_published),
+        gobierto_people_person_events(:richard_published_tomorrow)
       ]
     end
 
     def upcoming_event
       @upcoming_event ||= upcoming_events.first
+    end
+
+    def past_events
+      @past_events ||= [
+        gobierto_people_person_events(:richard_published_past),
+        gobierto_people_person_events(:richard_published_yesterday)
+      ]
     end
 
     def people
@@ -80,6 +88,43 @@ module GobiertoPeople
 
         within ".calendar-component" do
           assert has_link?(upcoming_event.starts_at.day)
+        end
+      end
+    end
+
+    def test_calendar_navigation_arrows
+      with_current_site(site) do
+        visit gobierto_people_events_path
+
+        within ".calendar-heading" do
+          click_link "next-month-link"
+        end
+
+        within ".calendar-component" do
+          assert has_link?(gobierto_people_person_events(:richard_published).starts_at.day)
+        end
+
+        visit gobierto_people_events_path
+
+        within ".calendar-heading" do
+          click_link "previous-month-link"
+        end
+
+        within ".calendar-component" do
+          assert has_link?(gobierto_people_person_events(:richard_published_past).starts_at.day)
+        end
+
+      end
+    end
+
+    def test_calendar_event_links
+      with_current_site(site) do
+        visit gobierto_people_events_path
+
+        within ".calendar-component" do
+          (past_events + upcoming_events).each do |event|
+            assert has_link?(event.starts_at.day)
+          end
         end
       end
     end

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -16,7 +16,6 @@ module GobiertoPeople
     def upcoming_events
       @upcoming_events ||= [
         gobierto_people_person_events(:richard_published),
-        gobierto_people_person_events(:richard_published_tomorrow)
       ]
     end
 

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -15,7 +15,7 @@ module GobiertoPeople
 
     def upcoming_events
       @upcoming_events ||= [
-        gobierto_people_person_events(:richard_published),
+        gobierto_people_person_events(:richard_published)
       ]
     end
 
@@ -23,12 +23,12 @@ module GobiertoPeople
       @upcoming_event ||= upcoming_events.first
     end
 
-    def create_visible_month_events
-      @visible_month_events ||= ["2017-02-28 16:00", "2017-03-14 16:00", "2017-03-16 16:00", "2017-04-01 16:00"].map do |date|
+    def create_events_for_dates(dates)
+      @visible_month_events ||= dates.map do |date|
         GobiertoPeople::PersonEvent.create!(
           person: gobierto_people_people(:richard),
-          title: "foo",
-          description: "bar",
+          title: "Event title",
+          description: "Event description",
           starts_at: Time.zone.parse(date),
           ends_at: (Time.zone.parse(date) + 1.hour),
           state: GobiertoPeople::PersonEvent.states["published"]
@@ -98,6 +98,8 @@ module GobiertoPeople
     end
 
     def test_calendar_navigation_arrows
+      visible_month_events = create_events_for_dates(["2017-02-15 16:00", "2017-04-15 16:00"])
+
       Timecop.freeze(Time.zone.parse("2017-03-15 16:00")) do
 
         with_current_site(site) do
@@ -108,7 +110,7 @@ module GobiertoPeople
           end
 
           within ".calendar-component" do
-            assert has_link?(gobierto_people_person_events(:richard_published).starts_at.day)
+            assert has_link?(visible_month_events.last.starts_at.day)
           end
 
           visit gobierto_people_events_path
@@ -118,7 +120,7 @@ module GobiertoPeople
           end
 
           within ".calendar-component" do
-            assert has_link?(gobierto_people_person_events(:richard_published_past).starts_at.day)
+            assert has_link?(visible_month_events.first.starts_at.day)
           end
         end
 
@@ -126,7 +128,7 @@ module GobiertoPeople
     end
 
     def test_calendar_event_links
-      visible_month_events = create_visible_month_events
+      visible_month_events = create_events_for_dates(["2017-02-28 16:00", "2017-03-14 16:00", "2017-03-16 16:00", "2017-04-01 16:00"])
 
       Timecop.freeze(Time.zone.parse("2017-03-15 16:00")) do
 

--- a/test/models/gobierto_people/person_event_test.rb
+++ b/test/models/gobierto_people/person_event_test.rb
@@ -32,6 +32,17 @@ module GobiertoPeople
       refute_includes subject, past_person_event
     end
 
+    def test_within_range_scope
+      past_events = PersonEvent.within_range (1.year.ago)..(Time.zone.now)
+      upcoming_events = PersonEvent.within_range (Time.zone.now)..(1.year.from_now)
+
+      assert_includes past_events, past_person_event
+      refute_includes past_events, person_event
+
+      assert_includes upcoming_events, person_event
+      refute_includes upcoming_events, past_person_event
+    end
+
     def test_by_site_scope
       person_site = person_event.person.site
       subject = PersonEvent.by_site(person_site)


### PR DESCRIPTION
Connects to #557 

### What does this PR do?

Fixes issues in Gobierto People events calendar related to linking past and future events from the calendar widget.

### How should this be manually tested?

When in the agenda view, both past and future events should always have links in their corresponding calendar day.