### PR TITLE
Fix nav display on Consultations

### DIFF
--- a/app/assets/stylesheets/module-consultations.scss
+++ b/app/assets/stylesheets/module-consultations.scss
@@ -9,7 +9,7 @@
   .header.meta .slim_nav_bar {
     display: none;
   }
-  menu.nav {
+  nav {
     display: none;
   }
   header.meta .site_header .logo {

--- a/app/views/gobierto_budget_consultations/layouts/application.html.erb
+++ b/app/views/gobierto_budget_consultations/layouts/application.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <% content_for :breadcrumb_items do %>
-  <span role="separator">/</span>
   <h1>
     <%= link_to t('gobierto_budget_consultations.layouts.menu_subsections.consultations'), gobierto_budget_consultations_consultations_path %>
   </h1>


### PR DESCRIPTION
Connects to #572.

### What does this PR do?
This PR hides the display of the main nav in the Consultation pages. 

Extra: removes an extra separator in the Consultation index.
