### PR TITLE
Don't require custom user records in responses created by admins

### DIFF
--- a/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form.rb
+++ b/app/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form.rb
@@ -18,7 +18,7 @@ module GobiertoAdmin
       delegate :to_model, :persisted?, to: :consultation_response
 
       validates :document_number_digest, :consultation, :selected_options,
-                :site, :census_item, :date_of_birth, :gender, presence: true
+                :site, :census_item, presence: true
 
       def save
         save_consultation_response if valid?
@@ -73,15 +73,9 @@ module GobiertoAdmin
 
       private
 
+      # User custom records are not mandatory if the consultation is being created by an admin
       def valid_custom_records
-        return if custom_records_attributes.nil? || custom_records_attributes.empty?
-
-        custom_records_attributes.each do |name, attributes|
-          custom_user_field = site.custom_user_fields.find_by(name: name)
-          if custom_user_field.mandatory? && attributes["raw_value"].blank?
-            errors[:base] << "#{custom_user_field.localized_title} #{I18n.t('errors.messages.blank')}"
-          end
-        end
+        return true
       end
 
       def consultation_class

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_responses_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_responses_test.rb
@@ -135,6 +135,57 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_add_new_response_without_user_information
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              assert has_content?("Responses until now: 2")
+              click_link "Check if an ID has responded"
+              # Document number already responded: dennis
+              fill_in "document_number", with: "00000000D"
+              click_button "Search"
+              assert has_content?("This ID hasn't responded yet")
+              click_link "Add a participation to this ID"
+
+              assert has_content?("Add response")
+
+              item1 = gobierto_budget_consultations_consultation_items(:madrid_sports_facilities)
+              item2 = gobierto_budget_consultations_consultation_items(:madrid_civil_protection)
+
+              # Don't fill user custom fields
+
+              page.find("#consultation_response_selected_options_#{item1.id}_5", visible: false).trigger('click')
+              page.find("#consultation_response_selected_options_#{item2.id}_5", visible: false).trigger('click')
+              click_button "Create"
+
+              assert has_alert?("Consultation couldn't be saved. Please, review the responses and try again")
+
+              page.find("#consultation_response_selected_options_#{item1.id}_0", visible: false).trigger('click')
+              page.find("#consultation_response_selected_options_#{item2.id}_-5", visible: false).trigger('click')
+              select "Center", from: "Districts"
+              fill_in "Association", with: "Asociación Vecinos Arganzuela"
+              fill_in "Bio", with: "My short bio"
+
+              click_button "Create"
+
+              assert has_message?("Response created successfully")
+              assert has_content?("Responses until now: 3")
+
+              activity = Activity.last
+              assert_equal consultation, activity.recipient
+              assert_equal admin, activity.author
+              assert_equal "gobierto_budget_consultations.consultation_response_created", activity.action
+              assert_equal "GobiertoBudgetConsultations::ConsultationResponse", activity.subject_type
+              assert activity.admin_activity
+              assert_equal site.id, activity.site_id
+            end
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR removes validations on custom user fields and user information in consultation responses  when created by an administrator
