### PR TITLE
Agenda events > Fix results filtering and output - 558 & 577

### DIFF
--- a/app/controllers/gobierto_people/executive_category_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_past_person_events_controller.rb
@@ -1,12 +1,9 @@
 module GobiertoPeople
   class ExecutiveCategoryPastPersonEventsController < PastPersonEventsController
     def index
-      super
       @person_event_scope = "executive_category"
       @person_category = Person.categories["executive"]
-      @events = @events.by_person_category(@person_category)
-      @calendar_events = @calendar_events.by_person_category(@person_category)
-      @people = @people.executive
+      super
     end
   end
 end

--- a/app/controllers/gobierto_people/executive_category_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_past_person_events_controller.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @person_category = Person.categories["executive"]
       @events = @events.by_person_category(@person_category)
       @calendar_events = @calendar_events.by_person_category(@person_category)
+      @people = @people.executive
     end
   end
 end

--- a/app/controllers/gobierto_people/executive_category_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_past_person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
       @person_event_scope = "executive_category"
       @person_category = Person.categories["executive"]
       @events = @events.by_person_category(@person_category)
+      @calendar_events = @calendar_events.by_person_category(@person_category)
     end
   end
 end

--- a/app/controllers/gobierto_people/executive_category_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_person_events_controller.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @person_category = Person.categories["executive"]
       @events = @events.by_person_category(@person_category)
       @calendar_events = @calendar_events.by_person_category(@person_category)
+      @people = @people.executive
 
       check_past_events
     end

--- a/app/controllers/gobierto_people/executive_category_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
       @person_event_scope = "executive_category"
       @person_category = Person.categories["executive"]
       @events = @events.by_person_category(@person_category)
+      @calendar_events = @calendar_events.by_person_category(@person_category)
 
       check_past_events
     end

--- a/app/controllers/gobierto_people/executive_category_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_person_events_controller.rb
@@ -5,6 +5,12 @@ module GobiertoPeople
       @person_event_scope = "executive_category"
       @person_category = Person.categories["executive"]
       @events = @events.by_person_category(@person_category)
+
+      @no_upcoming_events = @events.empty?
+
+      if @no_upcoming_events
+        @events = current_site.person_events.past.by_person_category(@person_category)
+      end
     end
   end
 end

--- a/app/controllers/gobierto_people/executive_category_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_person_events_controller.rb
@@ -6,11 +6,13 @@ module GobiertoPeople
       @person_category = Person.categories["executive"]
       @events = @events.by_person_category(@person_category)
 
-      @no_upcoming_events = @events.empty?
+      check_past_events
+    end
 
-      if @no_upcoming_events
-        @events = current_site.person_events.past.by_person_category(@person_category)
-      end
+    private
+
+    def past_events
+      current_site.person_events.past.by_person_category(@person_category)
     end
   end
 end

--- a/app/controllers/gobierto_people/executive_category_person_events_controller.rb
+++ b/app/controllers/gobierto_people/executive_category_person_events_controller.rb
@@ -1,20 +1,9 @@
 module GobiertoPeople
   class ExecutiveCategoryPersonEventsController < PersonEventsController
     def index
-      super
       @person_event_scope = "executive_category"
       @person_category = Person.categories["executive"]
-      @events = @events.by_person_category(@person_category)
-      @calendar_events = @calendar_events.by_person_category(@person_category)
-      @people = @people.executive
-
-      check_past_events
-    end
-
-    private
-
-    def past_events
-      current_site.person_events.past.by_person_category(@person_category)
+      super
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_past_person_events_controller.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @person_party = Person.parties["government"]
       @events = @events.by_person_party(@person_party)
       @calendar_events = @calendar_events.by_person_party(@person_party)
+      @people = @people.government
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_past_person_events_controller.rb
@@ -1,12 +1,9 @@
 module GobiertoPeople
   class GovernmentPartyPastPersonEventsController < PastPersonEventsController
     def index
-      super
       @person_event_scope = "government_party"
       @person_party = Person.parties["government"]
-      @events = @events.by_person_party(@person_party)
-      @calendar_events = @calendar_events.by_person_party(@person_party)
-      @people = @people.government
+      super
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_past_person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
       @person_event_scope = "government_party"
       @person_party = Person.parties["government"]
       @events = @events.by_person_party(@person_party)
+      @calendar_events = @calendar_events.by_person_party(@person_party)
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_person_events_controller.rb
@@ -5,6 +5,12 @@ module GobiertoPeople
       @person_event_scope = "government_party"
       @person_party = Person.parties["government"]
       @events = @events.by_person_party(@person_party)
+
+      @no_upcoming_events = @events.empty?
+
+      if @no_upcoming_events
+        @events = current_site.person_events.past.by_person_party(@person_party)
+      end
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_person_events_controller.rb
@@ -1,20 +1,9 @@
 module GobiertoPeople
   class GovernmentPartyPersonEventsController < PersonEventsController
     def index
-      super
       @person_event_scope = "government_party"
       @person_party = Person.parties["government"]
-      @events = @events.by_person_party(@person_party)
-      @calendar_events = @calendar_events.by_person_party(@person_party)
-      @people = @people.government
-
-      check_past_events
-    end
-
-    private
-
-    def past_events
-      current_site.person_events.past.by_person_party(@person_party)
+      super
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_person_events_controller.rb
@@ -6,11 +6,13 @@ module GobiertoPeople
       @person_party = Person.parties["government"]
       @events = @events.by_person_party(@person_party)
 
-      @no_upcoming_events = @events.empty?
+      check_past_events
+    end
 
-      if @no_upcoming_events
-        @events = current_site.person_events.past.by_person_party(@person_party)
-      end
+    private
+
+    def past_events
+      current_site.person_events.past.by_person_party(@person_party)
     end
   end
 end

--- a/app/controllers/gobierto_people/government_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
       @person_event_scope = "government_party"
       @person_party = Person.parties["government"]
       @events = @events.by_person_party(@person_party)
+      @calendar_events = @calendar_events.by_person_party(@person_party)
 
       check_past_events
     end

--- a/app/controllers/gobierto_people/government_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/government_party_person_events_controller.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @person_party = Person.parties["government"]
       @events = @events.by_person_party(@person_party)
       @calendar_events = @calendar_events.by_person_party(@person_party)
+      @people = @people.government
 
       check_past_events
     end

--- a/app/controllers/gobierto_people/opposition_party_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_past_person_events_controller.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @person_party = Person.parties["opposition"]
       @events = @events.by_person_party(@person_party)
       @calendar_events = @calendar_events.by_person_party(@person_party)
+      @people = @people.opposition
     end
   end
 end

--- a/app/controllers/gobierto_people/opposition_party_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_past_person_events_controller.rb
@@ -1,12 +1,9 @@
 module GobiertoPeople
   class OppositionPartyPastPersonEventsController < PastPersonEventsController
     def index
-      super
       @person_event_scope = "opposition_party"
       @person_party = Person.parties["opposition"]
-      @events = @events.by_person_party(@person_party)
-      @calendar_events = @calendar_events.by_person_party(@person_party)
-      @people = @people.opposition
+      super
     end
   end
 end

--- a/app/controllers/gobierto_people/opposition_party_past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_past_person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
       @person_event_scope = "opposition_party"
       @person_party = Person.parties["opposition"]
       @events = @events.by_person_party(@person_party)
+      @calendar_events = @calendar_events.by_person_party(@person_party)
     end
   end
 end

--- a/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
@@ -5,6 +5,12 @@ module GobiertoPeople
       @person_event_scope = "opposition_party"
       @person_party = Person.parties["opposition"]
       @events = @events.by_person_party(@person_party)
+
+      @no_upcoming_events = @events.empty?
+
+      if @no_upcoming_events
+        @events = current_site.person_events.past.by_person_party(@person_party)
+      end
     end
   end
 end

--- a/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
@@ -6,11 +6,13 @@ module GobiertoPeople
       @person_party = Person.parties["opposition"]
       @events = @events.by_person_party(@person_party)
 
-      @no_upcoming_events = @events.empty?
+      check_past_events
+    end
 
-      if @no_upcoming_events
-        @events = current_site.person_events.past.by_person_party(@person_party)
-      end
+    private
+
+    def past_events
+      current_site.person_events.past.by_person_party(@person_party)
     end
   end
 end

--- a/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @person_party = Person.parties["opposition"]
       @events = @events.by_person_party(@person_party)
       @calendar_events = @calendar_events.by_person_party(@person_party)
+      @people = @people.opposition
 
       check_past_events
     end

--- a/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
@@ -1,20 +1,9 @@
 module GobiertoPeople
   class OppositionPartyPersonEventsController < PersonEventsController
     def index
-      super
       @person_event_scope = "opposition_party"
       @person_party = Person.parties["opposition"]
-      @events = @events.by_person_party(@person_party)
-      @calendar_events = @calendar_events.by_person_party(@person_party)
-      @people = @people.opposition
-
-      check_past_events
-    end
-
-    private
-
-    def past_events
-      current_site.person_events.past.by_person_party(@person_party)
+      super
     end
   end
 end

--- a/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
+++ b/app/controllers/gobierto_people/opposition_party_person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
       @person_event_scope = "opposition_party"
       @person_party = Person.parties["opposition"]
       @events = @events.by_person_party(@person_party)
+      @calendar_events = @calendar_events.by_person_party(@person_party)
 
       check_past_events
     end

--- a/app/controllers/gobierto_people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/past_person_events_controller.rb
@@ -1,8 +1,8 @@
 module GobiertoPeople
   class PastPersonEventsController < PersonEventsController
     def index
+      @past_events = true
       super
-      @events = current_site.person_events.past.sorted
     end
   end
 end

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -9,6 +9,12 @@ module GobiertoPeople
       @people = current_site.people.active.sorted
       @political_groups = get_political_groups
 
+      @no_upcoming_events = @events.empty?
+
+      if @no_upcoming_events
+        @events = current_site.person_events.past.sorted
+      end
+
       respond_to do |format|
         format.html
         format.json { render json: @events }

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -9,11 +9,7 @@ module GobiertoPeople
       @people = current_site.people.active.sorted
       @political_groups = get_political_groups
 
-      @no_upcoming_events = @events.empty?
-
-      if @no_upcoming_events
-        @events = current_site.person_events.past.sorted
-      end
+      check_past_events
 
       respond_to do |format|
         format.html
@@ -38,6 +34,15 @@ module GobiertoPeople
       else
         (Time.zone.now.at_beginning_of_month.at_beginning_of_week)..(Time.zone.now.at_end_of_month.at_end_of_week)
       end
+    end
+
+    def past_events
+      current_site.person_events.past.sorted
+    end
+
+    def check_past_events
+      @no_upcoming_events = @events.empty?
+      if @no_upcoming_events then @events = past_events end
     end
 
   end

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -44,8 +44,8 @@ module GobiertoPeople
 
     def set_people
       @people = current_site.people.active.sorted
-      @people = @people.send(Person.categories.index(@person_category)) if @person_category
-      @people = @people.send(Person.parties.index(@person_party)) if @person_party
+      @people = @people.send(Person.categories.key(@person_category)) if @person_category
+      @people = @people.send(Person.parties.key(@person_party)) if @person_party
     end
 
     def filter_by_date_param

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -2,20 +2,21 @@
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
 
     <ul role="tablist" aria-label="<%= t('.agenda', name: @site.name) %>">
+      <% past_events_controller = controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) %>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
-        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path) %>
+        <% path = (past_events_controller ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path) %>
         <%= link_to t("gobierto_people.people_filter.parties.government"), path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
-        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path) %>
+        <% path = (past_events_controller ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path) %>
         <%= link_to t("gobierto_people.people_filter.parties.opposition"), path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
-        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path) %>
+        <% path = (past_events_controller ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path) %>
         <%= link_to t("gobierto_people.people_filter.categories.executive"), path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
-        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_past_events_path : gobierto_people_events_path) %>
+        <% path = (past_events_controller ? gobierto_people_past_events_path : gobierto_people_events_path) %>
         <%= link_to t("gobierto_people.people_filter.all"), path, tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
     </ul>

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -3,19 +3,22 @@
 
     <ul role="tablist" aria-label="<%= t('.agenda', name: @site.name) %>">
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_events_path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path) %>
+        <%= link_to t("gobierto_people.people_filter.parties.government"), path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"), gobierto_people_opposition_party_events_path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path) %>
+        <%= link_to t("gobierto_people.people_filter.parties.opposition"), path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.categories.executive"), gobierto_people_executive_category_events_path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path) %>
+        <%= link_to t("gobierto_people.people_filter.categories.executive"), path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.all"), gobierto_people_events_path, tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <% path = (controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) ? gobierto_people_past_events_path : gobierto_people_events_path) %>
+        <%= link_to t("gobierto_people.people_filter.all"), path, tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
     </ul>
-
   </div>
 </menu>
 

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -2,24 +2,28 @@
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
 
     <ul role="tablist" aria-label="<%= t('.agenda', name: @site.name) %>">
-      <% past_events_controller = controller.class.ancestors.include?(GobiertoPeople::PastPersonEventsController) %>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
-        <% path = (past_events_controller ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path) %>
-        <%= link_to t("gobierto_people.people_filter.parties.government"), path, tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <%= link_to t("gobierto_people.people_filter.parties.government"),
+                    (@past_events ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path),
+                    tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
-        <% path = (past_events_controller ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path) %>
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"), path, tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <%= link_to t("gobierto_people.people_filter.parties.opposition"),
+                    (@past_events ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path),
+                    tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
-        <% path = (past_events_controller ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path) %>
-        <%= link_to t("gobierto_people.people_filter.categories.executive"), path, tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <%= link_to t("gobierto_people.people_filter.categories.executive"),
+                    (@past_events ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path),
+                    tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
       <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
-        <% path = (past_events_controller ? gobierto_people_past_events_path : gobierto_people_events_path) %>
-        <%= link_to t("gobierto_people.people_filter.all"), path, tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        <%= link_to t("gobierto_people.people_filter.all"),
+                    (@past_events ? gobierto_people_past_events_path : gobierto_people_events_path),
+                    tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
       </li>
     </ul>
+
   </div>
 </menu>
 

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -93,7 +93,12 @@
 
         </div>
 
-        <%= render @events %>
+        <% if @no_upcoming_events %>
+          <div><p><strong>No hay eventos futuros.</strong> Échale un vistazo a los pasados:</p></div>
+        <% end %>
+
+        <%= render partial: "gobierto_people/person_events/person_event", collection: @events %>
+
 
       </div>
 

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -93,8 +93,14 @@
 
         </div>
 
-        <% if @no_upcoming_events %>
-          <div><p><strong>No hay eventos futuros.</strong> Échale un vistazo a los pasados:</p></div>
+        <% if @past_events && @events.empty? %>
+          <p>No hay eventos pasados.</p>
+        <% else %>
+          <% if @no_upcoming_events && @events.empty? %>
+            <p>No hay eventos futuros ni pasados.</p>
+          <% elsif @no_upcoming_events %>
+            <p><strong>No hay eventos futuros.</strong> Échale un vistazo a los pasados:</p>
+          <% end %>
         <% end %>
 
         <%= render partial: "gobierto_people/person_events/person_event", collection: @events %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -94,12 +94,12 @@
         </div>
 
         <% if @past_events && @events.empty? %>
-          <p>No hay eventos pasados.</p>
+          <p><%= t(".no_past_events") %></p>
         <% else %>
           <% if @no_upcoming_events && @events.empty? %>
-            <p>No hay eventos futuros ni pasados.</p>
+            <p><%= t(".no_events") %></p>
           <% elsif @no_upcoming_events %>
-            <p><strong>No hay eventos futuros.</strong> Échale un vistazo a los pasados:</p>
+            <p><%= t(".no_upcoming_events") %>:</p>
           <% end %>
         <% end %>
 

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -142,7 +142,7 @@ ca:
           title: Rep un resum de les agendes dels teus representants
         title: Agendes de %{site_name}
         upcoming_events: Agenda
-        no_upcoming_events: No hi ha events futurs. Mira els pròxims events.
+        no_upcoming_events: No hi ha events futurs. Mira els pròxims events
         no_past_events: No hi ha events passats.
         no_events: No hi ha events futurs ni passats.
     person_post_tags:

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -142,9 +142,9 @@ ca:
           title: Rep un resum de les agendes dels teus representants
         title: Agendes de %{site_name}
         upcoming_events: Agenda
-        no_upcoming_events: No hay eventos futuros. Échale un vistazo a los pasados
-        no_past_events: No hay eventos pasados.
-        no_events: No hay eventos futuros ni pasados.
+        no_upcoming_events: No hi ha events futurs. Mira els pròxims events.
+        no_past_events: No hi ha events passats.
+        no_events: No hi ha events futurs ni passats.
     person_post_tags:
       show:
         filtering_by_tag: Filtrant per "%{tag}"

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -142,6 +142,9 @@ ca:
           title: Rep un resum de les agendes dels teus representants
         title: Agendes de %{site_name}
         upcoming_events: Agenda
+        no_upcoming_events: No hay eventos futuros. Échale un vistazo a los pasados
+        no_past_events: No hay eventos pasados.
+        no_events: No hay eventos futuros ni pasados.
     person_post_tags:
       show:
         filtering_by_tag: Filtrant per "%{tag}"

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -142,6 +142,9 @@ en:
           title: Receive a summary of the agendas of your representatives
         title: "%{site_name}'s member agendas"
         upcoming_events: Agenda
+        no_upcoming_events: There are no future events. Take a look at past ones
+        no_past_events: There are no past events.
+        no_events: There are no future or past events.
     person_post_tags:
       show:
         filtering_by_tag: Filtering by "%{tag}"

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -143,6 +143,9 @@ es:
           title: Recibe un resumen de las agendas de tus representantes
         title: "Agendas de los miembros de %{site_name}"
         upcoming_events: Agenda
+        no_upcoming_events: No hay eventos futuros. Échale un vistazo a los pasados
+        no_past_events: No hay eventos pasados.
+        no_events: No hay eventos futuros ni pasados.
     person_post_tags:
       show:
         filtering_by_tag: Filtrando por "%{tag}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,13 +121,13 @@ Rails.application.routes.draw do
     constraints GobiertoSiteConstraint.new do
       get '/' => 'welcome#index', as: :root
 
-      resources :person_events, only: [:index], as: :events, path: 'agendas/eventos'
+      resources :person_events, only: [:index], as: :events, path: 'todos-los-cargos/agendas/eventos'
       resources :government_party_person_events, only: [:index], as: :government_party_events, path: 'equipo-gobierno/agendas/eventos'
       resources :opposition_party_person_events, only: [:index], as: :opposition_party_events, path: 'cargos-en-oposicion/agendas/eventos'
       resources :executive_category_person_events, only: [:index], as: :executive_category_events, path: 'cargos-directivos/agendas/eventos'
 
       resources :past_person_events, only: [:index], as: :past_events, path: 'todos-los-cargos/agendas/eventos-pasados'
-      resources :government_party_past_person_events, only: [:index], as: :government_party_past_events, path: 'agendas/eventos-pasados'
+      resources :government_party_past_person_events, only: [:index], as: :government_party_past_events, path: 'equipo-gobierno/agendas/eventos-pasados'
       resources :opposition_party_past_person_events, only: [:index], as: :opposition_party_past_events, path: 'cargos-en-oposicion/agendas/eventos-pasados'
       resources :executive_category_past_person_events, only: [:index], as: :executive_category_past_events, path: 'cargos-directivos/agendas/eventos-pasados'
 

--- a/test/fixtures/gobierto_people/person_events.yml
+++ b/test/fixtures/gobierto_people/person_events.yml
@@ -24,3 +24,12 @@ richard_published_past:
   ends_at: <%= 1.month.ago + 1.hour %>
   attachment_url: https://bit.ly/67890
   state: <%= GobiertoPeople::PersonEvent.states["published"] %>
+
+tamara_published_past:
+  person: tamara
+  title: Executive member event I
+  description: Executive member event.
+  starts_at: <%= 15.days.ago %>
+  ends_at: <%= 15.days.ago + 1.hour %>
+  attachment_url: https://bit.ly/67890
+  state: <%= GobiertoPeople::PersonEvent.states["published"] %>

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -38,6 +38,13 @@ module GobiertoPeople
       ]
     end
 
+    def past_events
+      @past_events ||= [
+        gobierto_people_person_events(:richard_published_past),
+        gobierto_people_person_events(:tamara_published_past)
+      ]
+    end
+
     def upcoming_event
       @upcoming_event ||= upcoming_events.first
     end
@@ -45,18 +52,12 @@ module GobiertoPeople
     def create_event(options = {})
       GobiertoPeople::PersonEvent.create!(
         person: options[:person] || government_member,
-        title: "Event title",
+        title: options[:title] || "Event title",
         description: "Event description",
         starts_at: Time.zone.parse(options[:starts_at]) || Time.zone.now,
-        ends_at: (Time.zone.parse(options[:starts_at]) || Time.zone.now) + 1.hour,
+        ends_at:  (Time.zone.parse(options[:starts_at]) || Time.zone.now) + 1.hour,
         state: GobiertoPeople::PersonEvent.states["published"]
       )
-    end
-
-    def create_events_for_dates(dates)
-      @visible_month_events ||= dates.map do |date|
-        create_event(starts_at: date)
-      end
     end
 
     def test_person_events_index
@@ -80,6 +81,102 @@ module GobiertoPeople
       end
     end
 
+    def test_person_events_filter_for_agenda_switcher
+      with_current_site(site) do
+        visit @path
+
+        click_link "All"
+
+        within ".agenda-switcher" do
+          assert has_link? government_member.name
+          assert has_link? executive_member.name
+        end
+
+        click_link "Government Team"
+
+        within ".agenda-switcher" do
+          assert has_link? government_member.name
+          refute has_link? executive_member.name
+        end
+
+        click_link "Opposition"
+
+        within ".agenda-switcher" do
+          refute has_link? government_member.name
+          refute has_link? executive_member.name
+        end
+
+      end
+    end
+
+    def test_person_events_filter_for_calendar_widget
+      government_event = create_event(person: government_member, starts_at: "2017-03-16")
+      executive_event  = create_event(person: executive_member,  starts_at: "2017-03-17")
+
+      government_event_day = government_event.starts_at.day
+      executive_event_day  = executive_event.starts_at.day
+
+      Timecop.freeze(Time.zone.parse("2017-03-15")) do
+        with_current_site(site) do
+          visit @path
+
+          click_link "All"
+
+          within ".calendar-component" do
+            assert has_link? government_event_day
+            assert has_link? executive_event_day
+          end
+
+          click_link "Government Team"
+
+          within ".calendar-component" do
+            assert has_link? government_event_day
+            refute has_link? executive_event_day
+          end
+
+          click_link "Opposition"
+
+          within ".calendar-component" do
+            refute has_link? government_event_day
+            refute has_link? executive_event_day
+          end
+
+        end
+      end
+    end
+
+    def test_person_events_filter_for_events_list
+      government_event = create_event(person: government_member, title: "Government event", starts_at: "2017-03-16")
+      executive_event  = create_event(person: executive_member,  title: "Executive event",  starts_at: "2017-03-16")
+
+      Timecop.freeze(Time.zone.parse("2017-03-15")) do
+        with_current_site(site) do
+          visit @path
+
+          click_link "All"
+
+          within ".events-summary" do
+            assert has_link?(government_event.title)
+            assert has_link?(executive_event.title)
+          end
+
+          click_link "Government Team"
+
+          within ".events-summary" do
+            assert has_link?(government_event.title)
+            refute has_link?(executive_event.title)
+          end
+
+          click_link "Opposition"
+
+          within ".events-summary" do
+            refute has_link?(government_event.title)
+            refute has_link?(executive_event.title)
+          end
+        end
+      end
+    end
+
     def test_events_summary
       with_current_site(site) do
         visit @path
@@ -96,44 +193,130 @@ module GobiertoPeople
       end
     end
 
-    def test_calendar_component
-      upcoming_event = create_events_for_dates(["2017-03-15 16:00"]).first
+    def test_events_summary_with_no_upcoming_events
+      past_event = create_event(starts_at: "2017-03-14")
 
-      Timecop.freeze(Time.zone.parse("2017-03-15 16:00")) do
+      Timecop.freeze(10.years.from_now) do
         with_current_site(site) do
-          visit gobierto_people_events_path(start_date: upcoming_event.starts_at)
+          visit @path
+
+          within ".events-summary" do
+            assert_text("There are no future events. Take a look at past ones")
+            assert has_link?(past_event.title)
+          end
+        end
+      end
+    end
+
+    def test_events_summary_with_no_past_events
+      Timecop.freeze(10.years.ago) do
+        with_current_site(site) do
+          visit @path
+
+          click_link "Past events"
+
+          assert_text("There are no past events.")
+        end
+      end
+    end
+
+    def test_events_summary_with_no_events
+      (upcoming_events + past_events).each { |event| event.update_columns(state: :pending) }
+
+      with_current_site(site) do
+        visit @path
+
+        assert_text("There are no future or past events.")
+      end
+    end
+
+    def test_future_and_past_events_filter
+      past_event   = create_event(title: "Past event title",   starts_at: "2017-02-15")
+      future_event = create_event(title: "Future event title", starts_at: "2017-04-15")
+
+      Timecop.freeze(Time.zone.parse("2017-03-15")) do
+
+        with_current_site(site) do
+          visit @path
+
+          within ".events-summary" do
+            refute has_content?(past_event.title)
+            assert has_content?(future_event.title)
+          end
+
+          click_link "Past events"
+
+          within ".events-summary" do
+            assert has_content?(past_event.title)
+            refute has_content?(future_event.title)
+          end
+        end
+
+      end
+    end
+
+    def test_future_and_past_events_filter_is_kept_when_changing_political_group
+      with_current_site(site) do
+        visit @path
+
+        within ".events-summary .events-filter" do
+          assert has_link? "Past events"
+          refute has_link? "Agenda"
+        end
+
+        click_link "Past events"
+        click_link "Government Team"
+
+        within ".events-summary .events-filter" do
+          refute has_link? "Past events"
+          assert has_link? "Agenda"
+        end
+
+        click_link "Agenda"
+        click_link "Executive"
+
+        within ".events-summary .events-filter" do
+          assert has_link? "Past events"
+          refute has_link? "Agenda"
+        end
+      end
+    end
+
+    def test_calendar_component
+      future_event = create_event(starts_at: "2017-03-16")
+
+      Timecop.freeze(Time.zone.parse("2017-03-15")) do
+        with_current_site(site) do
+          visit gobierto_people_events_path(start_date: future_event.starts_at)
 
           within ".calendar-component" do
-            assert has_link?(upcoming_event.starts_at.day)
+            assert has_link?(future_event.starts_at.day)
           end
         end
       end
     end
 
     def test_calendar_navigation_arrows
-      visible_month_events = create_events_for_dates(["2017-02-15 16:00", "2017-04-15 16:00"])
+      past_event   = create_event(starts_at: "2017-02-15")
+      future_event = create_event(starts_at: "2017-04-15")
 
-      Timecop.freeze(Time.zone.parse("2017-03-15 16:00")) do
+      Timecop.freeze(Time.zone.parse("2017-03-15")) do
 
         with_current_site(site) do
           visit gobierto_people_events_path
 
-          within ".calendar-heading" do
-            click_link "next-month-link"
-          end
+          click_link "next-month-link"
 
           within ".calendar-component" do
-            assert has_link?(visible_month_events.last.starts_at.day)
+            assert has_link?(future_event.starts_at.day)
           end
 
           visit gobierto_people_events_path
 
-          within ".calendar-heading" do
-            click_link "previous-month-link"
-          end
+          click_link "previous-month-link"
 
           within ".calendar-component" do
-            assert has_link?(visible_month_events.first.starts_at.day)
+            assert has_link?(past_event.starts_at.day)
           end
         end
 
@@ -141,9 +324,11 @@ module GobiertoPeople
     end
 
     def test_calendar_event_links
-      visible_month_events = create_events_for_dates(["2017-02-28 16:00", "2017-03-14 16:00", "2017-03-16 16:00", "2017-04-01 16:00"])
+      visible_month_events = ["2017-02-28", "2017-03-14", "2017-03-16", "2017-04-01"].map do |date|
+        create_event(starts_at: date)
+      end
 
-      Timecop.freeze(Time.zone.parse("2017-03-15 16:00")) do
+      Timecop.freeze(Time.zone.parse("2017-03-15")) do
 
         with_current_site(site) do
           visit gobierto_people_events_path

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -13,6 +13,25 @@ module GobiertoPeople
       @site ||= sites(:madrid)
     end
 
+    def government_member
+      gobierto_people_people(:richard)
+    end
+
+    def executive_member
+      gobierto_people_people(:tamara)
+    end
+
+    def people
+      @people ||= [government_member, executive_member]
+    end
+
+    def political_groups
+      @political_groups ||= [
+        gobierto_people_political_groups(:marvel),
+        gobierto_people_political_groups(:dc)
+      ]
+    end
+
     def upcoming_events
       @upcoming_events ||= [
         gobierto_people_person_events(:richard_published)
@@ -23,31 +42,21 @@ module GobiertoPeople
       @upcoming_event ||= upcoming_events.first
     end
 
+    def create_event(options = {})
+      GobiertoPeople::PersonEvent.create!(
+        person: options[:person] || government_member,
+        title: "Event title",
+        description: "Event description",
+        starts_at: Time.zone.parse(options[:starts_at]) || Time.zone.now,
+        ends_at: (Time.zone.parse(options[:starts_at]) || Time.zone.now) + 1.hour,
+        state: GobiertoPeople::PersonEvent.states["published"]
+      )
+    end
+
     def create_events_for_dates(dates)
       @visible_month_events ||= dates.map do |date|
-        GobiertoPeople::PersonEvent.create!(
-          person: gobierto_people_people(:richard),
-          title: "Event title",
-          description: "Event description",
-          starts_at: Time.zone.parse(date),
-          ends_at: (Time.zone.parse(date) + 1.hour),
-          state: GobiertoPeople::PersonEvent.states["published"]
-        )
+        create_event(starts_at: date)
       end
-    end
-
-    def people
-      @people ||= [
-        gobierto_people_people(:richard),
-        gobierto_people_people(:tamara)
-      ]
-    end
-
-    def political_groups
-      @political_groups ||= [
-        gobierto_people_political_groups(:marvel),
-        gobierto_people_political_groups(:dc)
-      ]
     end
 
     def test_person_events_index


### PR DESCRIPTION
Fixes  #558 and #577 

### What does this PR do?

Fixes filters used to navigate agenda events:

* Filtering calendar events by the selected political group.
* Remembering the *upcoming events* or *past events* filter when switching between the different political groups.
* Filtering people list by the selected political group.

Improves information given by the results output by:

* If no upcoming events are available for the selected filters, shows a notice ("There are no future events. Take a look at past ones.") and displays past events for the selected criteria.
* If there are no past events, shows notice: "There are no past events."
* If there are neither future or past events, shows notice "There are no future or past events".

### How should this be manually tested?

...