### PR TITLE
Avoid crash when module not in config

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -105,9 +105,9 @@ class Site < ApplicationRecord
     @added_modules_after_update ||= begin
       if self.configuration_data.has_key?('modules')
         if self.configuration_data_was && self.configuration_data_was.has_key?('modules')
-          self.configuration_data['modules'] - self.configuration_data_was['modules']
+          Array.wrap(self.configuration_data['modules']) - Array.wrap(self.configuration_data_was['modules'])
         else
-          self.configuration_data['modules']
+          Array.wrap(self.configuration_data['modules'])
         end
       else
         []

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -116,7 +116,7 @@
       <div class="menu_content">
 
         <ul>
-          <% if current_site.configuration.gobierto_budget_consultations_enabled? %>
+          <% if SITE_MODULES.include?("GobiertoBudgetConsultations") && current_site.configuration.gobierto_budget_consultations_enabled? %>
           <li>
             <%= link_to t(".budget_consultations"), admin_budget_consultations_path %>
           </li>


### PR DESCRIPTION
Unexpected

### What does this PR do?

Avoid crash when first creating a site from console and modules is empty. 
Also avoid exception if GobiertoBudgetConsultations is not in the module list in `APP_CONFIG` (`application.yml`)

