### PR TITLE
Fix links for longer domains

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_budget_consultations/consultations_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_budget_consultations/consultations_controller.rb
@@ -37,7 +37,7 @@ module GobiertoAdmin
         if @consultation_form.save
           redirect_to(
             admin_budget_consultation_consultation_items_path(@consultation_form.consultation),
-            notice: t(".success_html", link: gobierto_budget_consultations_consultation_url(@consultation_form.consultation, domain: current_site.domain))
+            notice: t(".success_html", link: gobierto_budget_consultations_consultation_url(@consultation_form.consultation, host: current_site.domain))
           )
         else
           @consultation_visibility_levels = get_consultation_visibility_levels
@@ -55,7 +55,7 @@ module GobiertoAdmin
         if @consultation_form.save
           redirect_to(
             edit_admin_budget_consultation_path(@consultation),
-            notice: t(".success_html", link: gobierto_budget_consultations_consultation_url(@consultation_form.consultation, domain: current_site.domain))
+            notice: t(".success_html", link: gobierto_budget_consultations_consultation_url(@consultation_form.consultation, host: current_site.domain))
           )
         else
           @consultation_visibility_levels = get_consultation_visibility_levels

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
 
           redirect_to(
             edit_admin_cms_page_path(@page_form.page.id),
-            notice: t(".success_html", link: gobierto_cms_page_url(@page_form.page, domain: current_site.domain))
+            notice: t(".success_html", link: gobierto_cms_page_url(@page_form.page, host: current_site.domain))
           )
         else
           @page_visibility_levels = get_page_visibility_levels
@@ -45,7 +45,7 @@ module GobiertoAdmin
 
           redirect_to(
             edit_admin_cms_page_path(@page_form.page.id),
-            notice: t(".success_html", link: gobierto_cms_page_url(@page_form.page, domain: current_site.domain))
+            notice: t(".success_html", link: gobierto_cms_page_url(@page_form.page, host: current_site.domain))
           )
         else
           @page_visibility_levels = get_page_visibility_levels

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
@@ -31,7 +31,7 @@ module GobiertoAdmin
           if @person_event_form.save
             redirect_to(
               edit_admin_people_person_event_path(@person, @person_event_form.person_event),
-              notice: t(".success_html", link: gobierto_people_person_event_url(@person, @person_event_form.person_event, domain: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_event_url(@person, @person_event_form.person_event, host: current_site.domain))
             )
           else
             @attendees = get_attendees
@@ -49,7 +49,7 @@ module GobiertoAdmin
           if @person_event_form.save
             redirect_to(
               edit_admin_people_person_event_path(@person, @person_event),
-              notice: t(".success_html", link: gobierto_people_person_event_url(@person, @person_event_form.person_event, domain: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_event_url(@person, @person_event_form.person_event, host: current_site.domain))
             )
           else
             @attendees = get_attendees

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_posts_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_posts_controller.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
           if @person_post_form.save
             redirect_to(
               edit_admin_people_person_post_path(@person, @person_post_form.person_post),
-              notice: t(".success_html", link: gobierto_people_person_post_url(@person, @person_post_form.person_post, domain: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_post_url(@person, @person_post_form.person_post, host: current_site.domain))
             )
           else
             @person_post_visibility_levels = get_person_post_visibility_levels
@@ -45,7 +45,7 @@ module GobiertoAdmin
           if @person_post_form.save
             redirect_to(
               edit_admin_people_person_post_path(@person, @person_post),
-              notice: t(".success_html", link: gobierto_people_person_post_url(@person, @person_post_form.person_post, domain: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_post_url(@person, @person_post_form.person_post, host: current_site.domain))
             )
           else
             @person_post_visibility_levels = get_person_post_visibility_levels

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_statements_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_statements_controller.rb
@@ -30,7 +30,7 @@ module GobiertoAdmin
           if @person_statement_form.save
             redirect_to(
               edit_admin_people_person_statement_path(@person, @person_statement_form.person_statement),
-              notice: t(".success_html", link: gobierto_people_person_statement_url(@person, @person_statement_form.person_statement, domain: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_statement_url(@person, @person_statement_form.person_statement, host: current_site.domain))
             )
           else
             @person_statement_visibility_levels = get_person_statement_visibility_levels
@@ -47,7 +47,7 @@ module GobiertoAdmin
           if @person_statement_form.save
             redirect_to(
               edit_admin_people_person_statement_path(@person, @person_statement),
-              notice: t(".success_html", link: gobierto_people_person_statement_url(@person, @person_statement_form.person_statement, domain: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_statement_url(@person, @person_statement_form.person_statement, host: current_site.domain))
             )
           else
             @person_statement_visibility_levels = get_person_statement_visibility_levels

--- a/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
@@ -37,7 +37,7 @@ module GobiertoAdmin
         if @person_form.save
           redirect_to(
             edit_admin_people_person_path(@person_form.person),
-            notice: t(".success_html", link: gobierto_people_person_url(@person_form.person, domain: current_site.domain))
+            notice: t(".success_html", link: gobierto_people_person_url(@person_form.person, host: current_site.domain))
           )
         else
           @person_visibility_levels = get_person_visibility_levels
@@ -57,7 +57,7 @@ module GobiertoAdmin
         if @person_form.save
           redirect_to(
             edit_admin_people_person_path(@person),
-            notice: t(".success_html", link: gobierto_people_person_url(@person_form.person, domain: current_site.domain))
+            notice: t(".success_html", link: gobierto_people_person_url(@person_form.person, host: current_site.domain))
           )
         else
           @person_visibility_levels = get_person_visibility_levels

--- a/app/controllers/user/subscriptions_controller.rb
+++ b/app/controllers/user/subscriptions_controller.rb
@@ -34,7 +34,7 @@ class User::SubscriptionsController < User::BaseController
       flash[:alert] = t(
         ".error",
         details: @user_subscription_form.errors.full_messages.to_sentence,
-        sign_in_path: new_user_sessions_path(domain: current_site.domain)
+        sign_in_path: new_user_sessions_path(host: current_site.domain)
       )
     end
 

--- a/app/decorators/user_notification_decorator.rb
+++ b/app/decorators/user_notification_decorator.rb
@@ -18,7 +18,7 @@ class UserNotificationDecorator < BaseDecorator
   end
 
   def url
-    @object.subject.to_url(domain: @object.site.domain)
+    @object.subject.to_url(host: @object.site.domain)
   end
 
   private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -11,6 +11,10 @@ class ApplicationMailer < ActionMailer::Base
     @site.presence && "#{@site.name} <#{APP_CONFIG["email_config"]["default_email"]}>"
   end
 
+  def site_host
+    @site.try(:domain) || ENV["HOST"]
+  end
+
   def default_from
     APP_CONFIG["email_config"]["default_from"]
   end

--- a/app/mailers/gobierto_admin/admin_mailer.rb
+++ b/app/mailers/gobierto_admin/admin_mailer.rb
@@ -3,6 +3,7 @@ module GobiertoAdmin
     def confirmation_instructions(admin)
       @admin = admin
       @site = admin.sites.first
+      @site_host = site_host
 
       mail(
         from: from,
@@ -15,6 +16,7 @@ module GobiertoAdmin
     def invitation_instructions(admin)
       @admin = admin
       @site = admin.sites.first
+      @site_host = site_host
 
       mail(
         from: from,
@@ -27,6 +29,7 @@ module GobiertoAdmin
     def reset_password_instructions(admin)
       @admin = admin
       @site = admin.sites.first
+      @site_host = site_host
 
       mail(
         from: from,

--- a/app/mailers/gobierto_people/person_mailer.rb
+++ b/app/mailers/gobierto_people/person_mailer.rb
@@ -6,6 +6,7 @@ module GobiertoPeople
       @name = args[:name]
       @body = args[:body]
       @site = @person.site
+      @site_host = site_host
 
       mail(
         from: from,

--- a/app/mailers/user/notification_mailer.rb
+++ b/app/mailers/user/notification_mailer.rb
@@ -6,6 +6,8 @@ class User::NotificationMailer < ApplicationMailer
     @user = user_notification.user
     @site = user_notification.site
 
+    @site_host = site_host
+
     mail(
       from: from,
       reply_to: default_reply_to,
@@ -18,6 +20,7 @@ class User::NotificationMailer < ApplicationMailer
     @user = user
     @user_notifications = UserNotificationCollectionDecorator.new(user_notifications)
     @site = user_notifications.first.site
+    @site_host = site_host
 
     mail(
       from: from,

--- a/app/mailers/user/user_mailer.rb
+++ b/app/mailers/user/user_mailer.rb
@@ -2,6 +2,7 @@ class User::UserMailer < ApplicationMailer
   def confirmation_instructions(user, site)
     @user = user
     @site = site
+    @site_host = site_host
 
     mail(
       from: from,
@@ -14,6 +15,7 @@ class User::UserMailer < ApplicationMailer
   def reset_password_instructions(user, site)
     @user = user
     @site = site
+    @site_host = site_host
 
     mail(
       from: from,
@@ -26,8 +28,9 @@ class User::UserMailer < ApplicationMailer
   def welcome(user, site)
     @user = user
     @site = site
-    @site_url = root_url(domain: @site.domain)
-    @notifications_url = user_notifications_url(domain: @site.domain)
+    @site_url = root_url(host: @site.domain)
+    @notifications_url = user_notifications_url(host: @site.domain)
+    @site_host = site_host
 
     mail(
       from: from,

--- a/app/views/gobierto_admin/admin_mailer/confirmation_instructions.html.erb
+++ b/app/views/gobierto_admin/admin_mailer/confirmation_instructions.html.erb
@@ -7,8 +7,8 @@
 </p>
 
 <p>
-  <%= link_to admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, domain: @site.try(:domain)),
-              admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, domain: @site.try(:domain)) %>
+  <%= link_to admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, host: @site_host),
+              admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, host: @site_host) %>
 </p>
 
 <p>

--- a/app/views/gobierto_admin/admin_mailer/confirmation_instructions.txt.erb
+++ b/app/views/gobierto_admin/admin_mailer/confirmation_instructions.txt.erb
@@ -2,6 +2,6 @@
 
 <%= t('.click_link') %>:
 
-<%= admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, domain: @site.try(:domain)) %>
+<%= admin_admin_confirmations_url(confirmation_token: @admin.confirmation_token, host: @site_host) %>
 
 <%= t('.bye') %>

--- a/app/views/gobierto_admin/admin_mailer/invitation_instructions.html.erb
+++ b/app/views/gobierto_admin/admin_mailer/invitation_instructions.html.erb
@@ -7,8 +7,8 @@
 </p>
 
 <p>
-  <%= link_to admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, domain: @site.try(:domain)),
-              admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, domain: @site.try(:domain)) %>
+  <%= link_to admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, host: @site_host),
+              admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, host: @site_host) %>
 </p>
 
 <p>

--- a/app/views/gobierto_admin/admin_mailer/invitation_instructions.txt.erb
+++ b/app/views/gobierto_admin/admin_mailer/invitation_instructions.txt.erb
@@ -2,6 +2,6 @@
 
 <%= t('.click_link') %>:
 
-<%= admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, domain: @site.try(:domain)) %>
+<%= admin_admin_invitation_acceptances_url(invitation_token: @admin.invitation_token, host: @site_host) %>
 
 <%= t('.bye') %>

--- a/app/views/gobierto_admin/admin_mailer/reset_password_instructions.html.erb
+++ b/app/views/gobierto_admin/admin_mailer/reset_password_instructions.html.erb
@@ -7,8 +7,8 @@
 </p>
 
 <p>
-  <%= link_to edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, domain: @site.try(:domain)),
-              edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, domain: @site.try(:domain)) %>
+  <%= link_to edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, host: @site_host),
+              edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, host: @site_host) %>
 </p>
 
 <p>

--- a/app/views/gobierto_admin/admin_mailer/reset_password_instructions.txt.erb
+++ b/app/views/gobierto_admin/admin_mailer/reset_password_instructions.txt.erb
@@ -2,6 +2,6 @@
 
 <%= t('.click_link') %>:
 
-<%= edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, domain: @site.try(:domain)) %>
+<%= edit_admin_admin_passwords_url(reset_password_token: @admin.reset_password_token, host: @site_host) %>
 
 <%= t('.bye') %>

--- a/app/views/gobierto_admin/gobierto_budget_consultations/consultations/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_budget_consultations/consultations/_form.html.erb
@@ -20,7 +20,7 @@
                     <div><%= t('.days_left_html', count: f.object.consultation.days_left, projected_count: f.object.consultation.projected_responses )%></div>
                   <% end %>
                 <% else %>
-                  <div><%= t('.no_response_html', url: f.object.consultation.to_url(domain: current_site.domain)) %></div>
+                  <div><%= t('.no_response_html', url: f.object.consultation.to_url(host: current_site.domain)) %></div>
                 <% end %>
               <% elsif f.object.consultation.upcoming? %>
                 <div><%= t('.upcoming') %></div>

--- a/app/views/gobierto_admin/gobierto_budget_consultations/consultations/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_budget_consultations/consultations/index.html.erb
@@ -51,7 +51,7 @@
         <%= t(".visibility_level.#{consultation.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_budget_consultations_consultation_url(consultation, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_budget_consultations_consultation_url(consultation, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_consultation") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -61,7 +61,7 @@
         <%= t(".visibility_level.#{person.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_url(person, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_url(person, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_person") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -77,7 +77,7 @@
         <%= t(".visibility_level.#{person_event.state}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_event_url(@person, person_event, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_event_url(@person, person_event, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_event") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
@@ -53,7 +53,7 @@
         <%= t(".visibility_level.#{person_post.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_post_url(@person, person_post, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_post_url(@person, person_post, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_post") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
@@ -47,7 +47,7 @@
         <%= t(".visibility_level.#{person_statement.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_statement_url(@person, person_statement, domain: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_statement_url(@person, person_statement, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_statement") %>
         <% end %>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -40,7 +40,7 @@
               <li class="pure-menu-item">
                 <%= link_to(
                   site.name,
-                  admin_root_url(domain: site.domain),
+                  admin_root_url(host: site.domain),
                   class: "pure-menu-link") %>
               </li>
             <% end %>

--- a/app/views/gobierto_people/people/_latest_activity.html.erb
+++ b/app/views/gobierto_people/people/_latest_activity.html.erb
@@ -7,7 +7,7 @@
     <ul>
       <% @latest_activity.each do |activity| %>
         <li>
-          <h4><%= link_to_if activity.active?, activity.translated_action, activity.subject.to_url(domain: @site.domain) %></h4>
+          <h4><%= link_to_if activity.active?, activity.translated_action, activity.subject.to_url(host: @site.domain) %></h4>
           <span class="soft">
             <%= l(activity.created_at.to_date, format: :short) %>
           </span>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -6,7 +6,7 @@
   <p>
   --<br>
   <%= @site.name %> <%= "· #{@site.location_name}" %><br>
-  <%= root_url(domain: @site.domain) %>
+  <%= root_url(host: @site_host) %>
   </p>
 <% end %>
   </body>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -2,4 +2,4 @@
 
 --
 <%= @site.name %> <%= "· #{@site.location_name}" %>
-<%= root_url(domain: @site.domain) %>
+<%= root_url(host: @site_host) %>

--- a/app/views/user/notification_mailer/notification_digest.html.erb
+++ b/app/views/user/notification_mailer/notification_digest.html.erb
@@ -13,7 +13,7 @@
 </ul>
 
 <p>
-  <%= t('.manage_notifications_html', url: user_subscriptions_url(domain: @site.domain)) %>.
+  <%= t('.manage_notifications_html', url: user_subscriptions_url(host: @site_host)) %>.
 </p>
 
 <p>

--- a/app/views/user/notification_mailer/notification_digest.txt.erb
+++ b/app/views/user/notification_mailer/notification_digest.txt.erb
@@ -6,6 +6,6 @@
   - <%= user_notification.translated_action %>: <%= user_notification.subject_name %> (<%=  user_notification.url %>)
 <% end %>
 
-<%= t('.manage_notifications', url: user_subscriptions_url(domain: @site.domain)) %>.
+<%= t('.manage_notifications', url: user_subscriptions_url(host: @site_host)) %>.
 
 <%= t('.bye') %>

--- a/app/views/user/notification_mailer/single_notification.html.erb
+++ b/app/views/user/notification_mailer/single_notification.html.erb
@@ -11,7 +11,7 @@
 </ul>
 
 <p>
-  <%= t('.manage_notifications_html', url: user_subscriptions_url(domain: @site.domain)) %>.
+  <%= t('.manage_notifications_html', url: user_subscriptions_url(host: @site_host)) %>.
 </p>
 
 <p>

--- a/app/views/user/notification_mailer/single_notification.txt.erb
+++ b/app/views/user/notification_mailer/single_notification.txt.erb
@@ -4,6 +4,6 @@
 
 - <%= @user_notification_decorated.translated_action %>: <%= @user_notification_decorated.subject_name %> (<%= @user_notification_decorated.url %>)
 
-<%= t('.manage_notifications', url: user_subscriptions_url(domain: @site.domain)) %>.
+<%= t('.manage_notifications', url: user_subscriptions_url(host: @site_host)) %>.
 
 <%= t('.bye') %>

--- a/app/views/user/user_mailer/confirmation_instructions.html.erb
+++ b/app/views/user/user_mailer/confirmation_instructions.html.erb
@@ -7,8 +7,8 @@
 </p>
 
 <p>
-  <%= link_to new_user_confirmations_url(confirmation_token: @user.confirmation_token, domain: @site.domain),
-              new_user_confirmations_url(confirmation_token: @user.confirmation_token, domain: @site.domain) %>
+  <%= link_to new_user_confirmations_url(confirmation_token: @user.confirmation_token, host: @site_host),
+              new_user_confirmations_url(confirmation_token: @user.confirmation_token, host: @site_host) %>
 </p>
 
 <p>

--- a/app/views/user/user_mailer/confirmation_instructions.txt.erb
+++ b/app/views/user/user_mailer/confirmation_instructions.txt.erb
@@ -2,7 +2,7 @@
 
 <%= t('.click_link') %>
 
-<%= new_user_confirmations_url(confirmation_token: @user.confirmation_token, domain: @site.domain) %>
+<%= new_user_confirmations_url(confirmation_token: @user.confirmation_token, host: @site_host) %>
 
 (<%= t('.ignore_link', site_name: @site.name) %>)
 

--- a/app/views/user/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user/user_mailer/reset_password_instructions.html.erb
@@ -7,8 +7,8 @@
 </p>
 
 <p>
-  <%= link_to edit_user_passwords_url(reset_password_token: @user.reset_password_token, domain: @site.domain),
-              edit_user_passwords_url(reset_password_token: @user.reset_password_token, domain: @site.domain) %>
+  <%= link_to edit_user_passwords_url(reset_password_token: @user.reset_password_token, host: @site_host),
+              edit_user_passwords_url(reset_password_token: @user.reset_password_token, host: @site_host) %>
 </p>
 
 <p>

--- a/app/views/user/user_mailer/reset_password_instructions.txt.erb
+++ b/app/views/user/user_mailer/reset_password_instructions.txt.erb
@@ -2,6 +2,6 @@
 
 <%= t('.click_link') %>
 
-<%= edit_user_passwords_url(reset_password_token: @user.reset_password_token, domain: @site.domain) %>
+<%= edit_user_passwords_url(reset_password_token: @user.reset_password_token, host: @site_host) %>
 
 <%= t('.bye') %>


### PR DESCRIPTION
Unexpected

### What does this PR do?

The links were wrongly generated in the emails and some views in a gobierto installation using a base domain of more than 2 elements (go.dival.es vs. gobierto.es).

This PR changes the use of the url helpers to use the `:host` option instead of the `:domain` option, which doesn't depend on the configured tld length to work properly.


### How should this be manually tested?

Check that the links in the emails and in the admin pages pointing to public pages are still correct for the current installation of gobierto.

