### PR TITLE
Extract FileUploadService adapter to config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ config/deploy/production.rb
 /coverage
 
 # Uploaded files
-/public/attachments
+/public/system/attachments

--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -17,7 +17,6 @@ module GobiertoAdmin
 
     def file_url
       @file_url ||= FileUploadService.new(
-        adapter: :s3,
         site: site,
         collection: collection,
         attribute_name: :attachment,

--- a/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
@@ -67,7 +67,6 @@ module GobiertoAdmin
           return person_event.attachment_url unless attachment_file.present?
 
           FileUploadService.new(
-            adapter: :s3,
             site: person.site,
             collection: person_event.model_name.collection,
             attribute_name: :attachment,

--- a/app/forms/gobierto_admin/gobierto_people/person_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_form.rb
@@ -82,7 +82,6 @@ module GobiertoAdmin
           return person.bio_url unless bio_file.present?
 
           FileUploadService.new(
-            adapter: :s3,
             site: site,
             collection: person.model_name.collection,
             attribute_name: :bio,
@@ -96,7 +95,6 @@ module GobiertoAdmin
           return person.avatar_url unless avatar_file.present?
 
           FileUploadService.new(
-            adapter: :s3,
             site: site,
             collection: person.model_name.collection,
             attribute_name: :avatar,

--- a/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
@@ -74,7 +74,6 @@ module GobiertoAdmin
           return person_statement.attachment_url unless attachment_file.present?
 
           FileUploadService.new(
-            adapter: :s3,
             site: person.site,
             collection: person_statement.model_name.collection,
             attribute_name: :attachment,

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -108,7 +108,6 @@ module GobiertoAdmin
         return site.configuration.logo unless logo_file.present?
 
         FileUploadService.new(
-          adapter: :s3,
           site: site,
           collection: site.model_name.collection,
           attribute_name: :logo,

--- a/app/services/gobierto_admin/file_upload_service.rb
+++ b/app/services/gobierto_admin/file_upload_service.rb
@@ -4,8 +4,8 @@ module GobiertoAdmin
   class FileUploadService
     attr_reader :file, :site, :collection
 
-    def initialize(adapter:, site:, collection:, attribute_name:, file:, content_disposition: nil)
-      @adapter = adapter
+    def initialize(site:, collection:, attribute_name:, file:, content_disposition: nil)
+      @adapter = APP_CONFIG['file_uploads_adapter'].presence.try(:to_sym) || :s3
       @site = site
       @collection = collection
       @attribute_name = attribute_name
@@ -22,6 +22,7 @@ module GobiertoAdmin
 
       case @adapter
       when :s3 then FileUploader::S3.new(file: file, file_name: file_name, content_disposition: @content_disposition)
+      when :filesystem then FileUploader::Local.new(file: file, file_name: file_name)
       end
     end
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -45,6 +45,7 @@ default: &default
     endpoint: <%= ENV["POPULATE_DATA_ENDPOINT"] %>
   gobierto_indicators:
     year: 2015
+  file_uploads_adapter: s3
 
 development:
   <<: *default

--- a/lib/file_uploader/local.rb
+++ b/lib/file_uploader/local.rb
@@ -1,6 +1,6 @@
 module FileUploader
   class Local
-    FILE_PATH_PREFIX = "attachments".freeze
+    FILE_PATH_PREFIX = "system/attachments".freeze
 
     attr_reader :file, :file_name
 

--- a/test/lib/file_uploader/local_test.rb
+++ b/test/lib/file_uploader/local_test.rb
@@ -19,7 +19,7 @@ module FileUploader
     end
 
     def test_call
-      assert_equal "/attachments/people/person/avatar.jpg", local_file_uploader.call
+      assert_equal "/system/attachments/people/person/avatar.jpg", local_file_uploader.call
     end
   end
 end

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -7,7 +7,6 @@ module GobiertoAdmin
 
     def file_upload_service
       @file_upload_service ||= FileUploadService.new(
-        adapter: :s3,
         site: site,
         collection: :test_collection,
         attribute_name: :test_attribute,


### PR DESCRIPTION
Connects to #593

### What does this PR do?
Extracts the adapter for FileUploadService to the application config, but leaves `:s3` as the default.


### How should this be manually tested?
Check that everything keeps working


### Does this PR changes any configuration file?

Adds a new entry in `config/application.yml`:
```
  file_uploads_adapter: s3
```
the value can be `s3` or `filesystem`

It's not necessary to change Ansible roles because the default is `s3` as before, so nothing should break. 