### PR TITLE
Compact smtp settings

### DIFF
--- a/config/initializers/action_mailer_settings.rb
+++ b/config/initializers/action_mailer_settings.rb
@@ -9,5 +9,5 @@ end
 
 if Rails.application.secrets.mailer_delivery_method == "smtp"
   Rails.application.config.action_mailer.delivery_method = :smtp
-  Rails.application.config.action_mailer.smtp_settings = Rails.application.secrets.mailer_smtp_settings
+  Rails.application.config.action_mailer.smtp_settings = Rails.application.secrets.mailer_smtp_settings.compact
 end

--- a/config/initializers/action_mailer_settings.rb
+++ b/config/initializers/action_mailer_settings.rb
@@ -9,5 +9,5 @@ end
 
 if Rails.application.secrets.mailer_delivery_method == "smtp"
   Rails.application.config.action_mailer.delivery_method = :smtp
-  Rails.application.config.action_mailer.smtp_settings = Rails.application.secrets.mailer_smtp_settings.compact
+  Rails.application.config.action_mailer.smtp_settings = Rails.application.secrets.mailer_smtp_settings.compact.symbolize_keys
 end


### PR DESCRIPTION
Connects to #580

### What does this PR do?

Compacts and symbolizes the keys to the smtp config introduced in #583 
Without this the keys for `mailer_smtp_settings` were being read as strings and adding them to `Rails.application.config.action_mailer.smtp_settings` didn't have any effect, as it didn't overwrite the default ones.
 