### PR TITLE
Activate module subsections

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include SubmodulesHelper
+
   protect_from_forgery with: :exception
 
   rescue_from ActionController::RoutingError, with: :render_404

--- a/app/controllers/concerns/submodules_helper.rb
+++ b/app/controllers/concerns/submodules_helper.rb
@@ -1,0 +1,75 @@
+module SubmodulesHelper
+  extend ActiveSupport::Concern
+
+  included do
+    if respond_to?(:helper_method)
+      helper_method :active_submodules, :welcome_submodule_active?, :officials_submodule_active?, :agendas_submodule_active?, :blog_submodule_active?, :statements_submodule_active?, :submodule_path_for, :submodule_title_for, :submodule_controller_for
+    end
+  end
+
+  private
+
+  def available_submodules
+    {
+      officials: {
+        root_path: gobierto_people_people_path,
+        layout_title: t('gobierto_people.layouts.menu_subsections.people'),
+        controller_name: 'people'
+      },
+      agendas: {
+        root_path: gobierto_people_events_path,
+        layout_title: t('gobierto_people.layouts.menu_subsections.agendas'),
+        controller_name: 'person_events'
+      },
+      blog: {
+        root_path: gobierto_people_posts_path,
+        layout_title: t('gobierto_people.layouts.menu_subsections.blogs'),
+        controller_name: 'person_posts'
+      },
+      statements: {
+        root_path: gobierto_people_statements_path,
+        layout_title: t('gobierto_people.layouts.menu_subsections.statements'),
+        controller_name: 'person_statements'
+      }
+    }
+  end
+
+  def active_submodules
+    active_submodules = GobiertoPeople::Setting.where("key ~* ?", ".*_submodule_active").where(value: 'true', site: current_site)
+    active_submodules_names = active_submodules.pluck(:key).map { |key| key.gsub("_submodule_active", "") }
+    active_submodules_names & available_submodules.keys.map { |key| key.to_s }
+  end
+
+  def welcome_submodule_active?
+    active_submodules.size > 1
+  end
+
+  def officials_submodule_active?
+    active_submodules.include?('officials')
+  end
+
+  def agendas_submodule_active?
+    active_submodules.include?('agendas')
+  end
+
+  def blog_submodule_active?
+    active_submodules.include?('blog')
+  end
+
+  def statements_submodule_active?
+    active_submodules.include?('statements')
+  end
+
+  def submodule_path_for(submodule)
+    available_submodules[submodule.to_sym][:root_path]
+  end
+
+  def submodule_title_for(submodule)
+    available_submodules[submodule.to_sym][:layout_title]
+  end
+
+  def submodule_controller_for(submodule)
+    available_submodules[submodule.to_sym][:controller_name]
+  end
+
+end

--- a/app/controllers/concerns/submodules_helper.rb
+++ b/app/controllers/concerns/submodules_helper.rb
@@ -2,9 +2,7 @@ module SubmodulesHelper
   extend ActiveSupport::Concern
 
   included do
-    if respond_to?(:helper_method)
-      helper_method :active_submodules, :welcome_submodule_active?, :officials_submodule_active?, :agendas_submodule_active?, :blog_submodule_active?, :statements_submodule_active?, :submodule_path_for, :submodule_title_for, :submodule_controller_for
-    end
+    helper_method :active_submodules, :welcome_submodule_active?, :officials_submodule_active?, :agendas_submodule_active?, :blog_submodule_active?, :statements_submodule_active?, :submodule_path_for, :submodule_title_for, :submodule_controller_for
   end
 
   private
@@ -37,7 +35,7 @@ module SubmodulesHelper
   def active_submodules
     active_submodules = GobiertoPeople::Setting.where("key ~* ?", ".*_submodule_active").where(value: 'true', site: current_site)
     active_submodules_names = active_submodules.pluck(:key).map { |key| key.gsub("_submodule_active", "") }
-    active_submodules_names & available_submodules.keys.map { |key| key.to_s }
+    active_submodules_names & available_submodules.keys.map(&:to_s)
   end
 
   def welcome_submodule_active?

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -2,6 +2,8 @@ module GobiertoPeople
   class PeopleController < GobiertoPeople::ApplicationController
     include PoliticalGroupsHelper
 
+    before_action :check_active_submodules, except: :show
+
     def index
 
       @political_groups = get_political_groups
@@ -25,6 +27,12 @@ module GobiertoPeople
     end
 
     private
+
+    def check_active_submodules
+      if !officials_submodule_active?
+        redirect_to gobierto_people_root_path
+      end
+    end
 
     def find_person
       current_site.people.active.find(params[:id])

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -2,6 +2,8 @@ module GobiertoPeople
   class PersonEventsController < GobiertoPeople::ApplicationController
     include PoliticalGroupsHelper
 
+    before_action :check_active_submodules
+
     def index
       @political_groups = get_political_groups
 
@@ -18,6 +20,12 @@ module GobiertoPeople
     end
 
     private
+
+    def check_active_submodules
+      if !agendas_submodule_active?
+        redirect_to gobierto_people_root_path
+      end
+    end
 
     def set_events
       @events = current_site.person_events

--- a/app/controllers/gobierto_people/person_gifts_controller.rb
+++ b/app/controllers/gobierto_people/person_gifts_controller.rb
@@ -1,5 +1,8 @@
 module GobiertoPeople
   class PersonGiftsController < GobiertoPeople::ApplicationController
+
+    before_action :check_active_submodules
+
     def index
       redirect_to gifts_service_url and return if gifts_service_url.present?
 
@@ -7,6 +10,12 @@ module GobiertoPeople
     end
 
     private
+
+    def check_active_submodules
+      if !statements_submodule_active?
+        redirect_to gobierto_people_root_path
+      end
+    end
 
     def gifts_service_url
       APP_CONFIG.dig("gobierto_people", "gifts_service_url")

--- a/app/controllers/gobierto_people/person_posts_controller.rb
+++ b/app/controllers/gobierto_people/person_posts_controller.rb
@@ -1,5 +1,8 @@
 module GobiertoPeople
   class PersonPostsController < GobiertoPeople::ApplicationController
+
+    before_action :check_active_submodules
+
     def index
       @people = current_site.people.active
       @posts = current_site.person_posts.active.sorted
@@ -8,5 +11,14 @@ module GobiertoPeople
         format.rss { render layout: false }
       end
     end
+
+    private
+
+    def check_active_submodules
+      if !blog_submodule_active?
+        redirect_to gobierto_people_root_path
+      end
+    end
+
   end
 end

--- a/app/controllers/gobierto_people/person_statements_controller.rb
+++ b/app/controllers/gobierto_people/person_statements_controller.rb
@@ -1,5 +1,8 @@
 module GobiertoPeople
   class PersonStatementsController < GobiertoPeople::ApplicationController
+
+    before_action :check_active_submodules
+
     def index
       @people = current_site.people.active
       @statements = current_site.person_statements.active.sorted
@@ -10,5 +13,14 @@ module GobiertoPeople
         format.csv  { render csv: GobiertoExports::CSVRenderer.new(@statements).to_csv, filename: 'statements' }
       end
     end
+
+    private
+
+    def check_active_submodules
+      if !statements_submodule_active?
+        redirect_to gobierto_people_root_path
+      end
+    end
+
   end
 end

--- a/app/controllers/gobierto_people/person_travels_controller.rb
+++ b/app/controllers/gobierto_people/person_travels_controller.rb
@@ -1,5 +1,8 @@
 module GobiertoPeople
   class PersonTravelsController < GobiertoPeople::ApplicationController
+
+    before_action :check_active_submodules
+
     def index
       redirect_to travels_service_url and return if travels_service_url.present?
 
@@ -7,6 +10,12 @@ module GobiertoPeople
     end
 
     private
+
+    def check_active_submodules
+      if !statements_submodule_active?
+        redirect_to gobierto_people_root_path
+      end
+    end
 
     def travels_service_url
       APP_CONFIG.dig("gobierto_people", "travels_service_url")

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -2,6 +2,8 @@ module GobiertoPeople
   class WelcomeController < GobiertoPeople::ApplicationController
     include PoliticalGroupsHelper
 
+    before_action :check_active_submodules
+
     def index
       @people = current_site.people.active.politician.government.last(10)
       @posts  = current_site.person_posts.active.sorted.last(10)
@@ -11,6 +13,12 @@ module GobiertoPeople
     end
 
     private
+
+    def check_active_submodules
+      if active_submodules.size == 1
+        redirect_to submodule_path_for(active_submodules.first)
+      end
+    end
 
     def set_events
       @events = current_site.person_events.by_person_party(Person.parties[:government])

--- a/app/views/gobierto_admin/gobierto_people/configuration/_navigation.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/configuration/_navigation.html.erb
@@ -13,11 +13,11 @@
 
 <div class="tabs">
   <ul>
-    <li <%= %Q{class="active"}.html_safe if controller_name == 'political_groups'%>>
-      <%= link_to t("gobierto_admin.gobierto_people.political_groups.title"), admin_people_configuration_political_groups_path %>
-    </li>
     <li <%= %Q{class="active"}.html_safe if controller_name == 'settings'%>>
       <%= link_to t("gobierto_admin.gobierto_people.settings.title"), admin_people_configuration_settings_path %>
+    </li>
+    <li <%= %Q{class="active"}.html_safe if controller_name == 'political_groups'%>>
+      <%= link_to t("gobierto_admin.gobierto_people.political_groups.title"), admin_people_configuration_political_groups_path %>
     </li>
   </ul>
 </div>

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -6,7 +6,7 @@
 <h1><%= title t(".title") %></h1>
 
 <div class="admin_tools right">
-  <%= link_to admin_people_configuration_political_groups_path do %>
+  <%= link_to admin_people_configuration_settings_path do %>
     <i class="fa fa-cog"></i>
     <%= t(".configuration") %>
   <% end %>

--- a/app/views/gobierto_people/layouts/_menu_subsections.html.erb
+++ b/app/views/gobierto_people/layouts/_menu_subsections.html.erb
@@ -1,11 +1,12 @@
-<menu class="sub_sections">
-  <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
-    <ul>
-      <li><%= link_to t('gobierto_people.layouts.menu_subsections.home'), gobierto_people_root_path, class: class_if('active', controller_name == 'welcome') %></li>
-      <li><%= link_to t('gobierto_people.layouts.menu_subsections.people'), gobierto_people_people_path, class: class_if('active', controller_name == 'people') %></li>
-      <li><%= link_to t('gobierto_people.layouts.menu_subsections.agendas'), gobierto_people_events_path, class: class_if('active', controller_name == 'person_events') %></li>
-      <li><%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path, class: class_if('active', controller_name == 'person_posts') %></li>
-      <li><%= link_to t('gobierto_people.layouts.menu_subsections.statements'), gobierto_people_statements_path, class: class_if('active', controller_name == 'person_statements') %></li>
-    </ul>
-  </div>
-</menu>
+<% if welcome_submodule_active? %>
+  <menu class="sub_sections">
+    <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
+      <ul>
+        <li><%= link_to t('gobierto_people.layouts.menu_subsections.home'), gobierto_people_root_path, class: class_if('active', controller_name == 'welcome') %></li>
+        <% active_submodules.each do |submodule| %>
+          <li><%= link_to submodule_title_for(submodule), submodule_path_for(submodule), class: class_if('active', controller_name == submodule_controller_for(submodule)) %></li>
+        <% end %>
+      </ul>
+    </div>
+  </menu>
+<% end %>

--- a/app/views/gobierto_people/layouts/_navigation.html.erb
+++ b/app/views/gobierto_people/layouts/_navigation.html.erb
@@ -1,7 +1,12 @@
 <div class="pure-u-1 pure-u-md-1-4 section">
-  <h2><%= link_to t("gobierto_people.layouts.application.title"), gobierto_people_root_path, class: class_if('active', controller_name == 'welcome')  %></h2>
-  <%= link_to t('gobierto_people.layouts.menu_subsections.people'), gobierto_people_people_path, class: class_if('active', controller_name == 'people') %>
-  <%= link_to t('gobierto_people.layouts.menu_subsections.agendas'), gobierto_people_events_path, class: class_if('active', controller_name == 'person_events') %>
-  <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path, class: class_if('active', controller_name == 'person_posts') %>
-  <%= link_to t('gobierto_people.layouts.menu_subsections.statements'), gobierto_people_statements_path, class: class_if('active', controller_name == 'person_statements') %>
+
+  <% if welcome_submodule_active? %>
+    <h2><%= link_to t("gobierto_people.layouts.application.title"), gobierto_people_root_path  %></h2>
+  <% end %>
+
+  <% active_submodules.each do |submodule| %>
+    <% if !welcome_submodule_active? %><h2><% end %>
+    <%= link_to submodule_title_for(submodule), submodule_path_for(submodule), class: class_if('active', controller_name == submodule_controller_for(submodule)) %>
+    <% if !welcome_submodule_active? %></h2><% end %>
+  <% end %>
 </div>

--- a/app/views/gobierto_people/layouts/application.html.erb
+++ b/app/views/gobierto_people/layouts/application.html.erb
@@ -4,15 +4,19 @@
 
 <% content_for :breadcrumb_items do %>
   <% if content_for?(:breadcrumb_current_item) %>
-    <strong>
-      <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
-    </strong>
-    <span role="separator">/</span>
+    <% if welcome_submodule_active? %>
+      <strong>
+        <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
+      </strong>
+      <span role="separator">/</span>
+    <% end %>
     <%= yield(:breadcrumb_current_item) %>
   <% else %>
-    <h1>
-      <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
-    </h1>
+    <% if welcome_submodule_active? %>
+      <h1>
+        <%= link_to t('gobierto_people.layouts.application.title'), gobierto_people_root_path %>
+      </h1>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/gobierto_people/people/_navigation.html.erb
+++ b/app/views/gobierto_people/people/_navigation.html.erb
@@ -2,9 +2,15 @@
 
   <ul>
     <li><h3><%= link_to t(".bio"), gobierto_people_person_bio_path(@person), class: class_if("active", controller_name == "person_bio") %></h3></li>
-    <li><h3><%= link_to t(".agenda"), gobierto_people_person_events_path(@person), class: class_if("active", controller_name == "person_events")  %></h3></li>
-    <li><h3><%= link_to t(".blog"), gobierto_people_person_posts_path(@person), class: class_if("active", controller_name == "person_posts")  %></h3></li>
-    <li><h3><%= link_to t(".statements"), gobierto_people_person_statements_path(@person), class: class_if("active", controller_name == "person_statements")  %></h3></li>
+    <% if agendas_submodule_active? %>
+      <li><h3><%= link_to t(".agenda"), gobierto_people_person_events_path(@person), class: class_if("active", controller_name == "person_events")  %></h3></li>
+    <% end %>
+    <% if blog_submodule_active? %>
+      <li><h3><%= link_to t(".blog"), gobierto_people_person_posts_path(@person), class: class_if("active", controller_name == "person_posts")  %></h3></li>
+    <% end %>
+    <% if statements_submodule_active? %>
+      <li><h3><%= link_to t(".statements"), gobierto_people_person_statements_path(@person), class: class_if("active", controller_name == "person_statements")  %></h3></li>
+    <% end %>
   </ul>
 
 </div>

--- a/app/views/gobierto_people/people/show.html.erb
+++ b/app/views/gobierto_people/people/show.html.erb
@@ -35,7 +35,10 @@
         <% end %>
       </div>
 
-      <%= render "upcoming_events" %>
+      <% if agendas_submodule_active? %>
+        <%= render "upcoming_events" %>
+      <% end %>
+
       <%= render("user/subscriptions/subscribable_box",
                  subscribable: @person,
                  title: t(".subscribable_box.title", person_name: @person.name)) %>

--- a/app/views/gobierto_people/person_events/_person_events_filter.html.erb
+++ b/app/views/gobierto_people/person_events/_person_events_filter.html.erb
@@ -1,44 +1,46 @@
-<menu class="filter_boxed">
-  <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
+<% if officials_submodule_active? %>
+  <menu class="filter_boxed">
+    <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
 
-    <ul role="tablist" aria-label="<%= t('.agenda', name: @site.name) %>">
-      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.government"),
-                    (@past_events ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path),
-                    tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
-      </li>
-      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.parties.opposition"),
-                    (@past_events ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path),
-                    tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
-      </li>
-      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.categories.executive"),
-                    (@past_events ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path),
-                    tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
-      </li>
-      <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
-        <%= link_to t("gobierto_people.people_filter.all"),
-                    (@past_events ? gobierto_people_past_events_path : gobierto_people_events_path),
-                    tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
-      </li>
+      <ul role="tablist" aria-label="<%= t('.agenda', name: @site.name) %>">
+        <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(government_party_person_events government_party_past_person_events))) %>">
+          <%= link_to t("gobierto_people.people_filter.parties.government"),
+                      (@past_events ? gobierto_people_government_party_past_events_path : gobierto_people_government_party_events_path),
+                      tab_attributes(controller_name.in?(%w(government_party_person_events government_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        </li>
+        <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))) %>">
+          <%= link_to t("gobierto_people.people_filter.parties.opposition"),
+                      (@past_events ? gobierto_people_opposition_party_past_events_path : gobierto_people_opposition_party_events_path),
+                      tab_attributes(controller_name.in?(%w(opposition_party_person_events opposition_party_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        </li>
+        <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))) %>">
+          <%= link_to t("gobierto_people.people_filter.categories.executive"),
+                      (@past_events ? gobierto_people_executive_category_past_events_path : gobierto_people_executive_category_events_path),
+                      tab_attributes(controller_name.in?(%w(executive_category_person_events executive_category_past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        </li>
+        <li role="presentation" class="<%= class_if('active', controller_name.in?(%w(person_events past_person_events))) %>">
+          <%= link_to t("gobierto_people.people_filter.all"),
+                      (@past_events ? gobierto_people_past_events_path : gobierto_people_events_path),
+                      tab_attributes(controller_name.in?(%w(person_events past_person_events))).merge('aria-controls' => 'person-agenda') %>
+        </li>
+      </ul>
+
+    </div>
+  </menu>
+
+  <% pending do %>
+  <div class="sub_filter center">
+
+    <%= t("gobierto_people.people_filter.political_groups.title") %>
+
+    <ul role="tablist" aria-label="Listado de partidos políticos">
+      <% @political_groups.each do |political_group| %>
+        <li role="presentation" class="<%= class_if('active', @political_group.try(:name) == political_group.name) %>">
+          <%= link_to political_group.name, gobierto_people_political_group_events_path(political_group), tab_attributes(@political_group.try(:name) == political_group.name) %>
+        </li>
+      <% end %>
     </ul>
 
   </div>
-</menu>
-
-<% pending do %>
-<div class="sub_filter center">
-
-  <%= t("gobierto_people.people_filter.political_groups.title") %>
-
-  <ul role="tablist" aria-label="Listado de partidos políticos">
-    <% @political_groups.each do |political_group| %>
-      <li role="presentation" class="<%= class_if('active', @political_group.try(:name) == political_group.name) %>">
-        <%= link_to political_group.name, gobierto_people_political_group_events_path(political_group), tab_attributes(@political_group.try(:name) == political_group.name) %>
-      </li>
-    <% end %>
-  </ul>
-
-</div>
+  <% end %>
 <% end %>

--- a/app/views/gobierto_people/welcome/index.html.erb
+++ b/app/views/gobierto_people/welcome/index.html.erb
@@ -22,30 +22,38 @@
 
   <div class="pure-g">
 
-    <div class="pure-u-1 pure-u-md-1-2 p_h_r_2">
+    <% if officials_submodule_active? %>
 
-      <div class="people-summary person-list item-list">
-        <div class="block">
-          <h2><%= t(".people_summary.title", site_name: current_site.name) %></h2>
+      <div class="pure-u-1 pure-u-md-1-2 p_h_r_2">
+
+        <div class="people-summary person-list item-list">
+          <div class="block">
+            <h2><%= t(".people_summary.title", site_name: current_site.name) %></h2>
+          </div>
+
+          <%= render "gobierto_people/welcome/people_filter" %>
+
+          <%= render(partial: "gobierto_people/people/people", locals: { people: @people } ) %>
+
         </div>
 
-        <%= render "gobierto_people/welcome/people_filter" %>
+      </div>
 
-        <%= render(partial: "gobierto_people/people/people", locals: { people: @people } ) %>
+    <% end %>
+
+    <% if agendas_submodule_active? %>
+
+      <div class="pure-u-1 pure-u-md-1-2 p_h_l_2">
+
+        <div class="events-summary person_event-list item-list">
+
+          <%= render(partial: "gobierto_people/people/person_events", locals: { person_events: @events, people_filter: 'government', no_upcoming_events: @no_upcoming_events } ) %>
+
+        </div>
 
       </div>
 
-    </div>
-
-    <div class="pure-u-1 pure-u-md-1-2 p_h_l_2">
-
-      <div class="events-summary person_event-list item-list">
-
-        <%= render(partial: "gobierto_people/people/person_events", locals: { person_events: @events, people_filter: 'government', no_upcoming_events: @no_upcoming_events } ) %>
-
-      </div>
-
-    </div>
+    <% end %>
 
   </div>
 
@@ -55,52 +63,60 @@
 
   <div class="pure-g">
 
-    <div class="pure-u-1 pure-u-md-1-2 site-references p_h_r_2">
+    <% if statements_submodule_active? %>
 
-      <div class="box fully_linked">
-        <%= link_to gobierto_people_statements_path, role: "button" do %>
-          <h2 class="linked_headline">
-            <i class="fa fa-money"></i>
-            <%= t(".statements") %>
-          </h2>
-        <% end %>
-      </div>
+      <div class="pure-u-1 pure-u-md-1-2 site-references p_h_r_2">
 
-      <div class="box fully_linked">
-        <%= link_to gobierto_people_gifts_path, role: "button" do %>
-          <h2 class="linked_headline">
-            <i class="fa fa-gift"></i>
-            <%= t(".gifts") %>
-          </h2>
-        <% end %>
-      </div>
+        <div class="box fully_linked">
+          <%= link_to gobierto_people_statements_path, role: "button" do %>
+            <h2 class="linked_headline">
+              <i class="fa fa-money"></i>
+              <%= t(".statements") %>
+            </h2>
+          <% end %>
+        </div>
 
-      <div class="box fully_linked">
-        <%= link_to gobierto_people_travels_path, role: "button" do %>
-          <h2 class="linked_headline">
-            <i class="fa fa-plane"></i>
-            <%= t(".travels") %>
-          </h2>
-        <% end %>
-      </div>
+        <div class="box fully_linked">
+          <%= link_to gobierto_people_gifts_path, role: "button" do %>
+            <h2 class="linked_headline">
+              <i class="fa fa-gift"></i>
+              <%= t(".gifts") %>
+            </h2>
+          <% end %>
+        </div>
 
-    </div>
-
-    <div class="pure-u-1 pure-u-md-1-2 p_h_l_2">
-
-      <div class="block">
-        <h2 class="slim"><%= t(".posts_summary.title") %></h2>
-      </div>
-
-      <div class="posts-summary person_post-list item-list">
-
-        <%= render @posts %>
-
-        <%= link_to t(".posts_summary.view_all"), gobierto_people_posts_path, class: "see_more", role: "button" %>
+        <div class="box fully_linked">
+          <%= link_to gobierto_people_travels_path, role: "button" do %>
+            <h2 class="linked_headline">
+              <i class="fa fa-plane"></i>
+              <%= t(".travels") %>
+            </h2>
+          <% end %>
+        </div>
 
       </div>
 
-    </div>
+    <% end %>
+
+    <% if blog_submodule_active? %>
+
+      <div class="pure-u-1 pure-u-md-1-2 p_h_l_2">
+
+        <div class="block">
+          <h2 class="slim"><%= t(".posts_summary.title") %></h2>
+        </div>
+
+        <div class="posts-summary person_post-list item-list">
+
+          <%= render @posts %>
+
+          <%= link_to t(".posts_summary.view_all"), gobierto_people_posts_path, class: "see_more", role: "button" %>
+
+        </div>
+
+      </div>
+
+    <% end %>
 
   </div>
 

--- a/db/migrate/20170410082426_add_initial_submodule_settings.rb
+++ b/db/migrate/20170410082426_add_initial_submodule_settings.rb
@@ -1,0 +1,18 @@
+class AddInitialSubmoduleSettings < ActiveRecord::Migration[5.0]
+
+  def up
+    Site.all.each do |site|
+      if site.configuration.gobierto_people_enabled?
+        GobiertoPeople::Setting.create site: site, key: "agendas_submodule_active", value: "true"
+        GobiertoPeople::Setting.create site: site, key: "officials_submodule_active", value: "true"
+        GobiertoPeople::Setting.create site: site, key: "blog_submodule_active", value: "true"
+        GobiertoPeople::Setting.create site: site, key: "statements_submodule_active", value: "true"
+      end
+    end
+  end
+
+  def down
+    GobiertoPeople::Setting.where("key ~* ?", ".*_submodule_active").destroy_all
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322144939) do
+ActiveRecord::Schema.define(version: 20170410082426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds/modules/gobierto_people/seeds.rb
+++ b/db/seeds/modules/gobierto_people/seeds.rb
@@ -4,6 +4,11 @@ module GobiertoSeeds
       # Config keys
       GobiertoPeople::Setting.find_or_create_by! site: site, key: "home_text_ca"
       GobiertoPeople::Setting.find_or_create_by! site: site, key: "home_text_es"
+      
+      GobiertoPeople::Setting.create site: site, key: "agendas_submodule_active", value: "true"
+      GobiertoPeople::Setting.create site: site, key: "officials_submodule_active", value: "true"
+      GobiertoPeople::Setting.create site: site, key: "blog_submodule_active", value: "true"
+      GobiertoPeople::Setting.create site: site, key: "statements_submodule_active", value: "true"
 
       #
       # Content blocks

--- a/test/fixtures/gobierto_people/settings.yml
+++ b/test/fixtures/gobierto_people/settings.yml
@@ -2,3 +2,23 @@ home_text:
   key: home_text
   value: this is the home text
   site: madrid
+
+madrid_agendas_submodule:
+  key: agendas_submodule_active
+  value: 'true'
+  site: madrid
+
+madrid_officials_submodule:
+  key: officials_submodule_active
+  value: 'true'
+  site: madrid
+
+madrid_blog_submodule:
+  key: blog_submodule_active
+  value: 'true'
+  site: madrid
+
+madrid_statements_submodule:
+  key: statements_submodule_active
+  value: 'true'
+  site: madrid

--- a/test/integration/gobierto_people/people_submodules_test.rb
+++ b/test/integration/gobierto_people/people_submodules_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+module GobiertoPeople
+  class PeopleSubmodulesTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = gobierto_people_people_path
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def richard
+      gobierto_people_people(:richard)
+    end
+
+    def enable_submodule(submodule_name)
+      GobiertoPeople::Setting.find_by_key("#{submodule_name}_submodule_active").update_attributes(value: 'true')
+    end
+
+    def disable_submodule(submodule_name)
+      GobiertoPeople::Setting.find_by_key("#{submodule_name}_submodule_active").update_attributes(value: 'false')
+    end
+
+    def disable_submodules(submodules_names)
+      submodules_names.each { |submodule_name| disable_submodule(submodule_name) }
+    end
+
+    def test_main_menu_subsections
+      with_current_site(site) do
+        visit @path
+
+        within '#main_menu' do
+          assert has_selector? 'h2', text: 'Officials and Agendas'
+          assert has_content? 'Agendas'
+          assert has_content? 'Officials'
+          assert has_content? 'Statements'
+          assert has_content? 'Blogs'
+        end
+
+        disable_submodule('blog')
+
+        visit @path
+
+        within '#main_menu' do
+          assert has_selector? 'h2', text: 'Officials and Agendas'
+          assert has_content? 'Agendas'
+          assert has_content? 'Officials'
+          assert has_content? 'Statements'
+          refute has_content? 'Blogs'
+        end
+
+        disable_submodule('officials')
+        disable_submodule('statements')
+
+        visit @path
+
+        within '#main_menu' do
+          refute has_content? 'Officials and Agendas'
+          assert has_selector? 'h2', text: 'Agendas'
+          refute has_content? 'Officials'
+          refute has_content? 'Statements'
+          refute has_content? 'Blogs'
+        end
+
+      end
+    end
+
+    def test_welcome_page_redirections
+      with_current_site(site) do
+        visit @path
+
+        assert_equal current_path, gobierto_people_people_path
+
+        disable_submodules ['blog', 'statements']
+        visit @path
+
+        assert_equal current_path, gobierto_people_people_path
+
+        disable_submodule 'officials'
+        visit @path
+
+        assert_equal current_path, gobierto_people_events_path
+      end
+    end
+
+    def test_submodule_page_hides_disabled_submodules_components
+      with_current_site(site) do
+        visit gobierto_people_person_path richard
+
+        within '.people-navigation' do
+          assert has_link? 'Agenda'
+          assert has_link? 'Goods and Activities'
+        end
+
+        assert has_selector? 'div .upcoming-events'
+
+        disable_submodules ['agendas', 'statements']
+
+        visit gobierto_people_person_path richard
+
+        within '.people-navigation' do
+          refute has_link? 'Agenda'
+          refute has_link? 'Goods and Activities'
+        end
+
+        refute has_selector? 'div .upcoming-events'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Connects to #560 

### What does this PR do?

This PR implements the possibility to activate only certain submodules of GobiertoPeople: *Agendas*, *Officials*, *Blog* and *Statements*. This can be done from the `.../admin/people/configuration/settings` page.

The following changes were implemented:

* Certain components of the views are now placed inside conditionals so they can be displayed or hidden depending on the active submodules.
* Certain controller actions are only permitted to be executed if the corresponding submodule is active. Otherwise a redirection is made to `gobierto_people_root_path`.
* Settings and fixtures were added so all Gobierto People submodules are active by default.
* When only one Gobierto People submodule is active, its root path becomes the new Gobierto People welcome page. Also, navigation breadcrumbs will only show the submodule name instead of `Officials and Agendas / submodule`.
* The `.../admin/people/configuration` settings tab now appears first in the list and is selected by default.

### How should this be manually tested?

Go to `.../admin/people/configuration/settings` and toggle the different submodules at your will. Then go to Gobierto as a regular user and check that only the desired submodules are being shown.

### Does this PR changes any configuration file?

No
