### PR TITLE
Globalize sites attributes

### DIFF
--- a/app/controllers/gobierto_admin/sites_controller.rb
+++ b/app/controllers/gobierto_admin/sites_controller.rb
@@ -26,7 +26,9 @@ module GobiertoAdmin
       site_policy = SitePolicy.new(current_admin, @site)
       raise Errors::NotAuthorized unless site_policy.update?
 
-      @site_form = SiteForm.new(@site.attributes)
+      @site_form = SiteForm.new(
+        @site.attributes.except(*ignored_site_attributes)
+      )
       @site_modules = get_site_modules
       @site_visibility_levels = get_site_visibility_levels
       @dns_config = get_dns_config
@@ -114,8 +116,6 @@ module GobiertoAdmin
 
     def site_params
       params.require(:site).permit(
-        :title,
-        :name,
         :domain,
         :location_name,
         :location_type,
@@ -137,6 +137,8 @@ module GobiertoAdmin
         :privacy_page_id,
         site_modules: [],
         available_locales: [],
+        title_translations: [*I18n.available_locales],
+        name_translations: [*I18n.available_locales]
       )
     end
 
@@ -162,6 +164,10 @@ module GobiertoAdmin
 
     def get_available_pages
       @site.pages.active.sorted
+    end
+
+    def ignored_site_attributes
+      %w( name title )
     end
   end
 end

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -7,8 +7,8 @@ module GobiertoAdmin
     attr_accessor(
       :id,
       :external_id,
-      :title,
-      :name,
+      :title_translations,
+      :name_translations,
       :domain,
       :configuration_data,
       :location_name,
@@ -46,8 +46,8 @@ module GobiertoAdmin
       allow_blank: true
 
     validates :username, :password, presence: true, if: :draft_visibility?
-    validates :title, presence: true
-    validates :name, presence: true
+    validates :title_translations, presence: true
+    validates :name_translations, presence: true
     validates :available_locales, length: { minimum: 1 }
     validates :default_locale, presence: true
 
@@ -124,8 +124,8 @@ module GobiertoAdmin
 
     def save_site
       @site = site.tap do |site_attributes|
-        site_attributes.title = title
-        site_attributes.name = name
+        site_attributes.title_translations = title_translations
+        site_attributes.name_translations = name_translations
         site_attributes.domain = domain
         site_attributes.location_name = location_name
         site_attributes.municipality_id = municipality_id

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,4 @@
 class Site < ApplicationRecord
-
   RESERVED_SUBDOMAINS = %W(presupuestos hosted)
 
   has_many :activities
@@ -38,7 +37,7 @@ class Site < ApplicationRecord
   after_save :run_seeder
 
   validates :title, presence: true
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true
   validates :domain, presence: true, uniqueness: true, domain: true
   validate :location_required
 
@@ -46,6 +45,9 @@ class Site < ApplicationRecord
   scope :alphabetically_sorted, -> { order(name: :asc) }
 
   enum visibility_level: { draft: 0, active: 1 }
+
+  translates :name, :title
+  include GobiertoCommon::LocalizedContent
 
   def self.find_by_allowed_domain(domain)
     unless reserved_domains.include?(domain)

--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -1,19 +1,22 @@
 <%= render "gobierto_admin/shared/validation_errors", resource: @site_form %>
 
-<%= form_for(@site_form, as: :site, url: @site_form.persisted? ? admin_site_path(@site_form) : :admin_sites) do |f| %>
-
+<%= form_for(@site_form, as: :site, url: @site_form.persisted? ? admin_site_path(@site_form) : :admin_sites, data: { "globalized-form-container" => true }) do |f| %>
   <div class="pure-g">
-
     <div class="pure-u-1 pure-u-md-16-24">
+      <div class="globalized_fields">
+        <%= render "gobierto_admin/shared/form_locale_switchers" %>
 
-      <div class="form_item input_text">
-        <%= f.label :title %>
-        <%= f.text_field :title, placeholder: t(".placeholders.title") %>
-      </div>
+        <% I18n.available_locales.map(&:to_s).each do |locale| %>
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "site[title_translations][#{locale}]", f.object.class.human_attribute_name(:title) %>
+            <%= text_field_tag "site[title_translations][#{locale}]", f.object.title_translations && f.object.title_translations[locale], placeholder: t(".placeholders.title") %>
+          </div>
 
-      <div class="form_item input_text">
-        <%= f.label :name %>
-        <%= f.text_field :name, placeholder: t(".placeholders.name") %>
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "site[name_translations][#{locale}]", f.object.class.human_attribute_name(:name) %>
+            <%= text_field_tag "site[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name") %>
+          </div>
+        <% end %>
       </div>
 
       <div class="form_item input_text">

--- a/db/migrate/20170411163634_add_sites_translations.rb
+++ b/db/migrate/20170411163634_add_sites_translations.rb
@@ -1,0 +1,9 @@
+class AddSitesTranslations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :sites, :name_translations, :jsonb
+    add_column :sites, :title_translations, :jsonb
+
+    add_index :sites, :name_translations, using: :gin
+    add_index :sites, :title_translations, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170410082426) do
+ActiveRecord::Schema.define(version: 20170411163634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -341,6 +341,10 @@ ActiveRecord::Schema.define(version: 20170410082426) do
     t.integer  "visibility_level",            default: 0,  null: false
     t.inet     "creation_ip"
     t.integer  "municipality_id"
+    t.jsonb    "name_translations"
+    t.jsonb    "title_translations"
+    t.index ["name_translations"], name: "index_sites_on_name_translations", using: :gin
+    t.index ["title_translations"], name: "index_sites_on_title_translations", using: :gin
   end
 
   create_table "user_notifications", force: :cascade do |t|

--- a/lib/tasks/gobierto_core/migrate_sites_to_globalize.rake
+++ b/lib/tasks/gobierto_core/migrate_sites_to_globalize.rake
@@ -1,0 +1,17 @@
+namespace :gobierto_core do
+  namespace :globalize do
+    desc "Migrates sites fields to globalize"
+    task migrate_sites: :environment do
+      Site.find_each do |site|
+        puts "* Migrating site id=#{site.id}"
+
+        I18n.available_locales.map(&:to_s).each do |locale|
+          site.send "title_#{locale}=", site.read_attribute(:title)
+          site.send "name_#{locale}=", site.read_attribute(:name)
+        end
+
+        site.save!
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_admin/sites_controller_test.rb
+++ b/test/controllers/gobierto_admin/sites_controller_test.rb
@@ -23,8 +23,8 @@ module GobiertoAdmin
 
     def valid_site_params
       {
-        title: 'Title',
-        name: 'Foo',
+        title_translations: { I18n.locale => 'Title'},
+        name_translations: { I18n.locale => 'Foo'},
         location_name: 'Madrid',
         municipality_id: 1,
         domain: 'test2.gobierto.dev',

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -1,6 +1,6 @@
 madrid:
-  title: Transparencia y Participción
-  name: Ayuntamiento de Madrid
+  title_translations: <%= { 'en' => 'Transparencia y Participción', 'es' => 'Transparencia y Participción' }.to_json %>
+  name_translations: <%= { 'en' => 'Ayuntamiento de Madrid', 'es' => 'Ayuntamiento de Madrid' }.to_json %>
   domain: madrid.gobierto.dev
   configuration_data: <%= {
     "links_markup" => %Q{<a href="http://madrid.es">Ayuntamiento de Madrid</a>},
@@ -21,8 +21,8 @@ madrid:
   visibility_level: <%= Site.visibility_levels["active"] %>
 
 santander:
-  title: Transparencia Ciudadana
-  name: Ayuntamiento de Santander
+  title_translations: <%= { 'en' => 'Transparencia Ciudadana', 'es' => 'Transparencia Ciudadana' }.to_json %>
+  name_translations: <%= { 'en' => 'Ayuntamiento de Santander', 'es' => 'Ayuntamiento de Santander' }.to_json %>
   domain: santander.gobierto.dev
   configuration_data: <%= {
     "links_markup" => %Q{<a href="http://santander.es">Ayuntamiento de Santander</a>},

--- a/test/forms/gobierto_admin/site_form_test.rb
+++ b/test/forms/gobierto_admin/site_form_test.rb
@@ -4,8 +4,8 @@ module GobiertoAdmin
   class SiteFormTest < ActiveSupport::TestCase
     def valid_site_form
       @valid_site_form ||= SiteForm.new(
-        title: site.title,
-        name: new_site_name, # To ensure uniqueness
+        title_translations: {I18n.locale => site.title},
+        name_translations: {I18n.locale => new_site_name}, # To ensure uniqueness
         domain: new_site_domain, # To ensure uniqueness
         location_name: site.location_name,
         municipality_id: 1,
@@ -18,8 +18,8 @@ module GobiertoAdmin
 
     def invalid_site_form
       @invalid_site_form ||= SiteForm.new(
-        title: nil,
-        name: nil,
+        title_translations: {},
+        name_translations: {},
         domain: site.domain,
         location_name: site.location_name,
         visibility_level: "active",
@@ -76,8 +76,8 @@ module GobiertoAdmin
     def test_error_messages_with_invalid_attributes
       invalid_site_form.save
 
-      assert invalid_site_form.errors.messages[:title].one?
-      assert invalid_site_form.errors.messages[:name].one?
+      assert invalid_site_form.errors.messages[:title_translations].one?
+      assert invalid_site_form.errors.messages[:name_translations].one?
       assert invalid_site_form.errors.messages[:available_locales].one?
     end
   end

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -15,49 +15,54 @@ module GobiertoAdmin
     end
 
     def test_site_create
-      with_signed_in_admin(admin) do
-        visit @path
+        with_signed_in_admin(admin) do
+          visit @path
 
-        within "form.new_site" do
-          fill_in "site_title", with: "Site Title"
-          fill_in "site_name", with: "Site Name"
-          fill_in "site_location_name", with: "Site Location"
-          fill_in "site_domain", with: "test.gobierto.dev"
-          fill_in "site_head_markup", with: "Site Head markup"
-          fill_in "site_foot_markup", with: "Site Foot markup"
-          fill_in "site_links_markup", with: "Site Links markup"
-          fill_in "site_google_analytics_id", with: "UA-000000-01"
+          within "form.new_site" do
+            fill_in "site_title_translations_en", with: "Site Title"
+            fill_in "site_name_translations_en", with: "Site Name"
 
-          within ".site-check-boxes" do
-            check "site_available_locales_es"
-            choose "site_default_locale_es"
+
+            fill_in "site_title_translations_es", with: "Site Title"
+            fill_in "site_name_translations_es", with: "Site Name"
+
+            fill_in "site_location_name", with: "Site Location"
+            fill_in "site_domain", with: "test.gobierto.dev"
+            fill_in "site_head_markup", with: "Site Head markup"
+            fill_in "site_foot_markup", with: "Site Foot markup"
+            fill_in "site_links_markup", with: "Site Links markup"
+            fill_in "site_google_analytics_id", with: "UA-000000-01"
+
+            within ".site-check-boxes" do
+              check "site_available_locales_es"
+              choose "site_default_locale_es"
+            end
+
+            # Simulate Location selection in user control
+            find("#site_municipality_id", visible: false).set("1")
+
+            attach_file "site_logo_file", "test/fixtures/files/sites/logo-madrid.png"
+
+            within ".site-module-check-boxes" do
+              check "Gobierto Development"
+            end
+
+            within ".site-visibility-level-radio-buttons" do
+              choose "Published"
+            end
+
+            with_stubbed_s3_file_upload do
+              click_button "Create"
+            end
           end
 
-          # Simulate Location selection in user control
-          find("#site_municipality_id", visible: false).set("1")
+          assert has_message?("Site was successfully created")
 
-          attach_file "site_logo_file", "test/fixtures/files/sites/logo-madrid.png"
-
-          within ".site-module-check-boxes" do
-            check "Gobierto Development"
+          within "table.site-list tbody tr", match: :first do
+            assert has_content?("Site Title")
+            assert has_content?("Site Name")
+            assert has_content?("Published")
           end
-
-          within ".site-visibility-level-radio-buttons" do
-            choose "Published"
-          end
-
-          with_stubbed_s3_file_upload do
-            click_button "Create"
-          end
-        end
-
-        assert has_message?("Site was successfully created")
-
-        within "table.site-list tbody tr", match: :first do
-          assert has_content?("Site Title")
-          assert has_content?("Site Name")
-          assert has_content?("Published")
-        end
       end
     end
   end

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -31,8 +31,8 @@ module GobiertoAdmin
         visit @path
 
         within "form.edit_site" do
-          fill_in "site_title", with: "Site Title"
-          fill_in "site_name", with: "Site Name"
+          fill_in "site_title_translations_es", with: "Site Title"
+          fill_in "site_name_translations_es", with: "Site Name"
           fill_in "site_location_name", with: "Site Location"
           fill_in "site_domain", with: "test.gobierto.dev"
           fill_in "site_head_markup", with: "Site Head markup"
@@ -60,8 +60,8 @@ module GobiertoAdmin
         assert has_message?("Site was successfully updated")
 
         within "form.edit_site" do
-          assert has_field?("site_name", with: "Site Name")
-          assert has_field?("site_title", with: "Site Title")
+          assert has_field?("site_name_translations_es", with: "Site Name")
+          assert has_field?("site_title_translations_es", with: "Site Title")
           assert has_field?("site_location_name", with: "Site Location")
           assert has_field?("site_domain", with: "test.gobierto.dev")
           assert has_field?("site_head_markup", with: "Site Head markup")
@@ -108,7 +108,7 @@ module GobiertoAdmin
             assert has_checked_field?("Draft")
           end
 
-          fill_in "site_title", with: "New Site Title"
+          fill_in "site_title_translations_en", with: "New Site Title"
           click_button "Update"
         end
 


### PR DESCRIPTION
Connects to #546

### What does this PR do?

This PR globalizes Site attributes: title and name

After releasing this PR you should run the task `bin/rails gobierto_core:globalize:migrate_sites`