### PR TITLE
Use default reporter to get a summary of the failing tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ I18n.locale = I18n.default_locale = :en
 Time.zone = "UTC"
 
 Minitest::Retry.use!
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
 
 WebMock.disable_net_connect!(
   allow_localhost: true,


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR updates the reporter of minitest to get a summary of failing tests at the end.
