### PR TITLE
Add support for liquid templates in site html blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem "redis", "~> 3.3"
 # Translations
 gem "json_translate", "~> 3.0"
 
+# Liquid
+gem "liquid", "~> 4.0"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.17)
+    liquid (4.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -379,6 +380,7 @@ DEPENDENCIES
   json_translate (~> 3.0)
   kaminari (~> 1.0)
   launchy
+  liquid (~> 4.0)
   meta-tags
   minitest-rails
   minitest-rails-capybara

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Toda la documentación y comunicación relativa al desarrollo la realizamos en i
 - [Desarrollar un módulo](docs/developing-module.md)
 - [Integrar la extensión Trackable](docs/trackable-extension.md)
 - [Integrar el componente DynamicContent](docs/dynamic-content-component.md)
+- [Integrar plantillas con Liquid](docs/liquid-templates.md)
 
 
 ## Licencia

--- a/app/helpers/liquid_helper.rb
+++ b/app/helpers/liquid_helper.rb
@@ -1,0 +1,9 @@
+module LiquidHelper
+
+  def render_liquid(template_content)
+    template = Liquid::Template.parse(template_content)
+    template.assigns["current_site"] = current_site
+    template.render.html_safe
+  end
+
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -143,7 +143,7 @@
     </div>
 
     <% if @site.configuration.head_markup.present? %>
-      <%= raw @site.configuration.head_markup %>
+      <%= render_liquid @site.configuration.head_markup %>
     <% end %>
 
     <div class="site_header">
@@ -206,37 +206,10 @@
       </div>
 
       <div class="pure-u-1 pure-u-md-15-24 custom_html_footer">
-      <% if @site.configuration.links_markup.present? %>
-        <%= raw @site.configuration.foot_markup %>
+      <% if @site.configuration.foot_markup.present? %>
+        <%= render_liquid @site.configuration.foot_markup %>
       <% end %>
       </div>
-
-      <!--
-      <div class="pure-u-1 pure-u-md-5-24">
-        <ul>
-          <li><a href="">Acerca de esta página</a></li>
-          <li><a href="">Preguntas frecuentes</a></li>
-          <li><a href="">Contacto</a></li>
-          <li><a href="">Datos abiertos</a></li>
-        </ul>
-      </div>
-
-      <div class="pure-u-1 pure-u-md-5-24">
-        <ul>
-          <li><a href="">Política de privacidad</a></li>
-          <li><a href="">Condiciones de uso</a></li>
-          <li><a href="">Accesibilidad</a></li>
-        </ul>
-      </div>
-
-      <div class="pure-u-1 pure-u-md-5-24">
-        <ul>
-          <li><a href="http://dival.es">Diputación de Valencia</a></li>
-          <li><a href="http://transparencia.dival.es">Portal de Transparencia</a></li>
-          <li><a href="http://participacion.madrid.es">Participación</a></li>
-        </ul>
-      </div>
-      -->
 
     </div>
 
@@ -253,7 +226,6 @@
       </div>
 
       <div class="pure-u-1 pure-u-md-5-24">
-
       </div>
 
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,3 +47,4 @@ module Gobierto
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end
+

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -1,0 +1,4 @@
+Liquid::Template.error_mode = :lax
+
+require "liquid/tags/page_url"
+require "liquid/tags/page_title"

--- a/docs/liquid-templates.md
+++ b/docs/liquid-templates.md
@@ -1,0 +1,31 @@
+![Gobierto](https://gobierto.es/assets/logo_gobierto.png)
+
+# Gobierto template engine
+
+[Liquid](https://github.com/Shopify/liquid) is very popular template engine written to be simple and secure.
+
+Gobierto implements a few Liquid tags to embed dynamic content in the site HTML blocks. In the future, all Gobierto templates will be fully customizable using Liquid and the administrator UI.
+
+## Available liquid tags
+
+### page_title
+
+Renders the title of a page (an instance of`GobiertoCms::Page`)
+
+- Arguments:
+  - `slug`: the slug of the page
+
+- Usage: `{% page_title about %}`
+
+- Returns: "About page"
+
+### page_url
+
+Renders the path of a page (an instance of`GobiertoCms::Page`)
+
+- Arguments:
+  - `slug`: the slug of the page
+
+- Usage: `{% page_url about %}`
+
+- Returns: "/paginas/about"

--- a/lib/liquid/tags/page_title.rb
+++ b/lib/liquid/tags/page_title.rb
@@ -1,0 +1,16 @@
+class PageTitle < Liquid::Tag
+  def initialize(tag_name, page_slug, tokens)
+    super
+    @page_slug = page_slug.strip
+  end
+
+  def render(context)
+    current_site = context.environments.first['current_site']
+    page = current_site.pages.find_by_slug!(@page_slug)
+    return page.title
+  rescue ActiveRecord::RecordNotFound
+    return ""
+  end
+end
+
+Liquid::Template.register_tag('page_title', PageTitle)

--- a/lib/liquid/tags/page_url.rb
+++ b/lib/liquid/tags/page_url.rb
@@ -1,0 +1,23 @@
+class PageUrl < Liquid::Tag
+  def initialize(tag_name, page_slug, tokens)
+    super
+    @page_slug = page_slug.strip
+  end
+
+  def render(context)
+    current_site = context.environments.first['current_site']
+    page = current_site.pages.find_by_slug!(@page_slug)
+    return url_helpers.gobierto_cms_page_path(page.slug)
+  rescue ActiveRecord::RecordNotFound
+    return ""
+  end
+
+  private
+
+  def url_helpers
+    Rails.application.routes.url_helpers
+  end
+
+end
+
+Liquid::Template.register_tag('page_url', PageUrl)

--- a/test/integration/gobierto_admin/site_html_templates_test.rb
+++ b/test/integration/gobierto_admin/site_html_templates_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "support/file_uploader_helpers"
+
+module GobiertoAdmin
+  class SiteHtmlTemplatesTest < ActionDispatch::IntegrationTest
+
+    def setup
+      super
+      @path = edit_admin_site_path(site)
+    end
+
+    def admin
+      @admin ||= gobierto_admin_admins(:nick)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def privacy_page
+      @privacy_page ||= gobierto_cms_pages(:privacy)
+    end
+
+    def template
+      %Q{<a href="{% page_url #{privacy_page.slug} %}">{% page_title #{privacy_page.slug} %}</a>}
+    end
+
+    def test_site_render_liquid_html_blocks
+      site.configuration.head_markup = template
+      site.configuration.foot_markup = template
+      site.save!
+
+      with_current_site(site) do
+        visit root_path
+        assert has_link?("Privacy")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to #547

### What does this PR do?

This PR adds support for liquid tags in the site custom html blocks. There's also a new doc page describing the new liquid tags.