### PR TITLE
Introduce I18n ActiveRecord backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "dalli"
 gem "cookies_eu"
 gem "actionpack-action_caching", git: "https://github.com/rails/actionpack-action_caching.git", ref: "9044141824650138bf27741e8f0ed95ccd9ef26d"
 gem "active_model_serializers"
-gem "timecop"
 gem "mechanize"
 
 # Frontend
@@ -61,6 +60,7 @@ gem "redis", "~> 3.3"
 
 # Translations
 gem "json_translate", "~> 3.0"
+gem "i18n-active_record", :require => "i18n/active_record"
 
 # Liquid
 gem "liquid", "~> 4.0"
@@ -85,6 +85,7 @@ group :test do
   gem "minitest-retry"
   gem "capybara-email"
   gem "vcr"
+  gem "timecop"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.8.3)
     i18n (0.8.1)
+    i18n-active_record (0.2.0)
+      i18n (>= 0.5.0)
     i18n-js (3.0.0)
       i18n (~> 0.6, >= 0.6.6)
     i18n-tasks (0.9.13)
@@ -390,6 +392,7 @@ DEPENDENCIES
   elasticsearch
   elasticsearch-extensions
   flight-for-rails
+  i18n-active_record
   i18n-js (>= 3.0.0.rc11)
   i18n-tasks
   ine-places

--- a/app/assets/javascripts/user/app/init.js
+++ b/app/assets/javascripts/user/app/init.js
@@ -1,7 +1,5 @@
 this.User = {
-  init: function() {
-    return console.log("User.init");
-  }
+  init: function() {}
 };
 
 $(document).ready(function() {

--- a/app/views/gobierto_admin/shared/_form_locale_switchers.html.erb
+++ b/app/views/gobierto_admin/shared/_form_locale_switchers.html.erb
@@ -3,7 +3,7 @@
     <label><%= t('.translate') %></label>
     <% current_site.configuration.available_locales.each do |locale| %>
       <a href="#" data-toggle-edit-locale="<%= locale %>" class="locale_option tipsit" title="<%= t('.define_content_in_locale', locale_name: t("locales.#{locale}")) %>" <%= %Q{data-loaded-locale="#{locale}"}.html_safe if locale == current_site.configuration.default_locale %>>
-        <span class="locale"><%= locale.upcase %></span>
+        <span class="locale"><%= t("locales.#{locale}_short").upcase %></span>
         <span class="status"></span>
       </a>
     <% end %>

--- a/app/views/layouts/_locale_selector.html.erb
+++ b/app/views/layouts/_locale_selector.html.erb
@@ -1,9 +1,9 @@
 <% if available_locales.length > 1 %>
   <% available_locales.each do |locale| %>
     <% if I18n.locale.to_s == locale.to_s %>
-      <strong><%= locale %></strong>
+      <strong><%= t("locales.#{locale}_short") %></strong>
     <% else %>
-      <%= link_to locale, {locale: locale}, data: { turbolinks: false } %>
+      <%= link_to t("locales.#{locale}_short"), {locale: locale}, data: { turbolinks: false } %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,13 @@
+require 'i18n/backend/active_record'
+
+Translation  = I18n::Backend::ActiveRecord::Translation
+
+if Translation.table_exists?
+  I18n.backend = I18n::Backend::ActiveRecord.new
+
+  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+
+  I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
+end

--- a/config/initializers/translations.rb
+++ b/config/initializers/translations.rb
@@ -1,5 +1,22 @@
 require 'i18n/backend/active_record'
 
+I18n::Backend::ActiveRecord.configure do |config|
+  config.cleanup_with_destroy = true # defaults to false
+end
+
+module I18n
+  module JS
+    def self.translations
+     ::I18n::Backend::Simple.new.instance_eval do
+        init_translations unless initialized?
+        Private::HashWithSymbolKeys.new(translations)
+                                   .slice(*::I18n.available_locales)
+                                   .to_h
+      end
+    end
+  end
+end
+
 Translation  = I18n::Backend::ActiveRecord::Translation
 
 if Translation.table_exists?

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -151,6 +151,9 @@ ca:
     ca: Català
     en: Anglès
     es: Castellà
+    ca_short: CA
+    en_short: EN
+    es_short: ES
   number:
     currency:
       format:

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -157,6 +157,9 @@ en:
     ca: Catalan
     en: English
     es: Spanish
+    ca_short: CA
+    en_short: EN
+    es_short: ES
   number:
     currency:
       format:

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -151,6 +151,9 @@ es:
     ca: Catalán
     en: Inglés
     es: Castellano
+    ca_short: CA
+    en_short: EN
+    es_short: ES
   number:
     currency:
       format:

--- a/db/migrate/20170420072054_create_translations.rb
+++ b/db/migrate/20170420072054_create_translations.rb
@@ -1,0 +1,16 @@
+class CreateTranslations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :translations do |t|
+      t.string :locale
+      t.string :key
+      t.text   :value
+      t.text   :interpolations
+      t.boolean :is_proc, default: false
+
+      t.timestamps
+    end
+
+    add_index :translations, :locale
+    add_index :translations, :key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170418145507) do
+ActiveRecord::Schema.define(version: 20170420072054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -362,6 +362,18 @@ ActiveRecord::Schema.define(version: 20170418145507) do
     t.jsonb    "title_translations"
     t.index ["name_translations"], name: "index_sites_on_name_translations", using: :gin
     t.index ["title_translations"], name: "index_sites_on_title_translations", using: :gin
+  end
+
+  create_table "translations", force: :cascade do |t|
+    t.string   "locale"
+    t.string   "key"
+    t.text     "value"
+    t.text     "interpolations"
+    t.boolean  "is_proc",        default: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.index ["key"], name: "index_translations_on_key", using: :btree
+    t.index ["locale"], name: "index_translations_on_locale", using: :btree
   end
 
   create_table "user_notifications", force: :cascade do |t|

--- a/test/models/gobierto_admin/admin_test.rb
+++ b/test/models/gobierto_admin/admin_test.rb
@@ -64,13 +64,13 @@ module GobiertoAdmin
 
     # -- Initialization
     def test_god_flag_initialization_when_it_is_already_present
-      assert_send [admin, :set_god_flag]
+      admin.send :set_god_flag
       refute admin.god
     end
 
     def test_god_flag_initialization_when_it_is_not_already_present
       Admin.god.delete_all
-      assert_send [admin, :set_god_flag]
+      admin.send :set_god_flag
       assert admin.god
     end
 

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -30,7 +30,7 @@ class SiteTest < ActiveSupport::TestCase
     site.admin_sites.delete_all
 
     assert_difference "site.admin_sites.size", 1 do
-      assert_send [site, :initialize_admins]
+      site.send :initialize_admins
     end
   end
 

--- a/test/support/integration/authentication_helpers.rb
+++ b/test/support/integration/authentication_helpers.rb
@@ -3,14 +3,12 @@ module Integration
     def with_signed_in_admin(admin)
       sign_in_admin(admin)
       yield
-    ensure
       sign_out_admin
     end
 
     def with_signed_in_user(user)
       sign_in_user(user)
       yield
-    ensure
       sign_out_user
     end
 


### PR DESCRIPTION
Connects to #636

### What does this PR do?

This PR introduces I18n ActiveRecord backend as a way to redefine I18n keys for specific installations (not sites for the moment).
