### PR TITLE
All IBM Notes imported events are public by default

### DIFF
--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -6,7 +6,7 @@ module IbmNotes
     def initialize(person, response_event)
       @external_id  = response_event['id']
       @title        = response_event['summary']
-      @state = (response_event['transparency'] == 'transparent') ? 'published' : 'pending'
+      @state        = 'published'
       @person       = person
       set_start_and_end_date(response_event)
     end

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -28,16 +28,6 @@ module GobiertoPeople
         })
       end
 
-      def new_private_ibm_notes_event
-        @new_private_ibm_notes_event ||= ::IbmNotes::PersonEvent.new(person, {
-          'id' => 'Ibm Notes new private event ID',
-          'summary' => 'Ibm Notes new private event summary',
-          'start' =>  { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-          'end'   =>  { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true },
-          'transparency' => 'opaque'
-        })
-      end
-
       def outdated_ibm_notes_event
         @outdated_ibm_notes_event ||= ::IbmNotes::PersonEvent.new(person, {
           'id' => 'Ibm Notes outdated event ID',
@@ -80,7 +70,7 @@ module GobiertoPeople
 
         refute outdated_ibm_notes_event.gobierto_event_outdated?
         assert updated_gobierto_event.title, 'Ibm Notes outdated event title - THIS HAS CHANGED'
-        refute updated_gobierto_event.published?
+        assert updated_gobierto_event.published?
       end
 
       def test_sync_doesnt_create_duplicated_events
@@ -94,14 +84,6 @@ module GobiertoPeople
           CalendarIntegration.sync_event(outdated_ibm_notes_event)
         end
       end
-
-      def test_sync_doesnt_import_new_private_events
-
-        assert_no_difference 'GobiertoPeople::PersonEvent.count' do
-          CalendarIntegration.sync_event(new_private_ibm_notes_event)
-        end
-      end
-
     end
   end
 end


### PR DESCRIPTION
Unexpected

### What does this PR do?

We were wrong assuming the 'transparency' field was the privacy field of a IBM Notes Event. By default IBM notes doesn't publish any private event, so we don't need to check any field.
