### PR TITLE
649 - Sync location for IBM Notes events

### DIFF
--- a/app/models/gobierto_people/person_event_location.rb
+++ b/app/models/gobierto_people/person_event_location.rb
@@ -5,5 +5,9 @@ module GobiertoPeople
     belongs_to :person_event
 
     validates :name, presence: true
+
+    def geolocated?
+      lat.present? && lng.present?
+    end
   end
 end

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -20,10 +20,11 @@ module GobiertoPeople
       end
 
       def self.sync_event(ibm_notes_event)
-        if ibm_notes_event.gobierto_event_outdated?
-          update_gobierto_event(ibm_notes_event)
-        elsif ibm_notes_event.public? && !ibm_notes_event.has_gobierto_event?
+        if ibm_notes_event.first_synchronization?
           create_gobierto_event(ibm_notes_event)
+        else
+          update_gobierto_event(ibm_notes_event) if ibm_notes_event.gobierto_event_outdated?
+          update_gobierto_event_location(ibm_notes_event) if ibm_notes_event.gobierto_event_location_outdated?
         end
       end
 
@@ -48,7 +49,7 @@ module GobiertoPeople
       end
 
       def self.create_gobierto_event(ibm_notes_event)
-        GobiertoPeople::PersonEvent.create!(
+        event = GobiertoPeople::PersonEvent.create!(
           external_id: ibm_notes_event.external_id,
           title: ibm_notes_event.title,
           starts_at: ibm_notes_event.starts_at,
@@ -56,6 +57,8 @@ module GobiertoPeople
           person: ibm_notes_event.person,
           state: GobiertoPeople::PersonEvent.states[:published]
         )
+
+        create_event_location(event, ibm_notes_event.location) if ibm_notes_event.location.present?
       end
 
       def self.update_gobierto_event(ibm_notes_event)
@@ -64,6 +67,25 @@ module GobiertoPeople
           starts_at: ibm_notes_event.starts_at,
           ends_at: ibm_notes_event.ends_at,
           state: ibm_notes_event.state
+        )
+      end
+
+      def self.update_gobierto_event_location(ibm_notes_event)
+        gobierto_event = ibm_notes_event.gobierto_event
+
+        if ibm_notes_event.location_previously_synced?
+          gobierto_event.locations.first.update_attributes!(name: ibm_notes_event.location)
+        elsif ibm_notes_event.location_has_been_added?
+          create_event_location(gobierto_event, ibm_notes_event.location)
+        elsif ibm_notes_event.location_has_been_removed?
+          gobierto_event.locations.destroy_all
+        end
+      end
+
+      def self.create_event_location(event, location_name)
+        GobiertoPeople::PersonEventLocation.create!(
+          person_event: event,
+          name: location_name
         )
       end
 

--- a/app/views/gobierto_people/person_events/_person_event.html.erb
+++ b/app/views/gobierto_people/person_events/_person_event.html.erb
@@ -20,7 +20,7 @@
       <% person_event.locations.each do |event_location| %>
         <div>
           <i class="fa fa-map-marker"></i>
-          <%= link_to event_location.name, external_location_service_url(event_location) %>
+          <%= event_location.name %>
           <%= event_location.address %>
         </div>
       <% end %>

--- a/app/views/gobierto_people/person_events/_person_event.html.erb
+++ b/app/views/gobierto_people/person_events/_person_event.html.erb
@@ -20,7 +20,7 @@
       <% person_event.locations.each do |event_location| %>
         <div>
           <i class="fa fa-map-marker"></i>
-          <%= event_location.name %>
+          <%= link_to_if event_location.geolocated?, event_location.name, external_location_service_url(event_location) %>
           <%= event_location.address %>
         </div>
       <% end %>

--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -1,13 +1,14 @@
 module IbmNotes
   class PersonEvent
 
-    attr_accessor :external_id, :title, :starts_at, :ends_at, :state, :person
+    attr_accessor :external_id, :title, :starts_at, :ends_at, :state, :person, :location
 
     def initialize(person, response_event)
       @external_id  = response_event['id']
       @title        = response_event['summary']
       @state        = 'published'
       @person       = person
+      @location     = response_event['location'] if response_event['location'].present?
       set_start_and_end_date(response_event)
     end
 
@@ -16,19 +17,39 @@ module IbmNotes
     end
 
     def gobierto_event
-      @gobierto_event ||= person.events.find_by_external_id(self.external_id)
+      person.events.find_by_external_id(self.external_id)
     end
 
     def has_gobierto_event?
       gobierto_event.present?
     end
 
+    def first_synchronization?
+      !has_gobierto_event?
+    end
+
     def gobierto_event_outdated?
       has_gobierto_event? && self.class.synchronized_attributes.any? { |attr_name| self.send(attr_name.to_sym) != gobierto_event.send(attr_name.to_sym) }
     end
 
-    def public?
-      state == 'published'
+    def gobierto_event_location_outdated?
+      has_gobierto_event? && (
+        location_has_been_added? ||
+        location_has_been_removed? ||
+        (gobierto_event.locations.first.present? && location != gobierto_event.locations.first.name)
+      )
+    end
+
+    def location_previously_synced?
+      location.present? && gobierto_event.locations.any?
+    end
+
+    def location_has_been_added?
+      location.present? && gobierto_event.locations.empty?
+    end
+
+    def location_has_been_removed?
+      location.blank? && gobierto_event.locations.any?
     end
 
     private

--- a/test/lib/ibm_notes/api_test.rb
+++ b/test/lib/ibm_notes/api_test.rb
@@ -12,13 +12,13 @@ class ApiTest < ActiveSupport::TestCase
 
       event = events.first
 
-      assert_equal events.size, 3
+      assert_equal events.size, 4
 
       assert_equal event['id'], 'Ibm Notes public event ID'
       assert_equal event['summary'], 'Ibm Notes public event summary'
+      assert_equal event['location'], 'Ibm Notes public event location'
       assert_equal event['start'], { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true }
       assert_equal event['end'],   { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true }
-      assert_equal event['transparency'], 'transparent'
     end
   end
 

--- a/test/lib/ibm_notes/person_event_test.rb
+++ b/test/lib/ibm_notes/person_event_test.rb
@@ -16,14 +16,22 @@ class PersonEventTest < ActiveSupport::TestCase
     Time.utc(d.year, d.month, d.day, d.hour, d.min, d.sec)
   end
 
-  def persisted_ibm_notes_event_response_data
-    @persisted_ibm_notes_event_response_data ||= {
-      'id' => 'Ibm Notes persisted event ID',
-      'summary' => 'Ibm Notes persisted event title',
-      'start' =>  { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-      'end'   =>  { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true },
-      'transparency' => 'transparent',
+  def response_data(params = {})
+    {
+      'id'       => params[:id] || 'Ibm Notes event ID',
+      'summary'  => params[:summary] || 'Ibm Notes event title',
+      'location' => params.has_key?(:location) ? params[:location] : 'Ibm Notes event location',
+      'start'    => params[:start] || { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
+      'end'      => params[:end] || { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true }
     }
+  end
+
+
+  def persisted_ibm_notes_event_response_data
+    @persisted_ibm_notes_event_response_data ||= response_data(
+      id: 'Ibm Notes persisted event ID',
+      summary: 'Ibm Notes persisted event title'
+    )
   end
 
   def persisted_ibm_notes_event
@@ -42,13 +50,10 @@ class PersonEventTest < ActiveSupport::TestCase
   end
 
   def new_ibm_notes_event_response_data
-    @new_ibm_notes_event_response_data ||= {
-      'id' => 'Ibm Notes new event ID',
-      'summary' => 'Ibm Notes new event title',
-      'start' =>  { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-      'end'   =>  { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true },
-      'transparency' => 'transparent',
-    }
+    @new_ibm_notes_event_response_data ||= response_data(
+      id: 'Ibm Notes new event ID',
+      summary: 'Ibm Notes new event title'
+    )
   end
 
   def new_ibm_notes_event
@@ -56,12 +61,26 @@ class PersonEventTest < ActiveSupport::TestCase
   end
 
   def test_initialize
-    assert_equal persisted_ibm_notes_event.external_id, 'Ibm Notes persisted event ID'
-    assert_equal persisted_ibm_notes_event.title,        'Ibm Notes persisted event title'
-    assert_equal persisted_ibm_notes_event.state,        'published'
-    assert_equal persisted_ibm_notes_event.person,       person
-    assert_equal persisted_ibm_notes_event.starts_at,    utc_time('2017-04-11 10:00:00')
-    assert_equal persisted_ibm_notes_event.ends_at,      utc_time('2017-04-11 11:00:00')
+    assert_equal 'Ibm Notes persisted event ID', persisted_ibm_notes_event.external_id
+    assert_equal 'Ibm Notes persisted event title', persisted_ibm_notes_event.title
+    assert_equal 'published', persisted_ibm_notes_event.state
+    assert_equal person, persisted_ibm_notes_event.person
+    assert_equal utc_time('2017-04-11 10:00:00'), persisted_ibm_notes_event.starts_at
+    assert_equal utc_time('2017-04-11 11:00:00'), persisted_ibm_notes_event.ends_at
+  end
+
+  def test_initialize_event_location
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: nil))
+
+    assert_nil ibm_notes_event.location
+
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: ''))
+
+    assert_nil ibm_notes_event.location
+
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: 'valid location name'))
+
+    assert_equal 'valid location name', ibm_notes_event.location
   end
 
   def test_gobierto_event

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -18,24 +18,30 @@ module GobiertoPeople
         @person ||= gobierto_people_people(:richard)
       end
 
-      def new_ibm_notes_event
-        @new_ibm_notes_event ||= ::IbmNotes::PersonEvent.new(person, {
-          'id' => 'Ibm Notes new event ID',
-          'summary' => 'Ibm Notes new event summary',
-          'start' =>  { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-          'end'   =>  { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true },
-          'transparency' => 'transparent'
+      def create_ibm_notes_event(params = {})
+        ::IbmNotes::PersonEvent.new((params[:person] || person), {
+          'id'       => params[:id] || 'Ibm Notes event ID',
+          'summary'  => params[:summary] || 'Ibm Notes event summary',
+          'location' => params.has_key?(:location) ? params[:location] : 'Ibm Notes event location',
+          'start'    => { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
+          'end'      => { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true }
         })
       end
 
+      def new_ibm_notes_event
+        @new_ibm_notes_event ||= create_ibm_notes_event(
+          id: 'Ibm Notes new event ID',
+          summary: 'Ibm Notes new event summary',
+          location: 'Ibm Notes new event location',
+        )
+      end
+
       def outdated_ibm_notes_event
-        @outdated_ibm_notes_event ||= ::IbmNotes::PersonEvent.new(person, {
-          'id' => 'Ibm Notes outdated event ID',
-          'summary' => 'Ibm Notes outdated event title - THIS HAS CHANGED',
-          'start' =>  { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-          'end'   =>  { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true },
-          'transparency' => 'opaque'
-        })
+        @outdated_ibm_notes_event ||= create_ibm_notes_event(
+          id: 'Ibm Notes outdated event ID',
+          summary: 'Ibm Notes outdated event title - THIS HAS CHANGED',
+          location: 'Ibm Notes outdated event location - THIS HAS CHANGED'
+        )
       end
 
       def outdated_ibm_notes_event_gobierto_event
@@ -49,7 +55,7 @@ module GobiertoPeople
         )
       end
 
-      def test_sync_creates_new_event
+      def test_sync_creates_new_event_with_location
         refute new_ibm_notes_event.has_gobierto_event?
 
         CalendarIntegration.sync_event(new_ibm_notes_event)
@@ -57,8 +63,12 @@ module GobiertoPeople
         refute new_ibm_notes_event.gobierto_event_outdated?
         assert new_ibm_notes_event.has_gobierto_event?
 
-        assert new_ibm_notes_event.gobierto_event.title, new_ibm_notes_event.title
-        assert new_ibm_notes_event.gobierto_event.person, person
+        gobierto_event = new_ibm_notes_event.gobierto_event
+
+        assert_equal new_ibm_notes_event.title, gobierto_event.title
+        assert_equal person, gobierto_event.person
+
+        assert_equal 'Ibm Notes new event location', gobierto_event.locations.first.name
       end
 
       def test_sync_updates_existing_event
@@ -69,8 +79,8 @@ module GobiertoPeople
         updated_gobierto_event = outdated_ibm_notes_event.gobierto_event
 
         refute outdated_ibm_notes_event.gobierto_event_outdated?
-        assert updated_gobierto_event.title, 'Ibm Notes outdated event title - THIS HAS CHANGED'
         assert updated_gobierto_event.published?
+        assert_equal 'Ibm Notes outdated event title - THIS HAS CHANGED', updated_gobierto_event.title
       end
 
       def test_sync_doesnt_create_duplicated_events
@@ -84,6 +94,33 @@ module GobiertoPeople
           CalendarIntegration.sync_event(outdated_ibm_notes_event)
         end
       end
+
+      def test_sync_creates_updates_and_removes_location_for_existing_gobierto_event
+        ibm_notes_event = create_ibm_notes_event(location: nil)
+
+        CalendarIntegration.sync_event(ibm_notes_event)
+
+        assert ibm_notes_event.gobierto_event.locations.empty?
+
+        ibm_notes_event.location = 'Location name added afterwards'
+
+        CalendarIntegration.sync_event(ibm_notes_event)
+
+        assert 'Location name added afterwards', ibm_notes_event.gobierto_event.locations.first.name
+
+        ibm_notes_event.location = 'Location name updated afterwards'
+
+        CalendarIntegration.sync_event(ibm_notes_event)
+
+        assert 'Location name updated afterwards', ibm_notes_event.gobierto_event.locations.first.name
+
+        ibm_notes_event.location = nil
+
+        CalendarIntegration.sync_event(ibm_notes_event)
+
+        assert ibm_notes_event.gobierto_event.locations.empty?
+      end
+
     end
   end
 end

--- a/test/vcr_cassettes/sample_calendar_events.yml
+++ b/test/vcr_cassettes/sample_calendar_events.yml
@@ -14,6 +14,8 @@ http_interactions:
       - '370'
     body:
       encoding: ASCII-8BIT
+      # The following lines contain a base64-encoded fake 'login form' which is
+      # used by Mechanize to perform authentication.
       string: !binary |-
         PCFET0NUWVBFIGh0bWw+PGh0bWw+PGhlYWQ+PHRpdGxlPjwvdGl0bGU+PC9oZWFkPjxib2R5Pjxm
         b3JtIGFjdGlvbj0iL25hbWVzLm5zZj9Mb2dpbiIgaWQ9Il9Eb21pbm9Gb3JtIiBtZXRob2Q9InBv
@@ -49,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1239'
+      - '1624'
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -59,6 +61,7 @@ http_interactions:
               "href":"https://host.wadus.com/wadus/1",
               "id":"Ibm Notes public event ID",
               "summary":"Ibm Notes public event summary",
+              "location":"Ibm Notes public event location",
               "start": {
                 "date":"2017-04-11",
                 "time":"10:00:00",
@@ -70,26 +73,26 @@ http_interactions:
                 "utc":true
               },
               "class":"public",
-              "transparency":"transparent",
               "sequence":0
             },
             {
               "href":"https://host.wadus.com/wadus/2",
               "id":"Ibm Notes public event without end date ID",
               "summary":"Ibm Notes public event without end date summary",
+              "location":"Ibm Notes public event without end date location",
               "start": {
                 "date":"2017-04-11",
                 "time":"10:00:00",
                 "utc":true
               },
               "class":"public",
-              "transparency":"transparent",
               "sequence":0
             },
             {
               "href":"https://host.wadus.com/wadus/3",
               "id":"Ibm Notes private event ID",
               "summary":"Ibm Notes private event summary",
+              "location":"Ibm Notes private event location",
               "start": {
                 "date":"2017-04-11",
                 "time":"10:00:00",
@@ -101,7 +104,18 @@ http_interactions:
                 "utc":true
               },
               "class":"public",
-              "transparency":"opaque",
+              "sequence":0
+            },
+            {
+              "href":"https://host.wadus.com/wadus/4",
+              "id":"Ibm Notes event without location ID",
+              "summary":"Ibm Notes event without location summary",
+              "start": {
+                "date":"2017-04-11",
+                "time":"10:00:00",
+                "utc":true
+              },
+              "class":"public",
               "sequence":0
             }
           ]


### PR DESCRIPTION
Connects to #649 

### What does this PR do?

This PR syncs events from IBM Notes location with the corresponding
Gobierto events locations.

Also does some minor refactoring in tests and removes *not-needed-anymore-stuff* related to event transparency/visibility.

### How should this be manually tested?

* Check that events synced from IBM Notes get their corresponding location.
* Create a IBM Notes event without location, sync it, check the corresponding event in Gobierto has no location and later add location in IBM Notes and check it gets synced.
* Remove event location from IBM Notes and check the corresponding Gobierto event deletes its location.

### Does this PR changes any configuration file?

No