### PR TITLE
628 - Don't show data download links for disabled submodules

### DIFF
--- a/app/views/gobierto_people/exports/_index.html.erb
+++ b/app/views/gobierto_people/exports/_index.html.erb
@@ -7,32 +7,44 @@
 
   <div class="pure-u-1 pure-u-md-17-24 main_content">
 
-    <div class="data_item">
-      <h3><%= t("gobierto_people.exports.index.people.title") %></h3>
-      <%= link_to 'CSV', gobierto_people_people_path(format: :csv), class: 'button small', role: "button" %>
-      <%= link_to 'JSON', gobierto_people_people_path(format: :json), class: 'button small', role: "button" %>
-      <p><%= t("gobierto_people.exports.index.people.description") %></p>
-    </div>
+    <% if active_submodules.empty? %>
+      <p><%= t("gobierto_exports.exports.index.no_submodules") %></p>
+    <% end %>
 
-    <div class="data_item">
-      <h3><%= t("gobierto_people.exports.index.events.title") %></h3>
-      <%= link_to 'CSV', gobierto_people_events_path(format: :csv), class: 'button small', role: "button" %>
-      <%= link_to 'JSON', gobierto_people_events_path(format: :json), class: 'button small', role: "button" %>
-      <p><%= t("gobierto_people.exports.index.events.description") %></p>
-    </div>
+    <% if officials_submodule_active? %>
+      <div class="data_item">
+        <h3><%= t("gobierto_people.exports.index.people.title") %></h3>
+        <%= link_to 'CSV', gobierto_people_people_path(format: :csv), class: 'button small', role: "button" %>
+        <%= link_to 'JSON', gobierto_people_people_path(format: :json), class: 'button small', role: "button" %>
+        <p><%= t("gobierto_people.exports.index.people.description") %></p>
+      </div>
+    <% end %>
 
-    <div class="data_item">
-      <h3><%= t("gobierto_people.exports.index.statements.title") %></h3>
-      <%= link_to 'CSV', gobierto_people_statements_path(format: :csv), class: 'button small', role: "button" %>
-      <%= link_to 'JSON', gobierto_people_statements_path(format: :json), class: 'button small', role: "button" %>
-      <p><%= t("gobierto_people.exports.index.statements.description") %></p>
-    </div>
+    <% if agendas_submodule_active? %>
+      <div class="data_item">
+        <h3><%= t("gobierto_people.exports.index.events.title") %></h3>
+        <%= link_to 'CSV', gobierto_people_events_path(format: :csv), class: 'button small', role: "button" %>
+        <%= link_to 'JSON', gobierto_people_events_path(format: :json), class: 'button small', role: "button" %>
+        <p><%= t("gobierto_people.exports.index.events.description") %></p>
+      </div>
+    <% end %>
 
-    <div class="data_item">
-      <h3><%= t("gobierto_people.exports.index.posts.title") %></h3>
-      <%= link_to 'RSS', gobierto_people_posts_path(format: :rss), class: 'button small', role: "button" %>
-      <p><%= t("gobierto_people.exports.index.posts.description") %></p>
-    </div>
+    <% if statements_submodule_active? %>
+      <div class="data_item">
+        <h3><%= t("gobierto_people.exports.index.statements.title") %></h3>
+        <%= link_to 'CSV', gobierto_people_statements_path(format: :csv), class: 'button small', role: "button" %>
+        <%= link_to 'JSON', gobierto_people_statements_path(format: :json), class: 'button small', role: "button" %>
+        <p><%= t("gobierto_people.exports.index.statements.description") %></p>
+      </div>
+    <% end %>
+
+    <% if blog_submodule_active? %>
+      <div class="data_item">
+        <h3><%= t("gobierto_people.exports.index.posts.title") %></h3>
+        <%= link_to 'RSS', gobierto_people_posts_path(format: :rss), class: 'button small', role: "button" %>
+        <p><%= t("gobierto_people.exports.index.posts.description") %></p>
+      </div>
+    <% end %>
 
   </div>
 

--- a/config/locales/gobierto_exports/views/ca.yml
+++ b/config/locales/gobierto_exports/views/ca.yml
@@ -8,4 +8,4 @@ ca:
       index:
         title: Descarrega dades
         subtitle: Des d'aquesta pàgina pots descarregar en format reutilitzable el contingut d'aquesta web
-
+        no_submodules: No hi ha cap submòdul actiu

--- a/config/locales/gobierto_exports/views/en.yml
+++ b/config/locales/gobierto_exports/views/en.yml
@@ -8,3 +8,4 @@ en:
       index:
         title: Download data
         subtitle: In this page you can download the site data in a reusable format.
+        no_submodules: There aren't any active submodules

--- a/config/locales/gobierto_exports/views/es.yml
+++ b/config/locales/gobierto_exports/views/es.yml
@@ -8,3 +8,4 @@ es:
       index:
         title: Descarga datos
         subtitle: Desde esta página puedes descargar en formato reutilizable el contenido de este site.
+        no_submodules: No hay ningún submódulo activo

--- a/test/integration/gobierto_exports/exports_page_test.rb
+++ b/test/integration/gobierto_exports/exports_page_test.rb
@@ -11,6 +11,10 @@ module GobiertoExports
       @site ||= sites(:madrid)
     end
 
+    def gp_enabled_submodules
+      site.gobierto_people_settings.submodules_enabled
+    end
+
     def test_index
       with_current_site(site) do
         visit @path
@@ -19,5 +23,31 @@ module GobiertoExports
         assert has_selector?("h2", text: "Officials and Agendas")
       end
     end
+
+    def test_index_hides_disabled_submodules
+
+      gp_enabled_submodules.delete('statements')
+
+      with_current_site(site) do
+        visit @path
+
+        assert has_selector?('h3', text: 'Agendas')
+        refute has_selector?('h3', text: 'Statements')
+      end
+    end
+
+    def test_index_without_any_submodules
+
+      gp_enabled_submodules.delete('officials')
+      gp_enabled_submodules.delete('agendas')
+      gp_enabled_submodules.delete('blogs')
+      gp_enabled_submodules.delete('statements')
+
+      with_current_site(site) do
+        visit @path
+        assert has_content? "There aren't any active submodules"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Connects to #628 

### What does this PR do?

Hides download links in Gobierto exports section for disabled Gobierto People submodules