### PR TITLE
Redirect person show to person events index when only agendas submodule is active

### DIFF
--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -21,8 +21,12 @@ module GobiertoPeople
 
     def show
       @person = PersonDecorator.new(find_person)
-      @upcoming_events = @person.events.upcoming.sorted.first(3)
 
+      if active_submodules.size == 1 && agendas_submodule_active?
+        redirect_to gobierto_people_person_events_path @person
+      end
+
+      @upcoming_events = @person.events.upcoming.sorted.first(3)
       @latest_activity = ActivityCollectionDecorator.new(Activity.for_recipient(@person).limit(30).sorted.page(params[:page]))
     end
 


### PR DESCRIPTION
Connects to #647 

### What does this PR do?

Redirect person show to person events index when only agendas submodule is active.

### How should this be manually tested?

The URLs specified in the issue should redirect to the same webpage (already deployed in staging).

### Does this PR changes any configuration file?

No
