### PR TITLE
648 - Change person agenda

### DIFF
--- a/app/controllers/gobierto_people/people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/past_person_events_controller.rb
@@ -2,7 +2,16 @@ module GobiertoPeople
   module People
     class PastPersonEventsController < People::PersonEventsController
       def index
-        @events = @person.events.past.sorted.page params[:page]
+
+        if params[:date]
+          @filtering_date = Date.parse(params[:date])
+          @events = @person.events.by_date(@filtering_date).sorted.page params[:page]
+        else
+          @events = @person.events.past.sorted.page params[:page]
+        end
+
+        @calendar_events = @person.events
+
         respond_to do |format|
           format.js { render 'gobierto_people/people/person_events/index' }
           format.html

--- a/app/controllers/gobierto_people/people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/past_person_events_controller.rb
@@ -1,8 +1,8 @@
 module GobiertoPeople
   module People
     class PastPersonEventsController < People::PersonEventsController
-      def index
 
+      def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
           @events = @person.events.by_date(@filtering_date).sorted.page params[:page]
@@ -10,13 +10,12 @@ module GobiertoPeople
           @events = @person.events.past.sorted.page params[:page]
         end
 
-        @calendar_events = @person.events
-
         respond_to do |format|
           format.js { render 'gobierto_people/people/person_events/index' }
           format.html
         end
       end
+
     end
   end
 end

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -1,16 +1,16 @@
 module GobiertoPeople
   module People
     class PersonEventsController < BaseController
-      def index
 
+      before_action :set_calendar_events, only: [:index]
+
+      def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
           @events = @person.events.by_date(@filtering_date).sorted.page params[:page]
         else
           @events = @person.events.upcoming.sorted.page params[:page]
         end
-
-        @calendar_events = @person.events
 
         respond_to do |format|
           format.js
@@ -26,6 +26,10 @@ module GobiertoPeople
 
       def find_event
         @person.events.published.find(params[:id])
+      end
+
+      def set_calendar_events
+        @calendar_events = @person.events
       end
     end
   end

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -2,7 +2,16 @@ module GobiertoPeople
   module People
     class PersonEventsController < BaseController
       def index
-        @events = @person.events.upcoming.sorted.page params[:page]
+
+        if params[:date]
+          @filtering_date = Date.parse(params[:date])
+          @events = @person.events.by_date(@filtering_date).sorted.page params[:page]
+        else
+          @events = @person.events.upcoming.sorted.page params[:page]
+        end
+
+        @calendar_events = @person.events
+
         respond_to do |format|
           format.js
           format.html

--- a/app/views/gobierto_people/layouts/people.html.erb
+++ b/app/views/gobierto_people/layouts/people.html.erb
@@ -13,8 +13,6 @@
           <%= render("gobierto_people/people/subscription_button", person: @person) %>
         </div>
 
-        <div class="separator"></div>
-
         <%= render "gobierto_people/people/navigation" %>
 
       </div>

--- a/app/views/gobierto_people/people/_navigation.html.erb
+++ b/app/views/gobierto_people/people/_navigation.html.erb
@@ -21,7 +21,7 @@
   </div>
 <% end %>
 
-<% if (controller_name == "person_events" || controller_name == "past_person_events") && action_name == "index" %>
+<% if @calendar_events %>
   <div class="separator"></div>
 
   <div class="calendar-component m_v_2">
@@ -31,11 +31,7 @@
       attribute: :starts_at,
       start_date: params[:start_date] || Date.current
     ) do |date, events| %>
-      <% if events.any? %>
-        <%= link_to date.day, date: date, start_date: params[:start_date] %>
-      <% else %>
-        <%= date.day %>
-      <% end %>
+      <%= link_to_if events.any?, date.day, date: date, start_date: params[:start_date] %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/gobierto_people/people/_navigation.html.erb
+++ b/app/views/gobierto_people/people/_navigation.html.erb
@@ -1,19 +1,44 @@
-<div class="people-navigation">
+<% if active_submodules.size > 1 %>
+  <div class="separator"></div>
 
-  <ul>
-    <li><h3><%= link_to t(".bio"), gobierto_people_person_bio_path(@person), class: class_if("active", controller_name == "person_bio") %></h3></li>
-    <% if agendas_submodule_active? %>
-      <li><h3><%= link_to t(".agenda"), gobierto_people_person_events_path(@person), class: class_if("active", controller_name == "person_events")  %></h3></li>
-    <% end %>
-    <% if blog_submodule_active? %>
-      <li><h3><%= link_to t(".blog"), gobierto_people_person_posts_path(@person), class: class_if("active", controller_name == "person_posts")  %></h3></li>
-    <% end %>
-    <% if statements_submodule_active? %>
-      <li><h3><%= link_to t(".statements"), gobierto_people_person_statements_path(@person), class: class_if("active", controller_name == "person_statements")  %></h3></li>
-    <% end %>
-  </ul>
+  <div class="people-navigation">
 
-</div>
+    <ul>
+      <% if officials_submodule_active? %>
+        <li><h3><%= link_to t(".bio"), gobierto_people_person_bio_path(@person), class: class_if("active", controller_name == "person_bio") %></h3></li>
+      <% end %>
+      <% if agendas_submodule_active? %>
+        <li><h3><%= link_to t(".agenda"), gobierto_people_person_events_path(@person), class: class_if("active", controller_name == "person_events")  %></h3></li>
+      <% end %>
+      <% if blog_submodule_active? %>
+        <li><h3><%= link_to t(".blog"), gobierto_people_person_posts_path(@person), class: class_if("active", controller_name == "person_posts")  %></h3></li>
+      <% end %>
+      <% if statements_submodule_active? %>
+        <li><h3><%= link_to t(".statements"), gobierto_people_person_statements_path(@person), class: class_if("active", controller_name == "person_statements")  %></h3></li>
+      <% end %>
+    </ul>
+
+  </div>
+<% end %>
+
+<% if (controller_name == "person_events" || controller_name == "past_person_events") && action_name == "index" %>
+  <div class="separator"></div>
+
+  <div class="calendar-component m_v_2">
+    <%= month_calendar(
+      partial: "gobierto_people/person_events/calendar_template",
+      events: @calendar_events,
+      attribute: :starts_at,
+      start_date: params[:start_date] || Date.current
+    ) do |date, events| %>
+      <% if events.any? %>
+        <%= link_to date.day, date: date, start_date: params[:start_date] %>
+      <% else %>
+        <%= date.day %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>
 
 <div class="download_open_data">
 

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -8,18 +8,14 @@
 
   <div class="events-filter">
 
-    <div class="events-filter">
-
-      <% if @filtering_date %>
-        <div class="box">
-          <div class="inner">
-            <%= t("gobierto_people.person_events.index.displaying_events_of", date: l(@filtering_date, format: :short)) %>
-            <%= link_to t("gobierto_people.person_events.index.go_back"), gobierto_people_person_events_path(@person) %>
-          </div>
+    <% if @filtering_date %>
+      <div class="box">
+        <div class="inner">
+          <%= t("gobierto_people.person_events.index.displaying_events_of", date: l(@filtering_date, format: :short)) %>
+          <%= link_to t("gobierto_people.person_events.index.go_back"), gobierto_people_person_events_path(@person) %>
         </div>
-      <% end %>
-
-    </div>
+      </div>
+    <% end %>
 
     <div class="pure-g block">
 

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -4,13 +4,22 @@
   <h2><%= title t(".title", person_name: @person.name) %></h2>
 </div>
 
-<%= render("user/subscriptions/subscribable_box",
-           subscribable: @person,
-           title: t(".subscribable_box.title", person_name: @person.name)) %>
-
 <div class="events-summary person_event-list item-list">
 
   <div class="events-filter">
+
+    <div class="events-filter">
+
+      <% if @filtering_date %>
+        <div class="box">
+          <div class="inner">
+            <%= t("gobierto_people.person_events.index.displaying_events_of", date: l(@filtering_date, format: :short)) %>
+            <%= link_to t("gobierto_people.person_events.index.go_back"), gobierto_people_person_events_path(@person) %>
+          </div>
+        </div>
+      <% end %>
+
+    </div>
 
     <div class="pure-g block">
 

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -38,11 +38,7 @@
           attribute: :starts_at,
           start_date: params[:start_date] || Date.current
         ) do |date, events| %>
-          <% if events.any? %>
-            <%= link_to date.day, date: date, start_date: params[:start_date] %>
-          <% else %>
-            <%= date.day %>
-          <% end %>
+          <%= link_to_if events.any?, date.day, date: date, start_date: params[:start_date] %>
         <% end %>
       </div>
 

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -64,8 +64,6 @@ ca:
         index:
           no_events: No hi ha esdeveniments a aquesta agenda
           past_events: Esdeveniments passats
-          subscribable_box:
-            title: Rebeix actualitzacions al teu correu-e sobre %{person_name}
           title: Agenda de %{person_name}
           upcoming_events: Agenda
           view_more: Veure més

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -64,8 +64,6 @@ en:
         index:
           no_events: There are no events in this agenda
           past_events: Past events
-          subscribable_box:
-            title: Receive %{person_name}'s updates in your inbox
           title: "%{person_name}'s agenda"
           upcoming_events: Agenda
           view_more: View more

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -64,8 +64,6 @@ es:
         index:
           no_events: No hay eventos en esta agenda.
           past_events: Eventos pasados
-          subscribable_box:
-            title: Recibe actualizaciones sobre la actividad de %{person_name}
           title: Agenda de %{person_name}
           upcoming_events: Próximos eventos
           view_more: Ver más

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 require_relative "base"
+require_relative "../../../support/person_event_helpers"
 
 module GobiertoPeople
   module People
     class PersonEventsIndexTest < ActionDispatch::IntegrationTest
       include Base
+      include ::PersonEventHelpers
 
       def setup
         super
@@ -50,6 +52,30 @@ module GobiertoPeople
         end
       end
 
+      def test_events_summary_upcoming_and_past_filters
+        past_event    = create_event(title: "Past event title", starts_at: "2014-02-15", person: person)
+        future_event  = create_event(title: "Future event title", starts_at: "2014-04-15", person: person)
+
+        Timecop.freeze(Time.zone.parse("2014-03-15")) do
+
+          with_current_site(site) do
+            visit gobierto_people_person_events_path(person)
+
+            within ".events-summary" do
+              refute has_content?(past_event.title)
+              assert has_content?(future_event.title)
+            end
+
+            click_link "Past events"
+
+            within ".events-summary" do
+              assert has_content?(past_event.title)
+              refute has_content?(future_event.title)
+            end
+          end
+        end
+      end
+
       def test_subscription_block
         with_current_site(site) do
           visit @path
@@ -77,6 +103,67 @@ module GobiertoPeople
           refute has_link?("View more")
         end
       end
+
+      def test_calendar_navigation_arrows
+        past_event    = create_event(starts_at: "2014-02-15", person: person)
+        present_event = create_event(starts_at: "2014-03-15", person: person)
+        future_event  = create_event(starts_at: "2014-04-15", person: person)
+
+        Timecop.freeze(Time.zone.parse("2014-03-15")) do
+
+          with_current_site(site) do
+            visit gobierto_people_person_events_path(person)
+
+            within ".calendar-component" do
+              assert has_link?(present_event.starts_at.day)
+            end
+
+            click_link "next-month-link"
+
+            within ".calendar-component" do
+              assert has_link?(future_event.starts_at.day)
+            end
+
+            visit gobierto_people_person_events_path(person)
+
+            click_link "previous-month-link"
+
+            within ".calendar-component" do
+              assert has_link?(past_event.starts_at.day)
+            end
+          end
+
+        end
+      end
+
+      def test_filter_events_by_calendar_date_link
+        past_event    = create_event(title: "Past event title", starts_at: "2014-03-10", person: person)
+        future_event  = create_event(title: "Future event title", starts_at: "2014-03-20", person: person)
+
+        Timecop.freeze(Time.zone.parse("2014-03-15")) do
+
+          with_current_site(site) do
+            visit gobierto_people_person_events_path(person)
+
+            within ".events-summary" do
+              refute has_content?(past_event.title)
+              assert has_content?(future_event.title)
+            end
+
+            within ".calendar-component" do
+              click_link past_event.starts_at.day
+            end
+
+            assert has_content? "Displaying events of #{past_event.starts_at.strftime("%b %d %Y")}"
+
+            within ".events-summary" do
+              assert has_content?(past_event.title)
+              refute has_content?(future_event.title)
+            end
+          end
+        end
+      end
+
     end
   end
 end

--- a/test/support/person_event_helpers.rb
+++ b/test/support/person_event_helpers.rb
@@ -1,0 +1,14 @@
+module PersonEventHelpers
+
+  def create_event(options = {})
+    GobiertoPeople::PersonEvent.create!(
+      person: options[:person] || gobierto_people_people(:richard),
+      title: options[:title] || "Event title",
+      description: "Event description",
+      starts_at: Time.zone.parse(options[:starts_at]) || Time.zone.now,
+      ends_at:  (Time.zone.parse(options[:starts_at]) || Time.zone.now) + 1.hour,
+      state: GobiertoPeople::PersonEvent.states["published"]
+    )
+  end
+
+end


### PR DESCRIPTION
Connects to #648 

* Reading #666 might be useful too.
* Already deployed to staging.

### What does this PR do?

Adds the features specified in the issue description:

* Removes the upper subscribe box from a person agenda.
* Adds the calendar widget in the sidebar of a GobiertoPeople person agenda.
* When only agendas submodule is enabled, the submodules menu in the GobiertoPeople people sidebar is removed.
* When the officials submodule is not active, the "Biography and CV" option in the submodules menu in the GobiertoPeople people sidebar is removed.

Also does some improvements to GobiertoPeople events index:

* Fixes bug in GobiertoPeople events index. When clicking on a past date link on the calendar widget and being on the future events controller, a "No future events" message was being rendered. It's obvious that when clicking on a past date, events will never be future.
* Adds some integration tests related to the calendar widget usage in GobiertoPeople events index.

### How should this be manually tested?

When browsing Gobierto, the upper requirements should be meeted.

### Does this PR changes any configuration file?

No
