### PR TITLE
Assign random name to content block fields

### DIFF
--- a/app/models/gobierto_common/content_block_field.rb
+++ b/app/models/gobierto_common/content_block_field.rb
@@ -35,7 +35,7 @@ module GobiertoCommon
     private
 
     def set_name
-      self.name ||= SecureRandom.uuid
+      self.name = SecureRandom.uuid if self.name.blank?
     end
 
     def set_position

--- a/db/migrate/20170428081148_fix_content_block_fields_data.rb
+++ b/db/migrate/20170428081148_fix_content_block_fields_data.rb
@@ -1,0 +1,11 @@
+class FixContentBlockFieldsData < ActiveRecord::Migration[5.0]
+  def change
+    GobiertoCommon::ContentBlockField.where("name = ''").each do |cbf|
+      if cbf.name.blank?
+        cbf.name = SecureRandom.uuid
+        cbf.save!
+        puts " - Updated ContentBlockField #{cbf.id}"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170424104048) do
+ActiveRecord::Schema.define(version: 20170428081148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Connects to #653

### What does this PR do?

This PR fixes a bug in DynamicContentField creation. Because the default value of the name field is blank string instead of nil, the `||=` assignment didn't work properly.
