### PR TITLE
Set site locale when importing events

### DIFF
--- a/app/services/gobierto_people/remote_calendars.rb
+++ b/app/services/gobierto_people/remote_calendars.rb
@@ -3,6 +3,7 @@ module GobiertoPeople
 
     def self.sync
       Site.with_agendas_integration_enabled.each do |site|
+        I18n.locale = site.configuration.default_locale
         calendar_integration = site.calendar_integration
 
         site.people.with_calendar_configuration.each do |person|

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -41,7 +41,7 @@
         <% end %>
       </td>
       <td>
-        <%= person.charge %>
+        <%= person.charge_with_fallback %>
       </td>
       <td>
         <%= person.events_count %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -64,7 +64,7 @@
       </td>
       <td>
         <%= link_to edit_admin_people_person_event_path(@person, person_event), data: { turbolinks: false } do %>
-          <%= person_event.title %>
+          <%= person_event.title_with_fallback %>
         <% end %>
       </td>
       <td>

--- a/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
@@ -32,7 +32,7 @@
       </td>
       <td>
         <%= link_to edit_admin_people_person_statement_path(@person, person_statement), data: { turbolinks: false } do %>
-          <%= person_statement.title %>
+          <%= person_statement.title_with_fallback %>
         <% end %>
       </td>
       <td>


### PR DESCRIPTION
Unexpected

### What does this PR do?

This is something I have just find out it was wrong. When importing the events, and in general, we should always work with Site custom settings, for example the locale (and maybe in the future the time zone). 

So this PR amends the Events importer to set the current locale to the default site locale.
