### PR TITLE
IBM Notes time zone fix

### DIFF
--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -97,24 +97,6 @@ module GobiertoPeople
       end
     end
 
-    def starts_at
-      @starts_at ||= (1.hour.from_now.beginning_of_hour + 1.day).localtime
-
-      if @starts_at.respond_to?(:strftime)
-        return @starts_at.strftime("%Y-%m-%d %H:%M")
-      end
-
-      @starts_at
-    end
-
-    def ends_at
-      if @ends_at.respond_to?(:strftime)
-        return @ends_at.strftime("%Y-%m-%d %H:%M")
-      end
-
-      @ends_at
-    end
-
     def state
       @state ||= person_event.state || "published"
     end

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -137,8 +137,8 @@ module GobiertoPeople
       end
 
       def test_filter_events_by_calendar_date_link
-        past_event    = create_event(title: "Past event title", starts_at: "2014-03-10", person: person)
-        future_event  = create_event(title: "Future event title", starts_at: "2014-03-20", person: person)
+        past_event    = create_event(title: "Past event title", starts_at: "2014-03-10 11:00", person: person)
+        future_event  = create_event(title: "Future event title", starts_at: "2014-03-20 11:00", person: person)
 
         Timecop.freeze(Time.zone.parse("2014-03-15")) do
 

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -365,8 +365,8 @@ module GobiertoPeople
     end
 
     def test_filter_events_by_calendar_date_link
-      past_event    = create_event(title: "Past event title", starts_at: "2014-03-10")
-      future_event  = create_event(title: "Future event title", starts_at: "2014-03-20")
+      past_event    = create_event(title: "Past event title", starts_at: "2014-03-10 11:00")
+      future_event  = create_event(title: "Future event title", starts_at: "2014-03-20 11:00")
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
 

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -87,10 +87,10 @@ module GobiertoPeople
         assert_equal 1, recurrent_events_instances.count
 
         assert_equal "Buscar alcaldessa al seu despatx i Sortida cap a l'acte Gran Via Corts Catalanes, 400", non_recurrent_events.first.title
-        assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_events.first.starts_at
+        assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_events.first.starts_at.utc
 
         assert_equal "Lliurament Premis Rac", non_recurrent_events.second.title
-        assert_equal rst_to_utc("2017-05-04 19:30:00"), non_recurrent_events.second.starts_at
+        assert_equal rst_to_utc("2017-05-04 19:30:00"), non_recurrent_events.second.starts_at.utc
 
         assert_equal "CAEM", recurrent_events_instances.first.title
         assert_equal rst_to_utc("2017-05-05 09:00:00"), recurrent_events_instances.first.starts_at

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,7 @@ if ENV["CI"]
 end
 
 I18n.locale = I18n.default_locale = :en
-Time.zone = "UTC"
+Time.zone = "Madrid"
 
 Minitest::Retry.use! if ENV["RETRY_FAILING_TEST"]
 Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)


### PR DESCRIPTION
Bugfix

### What does this PR do?

This PR fixes a couple of issues with time zones:

1. First, we should be running tests in the same time zone as the application runs
2. Second, there was a problem in the form object that parses the IBM notes event, it was losing the time zone information, and due to (1) we weren't detecting it
