### PR TITLE
Delay notification job to avoid transaction issue

### DIFF
--- a/app/forms/user/notification_form.rb
+++ b/app/forms/user/notification_form.rb
@@ -52,7 +52,7 @@ class User::NotificationForm
   end
 
   def deliver_notification_email
-    User::NotificationMailer.single_notification(user_notification).deliver_later
+    User::NotificationMailer.single_notification(user_notification).deliver_later(wait: 5.seconds)
   end
 
   def mark_as_sent

--- a/test/support/message_delivery_helpers.rb
+++ b/test/support/message_delivery_helpers.rb
@@ -1,5 +1,5 @@
 class ActionMailer::MessageDelivery
-  def deliver_later
+  def deliver_later(options = {})
     deliver_now
   end
 end


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR delays mailing notifications to avoid the job to be run before the database transaction has finished. This was causing a lot of Rollbar notifications.
