### PR TITLE
Google Calendar integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,6 @@ HOST=gobierto.dev
 PORT=3000
 RAILS_MAX_THREADS=5
 
-# Rails test log level
-TEST_LOG_LEVEL=fatal
-
 # Poltergeist debug and inspector variables
 INTEGRATION_DEBUG=false
 INTEGRATION_INSPECTOR=false

--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,14 @@ gem "i18n-active_record", :require => "i18n/active_record"
 # Liquid
 gem "liquid", "~> 4.0"
 
+# Google API
+gem "google-api-client"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "i18n-tasks"
+  gem "spring"
+  gem "spring-watcher-listen", "~> 2.0.0"
 end
 
 group :test do
@@ -86,10 +91,9 @@ group :test do
   gem "capybara-email"
   gem "vcr"
   gem "timecop"
+  gem "mocha"
 end
 
 group :development do
-  gem "spring"
-  gem "spring-watcher-listen", "~> 2.0.0"
   gem "puma"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
       railties (>= 3.1)
     dalli (2.7.6)
     database_cleaner (1.5.3)
+    declarative (0.0.9)
+    declarative-option (0.1.0)
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -138,6 +140,21 @@ GEM
       rails (>= 3.1.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    google-api-client (0.11.2)
+      addressable (>= 2.5.1)
+      googleauth (~> 0.5)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (>= 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
     hashdiff (0.3.2)
     highline (1.7.8)
     http-cookie (1.0.3)
@@ -176,6 +193,7 @@ GEM
     json_translate (3.0.1)
       activerecord (>= 4.2.0)
     jsonapi-renderer (0.1.2)
+    jwt (1.5.6)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.0.1)
@@ -196,6 +214,10 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -209,8 +231,10 @@ GEM
       nokogiri (~> 1.6)
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (>= 0.0.9, < 0.2)
+    memoist (0.15.0)
     meta-tags (2.4.0)
       actionpack (>= 3.2.0, <= 5.1.0)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -239,6 +263,8 @@ GEM
     minitest-retry (0.1.8)
       minitest (>= 5.0)
     minitest-stub_any_instance (1.0.1)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4.1)
@@ -247,6 +273,7 @@ GEM
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     ntlm-http (0.1.1)
+    os (0.9.6)
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
@@ -292,8 +319,13 @@ GEM
     redcarpet (3.4.0)
     redis (3.3.3)
     ref (2.0.0)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    retriable (3.0.2)
     rollbar (2.14.1)
       multi_json
     ruby-prof (0.16.2)
@@ -314,6 +346,11 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
     simple_calendar (2.2.5)
       rails (>= 3.0)
     simplecov (0.14.1)
@@ -349,6 +386,7 @@ GEM
     turbolinks-source (5.0.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
+    uber (0.1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
@@ -392,6 +430,7 @@ DEPENDENCIES
   elasticsearch
   elasticsearch-extensions
   flight-for-rails
+  google-api-client
   i18n-active_record
   i18n-js (>= 3.0.0.rc11)
   i18n-tasks
@@ -410,6 +449,7 @@ DEPENDENCIES
   minitest-reporters
   minitest-retry
   minitest-stub_any_instance
+  mocha
   pg (~> 0.19)
   poltergeist
   puma

--- a/app/assets/javascripts/admin/app/controllers/gobierto_people_configuration_settings_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/gobierto_people_configuration_settings_controller.js
@@ -14,11 +14,11 @@ this.GobiertoAdmin.GobiertoPeopleConfigurationSettingsController = (function() {
 
   function _ibm_settings_fields() {
     $("#calendar-integration-picker select").on('change', function(){
-      if ($(this).val() === "") {
+      if ($(this).val() === "ibm_notes") {
+        $(".ibm_notes_setting").show('slow');
+      } else {
         $(".ibm_notes_setting input").val('');
         $(".ibm_notes_setting").hide('slow');
-      } else {
-        $(".ibm_notes_setting").show('slow');
       }
     });
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,11 @@ class ApplicationController < ActionController::Base
   end
 
   def current_site
-    request.env['gobierto_site']
+    @current_site ||= if request.env['gobierto_site'].present?
+                        request.env['gobierto_site']
+                      else
+                        Site.first if Rails.env.test?
+                      end
   end
 
   private

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_calendar_configuration_controller.rb
@@ -6,6 +6,7 @@ module GobiertoAdmin
 
         def edit
           @calendar_configuration_form = PersonCalendarConfigurationForm.new(person_id: @person.id)
+          @google_calendar_configuration = find_google_calendar_configuration
 
           render 'gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/edit'
         end
@@ -25,9 +26,11 @@ module GobiertoAdmin
         private
 
         def calendar_configuration_params
-          params.require(:calendar_configuration).permit(
-            :ibm_notes_url
-          )
+          params.require(:calendar_configuration).permit(:ibm_notes_url, :clear_google_calendar_configuration)
+        end
+
+        def find_google_calendar_configuration
+          ::GobiertoPeople::PersonGoogleCalendarConfiguration.find_by person_id: @person.id
         end
 
       end

--- a/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
@@ -92,7 +92,7 @@ module GobiertoAdmin
 
       def person_params
         params.require(:person).permit(
-          :name, :email, :bio_file, :avatar_file, :visibility_level, :category, :party, :political_group_id,
+          :name, :email, :bio_file, :avatar_file, :visibility_level, :category, :party, :political_group_id, :google_calendar_token,
           charge_translations: [*I18n.available_locales],
           bio_translations: [*I18n.available_locales],
           content_block_records_attributes: [
@@ -105,7 +105,7 @@ module GobiertoAdmin
       end
 
       def ignored_person_attributes
-        %w( created_at updated_at events_count statements_count posts_count position charge bio slug )
+        %w( created_at updated_at events_count statements_count posts_count position charge bio slug google_calendar_token )
       end
     end
   end

--- a/app/controllers/gobierto_people/people/google_calendar_authorization_controller.rb
+++ b/app/controllers/gobierto_people/people/google_calendar_authorization_controller.rb
@@ -1,0 +1,53 @@
+module GobiertoPeople
+  module People
+    class GoogleCalendarAuthorizationController < ::ApplicationController
+      skip_before_action :set_current_site, :authenticate_user_in_site, :set_locale
+      before_action :load_person, :load_google_calendar_configuration
+
+      def new
+        scope = [Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY]
+
+        if params[:code].nil?
+          session[:google_calendar_person_id] = @person.id
+
+          client_id = Google::Auth::ClientId.from_file(client_secret_path)
+          token_store = Google::Auth::Stores::FileTokenStore.new(file: Tempfile.new.path)
+          authorizer = Google::Auth::WebUserAuthorizer.new(client_id, scope, token_store, new_gobierto_people_google_calendar_authorization_path)
+
+          redirect_to authorizer.get_authorization_url(login_hint: @person.id, request: request)
+        else
+          client_secrets = Google::APIClient::ClientSecrets.load(client_secret_path)
+
+          auth_client = client_secrets.to_authorization
+          auth_client.update!(:scope => scope)
+          auth_client.code = params[:code]
+          auth_client.fetch_access_token!
+          auth_client.client_secret = nil
+          @configuration.google_calendar_credentials = { GobiertoPeople::GoogleCalendar::CalendarIntegration::USERNAME => auth_client.to_json}.to_yaml
+          @configuration.save!
+
+          session[:google_calendar_person_id] = nil
+          redirect_to gobierto_people_person_url(@person.slug, host: @person.site.domain), notice: t('.success')
+        end
+      end
+
+      private
+
+      def load_person
+        @person = if params[:token]
+                    GobiertoPeople::Person.find_by! google_calendar_token: params[:token]
+                  else
+                    GobiertoPeople::Person.find session[:google_calendar_person_id]
+                  end
+      end
+
+      def load_google_calendar_configuration
+        @configuration = ::GobiertoPeople::PersonGoogleCalendarConfiguration.find_or_initialize_by person_id: @person.id
+      end
+
+      def client_secret_path
+        GobiertoPeople::GoogleCalendar::CalendarIntegration::CLIENT_SECRETS_PATH
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -7,9 +7,9 @@ module GobiertoPeople
       def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
-          @events = @person.events.by_date(@filtering_date).sorted.page params[:page]
+          @events = @person.attending_events.by_date(@filtering_date).sorted.page params[:page]
         else
-          @events = @person.events.upcoming.sorted.page params[:page]
+          @events = @person.attending_events.upcoming.sorted.page params[:page]
         end
 
         respond_to do |format|
@@ -25,11 +25,11 @@ module GobiertoPeople
       private
 
       def find_event
-        @person.events.published.find_by!(slug: params[:slug])
+        @person.attending_events.published.find_by!(slug: params[:slug])
       end
 
       def set_calendar_events
-        @calendar_events = @person.events
+        @calendar_events = @person.attending_events
       end
     end
   end

--- a/app/extensions/gobierto_common/trackable.rb
+++ b/app/extensions/gobierto_common/trackable.rb
@@ -33,6 +33,7 @@ module GobiertoCommon
     end
 
     def notify?
+      return false if trackable.admin_id.nil?
       return super if defined?(super)
 
       true

--- a/app/extensions/gobierto_common/trackable.rb
+++ b/app/extensions/gobierto_common/trackable.rb
@@ -33,7 +33,6 @@ module GobiertoCommon
     end
 
     def notify?
-      return false if trackable.admin_id.nil?
       return super if defined?(super)
 
       true

--- a/app/forms/gobierto_admin/gobierto_people/person_calendar_configuration_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_calendar_configuration_form.rb
@@ -5,7 +5,8 @@ module GobiertoAdmin
 
       attr_accessor(
         :person_id,
-        :ibm_notes_url
+        :ibm_notes_url,
+        :clear_google_calendar_configuration
       )
 
       def save
@@ -37,7 +38,12 @@ module GobiertoAdmin
       def save_calendar_configuration
         @person_calendar_configuration = person_calendar_configuration.tap do |calendar_configuration_attributes|
           calendar_configuration_attributes.person_id = person_id
-          
+
+          if clear_google_calendar_configuration
+            calendar_configuration_attributes.google_calendar_credentials = nil
+            calendar_configuration_attributes.google_calendar_id = nil
+          end
+
           if calendar_configuration_attributes.respond_to?(:endpoint)
             calendar_configuration_attributes.endpoint = ibm_notes_url
           end

--- a/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_event_form.rb
@@ -25,6 +25,7 @@ module GobiertoAdmin
       validates :title_translations, presence: true
       validates :starts_at, :ends_at, presence: true
       validates :person, presence: true
+      validates :site, presence: true
 
       trackable_on :person_event
 
@@ -39,7 +40,7 @@ module GobiertoAdmin
       end
 
       def site_id
-        @site_id ||= person_event.site_id
+        @site_id ||= person.site_id
       end
 
       def admin
@@ -47,7 +48,7 @@ module GobiertoAdmin
       end
 
       def site
-        @site ||= Site.find_by(id: site_id)
+        @site ||= person.try(:site)
       end
 
       def person_event
@@ -99,6 +100,17 @@ module GobiertoAdmin
 
       def attendees
         @attendees ||= person_event.attendees.presence || [build_person_event_attendee]
+
+        if person_event.attendees.any?
+          unless organizer = person_event.attendees.find_by(person_id: person_id)
+            organizer = person_event_attendee_class.new(person_id: person_id)
+          end
+        else
+          organizer = person_event_attendee_class.new(person_id: person_id)
+        end
+        @attendees.push(organizer) unless @attendees.include?(organizer)
+
+        @attendees
       end
 
       def attendees_attributes=(attributes)

--- a/app/forms/gobierto_admin/gobierto_people/person_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_form.rb
@@ -132,6 +132,7 @@ module GobiertoAdmin
           person_attributes.party = party
           person_attributes.political_group_id = political_group_id
           person_attributes.content_block_records = content_block_records
+          person_attributes.google_calendar_token ||= person_class.generate_unique_secure_token
         end
 
         if @person.valid?

--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -140,8 +140,7 @@ module GobiertoPeople
       @person_event = person_event.tap do |person_event_attributes|
         person_event_attributes.site_id = site_id
         person_event_attributes.external_id = external_id
-        person_event_attributes.person_id = person_id
-        person_event_attributes.site_id = site_id
+        person_event_attributes.person_id ||= person_id
         person_event_attributes.state = state
         person_event_attributes.title = title
         person_event_attributes.description = description

--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -12,6 +12,7 @@ module GobiertoPeople
       :starts_at,
       :ends_at,
       :state,
+      :notify,
       :locations,
       :attendees
     )
@@ -107,7 +108,7 @@ module GobiertoPeople
     end
 
     def notify?
-      person_event.active?
+      notify && person_event.active? && person.present?
     end
 
     private
@@ -152,7 +153,11 @@ module GobiertoPeople
 
       if @person_event.valid?
         if @person_event.changes.any?
-          run_callbacks(:save) do
+          if notify?
+            run_callbacks(:save) do
+              @person_event.save
+            end
+          else
             @person_event.save
           end
         end

--- a/app/jobs/gobierto_people/clear_imported_person_events_job.rb
+++ b/app/jobs/gobierto_people/clear_imported_person_events_job.rb
@@ -1,0 +1,25 @@
+class GobiertoPeople::ClearImportedPersonEventsJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(person)
+    # Person synchronized events
+    person.events.synchronized.each(&:destroy)
+    person.reload
+
+    # Person attending events from other person calendar
+    person.attending_events.each do |event|
+      if event.synchronized? && event.attendees.select{ |a| a.person_id.present? }.length == 1 &&
+          event.person_id == 0
+        event.destroy
+      end
+    end
+    person.reload
+
+    # Person attendance to events
+    person.attending_person_events.each do |attendee|
+      if attendee.person_event.nil? || attendee.person_event.synchronized?
+        attendee.destroy
+      end
+    end
+  end
+end

--- a/app/models/gobierto_common/search.rb
+++ b/app/models/gobierto_common/search.rb
@@ -3,6 +3,7 @@ module GobiertoCommon
     def initialize(site)
       @site = site
     end
+
     def search_in_indexes
       add_quotes = -> x{"'#{x}'"}
 

--- a/app/models/gobierto_people.rb
+++ b/app/models/gobierto_people.rb
@@ -12,6 +12,6 @@ module GobiertoPeople
   end
 
   def self.remote_calendar_integrations
-    %w( ibm_notes )
+    %w( ibm_notes google_calendar )
   end
 end

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -22,6 +22,8 @@ module GobiertoPeople
     belongs_to :political_group
 
     has_many :events, class_name: "PersonEvent", dependent: :destroy
+    has_many :attending_person_events, class_name: "PersonEventAttendee", dependent: :destroy
+    has_many :attending_events, class_name: "PersonEvent", through: :attending_person_events, source: :person_event
     has_many :statements, class_name: "PersonStatement", dependent: :destroy
     has_many :posts, class_name: "PersonPost", dependent: :destroy
 

--- a/app/models/gobierto_people/person_event.rb
+++ b/app/models/gobierto_people/person_event.rb
@@ -8,7 +8,6 @@ module GobiertoPeople
     include GobiertoCommon::Searchable
     include GobiertoPeople::Sluggable
 
-    validates :person, presence: true
     validates :site, presence: true
 
     translates :title, :description
@@ -35,7 +34,7 @@ module GobiertoPeople
     scope :by_date,  ->(date) { where("starts_at::date = ?", date) }
 
     scope :by_site, ->(site) do
-      joins(:person).where(Person.table_name => { site_id: site.id })
+      where(site_id: site.id)
     end
 
     scope :by_person_category, ->(category) do
@@ -46,10 +45,15 @@ module GobiertoPeople
       joins(:person).where(Person.table_name => { party: party })
     end
 
-    delegate :site_id, to: :person
     delegate :admin_id, to: :person
 
     enum state: { pending: 0, published: 1 }
+
+    def admin_id
+      if person
+        person.admin_id
+      end
+    end
 
     def parameterize
       { person_slug: person.slug, slug: slug }

--- a/app/models/gobierto_people/person_event.rb
+++ b/app/models/gobierto_people/person_event.rb
@@ -56,7 +56,12 @@ module GobiertoPeople
     end
 
     def parameterize
-      { person_slug: person.slug, slug: slug }
+      person_slug = if person.present?
+        person.slug
+      elsif attendee = attendees.detect{ |a| a.person_id.present? }
+        attendee.person.slug
+      end
+      { person_slug: person_slug, slug: slug }
     end
 
     def past?

--- a/app/models/gobierto_people/person_google_calendar_configuration.rb
+++ b/app/models/gobierto_people/person_google_calendar_configuration.rb
@@ -1,0 +1,19 @@
+module GobiertoPeople
+  class PersonGoogleCalendarConfiguration < PersonCalendarConfiguration
+    def google_calendar_credentials=(value)
+      data['google_calendar_credentials'] = value
+    end
+
+    def google_calendar_credentials
+      data['google_calendar_credentials']
+    end
+
+    def google_calendar_id
+      data['google_calendar_id']
+    end
+
+    def google_calendar_id=(value)
+      data['google_calendar_id'] = value
+    end
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -23,6 +23,7 @@ class Site < ApplicationRecord
   # GobiertoPeople integration
   has_many :people, dependent: :destroy, class_name: "GobiertoPeople::Person"
   has_many :person_events, through: :people, source: :events, class_name: "GobiertoPeople::PersonEvent"
+  has_many :person_attendee_events, class_name: "GobiertoPeople::PersonEvent", dependent: :destroy
   has_many :person_posts, through: :people, source: :posts, class_name: "GobiertoPeople::PersonPost"
   has_many :person_statements, through: :people, source: :statements, class_name: "GobiertoPeople::PersonStatement"
 
@@ -66,8 +67,13 @@ class Site < ApplicationRecord
   end
 
   def calendar_integration
-    if gobierto_people_settings && gobierto_people_settings.calendar_integration == 'ibm_notes'
-      GobiertoPeople::IbmNotes::CalendarIntegration
+    if gobierto_people_settings
+      case gobierto_people_settings.calendar_integration
+      when 'ibm_notes'
+        GobiertoPeople::IbmNotes::CalendarIntegration
+      when 'google_calendar'
+        GobiertoPeople::GoogleCalendar::CalendarIntegration
+      end
     end
   end
 

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -1,0 +1,129 @@
+require 'tempfile'
+require 'fileutils'
+
+module GobiertoPeople
+  module GoogleCalendar
+    class CalendarIntegration
+      CLIENT_SECRETS_PATH = Rails.root.join('config', 'google_calendar_integration_client_secret.json')
+      USERNAME = 'default'
+      SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
+
+      def self.person_calendar_configuration_class
+        ::GobiertoPeople::PersonGoogleCalendarConfiguration
+      end
+
+      def self.sync_person_events(person)
+        new(person).sync!
+      end
+
+      def initialize(person)
+        @person = person
+        @configuration = GobiertoPeople::PersonGoogleCalendarConfiguration.find_by person_id: person.id
+
+        @service = Google::Apis::CalendarV3::CalendarService.new
+        @service.client_options.application_name = person.site.name
+        @service.authorization = authorize(person)
+      end
+      private_class_method :new
+
+      def sync!
+        set_google_calendar_id!
+
+        service.list_calendar_lists(max_results: 100).items.each do |calendar|
+          sync_calendar_events(calendar)
+        end
+      end
+
+      private
+
+      attr_reader :person, :configuration, :service
+
+      def set_google_calendar_id!
+        if @configuration.google_calendar_id.nil?
+          @configuration.google_calendar_id = service.list_calendar_lists(max_results: 100).items.select{ |c| c.primary? }.first.id
+          @configuration.save
+        end
+      end
+
+      def sync_calendar_events( calendar)
+        response = service.list_events(calendar.id, always_include_email: true, time_min: Time.now.iso8601)
+        response.items.each do |event|
+          next if is_private?(event) || (!is_creator?(event) && !is_attendee?(event))
+
+          if is_recurring?(event)
+            service.list_event_instances(calendar.id, event.id).items.each do |event|
+              sync_event(event)
+            end
+          else
+            sync_event(event)
+          end
+        end
+      end
+
+      def is_private?(event)
+        %w( private confidential ).include?(event.visibility)
+      end
+
+      def is_creator?(event)
+        event.creator.email == configuration.google_calendar_id
+      end
+
+      def is_attendee?(event)
+        Array(event.attendees).any?{ |a| a.email == configuration.google_calendar_id }
+      end
+
+      def is_recurring?(event)
+        event.recurrence.present?
+      end
+
+      def event_attendees(event)
+        return [] if event.attendees.nil?
+
+        event.attendees.map do |attendee_attributes|
+          {
+            name: attendee_attributes.display_name,
+            email: attendee_attributes.email,
+            person: (attendee_attributes.self? ? person : nil)
+          }
+        end
+      end
+
+      def sync_event(event)
+        person_event_params = {
+          site_id: person.site_id,
+          external_id: event.id,
+          title: event.summary,
+          starts_at: event.start.date_time || DateTime.parse(event.start.date),
+          ends_at: event.end.date_time || DateTime.parse(event.end.date),
+          state: GobiertoPeople::PersonEvent.states[:published],
+          attendees: event_attendees(event),
+        }
+        if is_creator?(event)
+          person_event_params.merge!(person_id: person.id)
+        else
+          person_event_params.merge!(person_id: 0)
+        end
+
+        if event.location.present?
+          person_event_params.merge!(locations_attributes: {"0" => {name: event.location} })
+        else
+          person_event_params.merge!(locations_attributes: {"0" => {"_destroy" => "1" }})
+        end
+
+        event = GobiertoPeople::PersonEventForm.new(person_event_params)
+        event.save
+      end
+
+      def authorize(person)
+        file = Tempfile.new [person.site_id, person.id].join('_')
+        file.write @configuration.google_calendar_credentials
+        file.rewind
+
+        client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
+        token_store = Google::Auth::Stores::FileTokenStore.new(file: file.path)
+        authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
+        authorizer.get_credentials(USERNAME)
+      end
+    end
+  end
+end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -51,8 +51,8 @@ module GobiertoPeople
           next if is_private?(event) || (!is_creator?(event) && !is_attendee?(event))
 
           if is_recurring?(event)
-            service.list_event_instances(calendar.id, event.id).items.each do |event|
-              sync_event(event)
+            service.list_event_instances(calendar.id, event.id).items.each_with_index do |event, i|
+              sync_event(event, i)
             end
           else
             sync_event(event)
@@ -88,7 +88,7 @@ module GobiertoPeople
         end
       end
 
-      def sync_event(event)
+      def sync_event(event, i = nil)
         person_event_params = {
           site_id: person.site_id,
           external_id: event.id,
@@ -97,6 +97,7 @@ module GobiertoPeople
           ends_at: event.end.date_time || DateTime.parse(event.end.date),
           state: GobiertoPeople::PersonEvent.states[:published],
           attendees: event_attendees(event),
+          notify: i.nil? || i == 0
         }
         if is_creator?(event)
           person_event_params.merge!(person_id: person.id)

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -47,7 +47,8 @@ module GobiertoPeople
           ends_at: ibm_notes_event.ends_at,
           state: GobiertoPeople::PersonEvent.states[:published],
           attendees: ibm_notes_event.attendees,
-          locations_attributes: {"0" => locations_attributes }
+          locations_attributes: {"0" => locations_attributes },
+          notify: true
         }
 
         event = GobiertoPeople::PersonEventForm.new(person_event_params)

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -38,6 +38,7 @@ module GobiertoPeople
                                end
 
         person_event_params = {
+          site_id: ibm_notes_event.person.site.id,
           external_id: ibm_notes_event.id,
           person_id: ibm_notes_event.person.id,
           title: ibm_notes_event.title,

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/_attendees_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/_attendees_form.html.erb
@@ -17,6 +17,7 @@
           <td class="content-block-record-value">
             <% if attendee_form.object.person.present? %>
               <%= attendee_form.object.person.name %>
+
               <%= link_to "#", class: "view_item" do %>
                 <i class="fa fa-eye"></i>
                 <%= t(".view_person") %>
@@ -27,14 +28,16 @@
           <td class="content-block-record-value"><%= attendee_form.object.charge %></td>
 
           <td class="edit_cell">
-            <%= attendee_form.check_box :_destroy, class: "hidden destroy-content-block-record" %>
+            <% if attendee_form.object.person != form_builder.object.person %>
+              <%= attendee_form.check_box :_destroy, class: "hidden destroy-content-block-record" %>
 
-            <%= link_to "#", data: { behavior: "edit_record" } do %>
-              <i class="fa fa-edit"></i>
-            <% end %>
+              <%= link_to "#", data: { behavior: "edit_record" } do %>
+                <i class="fa fa-edit"></i>
+              <% end %>
 
-            <%= link_to "#", data: { behavior: "delete_record" } do %>
-              <i class="fa fa-trash"></i>
+              <%= link_to "#", data: { behavior: "delete_record" } do %>
+                <i class="fa fa-trash"></i>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -34,9 +34,11 @@
 
   <div class="pure-u-1 pure-u-md-2-5">
     <div class="admin_tools right">
-      <%= link_to edit_admin_people_person_calendar_configuration_path(@person) do %>
-        <i class="fa fa-cog"></i>
-        <%= t(".configuration") %>
+      <% if current_site.calendar_integration.present? %>
+        <%= link_to edit_admin_people_person_calendar_configuration_path(@person) do %>
+          <i class="fa fa-cog"></i>
+          <%= t(".configuration") %>
+        <% end %>
       <% end %>
       <%= link_to t(".new"), new_admin_people_person_event_path(@person), class: "button", data: { turbolinks: false } %>
     </div>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/edit.html.erb
@@ -1,23 +1,41 @@
 <%= render 'gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/navigation' %>
 
-<% if current_site.calendar_integration.present? %>
+<%= form_for @calendar_configuration_form, as: :calendar_configuration, url: admin_people_person_calendar_configuration_path,  method: :patch do |f| %>
+  <div class="pure-g">
 
-  <%= form_for @calendar_configuration_form, as: :calendar_configuration, url: admin_people_person_calendar_configuration_path,  method: :patch do |f| %>
-    <div class="pure-g">
-
-      <% if current_site.calendar_integration == ::GobiertoPeople::IbmNotes::CalendarIntegration %>
-        <%= render 'gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/ibm_notes_fields', f: f %>
-      <% end %>
-
-      <div class="pure-u-1 pure-u-md-2-24"></div>
-
-      <div class="pure-u-1 pure-u-md-1-4 stick_in_parent" id="stick_in_parent">
-        <div class="widget_save">
-          <%= f.submit t(".update"), class: "button" %>
-        </div>
+    <% if current_site.calendar_integration == ::GobiertoPeople::IbmNotes::CalendarIntegration %>
+      <%= render 'gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/ibm_notes_fields', f: f %>
+    <% elsif current_site.calendar_integration == ::GobiertoPeople::GoogleCalendar::CalendarIntegration %>
+      <div class="pure-u-1 pure-u-md-16-24">
+        <% if @google_calendar_configuration.nil? || @google_calendar_configuration.google_calendar_credentials.blank? %>
+          <div class="form_item input_text">
+            <p><%= t('.share_link') %></p>
+            <p><input type="text" name="google_calendar_invitation_url" value="<%= new_gobierto_people_google_calendar_authorization_url(token: @person.google_calendar_token) %>"/></p>
+          </div>
+        <% else %>
+          <div class="form_item site-check-boxes">
+            <p><%= t('.calendar_configured') %></p>
+            <div class="options compact">
+              <div class="option">
+                <%= f.check_box :clear_google_calendar_configuration %>
+                <%= f.label :clear_google_calendar_configuration do %>
+                  <span></span>
+                  <%= t('.remove_integration') %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
       </div>
+    <% end %>
 
+    <div class="pure-u-1 pure-u-md-2-24"></div>
+
+    <div class="pure-u-1 pure-u-md-1-4 stick_in_parent" id="stick_in_parent">
+      <div class="widget_save">
+        <%= f.submit t(".update"), class: "button" %>
+      </div>
     </div>
-  <% end %>
 
+  </div>
 <% end %>

--- a/app/views/gobierto_people/people/_person_events.html.erb
+++ b/app/views/gobierto_people/people/_person_events.html.erb
@@ -14,7 +14,9 @@
     <% end %>
 
     <div id="events">
-      <%= render(partial: 'gobierto_people/person_events/person_event', collection: person_events) %>
+      <% person_events.each do |event| %>
+        <%= render(partial: 'gobierto_people/person_events/person_event', locals: {person_event: event, person: event.person}) %>
+      <% end %>
     </div>
 
     <%= link_to t("gobierto_people.welcome.index.events_summary.view_all"), gobierto_people_events_path, class: "see_more", role: "button" %>

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -41,7 +41,7 @@
 
   <% if @events.any? %>
     <div id="events">
-      <%= render @events %>
+      <%= render partial: 'gobierto_people/person_events/person_event', collection: @events, locals: {person: @person} %>
     </div>
     <%= link_to_next_page @events, t('.view_more'), class: "see_more", role: "button", remote: true %>
   <% else %>

--- a/app/views/gobierto_people/person_events/_person_event.html.erb
+++ b/app/views/gobierto_people/person_events/_person_event.html.erb
@@ -8,13 +8,21 @@
 
   <div class="pure-u-1 pure-u-md-5-6 event-content">
 
-    <h3><%= link_to person_event.title, gobierto_people_person_event_path(person_event.person.slug, person_event.slug) %></h3>
+    <h3>
+      <% if person.present? %>
+        <%= link_to person_event.title, gobierto_people_person_event_path(person.slug, person_event.slug) %>
+      <% else %>
+        <%= person_event.title %>
+      <% end %>
+    </h3>
 
     <div class="soft meta">
       <div>
         <i class="fa fa-user"></i>
-        <%= link_to person_event.person.name, gobierto_people_person_path(person_event.person.slug) %>
-        <%= person_event.person.charge %>
+        <% if person %>
+          <%= link_to person.name, gobierto_people_person_path(person.slug)%>
+          <%= person.charge %>
+        <% end %>
       </div>
 
       <% person_event.locations.each do |event_location| %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -22,7 +22,7 @@
         <p><small><%= t(".agenda_switcher.subtitle") %></small></p>
 
         <div class="hidden_options">
-          <ul >
+          <ul>
             <% @people.each do |person| %>
               <li><%= link_to person.name, gobierto_people_person_events_path(person.slug) %></li>
             <% end %>
@@ -102,7 +102,9 @@
         </p>
 
         <div id="events">
-          <%= render partial: "gobierto_people/person_events/person_event", collection: @events %>
+          <% @events.each do |event| %>
+            <%= render partial: "gobierto_people/person_events/person_event", locals: { person: event.person, person_event: event } %>
+          <% end %>
         </div>
 
         <%= link_to_next_page @events, t('.view_more'), class: "see_more", role: "button", remote: true %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,10 @@ require "rails/test_unit/railtie"
 
 require "ostruct"
 require "csv"
+require "google/apis/calendar_v3"
+require "googleauth"
+require "google/api_client/client_secrets"
+require "googleauth/stores/file_token_store"
 
 Bundler.require(*Rails.groups)
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Increase log level to speed up the test suite
-  config.log_level = ENV.fetch("TEST_LOG_LEVEL") { :fatal }.to_sym
+  config.log_level = ENV["CI"] ? :fatal : :debug
 
   config.action_mailer.default_url_options = { host: 'gobierto.dev' }
 end

--- a/config/google_calendar_integration_client_secret.json
+++ b/config/google_calendar_integration_client_secret.json
@@ -1,0 +1,1 @@
+{"web":{"client_id":"xxxxxxxxxx","project_id":"xxxxxxxxxxxx","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"xxxxxxxxxxx","redirect_uris":["http://gobierto.dev/cargos-y-agendas/google_calendar_authorization/new"]}}

--- a/config/locales/gobierto_admin/gobierto_people/views/configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/configuration/ca.yml
@@ -27,6 +27,7 @@ ca:
               ibm_notes_usr: Usuari d'IBM Notes
             update: Actualitzar
             ibm_notes: IBM Notes
+            google_calendar: Google Calendar
             ibm_notes_usr: Usuari d'IBM Notes
             ibm_notes_pwd: Contrasenya d'IBM Notes
             submodules_enabled: Submòduls habilitats

--- a/config/locales/gobierto_admin/gobierto_people/views/configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/configuration/en.yml
@@ -27,6 +27,7 @@ en:
               ibm_notes_usr: IBM Notes user
             update: Update
             ibm_notes: IBM Notes
+            google_calendar: Google Calendar
             ibm_notes_usr: IBM Notes user
             ibm_notes_pwd: IBM Notes password
             submodules_enabled: Enabled submodules

--- a/config/locales/gobierto_admin/gobierto_people/views/configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/configuration/es.yml
@@ -27,6 +27,7 @@ es:
               ibm_notes_usr: Usuario de IBM Notes
             update: Actualizar
             ibm_notes: IBM Notes
+            google_calendar: Google Calendar
             ibm_notes_usr: Usuario de IBM Notes
             ibm_notes_pwd: Contraseña de IBM Notes
             submodules_enabled: Submódulos habilitados

--- a/config/locales/gobierto_admin/gobierto_people/views/people/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/en.yml
@@ -32,7 +32,7 @@ en:
             statements: Statements
             status: Status
           new: New person
-          title: Persons
+          title: People
           view_person: View person
           visibility_level:
             active: Published

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/person_calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/person_calendar_configuration/ca.yml
@@ -11,5 +11,8 @@ ca:
               placeholders:
                 ibm_notes_url: URL del calendari d'IBM Notes
               update: Actualitzar
+              share_link: "Comparteix aquest enllaç amb el alt càrrec per a permetre a Gobierto llegir els seus esdeveniments de Google Calendar:"
+              calendar_configured: Actualment esta persona té configurat Google Calendar.
+              remove_integration: Eliminar la configuració de Google Calendar
             navigation:
                 calendar_configuration: Configuració del calendari

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/person_calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/person_calendar_configuration/en.yml
@@ -11,5 +11,8 @@ en:
               placeholders:
                 ibm_notes_url: IBM Notes calendar URL
               update: Update
+              share_link: "Share this link with the person to allow Gobierto to read her public events from Google Calendar:"
+              calendar_configured: Currently this person has Google Calendar integrated.
+              remove_integration: Remove Google Calendar integration
             navigation:
                 calendar_configuration: Calendar configuration

--- a/config/locales/gobierto_admin/gobierto_people/views/people/person_events/person_calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/people/person_events/person_calendar_configuration/es.yml
@@ -11,5 +11,8 @@ es:
               placeholders:
                 ibm_notes_url: URL del calendario de IBM Notes
               update: Actualizar
+              share_link: "Comparte este enlace con el Alto Cargo para que permita a Gobierto leer sus eventos de Google Calendar:"
+              calendar_configured: Actualmente esta persona tiene configurado Google Calendar.
+              remove_integration: Eliminar configuración de Google Calendar
             navigation:
                 calendar_configuration: Configuración del calendario

--- a/config/locales/gobierto_indicators/views/en.yml
+++ b/config/locales/gobierto_indicators/views/en.yml
@@ -69,7 +69,7 @@ en:
       active_pop:
         title: Active population
         figure_first: of total
-        figure_second: persons
+        figure_second: people
       houses:
         title: Houses
         figure_first: family houses

--- a/config/locales/gobierto_people/controllers/google_calendar_authorization/ca.yml
+++ b/config/locales/gobierto_people/controllers/google_calendar_authorization/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  gobierto_people:
+    people:
+      google_calendar_authorization:
+        new:
+          success: Configuració guardada correctament. A partir d'ara els teus events públics de Google Calendar apareixeran publicats a la teva agenda.

--- a/config/locales/gobierto_people/controllers/google_calendar_authorization/en.yml
+++ b/config/locales/gobierto_people/controllers/google_calendar_authorization/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  gobierto_people:
+    people:
+      google_calendar_authorization:
+        new:
+          success: Configuration stored successfully. From now on, your public events from Google Calendar will be automatically published in your agenda.

--- a/config/locales/gobierto_people/controllers/google_calendar_authorization/es.yml
+++ b/config/locales/gobierto_people/controllers/google_calendar_authorization/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  gobierto_people:
+    people:
+      google_calendar_authorization:
+        new:
+          success: Configuración guardada correctamente. A partir de ahora tus eventos públicos de Google Calendar aparecerán publicados en tu agenda.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,6 @@ Rails.application.routes.draw do
       get '/' => 'welcome#index', as: :root
 
       # Agendas
-
       resources :person_events, only: [:index], as: :events, path: 'agendas'
       resources :government_party_person_events, only: [:index], as: :government_party_events, path: 'agendas/gobierno'
       resources :opposition_party_person_events, only: [:index], as: :opposition_party_events, path: 'agendas/oposicion'
@@ -138,7 +137,6 @@ Rails.application.routes.draw do
       resources :people_person_events, only: [:index, :show], controller: "people/person_events", as: :person_events, path: 'agendas/:person_slug', param: :slug
 
       # Blogs
-
       resources :person_posts, only: [:index], as: :posts, path: 'blogs/posts'
       resources :person_post_tags, only: [:show], as: :post_tags, path: 'blogs/tags'
 
@@ -146,24 +144,23 @@ Rails.application.routes.draw do
       resources :people_person_posts, only: [:index, :show], controller: "people/person_posts", as: :person_posts, path: 'blogs/:person_slug', param: :slug
 
       # Statements
-
       resources :person_statements, only: [:index], as: :statements, path: 'declaraciones'
       resources :person_gifts, only: [:index], as: :gifts, path: 'obsequios-y-regalos'
       resources :person_travels, only: [:index], as: :travels, path: 'viajes-y-desplazamientos'
-
       resources :people_person_statements, only: [:index, :show], controller: "people/person_statements", as: :person_statements, path: 'declaraciones/:person_slug', param: :slug
 
       # Officials
-
       resources :people, only: [:index], path: 'personas'
       resources :government_party_people, only: [:index], path: 'personas/gobierno'
       resources :opposition_party_people, only: [:index], path: 'personas/oposicion'
       resources :executive_category_people, only: [:index], path: 'personas/directivos'
 
+      # Political Groups
       resources :political_group, only: [:show], path: 'personas/grupos-politicos', param: :slug do
         resources :people, only: [:index], controller: 'political_groups/people', path: '/'
       end
 
+      # People
       resources :people, only: [:show], path: 'personas', param: :slug do
         resource :person_bio, only: [:show], controller: "people/person_bio", as: :bio, path: 'biografia'
         resources :person_messages, only: [:create], controller: "people/person_messages", as: :messages, path: 'contacto', param: :slug do
@@ -172,8 +169,10 @@ Rails.application.routes.draw do
           end
         end
       end
-
     end
+
+    # Google calendar integration hook
+    resource :google_calendar_authorization, only: [:new], controller: "people/google_calendar_authorization", as: :google_calendar_authorization
   end
 
   # Gobierto Budgets module

--- a/db/migrate/20170519070559_add_google_calendar_token_to_gp_people_people.rb
+++ b/db/migrate/20170519070559_add_google_calendar_token_to_gp_people_people.rb
@@ -1,0 +1,6 @@
+class AddGoogleCalendarTokenToGpPeoplePeople < ActiveRecord::Migration[5.0]
+  def change
+    add_column :gp_people, :google_calendar_token, :string
+    add_index :gp_people, :google_calendar_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170516111435) do
+ActiveRecord::Schema.define(version: 20170519070559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,28 +226,30 @@ ActiveRecord::Schema.define(version: 20170516111435) do
   create_table "gp_people", force: :cascade do |t|
     t.integer  "site_id"
     t.integer  "admin_id"
-    t.string   "name",                default: "",     null: false
+    t.string   "name",                  default: "",     null: false
     t.string   "bio_url"
-    t.integer  "visibility_level",    default: 0,      null: false
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.integer  "visibility_level",      default: 0,      null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.string   "avatar_url"
-    t.integer  "events_count",        default: 0,      null: false
-    t.integer  "statements_count",    default: 0,      null: false
-    t.integer  "posts_count",         default: 0,      null: false
+    t.integer  "events_count",          default: 0,      null: false
+    t.integer  "statements_count",      default: 0,      null: false
+    t.integer  "posts_count",           default: 0,      null: false
     t.integer  "political_group_id"
-    t.integer  "category",            default: 0,      null: false
+    t.integer  "category",              default: 0,      null: false
     t.integer  "party"
-    t.integer  "position",            default: 999999, null: false
+    t.integer  "position",              default: 999999, null: false
     t.string   "email"
     t.jsonb    "charge_translations"
     t.jsonb    "bio_translations"
-    t.string   "slug",                                 null: false
+    t.string   "slug",                                   null: false
+    t.string   "google_calendar_token"
     t.index ["admin_id"], name: "index_gp_people_on_admin_id", using: :btree
     t.index ["bio_translations"], name: "index_gp_people_on_bio_translations", using: :gin
     t.index ["category", "party"], name: "index_gp_people_on_category_and_party", using: :btree
     t.index ["category"], name: "index_gp_people_on_category", using: :btree
     t.index ["charge_translations"], name: "index_gp_people_on_charge_translations", using: :gin
+    t.index ["google_calendar_token"], name: "index_gp_people_on_google_calendar_token", unique: true, using: :btree
     t.index ["party"], name: "index_gp_people_on_party", using: :btree
     t.index ["political_group_id"], name: "index_gp_people_on_political_group_id", using: :btree
     t.index ["site_id"], name: "index_gp_people_on_site_id", using: :btree

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -16,9 +16,6 @@ HOST=gobierto.dev
 PORT=3000
 RAILS_MAX_THREADS=5
 
-# Rails test log level
-TEST_LOG_LEVEL=fatal
-
 # Poltergeist debug and inspector variables
 INTEGRATION_DEBUG=false
 INTEGRATION_INSPECTOR=false

--- a/lib/constraints/gobierto_site_constraint.rb
+++ b/lib/constraints/gobierto_site_constraint.rb
@@ -1,7 +1,4 @@
 class GobiertoSiteConstraint
-  def initialize
-  end
-
   def matches?(request)
     full_domain = (request.env['HTTP_HOST'] || request.env['SERVER_NAME'] || request.env['SERVER_ADDR']).split(':').first
 

--- a/test/controllers/gobierto_people/people/google_calendar_authorization_controller_test.rb
+++ b/test/controllers/gobierto_people/people/google_calendar_authorization_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class GobiertoPeople::People::GoogleCalendarAuthorizationControllerTest < ActionController::TestCase
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def person
+    @person ||= gobierto_people_people(:richard)
+  end
+
+  def test_new_request_without_code
+    get :new, params: { token: person.google_calendar_token }
+    assert_equal person.id, session[:google_calendar_person_id]
+    assert_response :redirect
+  end
+
+  def test_new_request_with_code
+    client_secrets = mock()
+    auth_client = mock()
+
+    client_secrets.stubs(to_authorization: auth_client)
+    auth_client.stubs(update!: true, fetch_access_token!: true, to_json: 'json')
+    auth_client.stubs(:code=, true)
+    auth_client.stubs(:client_secret=, true)
+    Google::APIClient::ClientSecrets.stubs(:load).returns(client_secrets)
+
+    get :new, params: { code: 'foo'}, session: { google_calendar_person_id: person.id }
+    assert_response :redirect
+
+    configuration = GobiertoPeople::PersonGoogleCalendarConfiguration.find_by person_id: person.id
+    assert configuration.data['google_calendar_credentials'].present?
+  end
+end

--- a/test/controllers/meta_welcome_controller_test.rb
+++ b/test/controllers/meta_welcome_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class MetaWelcomeControllerTest < GobiertoControllerTest
-  def test_index_without_site_directs_to_404
-    get root_path
-    assert_response :missing
-  end
-end

--- a/test/fixtures/gobierto_people/people.yml
+++ b/test/fixtures/gobierto_people/people.yml
@@ -16,6 +16,7 @@ richard:
   political_group: marvel
   position: 1
   email: richard@example.com
+  google_calendar_token: gct1
 
 nelson:
   site: madrid
@@ -35,6 +36,7 @@ nelson:
   political_group: marvel
   position: 2
   email: nelson@example.com
+  google_calendar_token: gct2
 
 tamara:
   site: madrid
@@ -54,3 +56,4 @@ tamara:
   political_group:
   position: 3
   email: tamara@example.com
+  google_calendar_token: gct3

--- a/test/fixtures/gobierto_people/person_event_attendees.yml
+++ b/test/fixtures/gobierto_people/person_event_attendees.yml
@@ -1,3 +1,21 @@
+richard_richard_pending:
+  person_event: richard_pending
+  person: richard
+  name:
+  charge:
+
+richard_richard_published:
+  person_event: richard_published
+  person: richard
+  name:
+  charge:
+
+richard_richard_published_just_attending:
+  person_event: richard_published_just_attending
+  person: richard
+  name:
+  charge:
+
 tamara:
   person_event: richard_published
   person: tamara
@@ -9,3 +27,28 @@ custom:
   person:
   name: John Custom
   charge: President
+
+richard_richard_past:
+  person_event: richard_past
+  person: richard
+  name:
+  charge:
+
+nelson_nelson_tomorrow:
+  person_event: nelson_tomorrow
+  person: nelson
+  name:
+  charge:
+
+nelson_nelson_yesterday:
+  person_event: nelson_yesterday
+  person: nelson
+  name:
+  charge:
+
+tamara_published_past:
+  person_event: tamara_published
+  person: tamara
+  name:
+  charge:
+

--- a/test/fixtures/gobierto_people/person_events.yml
+++ b/test/fixtures/gobierto_people/person_events.yml
@@ -32,6 +32,23 @@ richard_published:
   attachment_url: https://bit.ly/67890
   state: <%= GobiertoPeople::PersonEvent.states["published"] %>
 
+richard_published_just_attending:
+  person: nil
+  site: madrid
+  slug: <%= "#{1.month.from_now.strftime('%F')}-invitado-evento" %>
+  title_translations: <%= {
+    'en' => 'Invited event',
+    'es' => 'Invited event',
+  }.to_json %>
+  description_translations: <%= {
+    'en' => 'El Presidente analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.',
+    'es' => 'El Presidente analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.',
+  }.to_json %>
+  starts_at: <%= 1.month.from_now %>
+  ends_at: <%= 1.month.from_now + 1.hour %>
+  attachment_url: https://bit.ly/67890
+  state: <%= GobiertoPeople::PersonEvent.states["published"] %>
+
 richard_published_past:
   person: richard
   site: madrid

--- a/test/fixtures/gobierto_people/person_events.yml
+++ b/test/fixtures/gobierto_people/person_events.yml
@@ -36,6 +36,7 @@ richard_published_just_attending:
   person: nil
   site: madrid
   slug: <%= "#{1.month.from_now.strftime('%F')}-invitado-evento" %>
+  external_id: justattending
   title_translations: <%= {
     'en' => 'Invited event',
     'es' => 'Invited event',

--- a/test/forms/gobierto_admin/gobierto_people/person_calendar_configuration_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_calendar_configuration_form_test.rb
@@ -23,7 +23,7 @@ module GobiertoAdmin
       end
 
       def test_save_with_valid_attributes
-        activate_calendar_integration(person.site)
+        activate_ibm_notes_calendar_integration(person.site)
 
         assert valid_person_calendar_configuration_form.save
         assert_equal({ 'endpoint' => 'http://foo.com'}, person.calendar_configuration.data)

--- a/test/forms/gobierto_admin/gobierto_people/person_event_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_event_form_test.rb
@@ -47,6 +47,7 @@ module GobiertoAdmin
         invalid_person_event_form.save
 
         assert_equal 1, invalid_person_event_form.errors.messages[:person].size
+        assert_equal 1, invalid_person_event_form.errors.messages[:site].size
         assert_equal 1, invalid_person_event_form.errors.messages[:title_translations].size
         assert_equal 1, invalid_person_event_form.errors.messages[:ends_at].size
       end

--- a/test/forms/gobierto_admin/gobierto_people/person_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_form_test.rb
@@ -40,6 +40,7 @@ module GobiertoAdmin
 
       def test_save_with_valid_attributes
         assert valid_person_form.save
+        assert valid_person_form.person.google_calendar_token.present?
       end
 
       def test_error_messages_with_invalid_attributes

--- a/test/forms/gobierto_people/person_event_form_test.rb
+++ b/test/forms/gobierto_people/person_event_form_test.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
     def valid_person_event_form
       @valid_person_event_form ||= PersonEventForm.new(
         external_id: '123',
+        site_id: site.id,
         person_id: person.id,
         title: person_event.title,
         description: person_event.description,
@@ -19,6 +20,7 @@ module GobiertoPeople
     def invalid_person_event_form
       @invalid_person_event_form ||= PersonEventForm.new(
         external_id: nil,
+        site_id: nil,
         person_id: nil,
         title: nil,
         description: nil,
@@ -28,6 +30,10 @@ module GobiertoPeople
         locations: [],
         attendees: []
       )
+    end
+
+    def site
+      @site ||= sites(:madrid)
     end
 
     def person_event

--- a/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
@@ -43,6 +43,13 @@ module GobiertoAdmin
 
             assert has_field?('calendar_configuration[ibm_notes_url]', with: 'http://calendar/richard/new')
             refute has_field?('calendar_configuration[ibm_notes_url]', with: 'http://calendar/richard')
+
+            assert_enqueued_with(job: ::GobiertoPeople::ClearImportedPersonEventsJob, args: [person], queue: "default") do
+              fill_in 'calendar_configuration_ibm_notes_url', with: ''
+              click_button 'Update'
+            end
+
+            assert has_field?('calendar_configuration[ibm_notes_url]')
           end
         end
       end
@@ -77,11 +84,17 @@ module GobiertoAdmin
 
             refute has_field?('google_calendar_invitation_url')
             assert has_field?('calendar_configuration[clear_google_calendar_configuration]')
+
+            assert_enqueued_with(job: ::GobiertoPeople::ClearImportedPersonEventsJob, args: [person], queue: "default") do
+              check 'calendar_configuration[clear_google_calendar_configuration]'
+              click_button "Update"
+            end
+
+            assert has_field?('google_calendar_invitation_url')
+            refute has_field?('calendar_configuration[clear_google_calendar_configuration]')
           end
         end
       end
-
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_people/person_event_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_event_create_test.rb
@@ -62,7 +62,7 @@ module GobiertoAdmin
                 within "#person-event-attendees" do
                   find("a[data-behavior=add_child]").click
 
-                  within ".cloned-dynamic-content-record-wrapper" do
+                  within all(".cloned-dynamic-content-record-wrapper")[0] do
                     select attendee.name, from: "Person"
                     fill_in "Name", with: ""
                     fill_in "Charge", with: ""
@@ -102,9 +102,7 @@ module GobiertoAdmin
                   assert has_selector?(".content-block-record-value", text: "Location Address")
                 end
 
-                within "#person-event-attendees .dynamic-content-record-view" do
-                  assert has_selector?(".content-block-record-value", text: attendee.name)
-                end
+                assert all(".content-block-record-value").any?{ |v| v.text.include?(attendee.name) }
 
                 within ".person-event-state-radio-buttons" do
                   with_hidden_elements do

--- a/test/integration/gobierto_admin/gobierto_people/person_event_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_event_update_test.rb
@@ -66,6 +66,7 @@ module GobiertoAdmin
                 within "#person-event-attendees" do
                   person_event.attendees.each do |attendee|
                     within ".dynamic-content-record-wrapper.content-block-record-#{attendee.id}" do
+                      next if attendee.person && attendee.person == person
                       with_hidden_elements do
                         find("a[data-behavior=edit_record]").trigger("click")
                       end
@@ -111,10 +112,8 @@ module GobiertoAdmin
                   assert has_selector?(".content-block-record-value", text: "Location Address")
                 end
 
-                within "#person-event-attendees .dynamic-content-record-view", match: :first do
-                  assert has_selector?(".content-block-record-value", text: "Attendee Name")
-                  assert has_selector?(".content-block-record-value", text: "Attendee Charge")
-                end
+                assert all(".content-block-record-value").any?{ |v| v.text.include?("Attendee Name") }
+                assert all(".content-block-record-value").any?{ |v| v.text.include?("Attendee Charge") }
 
                 within ".person-event-state-radio-buttons" do
                   with_hidden_elements do

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -88,13 +88,7 @@ module GobiertoPeople
 
       def test_person_events_index_pagination
         10.times do |i|
-          person.events.create!(
-            title: "Event #{i}",
-            site: person.site,
-            starts_at: Time.now.tomorrow + i.days,
-            ends_at:   Time.now.tomorrow + i.days + 1.hour,
-            state: GobiertoPeople::PersonEvent.states["published"]
-          )
+          create_event(person: person, title: "Event #{i}", starts_at: (Time.now.tomorrow + i.days).to_s)
         end
 
         with_current_site(site) do

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -45,7 +45,8 @@ module GobiertoPeople
     def upcoming_events
       @upcoming_events ||= [
         gobierto_people_person_events(:nelson_tomorrow),
-        gobierto_people_person_events(:richard_published)
+        gobierto_people_person_events(:richard_published),
+        gobierto_people_person_events(:richard_published_just_attending)
       ]
     end
 
@@ -72,13 +73,7 @@ module GobiertoPeople
 
     def test_person_events_index_pagination
       10.times do |i|
-        government_member.events.create!(
-          title: "Event #{i}",
-          site: government_member.site,
-          starts_at: Time.now.tomorrow + i.days,
-          ends_at:   Time.now.tomorrow + i.days + 1.hour,
-          state: GobiertoPeople::PersonEvent.states["published"]
-        )
+        create_event(person: government_member, starts_at: (Time.now.tomorrow + i.days).to_s, title: "Event #{i}")
       end
 
       with_current_site(site) do
@@ -211,6 +206,8 @@ module GobiertoPeople
           assert has_link?("Past events")
 
           upcoming_events.each do |event|
+            next if event.person.nil?
+
             assert has_selector?(".person_event-item", text: event.title)
             assert has_link?(event.title)
           end

--- a/test/jobs/gobierto_people/clear_imported_person_events_job_test.rb
+++ b/test/jobs/gobierto_people/clear_imported_person_events_job_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class GobiertoPeople::ClearImportedPersonEventsJobTest < ActiveSupport::TestCase
+  def person
+    @person ||= gobierto_people_people(:richard)
+  end
+
+  def test_perform
+    event1 = gobierto_people_person_events(:richard_published)
+    event1.update_column(:external_id, 'richard_published')
+
+    GobiertoPeople::ClearImportedPersonEventsJob.new.perform(person)
+
+    assert_nil GobiertoPeople::PersonEvent.find_by(id: event1.id)
+  end
+end

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -1,0 +1,181 @@
+require 'test_helper'
+require 'support/calendar_integration_helpers'
+
+module GobiertoPeople
+  module GoogleCalendar
+    class CalendarIntegrationTest < ActiveSupport::TestCase
+
+      include ::CalendarIntegrationHelpers
+
+      def richard
+        @richard ||= gobierto_people_people(:richard)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def google_calendar_id
+        'richard@google-calendar.com'
+      end
+
+      def setup
+        super
+
+        ## Mocks
+        date1 = mock()
+        date1.stubs(date_time: Time.now)
+        date2 = mock()
+        date2.stubs(date_time: 1.hour.from_now)
+
+        # Private event, ignored
+        event1 = mock()
+        event1.stubs(visibility: 'private')
+
+        creator_event2 = mock()
+        creator_event2.stubs(email: google_calendar_id)
+
+        creator_event3 = mock()
+        creator_event3.stubs(email: 'foo@google-calendar.com')
+
+        attendee1 = mock()
+        attendee1.stubs(self?: true, display_name: richard.name, email: google_calendar_id)
+
+        attendee2 = mock()
+        attendee2.stubs(self?: false, display_name: 'Wadus person', email: nil)
+
+        # Single event, organized by richard, with two attendees
+        event2 = mock()
+        event2.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: 'event2',
+                     summary: 'Event 2', start: date1, end: date2, attendees: [attendee1, attendee2])
+
+        # Single event, organized by other, Richard is invited
+        event3 = mock()
+        event3.stubs(visibility: nil, location: 'Patio de mi casa 1, 28005, Madrid', creator: creator_event3, recurrence: nil, id: 'event3',
+                     summary: 'Event 3', start: date1, end: date2, attendees: [attendee1, attendee2])
+
+        # Recurring event
+        event4 = mock()
+        event4.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: ["WEEK=1"], id: 'event4',
+                     summary: 'Event 4', start: date1, end: date2, attendees: [attendee1, attendee2])
+
+        # Instance 1 of recurring event event4
+        event5 = mock()
+        event5.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: 'event4_instance_1',
+                     summary: 'Event 5', start: date1, end: date2, attendees: [attendee1, attendee2])
+
+        # Instance 2 of recurring event event4
+        event6 = mock()
+        event6.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: 'event4_instance_2',
+                     summary: 'Event 6', start: date1, end: date2, attendees: [attendee1, attendee2])
+
+        calendar1 = mock()
+        calendar1.stubs(id: google_calendar_id, primary?: true)
+
+        calendar2 = mock()
+        calendar2.stubs(id: 2, primary?: false)
+
+        calendar_1_items_response = mock()
+        calendar_1_items_response.stubs(:items).returns([event1, event2])
+
+        calendar_2_items_response = mock()
+        calendar_2_items_response.stubs(:items).returns([event3, event4])
+
+        event_4_instances_response = mock()
+        event_4_instances_response.stubs(:items).returns([event5, event6])
+
+        calendar_items_response = mock()
+        calendar_items_response.stubs(:items).returns([calendar1, calendar2])
+
+        client_options = mock()
+        client_options.stubs(:application_name=).returns(true)
+
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_calendar_lists).returns(calendar_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_events).with(calendar1.id, instance_of(Hash)).returns(calendar_1_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_events).with(calendar2.id, instance_of(Hash)).returns(calendar_2_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_event_instances).with(calendar2.id, event4.id).returns(event_4_instances_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:client_options).returns(client_options)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:authorization=).returns(true)
+
+        ## Configure site and person
+        activate_google_calendar_calendar_integration(sites(:madrid))
+      end
+
+      def test_sync_events
+        assert_difference 'GobiertoPeople::PersonEvent.count', 4 do
+          CalendarIntegration.sync_person_events(richard)
+        end
+
+        # Event 2 checks
+        event = richard.events.find_by external_id: 'event2'
+        assert_equal 'Event 2', event.title
+        assert_empty event.locations
+        assert_equal 2, event.attendees.size
+        assert_equal richard, event.attendees.first.person
+        assert_nil event.attendees.second.person
+        assert_equal 'Wadus person', event.attendees.second.name
+
+        # Event 3 checks
+        event = site.person_attendee_events.find_by external_id: 'event3'
+        assert_equal 'Event 3', event.title
+        assert_equal 'Patio de mi casa 1, 28005, Madrid', event.locations.first.name
+        assert_equal 2, event.attendees.size
+        assert_equal richard, event.attendees.first.person
+        assert_equal 'Wadus person', event.attendees.second.name
+
+        # Event 5 checks
+        event = site.person_attendee_events.find_by external_id: 'event4_instance_1'
+        assert_equal 'Event 5', event.title
+        assert_empty event.locations
+        assert_equal 2, event.attendees.size
+        assert_equal richard, event.attendees.first.person
+        assert_equal 'Wadus person', event.attendees.second.name
+
+        # Event 6 checks
+        event = site.person_attendee_events.find_by external_id: 'event4_instance_2'
+        assert_equal 'Event 6', event.title
+        assert_empty event.locations
+        assert_equal 2, event.attendees.size
+        assert_equal richard, event.attendees.first.person
+        assert_equal 'Wadus person', event.attendees.second.name
+      end
+
+      def test_sync_events_updates_event_attributes
+        CalendarIntegration.sync_person_events(richard)
+
+        event = richard.events.find_by external_id: 'event2'
+        event.title = 'Event 2 updated'
+        event.save
+
+        CalendarIntegration.sync_person_events(richard)
+
+        event.reload
+        assert_equal 'Event 2', event.title
+      end
+
+      def test_sync_events_removes_deleted_event_attributes
+        CalendarIntegration.sync_person_events(richard)
+
+        event = richard.events.find_by external_id: 'event2'
+        GobiertoPeople::PersonEventLocation.create!(person_event: event, name: "I'll be deleted")
+
+        CalendarIntegration.sync_person_events(richard)
+
+        event.reload
+        assert event.locations.empty?
+      end
+
+      def test_sync_attendees
+        CalendarIntegration.sync_person_events(richard)
+
+        event = richard.events.find_by external_id: 'event2'
+        event.attendees.second.delete
+
+        CalendarIntegration.sync_person_events(richard)
+
+        event.reload
+        assert_equal 2, event.attendees.reload.size
+      end
+    end
+  end
+end

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -36,7 +36,7 @@ module GobiertoPeople
         creator_event2.stubs(email: google_calendar_id)
 
         creator_event3 = mock()
-        creator_event3.stubs(email: 'foo@google-calendar.com')
+        creator_event3.stubs(email: google_calendar_id)
 
         attendee1 = mock()
         attendee1.stubs(self?: true, display_name: richard.name, email: google_calendar_id)
@@ -102,6 +102,8 @@ module GobiertoPeople
       end
 
       def test_sync_events
+        Publishers::Trackable.expects(:broadcast_event).times(3)
+
         assert_difference 'GobiertoPeople::PersonEvent.count', 4 do
           CalendarIntegration.sync_person_events(richard)
         end

--- a/test/support/calendar_integration_helpers.rb
+++ b/test/support/calendar_integration_helpers.rb
@@ -1,6 +1,6 @@
 module CalendarIntegrationHelpers
 
-  def activate_calendar_integration(site)
+  def activate_ibm_notes_calendar_integration(site)
     gp_module_settings = site.module_settings.find_by(module_name: 'GobiertoPeople')
 
     gp_module_settings.calendar_integration = 'ibm_notes'
@@ -10,9 +10,21 @@ module CalendarIntegrationHelpers
     gp_module_settings.save!
   end
 
-  def set_calendar_endpoint(person, endpoint)
+  def activate_google_calendar_calendar_integration(site)
+    gp_module_settings = site.module_settings.find_by(module_name: 'GobiertoPeople')
+    gp_module_settings.calendar_integration = 'google_calendar'
+    gp_module_settings.save!
+  end
+
+  def set_ibm_notes_calendar_endpoint(person, endpoint)
     calendar_conf = person.calendar_configuration
     calendar_conf.data = { endpoint: endpoint }
+    calendar_conf.save!
+  end
+
+  def configure_google_calendar_integration(person, options)
+    calendar_conf = person.calendar_configuration
+    calendar_conf.data = options
     calendar_conf.save!
   end
 

--- a/test/support/extensions/gobierto_common/trackable_test.rb
+++ b/test/support/extensions/gobierto_common/trackable_test.rb
@@ -19,7 +19,9 @@ module GobiertoCommon::TrackableTest
   def test_trackable_notify?
     if trackable.trackable.respond_to?(:active?)
       trackable.trackable.stub(:active?, true) do
-        assert trackable.notify?
+        if trackable.trackable.admin_id.present?
+          assert trackable.notify?
+        end
       end
 
       trackable.trackable.stub(:active?, false) do

--- a/test/support/integration/authentication_helpers.rb
+++ b/test/support/integration/authentication_helpers.rb
@@ -23,6 +23,7 @@ module Integration
 
         click_button "Send"
       end
+    rescue Capybara::ElementNotFound
     end
 
     def sign_out_admin
@@ -35,6 +36,7 @@ module Integration
           click_link "admin-sign-out"
         end
       end
+    rescue Capybara::ElementNotFound
     end
 
     def sign_in_user(user)

--- a/test/support/person_event_helpers.rb
+++ b/test/support/person_event_helpers.rb
@@ -1,15 +1,22 @@
 module PersonEventHelpers
 
   def create_event(options = {})
-    GobiertoPeople::PersonEvent.create!(
-      person: options[:person] || gobierto_people_people(:richard),
-      site: options[:site] || sites(:madrid),
+    person = options[:person] || gobierto_people_people(:richard)
+    site = person.site
+
+    event = GobiertoPeople::PersonEvent.create!(
+      person: person,
       title: options[:title] || "Event title",
       description: "Event description",
       starts_at: Time.zone.parse(options[:starts_at]) || Time.zone.now,
       ends_at:  (Time.zone.parse(options[:starts_at]) || Time.zone.now) + 1.hour,
-      state: GobiertoPeople::PersonEvent.states["published"]
+      state: GobiertoPeople::PersonEvent.states["published"],
+      site: site
     )
+
+    event.attendees.create person: person
+
+    event
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ require "support/gobierto_site_constraint_helpers"
 require "capybara/email"
 require "minitest/retry"
 require "vcr"
+require "mocha/mini_test"
 
 if ENV["CI"] || ENV["RUN_COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
Connects to #637, #705 and #704

### What does this PR do?

This PR introduces Google calendar integration to GobiertoPeople module.

It also changes the Person - Event relationship, because didn't consider in our first implementation how attendees could be invited to events which creator (organizer) is not part of the Gobierto module.

So, now PersonEvents controller shows the events the person is attending (instead of just the events she's organizing). As a consequence, each event created has at least one attendee, which is the organizer.

In the future, because of this decoupling we'll be able to add a Calendar model which doesn't need to belong to a person but to something more generic.
