### PR TITLE
Fix Gobierto People urls namespace

### DIFF
--- a/app/controllers/gobierto_people/people/person_statements_controller.rb
+++ b/app/controllers/gobierto_people/people/person_statements_controller.rb
@@ -5,7 +5,7 @@ module GobiertoPeople
         @statements = find_statements
 
         if @statements.any?
-          redirect_to gobierto_people_person_statement_path(@person, @statements.first)
+          redirect_to gobierto_people_person_statement_path(@person.slug, @statements.first.slug)
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,9 +118,9 @@ Rails.application.routes.draw do
   end
 
   # Gobierto People module
-  namespace :gobierto_people, path: 'cargos-y-agendas' do
+  namespace :gobierto_people, path: '/' do
     constraints GobiertoSiteConstraint.new do
-      get '/' => 'welcome#index', as: :root
+      get 'cargos-y-agendas' => 'welcome#index', as: :root
 
       # Agendas
 


### PR DESCRIPTION
Connects to #635 

### What does this PR do?

* Removes the `cargos-y-agendas` namespace except for the welcome page.
* Fixes broken url

### Does this PR changes any configuration file?

No
