### PR TITLE
Add Rubocop and config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - db/schema.rb
+    - 'config/**/*'
+    - 'script/**/*'
+Documentation:
+  Enabled: false
+Rails:
+  Enabled: true
+Metrics/LineLength:
+  Max: 140

--- a/Gemfile
+++ b/Gemfile
@@ -96,4 +96,5 @@ end
 
 group :development do
   gem "puma"
+  gem "rubocop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
+    powerpack (0.1.1)
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.3)
@@ -328,6 +329,12 @@ GEM
     retriable (3.0.2)
     rollbar (2.14.1)
       multi_json
+    rubocop (0.48.1)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-prof (0.16.2)
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
@@ -459,6 +466,7 @@ DEPENDENCIES
   redis (~> 3.3)
   responders
   rollbar
+  rubocop
   ruby_px
   sass-rails (~> 5.0.0)
   sidekiq (~> 4.2.6)
@@ -474,4 +482,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
Connects to https://github.com/PopulateTools/gobierto/issues/6

### What does this PR do?
- Add [Rubocop](https://github.com/bbatsov/rubocop) gem that tries to enforce [ruby style guide](https://github.com/bbatsov/ruby-style-guide)
- Add a basic (and opinionated) .rubocop.yml config file

### How should this be manually tested?
Not much really, only try to use it!. I suggest you:
* Add rubocop to your IDE/editor (sublimetext and other editors have plugins easy to config) to see problems while writting code
* Run rubocop from git just on the files you have changed/staged with my custom git aliases (add them to your `.gitconfig` file) https://github.com/bertocq/dotfiles/blob/master/.gitconfig#L66-L69
```
  ru = "! git status --porcelain | cut -c4- | grep -E 'rb|rake|Gemfile|ru' | xargs rubocop -a"
  rubo = "! git status --porcelain | cut -c4- | grep -E 'rb|rake|Gemfile|ru' | xargs rubocop"
  rup = "!sh -c \"git diff --name-only HEAD..$1 | grep -E 'rb|rake|Gemfile|ru' | xargs rubocop -a\" -"
  rubop = "!sh -c \"git diff --name-only HEAD..$1 | grep -E 'rb|rake|Gemfile|ru' | xargs rubocop \" -"
```
1. ru : runs rubocop only on modified/staged files and autocorrects whenever he cans
2. rubo : runs rubocop only on modified/staged files but just prompts you issues (no autocorrections)
3. rup : runs rubocop only on the files that appear on the diff with another branch (ie: `git rup master`) and tries to autocorrect all possible issues
4. rubop : runs rubocop only on the files that appear on the diff with another branch (ie: `git rup master`) but only displays issues, no autocorrections

### Does this PR changes any configuration file?

- [X] new `.rubocop.yml` file

Although I think this should not be important... only if you end up adding CodeClimate to the project (that would be cool... @ferblape) thats when someone else (apart from dev's in localhost) would be using it.