### PR TITLE
Remove duplicated hash key in calendar spec

### DIFF
--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -68,8 +68,7 @@ module GobiertoPeople
           starts_at: utc_time("2017-04-11 10:00:00"),
           ends_at:   utc_time("2017-04-11 11:00:00"),
           state: GobiertoPeople::PersonEvent.states['published'],
-          person: richard,
-          site: site
+          person: richard
         )
       end
 
@@ -81,8 +80,7 @@ module GobiertoPeople
           starts_at: utc_time("2017-04-11 10:00:00"),
           ends_at:   utc_time("2017-04-11 11:00:00"),
           state: GobiertoPeople::PersonEvent.states['published'],
-          person: richard,
-          site: site
+          person: richard
         )
       end
 

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -194,7 +194,7 @@ module GobiertoPeople
           richard_synchronized_events = richard.events.synchronized
 
           assert_equal 3, richard_synchronized_events.count
-          assert richard_synchronized_events.all? { |event| event.active? }
+          assert richard_synchronized_events.all?(&:active?)
         end
 
         Timecop.freeze(Time.zone.parse('2017-05-05 01:00:00')) do


### PR DESCRIPTION
### What does this PR do?

Just remove a duplicated key on a hash at the calendar integration test spec to avoid the warning while running tests:
```log
/Users/bertocq/work/projects/gobierto/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb:65: warning: key :site is duplicated and overwritten on line 72
/Users/bertocq/work/projects/gobierto/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb:78: warning: key :site is duplicated and overwritten on line 85
```

Bonus a small rubocop change from `all? { |event| event.active? }` to `.all?(&:active?)` that I consider shorter and easier to read.

### How should this be manually tested?
Just running specs and see them pass

### Does this PR changes any configuration file?
No
