### PR TITLE
716 - Previsualization of draft elements

### DIFF
--- a/app/controllers/concerns/preview_token_helper.rb
+++ b/app/controllers/concerns/preview_token_helper.rb
@@ -1,0 +1,11 @@
+module PreviewTokenHelper
+  extend ActiveSupport::Concern
+
+  private
+
+  def valid_preview_token?
+    preview_token = params[:preview_token]
+    preview_token && ::GobiertoAdmin::Admin.where(preview_token: preview_token).exists?
+  end
+
+end

--- a/app/controllers/gobierto_admin/admins_controller.rb
+++ b/app/controllers/gobierto_admin/admins_controller.rb
@@ -94,7 +94,7 @@ module GobiertoAdmin
       %w(
       created_at updated_at password_digest god
       confirmation_token reset_password_token
-      invitation_token invitation_sent_at
+      invitation_token invitation_sent_at preview_token
       )
     end
 

--- a/app/controllers/gobierto_admin/gobierto_budget_consultations/consultations_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_budget_consultations/consultations_controller.rb
@@ -1,8 +1,11 @@
 module GobiertoAdmin
   module GobiertoBudgetConsultations
     class ConsultationsController < BaseController
+
       before_action { module_enabled!(current_site, "GobiertoBudgetConsultations") }
       before_action { module_allowed!(current_admin, "GobiertoBudgetConsultations") }
+
+      helper_method :gobierto_budget_consultations_consultation_preview_url
 
       def index
         @consultations = current_site.budget_consultations.sorted
@@ -38,7 +41,7 @@ module GobiertoAdmin
         if @consultation_form.save
           redirect_to(
             admin_budget_consultation_consultation_items_path(@consultation_form.consultation),
-            notice: t(".success_html", link: gobierto_budget_consultations_consultation_url(@consultation_form.consultation, host: current_site.domain))
+            notice: t(".success_html", link: gobierto_budget_consultations_consultation_preview_url(@consultation_form.consultation, host: current_site.domain))
           )
         else
           @consultation_visibility_levels = get_consultation_visibility_levels
@@ -56,7 +59,7 @@ module GobiertoAdmin
         if @consultation_form.save
           redirect_to(
             edit_admin_budget_consultation_path(@consultation),
-            notice: t(".success_html", link: gobierto_budget_consultations_consultation_url(@consultation_form.consultation, host: current_site.domain))
+            notice: t(".success_html", link: gobierto_budget_consultations_consultation_preview_url(@consultation_form.consultation, host: current_site.domain))
           )
         else
           @consultation_visibility_levels = get_consultation_visibility_levels
@@ -93,6 +96,12 @@ module GobiertoAdmin
       def ignored_consultation_attributes
         %w( created_at updated_at budget_amount )
       end
+
+      def gobierto_budget_consultations_consultation_preview_url(consultation, options = {})
+        options.merge!(preview_token: current_admin.preview_token) unless consultation.not_draft?
+        gobierto_budget_consultations_consultation_url(consultation, options)
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -1,8 +1,11 @@
 module GobiertoAdmin
   module GobiertoCms
     class PagesController < BaseController
+
       before_action { module_enabled!(current_site, "GobiertoCms") }
       before_action { module_allowed!(current_admin, "GobiertoCms") }
+
+      helper_method :gobierto_cms_page_preview_url
 
       def index
         @pages = current_site.pages.sorted
@@ -29,7 +32,7 @@ module GobiertoAdmin
 
           redirect_to(
             edit_admin_cms_page_path(@page_form.page.id),
-            notice: t(".success_html", link: gobierto_cms_page_url(@page_form.page, host: current_site.domain))
+            notice: t(".success_html", link: gobierto_cms_page_preview_url(@page_form.page, host: current_site.domain))
           )
         else
           @page_visibility_levels = get_page_visibility_levels
@@ -46,7 +49,7 @@ module GobiertoAdmin
 
           redirect_to(
             edit_admin_cms_page_path(@page_form.page.id),
-            notice: t(".success_html", link: gobierto_cms_page_url(@page_form.page, host: current_site.domain))
+            notice: t(".success_html", link: gobierto_cms_page_preview_url(@page_form.page, host: current_site.domain))
           )
         else
           @page_visibility_levels = get_page_visibility_levels
@@ -100,7 +103,11 @@ module GobiertoAdmin
       def find_page
         current_site.pages.find(params[:id])
       end
+
+      def gobierto_cms_page_preview_url(page, options = {})
+        options.merge!(preview_token: current_admin.preview_token) unless page.active?
+        gobierto_cms_page_url(page.slug, options)
+      end
     end
   end
 end
-

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
@@ -96,7 +96,9 @@ module GobiertoAdmin
         end
 
         def gobierto_people_person_event_preview_url(person, event, options = {})
-          options.merge!(preview_token: current_admin.preview_token) unless event.active?
+          if event.pending? || event.person.draft?
+            options.merge!(preview_token: current_admin.preview_token)
+          end
           gobierto_people_person_event_url(person.slug, event.slug, options)
         end
 

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
@@ -2,6 +2,9 @@ module GobiertoAdmin
   module GobiertoPeople
     module People
       class PersonEventsController < People::BaseController
+
+        helper_method :gobierto_people_person_event_preview_url
+
         def index
           @person_events = @person.events.sorted
           @person_events_presenter = PersonEventsPresenter.new(@person)
@@ -31,7 +34,7 @@ module GobiertoAdmin
           if @person_event_form.save
             redirect_to(
               edit_admin_people_person_event_path(@person, @person_event_form.person_event),
-              notice: t(".success_html", link: gobierto_people_person_event_url(@person.slug, @person_event_form.person_event.slug, host: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_event_preview_url(@person, @person_event_form.person_event, host: current_site.domain))
             )
           else
             @attendees = get_attendees
@@ -49,7 +52,7 @@ module GobiertoAdmin
           if @person_event_form.save
             redirect_to(
               edit_admin_people_person_event_path(@person, @person_event),
-              notice: t(".success_html", link: gobierto_people_person_event_url(@person.slug, @person_event_form.person_event.slug, host: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_event_preview_url(@person, @person_event_form.person_event, host: current_site.domain))
             )
           else
             @attendees = get_attendees
@@ -91,6 +94,12 @@ module GobiertoAdmin
         def ignored_person_event_attributes
           %w( created_at updated_at title description external_id slug site_id )
         end
+
+        def gobierto_people_person_event_preview_url(person, event, options = {})
+          options.merge!(preview_token: current_admin.preview_token) unless event.active?
+          gobierto_people_person_event_url(person.slug, event.slug, options)
+        end
+
       end
     end
   end

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_posts_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_posts_controller.rb
@@ -80,7 +80,9 @@ module GobiertoAdmin
         end
 
         def gobierto_people_person_post_preview_url(person, post, options = {})
-          options.merge!(preview_token: current_admin.preview_token) unless post.active?
+          if post.draft? || post.person.draft?
+            options.merge!(preview_token: current_admin.preview_token)
+          end
           gobierto_people_person_post_url(person.slug, post.slug, options)
         end
 

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_posts_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_posts_controller.rb
@@ -2,6 +2,9 @@ module GobiertoAdmin
   module GobiertoPeople
     module People
       class PersonPostsController < People::BaseController
+
+        helper_method :gobierto_people_person_post_preview_url
+
         def index
           @person_posts = @person.posts.sorted
         end
@@ -28,7 +31,7 @@ module GobiertoAdmin
           if @person_post_form.save
             redirect_to(
               edit_admin_people_person_post_path(@person, @person_post_form.person_post),
-              notice: t(".success_html", link: gobierto_people_person_post_url(@person.slug, @person_post_form.person_post.slug, host: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_post_preview_url(@person, @person_post_form.person_post, host: current_site.domain))
             )
           else
             @person_post_visibility_levels = get_person_post_visibility_levels
@@ -45,7 +48,7 @@ module GobiertoAdmin
           if @person_post_form.save
             redirect_to(
               edit_admin_people_person_post_path(@person, @person_post),
-              notice: t(".success_html", link: gobierto_people_person_post_url(@person.slug, @person_post_form.person_post.slug, host: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_post_preview_url(@person, @person_post_form.person_post, host: current_site.domain))
             )
           else
             @person_post_visibility_levels = get_person_post_visibility_levels
@@ -75,6 +78,12 @@ module GobiertoAdmin
         def ignored_person_post_attributes
           %w( created_at updated_at slug site_id )
         end
+
+        def gobierto_people_person_post_preview_url(person, post, options = {})
+          options.merge!(preview_token: current_admin.preview_token) unless post.active?
+          gobierto_people_person_post_url(person.slug, post.slug, options)
+        end
+
       end
     end
   end

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_statements_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_statements_controller.rb
@@ -2,7 +2,10 @@ module GobiertoAdmin
   module GobiertoPeople
     module People
       class PersonStatementsController < People::BaseController
+
         include ::GobiertoCommon::DynamicContentHelper
+
+        helper_method :gobierto_people_person_statement_preview_url
 
         def index
           @person_statements = @person.statements.sorted
@@ -30,7 +33,7 @@ module GobiertoAdmin
           if @person_statement_form.save
             redirect_to(
               edit_admin_people_person_statement_path(@person, @person_statement_form.person_statement),
-              notice: t(".success_html", link: gobierto_people_person_statement_url(@person.slug, @person_statement_form.person_statement.slug, host: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_statement_preview_url(@person, @person_statement_form.person_statement, host: current_site.domain))
             )
           else
             @person_statement_visibility_levels = get_person_statement_visibility_levels
@@ -47,7 +50,7 @@ module GobiertoAdmin
           if @person_statement_form.save
             redirect_to(
               edit_admin_people_person_statement_path(@person, @person_statement),
-              notice: t(".success_html", link: gobierto_people_person_statement_url(@person.slug, @person_statement_form.person_statement.slug, host: current_site.domain))
+              notice: t(".success_html", link: gobierto_people_person_statement_preview_url(@person, @person_statement_form.person_statement, host: current_site.domain))
             )
           else
             @person_statement_visibility_levels = get_person_statement_visibility_levels
@@ -83,6 +86,12 @@ module GobiertoAdmin
         def ignored_person_statement_attributes
           %w( created_at updated_at title slug site_id )
         end
+
+        def gobierto_people_person_statement_preview_url(person, statement, options = {})
+          options.merge!(preview_token: current_admin.preview_token) unless statement.active?
+          gobierto_people_person_statement_url(person.slug, statement.slug, options)
+        end
+
       end
     end
   end

--- a/app/controllers/gobierto_admin/gobierto_people/people/person_statements_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_statements_controller.rb
@@ -88,7 +88,9 @@ module GobiertoAdmin
         end
 
         def gobierto_people_person_statement_preview_url(person, statement, options = {})
-          options.merge!(preview_token: current_admin.preview_token) unless statement.active?
+          if statement.draft? || statement.person.draft?
+            options.merge!(preview_token: current_admin.preview_token)
+          end
           gobierto_people_person_statement_url(person.slug, statement.slug, options)
         end
 

--- a/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
@@ -6,6 +6,8 @@ module GobiertoAdmin
       before_action { module_enabled!(current_site, "GobiertoPeople") }
       before_action { module_allowed!(current_admin, "GobiertoPeople") }
 
+      helper_method :gobierto_people_person_preview_url
+
       def index
         @people = current_site.people.sorted
       end
@@ -38,7 +40,7 @@ module GobiertoAdmin
         if @person_form.save
           redirect_to(
             edit_admin_people_person_path(@person_form.person),
-            notice: t(".success_html", link: gobierto_people_person_url(@person_form.person.slug, host: current_site.domain))
+            notice: t(".success_html", link: gobierto_people_person_preview_url(@person_form.person, host: current_site.domain))
           )
         else
           @person_visibility_levels = get_person_visibility_levels
@@ -58,7 +60,7 @@ module GobiertoAdmin
         if @person_form.save
           redirect_to(
             edit_admin_people_person_path(@person),
-            notice: t(".success_html", link: gobierto_people_person_url(@person_form.person.slug, host: current_site.domain))
+            notice: t(".success_html", link: gobierto_people_person_preview_url(@person_form.person, host: current_site.domain))
           )
         else
           @person_visibility_levels = get_person_visibility_levels
@@ -107,6 +109,11 @@ module GobiertoAdmin
 
       def ignored_person_attributes
         %w( created_at updated_at events_count statements_count posts_count position charge bio slug google_calendar_token )
+      end
+
+      def gobierto_people_person_preview_url(person, options = {})
+        options.merge!(preview_token: current_admin.preview_token) unless person.active?
+        gobierto_people_person_url(person.slug, options)
       end
     end
   end

--- a/app/controllers/gobierto_budget_consultations/consultations_controller.rb
+++ b/app/controllers/gobierto_budget_consultations/consultations_controller.rb
@@ -1,5 +1,8 @@
 module GobiertoBudgetConsultations
   class ConsultationsController < GobiertoBudgetConsultations::ApplicationController
+
+    include PreviewTokenHelper
+
     before_action :set_consultation, only: [:show]
     before_action :check_not_responded, only: [:show]
 
@@ -22,10 +25,14 @@ module GobiertoBudgetConsultations
       @consultation = ConsultationDecorator.new(find_consultation)
     end
 
+    def budget_consultations_scope
+      valid_preview_token? ? current_site.budget_consultations.draft : current_site.budget_consultations.not_draft
+    end
+
     protected
 
     def find_consultation
-      current_site.budget_consultations.find(params[:id])
+      budget_consultations_scope.find(params[:id])
     end
   end
 end

--- a/app/controllers/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_cms/pages_controller.rb
@@ -1,5 +1,8 @@
 module GobiertoCms
   class PagesController < GobiertoCms::ApplicationController
+
+    include ::PreviewTokenHelper
+
     before_action :find_page_by_id_and_redirect
 
     def show
@@ -17,7 +20,12 @@ module GobiertoCms
     end
 
     def find_page
-      current_site.pages.active.find_by_slug!(params[:id])
+      pages_scope.find_by_slug!(params[:id])
     end
+
+    def pages_scope
+      valid_preview_token? ? current_site.pages.draft : current_site.pages.active
+    end
+
   end
 end

--- a/app/controllers/gobierto_people/people/base_controller.rb
+++ b/app/controllers/gobierto_people/people/base_controller.rb
@@ -1,6 +1,9 @@
 module GobiertoPeople
   module People
     class BaseController < GobiertoPeople::ApplicationController
+
+      include PreviewTokenHelper
+
       before_action :set_person
 
       layout "gobierto_people/layouts/people"
@@ -14,8 +17,13 @@ module GobiertoPeople
       protected
 
       def find_person
-        current_site.people.active.find_by!(slug: params[:person_slug])
+        people_scope.find_by!(slug: params[:person_slug])
       end
+
+      def people_scope
+        valid_preview_token? ? current_site.people : current_site.people.active
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -2,6 +2,8 @@ module GobiertoPeople
   module People
     class PersonEventsController < BaseController
 
+      include PreviewTokenHelper
+
       before_action :set_calendar_events, only: [:index]
 
       def index
@@ -25,12 +27,17 @@ module GobiertoPeople
       private
 
       def find_event
-        @person.attending_events.published.find_by!(slug: params[:slug])
+        person_events_scope.find_by!(slug: params[:slug])
       end
 
       def set_calendar_events
         @calendar_events = @person.attending_events
       end
+
+      def person_events_scope
+        valid_preview_token? ? @person.attending_events.pending : @person.attending_events.published
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -2,8 +2,6 @@ module GobiertoPeople
   module People
     class PersonEventsController < BaseController
 
-      include PreviewTokenHelper
-
       before_action :set_calendar_events, only: [:index]
 
       def index
@@ -35,7 +33,7 @@ module GobiertoPeople
       end
 
       def person_events_scope
-        valid_preview_token? ? @person.attending_events.pending : @person.attending_events.published
+        valid_preview_token? ? @person.attending_events : @person.attending_events.published
       end
 
     end

--- a/app/controllers/gobierto_people/people/person_posts_controller.rb
+++ b/app/controllers/gobierto_people/people/person_posts_controller.rb
@@ -2,8 +2,6 @@ module GobiertoPeople
   module People
     class PersonPostsController < BaseController
 
-      include PreviewTokenHelper
-
       def index
         @posts = @person.posts.active.sorted
       end
@@ -19,7 +17,7 @@ module GobiertoPeople
       end
 
       def person_posts_scope
-        valid_preview_token? ? @person.posts.draft : @person.posts.active
+        valid_preview_token? ? @person.posts : @person.posts.active
       end
 
     end

--- a/app/controllers/gobierto_people/people/person_posts_controller.rb
+++ b/app/controllers/gobierto_people/people/person_posts_controller.rb
@@ -1,6 +1,9 @@
 module GobiertoPeople
   module People
     class PersonPostsController < BaseController
+
+      include PreviewTokenHelper
+
       def index
         @posts = @person.posts.active.sorted
       end
@@ -12,8 +15,13 @@ module GobiertoPeople
       private
 
       def find_post
-        @person.posts.active.find_by!(slug: params[:slug])
+        person_posts_scope.find_by!(slug: params[:slug])
       end
+
+      def person_posts_scope
+        valid_preview_token? ? @person.posts.draft : @person.posts.active
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_people/people/person_statements_controller.rb
+++ b/app/controllers/gobierto_people/people/person_statements_controller.rb
@@ -2,8 +2,6 @@ module GobiertoPeople
   module People
     class PersonStatementsController < BaseController
 
-      include PreviewTokenHelper
-
       def index
         @statements = find_statements
 
@@ -29,7 +27,7 @@ module GobiertoPeople
       end
 
       def person_statements_scope
-        valid_preview_token? ? @person.statements.draft : @person.statements.active
+        valid_preview_token? ? @person.statements : @person.statements.active
       end
 
     end

--- a/app/controllers/gobierto_people/people/person_statements_controller.rb
+++ b/app/controllers/gobierto_people/people/person_statements_controller.rb
@@ -1,6 +1,9 @@
 module GobiertoPeople
   module People
     class PersonStatementsController < BaseController
+
+      include PreviewTokenHelper
+
       def index
         @statements = find_statements
 
@@ -18,12 +21,17 @@ module GobiertoPeople
       private
 
       def find_statement
-        @person.statements.active.find_by!(slug: params[:slug])
+        person_statements_scope.find_by!(slug: params[:slug])
       end
 
       def find_statements
         @person.statements.active.sorted
       end
+
+      def person_statements_scope
+        valid_preview_token? ? @person.statements.draft : @person.statements.active
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -1,6 +1,8 @@
 module GobiertoPeople
   class PeopleController < GobiertoPeople::ApplicationController
+
     include PoliticalGroupsHelper
+    include PreviewTokenHelper
 
     before_action :check_active_submodules, except: :show
 
@@ -39,7 +41,11 @@ module GobiertoPeople
     end
 
     def find_person
-      current_site.people.active.find_by!(slug: params[:slug])
+      people_scope.find_by!(slug: params[:slug])
+    end
+
+    def people_scope
+      valid_preview_token? ? current_site.people.draft : current_site.people.active
     end
 
     def set_people

--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
 
     has_many :census_imports
 
-    before_create :set_god_flag
+    before_create :set_god_flag, :generate_preview_token
 
     validates :email, uniqueness: true
 
@@ -70,6 +70,10 @@ module GobiertoAdmin
 
       # Always return successfully to avoid halting execution.
       true
+    end
+
+    def generate_preview_token
+      self.preview_token = self.class.generate_unique_secure_token
     end
   end
 end

--- a/app/models/gobierto_budget_consultations/consultation.rb
+++ b/app/models/gobierto_budget_consultations/consultation.rb
@@ -37,6 +37,10 @@ module GobiertoBudgetConsultations
       opens_on > Date.current
     end
 
+    def not_draft?
+      self.class.visibility_levels[visibility_level] == self.class.visibility_levels[:active]
+    end
+
     def calculate_budget_amount
       update_columns(budget_amount: consultation_items.sum(:budget_line_amount))
     end

--- a/app/views/gobierto_admin/gobierto_budget_consultations/consultations/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_budget_consultations/consultations/index.html.erb
@@ -51,7 +51,7 @@
         <%= t(".visibility_level.#{consultation.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_budget_consultations_consultation_url(consultation, host: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_budget_consultations_consultation_preview_url(consultation, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_consultation") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
@@ -34,7 +34,7 @@
             <%= t(".visibility_level.active") %>
           <% end %>
         </td>
-        <td><%= link_to %Q{<i class="fa fa-eye"></i> #{t('.view')}}.html_safe, gobierto_cms_page_url(page, host: current_site.domain), class: 'view_item' %></td>
+        <td><%= link_to %Q{<i class="fa fa-eye"></i> #{t('.view')}}.html_safe, gobierto_cms_page_preview_url(page, host: current_site.domain), class: 'view_item' %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -61,7 +61,7 @@
         <%= t(".visibility_level.#{person.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_url(person.slug, host: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_preview_url(person, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_person") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -83,7 +83,7 @@
         <%= t(".visibility_level.#{person_event.state}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_event_url(@person.slug, person_event.slug, host: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_event_preview_url(@person, person_event, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_event") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_posts/index.html.erb
@@ -53,7 +53,7 @@
         <%= t(".visibility_level.#{person_post.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_post_url(@person.slug, person_post.slug, host: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_post_preview_url(@person, person_post, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_post") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_statements/index.html.erb
@@ -47,7 +47,7 @@
         <%= t(".visibility_level.#{person_statement.visibility_level}") %>
       </td>
       <td>
-        <%= link_to gobierto_people_person_statement_url(@person.slug, person_statement.slug, host: current_site.domain), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_people_person_statement_preview_url(@person, person_statement, host: current_site.domain), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".view_statement") %>
         <% end %>

--- a/db/migrate/20170530144711_add_preview_token_to_admins.rb
+++ b/db/migrate/20170530144711_add_preview_token_to_admins.rb
@@ -1,0 +1,25 @@
+class AddPreviewTokenToAdmins < ActiveRecord::Migration[5.1]
+
+  def up
+    add_column :admin_admins, :preview_token, :string
+    GobiertoAdmin::Admin.reset_column_information
+    generate_preview_token_for_existing_admins
+    change_column :admin_admins, :preview_token, :string, null: false
+    add_index :admin_admins, :preview_token, unique: true
+  end
+
+  def down
+    remove_index :admin_admins, :preview_token
+    remove_column :admin_admins, :preview_token
+  end
+
+  private
+
+  def generate_preview_token_for_existing_admins
+    GobiertoAdmin::Admin.where(preview_token: nil).each do |admin|
+      admin.send(:generate_preview_token)
+      admin.save!
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519070559) do
+ActiveRecord::Schema.define(version: 20170530144711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,10 +59,12 @@ ActiveRecord::Schema.define(version: 20170519070559) do
     t.boolean  "god",                  default: false, null: false
     t.string   "invitation_token"
     t.datetime "invitation_sent_at"
+    t.string "preview_token",                          null: false
     t.index ["confirmation_token"], name: "index_admin_admins_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_admin_admins_on_email", unique: true, using: :btree
     t.index ["invitation_token"], name: "index_admin_admins_on_invitation_token", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_admin_admins_on_reset_password_token", unique: true, using: :btree
+    t.index ["preview_token"], name: "index_admin_admins_on_preview_token", unique: true
   end
 
   create_table "admin_census_imports", force: :cascade do |t|

--- a/lib/tasks/gobierto_admin/reset_preview_tokens.rake
+++ b/lib/tasks/gobierto_admin/reset_preview_tokens.rake
@@ -1,0 +1,9 @@
+namespace :gobierto_admin do
+  desc "Regenerates admins preview token"
+  task regenerate_preview_tokens: :environment do
+    GobiertoAdmin::Admin.all.each do |admin|
+      admin.send(:generate_preview_token)
+      admin.save!
+    end
+  end
+end

--- a/test/fixtures/gobierto_admin/admins.yml
+++ b/test/fixtures/gobierto_admin/admins.yml
@@ -9,6 +9,7 @@ tony:
   sites: madrid
   last_sign_in_at: 2016-12-01 00:00:00
   last_sign_in_ip: 0.0.0.0
+  preview_token: tony-preview-token
 
 steve:
   email: steve@gobierto.dev
@@ -22,6 +23,7 @@ steve:
   created_at: 2016-11-01 00:01:00
   updated_at: 2016-11-01 00:01:00
   sites: madrid
+  preview_token: steve-preview-token
 
 nick:
   email: nick@gobierto.dev
@@ -34,6 +36,7 @@ nick:
   sites:
   last_sign_in_at: 2016-12-01 00:02:00
   last_sign_in_ip: 0.0.0.0
+  preview_token: nick-preview-token
 
 natasha:
   email: natasha@gobierto.dev
@@ -47,3 +50,4 @@ natasha:
   sites:
   last_sign_in_at: 2016-12-01 00:03:00
   last_sign_in_ip: 0.0.0.0
+  preview_token: natasha-preview-token

--- a/test/fixtures/gobierto_budget_consultations/consultations.yml
+++ b/test/fixtures/gobierto_budget_consultations/consultations.yml
@@ -88,3 +88,14 @@ madrid_upcoming:
   show_figures: true
   force_responses_balance: false
 
+madrid_draft:
+  site: madrid
+  admin: tony
+  title: Borrador de consulta sobre partidas destinadas a Museos en Madrid
+  description: Descripción incompleta del borrador.
+  opens_on: <%= 2.year.from_now.to_date %>
+  closes_on: <%= 2.year.from_now.to_date %>
+  budget_amount: 19.99
+  visibility_level: <%= GobiertoBudgetConsultations::Consultation.visibility_levels["draft"] %>
+  show_figures: true
+  force_responses_balance: false

--- a/test/fixtures/gobierto_people/people.yml
+++ b/test/fixtures/gobierto_people/people.yml
@@ -57,3 +57,23 @@ tamara:
   position: 3
   email: tamara@example.com
   google_calendar_token: gct3
+
+juana:
+  site: madrid
+  admin: tony
+  name: Juana de Arco
+  slug: juana-de-arco
+  charge_translations: <%= { 'en' => 'Heroine of France', 'es' => 'Heroína de Francia' }.to_json %>
+  bio_translations: <%= {
+    'en' => 'Heroine of France',
+    'es' => 'Heroína de Francia'
+  }.to_json %>
+  bio_url: https://en.wikipedia.org/wiki/Joan_of_Arc
+  avatar_url: https://upload.wikimedia.org/wikipedia/commons/c/c3/Joan_of_Arc_miniature_graded.jpg
+  visibility_level: <%= GobiertoPeople::Person.visibility_levels["draft"] %>
+  category: <%= GobiertoPeople::Person.categories["executive"] %>
+  party:
+  political_group:
+  position: 3
+  email: juana@example.com
+  google_calendar_token:

--- a/test/fixtures/gobierto_people/person_event_attendees.yml
+++ b/test/fixtures/gobierto_people/person_event_attendees.yml
@@ -16,7 +16,7 @@ richard_richard_published_just_attending:
   name:
   charge:
 
-tamara:
+tamara_richard_published:
   person_event: richard_published
   person: tamara
   name:
@@ -28,8 +28,8 @@ custom:
   name: John Custom
   charge: President
 
-richard_richard_past:
-  person_event: richard_past
+richard_richard_published_past:
+  person_event: richard_published_past
   person: richard
   name:
   charge:
@@ -46,9 +46,8 @@ nelson_nelson_yesterday:
   name:
   charge:
 
-tamara_published_past:
-  person_event: tamara_published
+tamara_tamara_published_past:
+  person_event: tamara_published_past
   person: tamara
   name:
   charge:
-

--- a/test/fixtures/gobierto_people/person_posts.yml
+++ b/test/fixtures/gobierto_people/person_posts.yml
@@ -17,3 +17,13 @@ richard_achievements:
   tags:
   visibility_level: <%= GobiertoPeople::PersonPost.visibility_levels["active"] %>
   created_at: <%= 1.week.ago %>
+
+richard_draft:
+  person: richard
+  site: madrid
+  title: Draft Post
+  slug: <%= "#{1.week.ago.strftime('%F')}-draft-post" %>
+  body: Article about how to not finish a post.
+  tags:
+  visibility_level: <%= GobiertoPeople::PersonPost.visibility_levels["draft"] %>
+  created_at: <%= 1.week.ago %>

--- a/test/fixtures/gobierto_people/person_statements.yml
+++ b/test/fixtures/gobierto_people/person_statements.yml
@@ -23,3 +23,16 @@ richard_past:
   attachment_size: <%= 100.kilobytes %>
   published_on: <%= 1.year.ago.to_date %>
   visibility_level: <%= GobiertoPeople::PersonStatement.visibility_levels["active"] %>
+
+richard_draft:
+  person: richard
+  site: madrid
+  title_translations: <%= {
+    'en' => 'Statement draft',
+    'es' => 'Borrador de delcaración'
+  }.to_json %>
+  slug: <%= "#{1.year.ago.strftime('%F')}-borrador-de-declaracion" %>
+  attachment_url:
+  attachment_size:
+  published_on: <%= 1.year.ago.to_date %>
+  visibility_level: <%= GobiertoPeople::PersonStatement.visibility_levels["draft"] %>

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_preview_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+module GobiertoBudgetConsultations
+  class ConsultationPreviewTest < ActionDispatch::IntegrationTest
+
+    def setup
+      super
+      @path = admin_budget_consultations_path
+    end
+
+    def admin
+      @admin ||= gobierto_admin_admins(:nick)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def active_consultation
+      @active_consultation ||= gobierto_budget_consultations_consultations(:madrid_open)
+    end
+
+    def draft_consultation
+      @draft_consultation ||= gobierto_budget_consultations_consultations(:madrid_draft)
+    end
+
+    def test_preview_active_consultation
+      with_signed_in_admin(admin) do
+        with_current_site(site) do
+          visit @path
+
+          within "tr#consultation-item-#{active_consultation.id}" do
+
+            preview_link = find("a", text: "View consultation")
+
+            refute preview_link[:href].include?(admin.preview_token)
+
+            preview_link.click
+          end
+
+          assert_equal gobierto_budget_consultations_consultation_path(active_consultation), current_path
+
+          within "div.consultation-intro-wrapper" do
+            assert has_content?(active_consultation.description)
+          end
+        end
+      end
+    end
+
+    def test_preview_draft_consultation_as_admin
+      with_signed_in_admin(admin) do
+        with_current_site(site) do
+          visit @path
+
+          within "tr#consultation-item-#{draft_consultation.id}" do
+            preview_link = find("a", text: "View consultation")
+
+            assert preview_link[:href].include?(admin.preview_token)
+
+            preview_link.click
+          end
+
+          assert_equal gobierto_budget_consultations_consultation_path(draft_consultation), current_path
+
+          within "div.consultation-intro-wrapper" do
+            assert has_content?(draft_consultation.description)
+          end
+        end
+      end
+    end
+
+    def test_preview_draft_page_if_not_admin
+      with_current_site(site) do
+
+        assert_raises ActiveRecord::RecordNotFound do
+          visit gobierto_budget_consultations_consultation_path(draft_consultation)
+        end
+
+        # assert_response :not_found
+        refute has_selector?("h2", text: draft_consultation.title)
+      end
+    end
+
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_cms/page_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/page_preview_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCms
+    class PagePreviewTest < ActionDispatch::IntegrationTest
+      
+      def setup
+        super
+        @path = admin_cms_pages_path
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def published_page
+        @published_page ||= site.pages.active.first
+      end
+
+      def draft_page
+        @draft_page ||= site.pages.draft.first
+      end
+
+      def test_preview_published_page
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#page-item-#{published_page.id}" do
+              preview_link = find("a", text: "View page")
+
+              refute preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_cms_page_path(published_page.slug), current_path
+            assert has_selector?("h1", text: published_page.title)
+          end
+        end
+      end
+
+      def test_preview_draft_page_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#page-item-#{draft_page.id}" do
+              preview_link = find("a", text: "View page")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_cms_page_path(draft_page.slug), current_path
+            assert has_selector?("h1", text: draft_page.title)
+          end
+        end
+      end
+
+      def test_preview_draft_page_if_not_admin
+        with_current_site(site) do
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_cms_page_path(draft_page.slug)
+          end
+
+          # assert_response :not_found
+          refute has_selector?("h1", text: draft_page.title)
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/person_event_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_event_preview_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PersonEventPreviewTest < ActionDispatch::IntegrationTest
+
+      def setup
+        super
+        @path = admin_people_person_events_path(richard)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def richard
+        @person ||= gobierto_people_people(:richard)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def published_event
+        @published_event ||= richard.events.published.first
+      end
+
+      def pending_event
+        @pending_event ||= richard.events.pending.first
+      end
+
+      def test_preview_published_event
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-event-item-#{published_event.id}" do
+
+              preview_link = find("a", text: "View event")
+
+              refute preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_event_path(published_event.person.slug, published_event.slug), current_path
+            assert has_selector?("h2", text: published_event.title)
+          end
+        end
+      end
+
+      def test_preview_pending_event_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-event-item-#{pending_event.id}" do
+              preview_link = find("a", text: "View event")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_event_path(pending_event.person.slug, pending_event.slug), current_path
+            assert has_selector?("h2", text: pending_event.title)
+          end
+        end
+      end
+
+      def test_preview_pending_event_if_not_admin
+        with_current_site(site) do
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_event_path(pending_event.person.slug, pending_event.slug)
+          end
+
+          # assert_response :not_found
+          refute has_selector?("h2", text: pending_event.title)
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/person_event_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_event_preview_test.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
       end
 
       def richard
-        @person ||= gobierto_people_people(:richard)
+        gobierto_people_people(:richard)
       end
 
       def site
@@ -22,14 +22,14 @@ module GobiertoAdmin
       end
 
       def published_event
-        @published_event ||= richard.events.published.first
+        richard.events.published.first
       end
 
       def pending_event
-        @pending_event ||= richard.events.pending.first
+        richard.events.pending.first
       end
 
-      def test_preview_published_event
+      def test_preview_active_person_published_event
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
@@ -49,7 +49,50 @@ module GobiertoAdmin
         end
       end
 
-      def test_preview_pending_event_as_admin
+      def test_preview_active_person_pending_event
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-event-item-#{pending_event.id}" do
+              preview_link = find("a", text: "View event")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_event_path(pending_event.person.slug, pending_event.slug), current_path
+            assert has_selector?("h2", text: pending_event.title)
+          end
+        end
+      end
+
+      def test_preview_draft_person_published_event
+        published_event.person.draft!
+
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-event-item-#{published_event.id}" do
+
+              preview_link = find("a", text: "View event")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_event_path(published_event.person.slug, published_event.slug), current_path
+            assert has_selector?("h2", text: published_event.title)
+          end
+        end
+      end
+
+      def test_preview_draft_person_pending_event
+        pending_event.person.draft!
+
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
@@ -75,7 +118,14 @@ module GobiertoAdmin
             visit gobierto_people_person_event_path(pending_event.person.slug, pending_event.slug)
           end
 
-          # assert_response :not_found
+          refute has_selector?("h2", text: pending_event.title)
+
+          pending_event.person.draft!
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_event_path(pending_event.person.slug, pending_event.slug)
+          end
+
           refute has_selector?("h2", text: pending_event.title)
         end
       end

--- a/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
       end
 
       def richard
-        @person ||= gobierto_people_people(:richard)
+        gobierto_people_people(:richard)
       end
 
       def site
@@ -22,14 +22,14 @@ module GobiertoAdmin
       end
 
       def active_post
-        @active_post ||= richard.posts.active.first
+        richard.posts.active.first
       end
 
       def draft_post
-        @draft_post ||= richard.posts.draft.first
+        richard.posts.draft.first
       end
 
-      def test_preview_active_post
+      def test_preview_active_person_active_post
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
@@ -49,7 +49,50 @@ module GobiertoAdmin
         end
       end
 
-      def test_preview_draft_post_as_admin
+      def test_preview_active_person_draft_post_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-post-item-#{draft_post.id}" do
+              preview_link = find("a", text: "View post")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug), current_path
+            assert has_selector?("h1", text: draft_post.title)
+          end
+        end
+      end
+
+      def test_preview_draft_person_active_post
+        draft_post.person.draft!
+
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-post-item-#{active_post.id}" do
+
+              preview_link = find("a", text: "View post")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_post_path(active_post.person.slug, active_post.slug), current_path
+            assert has_selector?("h1", text: active_post.title)
+          end
+        end
+      end
+
+      def test_preview_draft_person_draft_post_as_admin
+        draft_post.person.draft!
+
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
@@ -75,7 +118,14 @@ module GobiertoAdmin
             visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
           end
 
-          # assert_response :not_found
+          refute has_selector?("h1", text: draft_post.title)
+
+          draft_post.person.draft!
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
+          end
+
           refute has_selector?("h1", text: draft_post.title)
         end
       end

--- a/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PersonPostPreviewTest < ActionDispatch::IntegrationTest
+
+      def setup
+        super
+        @path = admin_people_person_posts_path(richard)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def richard
+        @person ||= gobierto_people_people(:richard)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def active_post
+        @active_post ||= richard.posts.active.first
+      end
+
+      def draft_post
+        @draft_post ||= richard.posts.draft.first
+      end
+
+      def test_preview_active_post
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-post-item-#{active_post.id}" do
+
+              preview_link = find("a", text: "View post")
+
+              refute preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_post_path(active_post.person.slug, active_post.slug), current_path
+            assert has_selector?("h1", text: active_post.title)
+          end
+        end
+      end
+
+      def test_preview_draft_post_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-post-item-#{draft_post.id}" do
+              preview_link = find("a", text: "View post")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug), current_path
+            assert has_selector?("h1", text: draft_post.title)
+          end
+        end
+      end
+
+      def test_preview_draft_post_if_not_admin
+        with_current_site(site) do
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
+          end
+
+          # assert_response :not_found
+          refute has_selector?("h1", text: draft_post.title)
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/person_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_preview_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PersonPreviewTest < ActionDispatch::IntegrationTest
+
+      def setup
+        super
+        @path = admin_people_people_path
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def published_person
+        @published_person ||= site.people.active.first
+      end
+
+      def draft_person
+        @draft_person ||= site.people.draft.first
+      end
+
+      def test_preview_published_person
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-item-#{published_person.id}" do
+
+              preview_link = find("a", text: "View person")
+
+              refute preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_path(published_person.slug), current_path
+            assert has_selector?("h2", text: published_person.name)
+          end
+        end
+      end
+
+      def test_preview_draft_person_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-item-#{draft_person.id}" do
+              preview_link = find("a", text: "View person")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_path(draft_person.slug), current_path
+            assert has_selector?("h2", text: draft_person.name)
+          end
+        end
+      end
+
+      def test_preview_draft_page_if_not_admin
+        with_current_site(site) do
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_path(draft_person.slug)
+          end
+
+          # assert_response :not_found
+          refute has_selector?("h2", text: draft_person.name)
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
       end
 
       def richard
-        @person ||= gobierto_people_people(:richard)
+        gobierto_people_people(:richard)
       end
 
       def site
@@ -22,14 +22,14 @@ module GobiertoAdmin
       end
 
       def active_statement
-        @active_statement ||= richard.statements.active.first
+        richard.statements.active.first
       end
 
       def draft_statement
-        @draft_statement ||= richard.statements.draft.first
+        richard.statements.draft.first
       end
 
-      def test_preview_active_statement
+      def test_preview_active_person_active_statement
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
@@ -49,7 +49,50 @@ module GobiertoAdmin
         end
       end
 
-      def test_preview_draft_statement_as_admin
+      def test_preview_active_person_draft_statement
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-statement-item-#{draft_statement.id}" do
+              preview_link = find("a", text: "View statement")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug), current_path
+            assert has_selector?("h3", text: draft_statement.title)
+          end
+        end
+      end
+
+      def test_preview_draft_person_active_statement
+        active_statement.person.draft!
+
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-statement-item-#{active_statement.id}" do
+
+              preview_link = find("a", text: "View statement")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_statement_path(active_statement.person.slug, active_statement.slug), current_path
+            assert has_selector?("h3", text: active_statement.title)
+          end
+        end
+      end
+
+      def test_preview_draft_person_draft_statement
+        draft_statement.person.draft!
+
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
@@ -75,7 +118,14 @@ module GobiertoAdmin
             visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
           end
 
-          # assert_response :not_found
+          refute has_selector?("h3", text: draft_statement.title)
+
+          draft_statement.person.draft!
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
+          end
+
           refute has_selector?("h3", text: draft_statement.title)
         end
       end

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class PersonStatementPreviewTest < ActionDispatch::IntegrationTest
+
+      def setup
+        super
+        @path = admin_people_person_statements_path(richard)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def richard
+        @person ||= gobierto_people_people(:richard)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def active_statement
+        @active_statement ||= richard.statements.active.first
+      end
+
+      def draft_statement
+        @draft_statement ||= richard.statements.draft.first
+      end
+
+      def test_preview_active_statement
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-statement-item-#{active_statement.id}" do
+
+              preview_link = find("a", text: "View statement")
+
+              refute preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_statement_path(active_statement.person.slug, active_statement.slug), current_path
+            assert has_selector?("h3", text: active_statement.title)
+          end
+        end
+      end
+
+      def test_preview_draft_statement_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "tr#person-statement-item-#{draft_statement.id}" do
+              preview_link = find("a", text: "View statement")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            assert_equal gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug), current_path
+            assert has_selector?("h3", text: draft_statement.title)
+          end
+        end
+      end
+
+      def test_preview_draft_statement_if_not_admin
+        with_current_site(site) do
+
+          assert_raises ActiveRecord::RecordNotFound do
+            visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
+          end
+
+          # assert_response :not_found
+          refute has_selector?("h3", text: draft_statement.title)
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_budget_consultations/consultation_show_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_show_test.rb
@@ -70,9 +70,12 @@ module GobiertoBudgetConsultations
 
       with_current_site(site) do
         with_signed_in_user(user) do
-          visit @path
 
-          refute has_link?("Participa en la consulta")
+          assert_raises(ActiveRecord::RecordNotFound) do
+            visit @path
+          end
+
+          refute has_link?("Do you want to opinate?")
         end
       end
     end

--- a/test/models/gobierto_people/person_event_attendee_test.rb
+++ b/test/models/gobierto_people/person_event_attendee_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class GobiertoPeople::PersonEventAttendeeTest < ActiveSupport::TestCase
   def person_event_attendee
-    @person_event_attendee ||= gobierto_people_person_event_attendees(:tamara)
+    @person_event_attendee ||= gobierto_people_person_event_attendees(:tamara_richard_published)
   end
 
   def custom_person_event_attendee


### PR DESCRIPTION
Connects to #716 

### What does this PR do?

Permits admins to see draft elements in the frontend.

### How should this be manually tested?

Check both draft and published elements are visible in the frontend by clicking on their links from the admin view.

### Does this PR changes any configuration file?

This PR provides a rake task to regenerate admin preview tokens. This task should be executed periodically.
