### PR TITLE
Use a Populate Data account for each site

### DIFF
--- a/app/controllers/gobierto_admin/sites_controller.rb
+++ b/app/controllers/gobierto_admin/sites_controller.rb
@@ -135,6 +135,7 @@ module GobiertoAdmin
         :logo_file,
         :default_locale,
         :privacy_page_id,
+        :populate_data_api_token,
         site_modules: [],
         available_locales: [],
         title_translations: [*I18n.available_locales],

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -33,7 +33,8 @@ module GobiertoAdmin
       :logo_file,
       :available_locales,
       :default_locale,
-      :privacy_page_id
+      :privacy_page_id,
+      :populate_data_api_token
     )
 
     attr_reader :logo_url
@@ -103,6 +104,10 @@ module GobiertoAdmin
       @privacy_page_id ||= site.configuration.privacy_page_id
     end
 
+    def populate_data_api_token
+      @populate_data_api_token ||= site.configuration.populate_data_api_token
+    end
+
     def logo_url
       @logo_url ||= begin
         return site.configuration.logo unless logo_file.present?
@@ -148,6 +153,7 @@ module GobiertoAdmin
         site_attributes.configuration.default_locale = default_locale
         site_attributes.configuration.available_locales = (available_locales.select{ |l| l.present? } + [default_locale]).uniq
         site_attributes.configuration.privacy_page_id = privacy_page_id
+        site_attributes.configuration.populate_data_api_token = populate_data_api_token
       end
 
       if @site.valid?

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -13,6 +13,7 @@ class SiteConfiguration
     :available_locales,
     :default_locale,
     :privacy_page_id,
+    :populate_data_api_token,
   ].freeze
 
   DEFAULT_LOGO_PATH = "sites/logo-default.png".freeze

--- a/app/services/gobierto_admin/gobierto_budget_consultations/budget_line_collection_builder.rb
+++ b/app/services/gobierto_admin/gobierto_budget_consultations/budget_line_collection_builder.rb
@@ -4,6 +4,7 @@ module GobiertoAdmin
   module GobiertoBudgetConsultations
     class BudgetLineCollectionBuilder
       def initialize(site, options = {})
+        @site = site
         @municipality_id = site.municipality_id
         @year = options.fetch(:year) { Date.current.year }
       end
@@ -39,13 +40,17 @@ module GobiertoAdmin
           kind: "expense",
           area: "functional",
           date: @year,
-          entity_id: entity_id
+          entity_id: entity_id,
+          origin: @site.domain,
+          api_token: @site.configuration.populate_data_api_token
         ).fetch
       end
 
       def entities
         @entities ||= PopulateData::Gobierto::Entity.new(
-          municipality_id: @municipality_id
+          municipality_id: @municipality_id,
+          origin: @site.domain,
+          api_token: @site.configuration.populate_data_api_token
         ).fetch
       end
 
@@ -54,6 +59,8 @@ module GobiertoAdmin
           level: 3,
           kind: "expense",
           area: "functional",
+          origin: @site.domain,
+          api_token: @site.configuration.populate_data_api_token
         ).fetch
       end
     end

--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -87,6 +87,11 @@
           <%= f.select :privacy_page_id, @available_pages.map{ |p| [p.title, p.id] }, { include_blank: true } %>
         </div>
 
+        <div class="form_item input_text">
+          <%= f.label :populate_data_api_token %>
+          <%= f.text_field :populate_data_api_token, placeholder: t(".placeholders.populate_data_api_token") %>
+        </div>
+
       </div>
 
       <div class="form_block">
@@ -188,6 +193,6 @@
 
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
-    window.GobiertoAdmin.sites_controller.edit("<%= Rails.application.secrets.tbi_api_token %>");
+    window.GobiertoAdmin.sites_controller.edit("<%= current_site.configuration.populate_data_api_token %>");
   <% end %>
 <% end %>

--- a/app/views/gobierto_indicators/layouts/application.html.erb
+++ b/app/views/gobierto_indicators/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <% content_for :javascript_include do %>
   <%= javascript_tag do %>
     window.populateData = {
-      token: "<%= Rails.application.secrets.tbi_api_token %>",
+      token: "<%= @site.configuration.populate_data_api_token %>",
       municipalityId: "<%= @site.place.id %>",
       municipalityName: "<%= @site.place.name %>",
       provinceId: "<%= @site.place.province.id %>",

--- a/app/views/layouts/sandbox/application.html.erb
+++ b/app/views/layouts/sandbox/application.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <script type="text/javascript">
-    window.tbiToken = "<%= ENV['TBI_API_TOKEN'] %>";
+    window.tbiToken = "<%= current_site.configuration.populate_data_api_token %>";
   </script>
 </head>
 

--- a/config/locales/gobierto_admin/models/ca.yml
+++ b/config/locales/gobierto_admin/models/ca.yml
@@ -29,6 +29,7 @@ ca:
         municipality_id: Municipi
         name: Nom de l'entitat
         privacy_page_id: Pàgina privacitat
+        populate_data_api_token: API token Populate Data
         title: Nom del site
       gobierto_admin/user_form:
         email: Email

--- a/config/locales/gobierto_admin/models/en.yml
+++ b/config/locales/gobierto_admin/models/en.yml
@@ -29,6 +29,7 @@ en:
         municipality_id: Municipality
         name: Entity ame
         privacy_page_id: Privacy page
+        populate_data_api_token: API token Populate Data
         title: Site name
       gobierto_admin/user_form:
         email: Email

--- a/config/locales/gobierto_admin/models/es.yml
+++ b/config/locales/gobierto_admin/models/es.yml
@@ -29,6 +29,7 @@ es:
         municipality_id: Municipio
         name: Nombre de la entidad
         privacy_page_id: Página de privacidad
+        populate_data_api_token: API token Populate Data
         title: Nombre del site
       gobierto_admin/user_form:
         email: Email

--- a/config/locales/gobierto_admin/views/sites/ca.yml
+++ b/config/locales/gobierto_admin/views/sites/ca.yml
@@ -21,6 +21,7 @@ ca:
           location_name: Burjassot
           name: Ajuntament de Burjassot
           title: Transparencia i Participció
+          populate_data_api_token: Token de API de Populate Data
         username: Noe d'usuari
         visibility_level:
           active: Publicat

--- a/config/locales/gobierto_admin/views/sites/en.yml
+++ b/config/locales/gobierto_admin/views/sites/en.yml
@@ -21,6 +21,7 @@ en:
           location_name: Burjassot
           name: Ayuntamiento de Burjassot
           title: Transparencia y Participción
+          populate_data_api_token: API Token Populate Data
         username: Username
         visibility_level:
           active: Published

--- a/config/locales/gobierto_admin/views/sites/es.yml
+++ b/config/locales/gobierto_admin/views/sites/es.yml
@@ -21,6 +21,7 @@ es:
           location_name: Burjassot
           name: Ayuntamiento de Burjassot
           title: Transparencia y Participción
+          populate_data_api_token: Token de API de Populate Data
         username: Nombre de usuario
         visibility_level:
           active: Publicado

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,7 +1,6 @@
 default: &default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   elastic_url: <%= ENV.fetch("ELASTICSEARCH_URL") { "http://localhost:9200" } %>
-  tbi_api_token: <%= ENV["TBI_API_TOKEN"] %>
   google_places_api_key: <%= ENV["GOOGLE_PLACES_API_KEY"] %>
   algolia_application_id: <%= ENV["ALGOLIA_APPLICATION_ID"] %>
   algolia_api_key: <%= ENV["ALGOLIA_API_KEY"] %>

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,7 +1,6 @@
 default: &default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   elastic_url: <%= ENV.fetch("ELASTICSEARCH_URL") { "http://localhost:9200" } %>
-  tbi_api_token: <%= ENV["TBI_API_TOKEN"] %>
   google_places_api_key: <%= ENV["GOOGLE_PLACES_API_KEY"] %>
   algolia_application_id: <%= ENV["ALGOLIA_APPLICATION_ID"] %>
   algolia_api_key: <%= ENV["ALGOLIA_API_KEY"] %>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,8 +21,6 @@ INTEGRATION_DEBUG=false
 INTEGRATION_INSPECTOR=false
 
 # Populate data variables
-# - API Token
-TBI_API_TOKEN=
 # - Main endpoint
 POPULATE_DATA_ENDPOINT=
 # - Suggestion endpoint for municipalities suggestion
@@ -76,7 +74,6 @@ MAILER_SMTP_PASSWORD=
 
 Populate Data is a tool developed by Populate that stores many of the open date used by Gobierto. Gobierto needs Populate Data to run. If you need access just write us to: `lets@populate.tools`
 
-- `TBI_API_TOKEN`: Populate Data API token
 - `POPULATE_DATA_ENDPOINT`: The endpoint of the Populate Data account
 - `MUNICIPALITIES_SUGGESTIONS_ENDPOINT`: The endpoint from Populate data with the places autosuggestion
 

--- a/lib/populate_data/gobierto/client.rb
+++ b/lib/populate_data/gobierto/client.rb
@@ -10,6 +10,9 @@ module PopulateData
       BASE_URI = APP_CONFIG["populate_data"]["endpoint"]
 
       def initialize(options = {})
+        @origin = options.fetch(:origin)
+        @api_token = options.fetch(:api_token)
+
         Client.logger.debug("Initializing #{self.class.name} with options #{options}")
       end
 
@@ -26,6 +29,8 @@ module PopulateData
 
       private
 
+      attr_reader :origin, :api_token
+
       def http_client
         @http_client ||= setup_http_client
       end
@@ -41,8 +46,8 @@ module PopulateData
 
         request["Content-Type"] = "application/json"
         request["Accept"] = "application/json"
-        request["Authorization"] = "Bearer #{ENV["TBI_API_TOKEN"]}"
-        request["Origin"] = "http://#{ENV["HOST"]}"
+        request["Authorization"] = "Bearer #{api_token}"
+        request["Origin"] = origin
 
         request.body = request_body
 

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -32,6 +32,7 @@ module GobiertoAdmin
             fill_in "site_foot_markup", with: "Site Foot markup"
             fill_in "site_links_markup", with: "Site Links markup"
             fill_in "site_google_analytics_id", with: "UA-000000-01"
+            fill_in "site_populate_data_api_token", with: "APITOKEN"
 
             within ".site-check-boxes" do
               check "site_available_locales_es"

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -39,6 +39,7 @@ module GobiertoAdmin
           fill_in "site_foot_markup", with: "Site Foot markup"
           fill_in "site_links_markup", with: "Site Links markup"
           fill_in "site_google_analytics_id", with: "UA-000000-01"
+          fill_in "site_populate_data_api_token", with: "APITOKEN"
 
           attach_file "site_logo_file", "test/fixtures/files/sites/logo-madrid.png"
 
@@ -69,6 +70,7 @@ module GobiertoAdmin
           assert has_field?("site_links_markup", with: "Site Links markup")
           assert has_field?("site_google_analytics_id", with: "UA-000000-01")
           assert has_select?("Privacy page", selected: privacy_page.title)
+          assert has_field?("site_populate_data_api_token", with: "APITOKEN")
 
           within ".site-module-check-boxes" do
             assert has_checked_field?("Gobierto Development")


### PR DESCRIPTION
Connects to #393

### What does this PR do?

This PR forces a site that is going to use Populate Data to have a api key associated. This way we'd need to set a key for each group of hosts, so we can use the same for all the *.gobierto.es sites, and use special ones for custom domain sites.
