### PR TITLE
Flacky test between 0:00 - 2:00 😴 😴

### DIFF
--- a/test/models/gobierto_people/person_event_test.rb
+++ b/test/models/gobierto_people/person_event_test.rb
@@ -87,7 +87,7 @@ module GobiertoPeople
     end
 
     def test_by_date_scope
-      subject = PersonEvent.by_date(person_event.starts_at.to_date)
+      subject = PersonEvent.by_date(person_event.starts_at)
 
       assert_includes subject, person_event
       refute_includes subject, past_person_event


### PR DESCRIPTION
Calling `.to_date` causes lose of timezone info. DB dates are stored as
UTC, but person_event.starts at is CEST +2:00, so at certain hours
(1:00 a.m.) the test fails.

The build fails but because when it was executed, the other 3 flacky tests we currently have, failed. Actually you can see this commit actually fixes one issue: [before, 4 failures](https://circleci.com/gh/PopulateTools/gobierto/1905) - [after, 3 failures](https://circleci.com/gh/PopulateTools/gobierto/1904)