### PR TITLE
Bubble fixes

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
@@ -3,6 +3,7 @@
 var VisBubbles = Class.extend({
   init: function(divId, budgetCategory, data) {
     this.container = divId;
+    $(this.container).html('');
     this.currentYear = parseInt(d3.select('body').attr('data-year'));
     this.data = data;
     this.budget_category = budgetCategory;

--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
@@ -12,8 +12,6 @@ var VisBubbles = Class.extend({
 
     d3.formatDefaultLocale(eval(this.locale));
 
-    console.log(this.locale);
-
     this.margin = {top: 20, right: 10, bottom: 20, left: 10},
     this.width = parseInt(d3.select(this.container).style('width')) - this.margin.left - this.margin.right;
     this.height = this.isMobile ? 320 : 520 - this.margin.top - this.margin.bottom;
@@ -142,8 +140,8 @@ var VisBubbles = Class.extend({
       .attr('r', function (d) { return d.radius; })
       .attr('fill', function(d) { return this.budgetColor(d.pct_diff)}.bind(this))
       .attr('stroke-width', 2)
-      .on('mousemove', this._mousemoved.bind(this))
-      .on('mouseleave', this._mouseleft.bind(this));
+      .on('mousemove', !this.isMobile && this._mousemoved.bind(this))
+      .on('mouseleave', !this.isMobile && this._mouseleft.bind(this));
 
     this.bubbles = this.bubbles.merge(bubblesG);
 

--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
@@ -8,8 +8,11 @@ var VisBubbles = Class.extend({
     this.budget_category = budgetCategory;
     this.forceStrength = 0.045;
     this.isMobile = window.innerWidth <= 590;
+    this.locale = I18n.locale;
 
-    d3.formatDefaultLocale(eval(I18n.locale));
+    d3.formatDefaultLocale(eval(this.locale));
+
+    console.log(this.locale);
 
     this.margin = {top: 20, right: 10, bottom: 20, left: 10},
     this.width = parseInt(d3.select(this.container).style('width')) - this.margin.left - this.margin.right;
@@ -53,8 +56,7 @@ var VisBubbles = Class.extend({
   },
   createNodes: function(rawData, year) {
     var data = rawData;
-    var locale = I18n.locale;
-    if(locale === 'en') locale = 'es';
+    if(this.locale === 'en') this.locale = 'es';
 
     this.maxAmount = d3.max(data, function (d) { return d.values[year] }.bind(this));
     this.filtered = data.filter(function(d) { return d.budget_category === this.budget_category; }.bind(this));
@@ -74,7 +76,7 @@ var VisBubbles = Class.extend({
           id: d.id,
           radius: this.radiusScale(d.values[year]),
           value: d.values[year],
-          name: d['level_2_' + locale],
+          name: d['level_2_' + this.locale],
           pct_diff: d.pct_diff[year],
           per_inhabitant: d.values_per_inhabitant[year],
           x: Math.random() * 600,
@@ -129,8 +131,6 @@ var VisBubbles = Class.extend({
       .enter()
       .append('g')
       .attr('class', 'bubble-g');
-
-      console.log(this.data);
 
     var bubblesG = this.bubbles.append('a')
       .attr('xlink:href', function(d) {

--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
@@ -71,7 +71,7 @@ var VisBubbles = Class.extend({
           values: d.values,
           pct_diffs: d.pct_diff,
           values_per_inhabitant: d.values_per_inhabitant,
-          id: +d.id,
+          id: d.id,
           radius: this.radiusScale(d.values[year]),
           value: d.values[year],
           name: d['level_2_' + locale],
@@ -128,7 +128,9 @@ var VisBubbles = Class.extend({
       .data(this.nodes, function (d) { return d.name; })
       .enter()
       .append('g')
-      .attr('class', 'bubble-g')
+      .attr('class', 'bubble-g');
+
+      console.log(this.data);
 
     var bubblesG = this.bubbles.append('a')
       .attr('xlink:href', function(d) {


### PR DESCRIPTION
Connects to #700.

### What does this PR do?
This PR fixes an ID issue with the links to the budget lines, and a turbolinks issue.

Extra ball: disable the tooltip on phones while we figure out what to do. Safari triggers the hover, so it's not consistent with the rest of the browsers (which follow the link). I would say the best option is just triggering the tooltip, but we can discuss it.