### PR TITLE
Include custom code into budget lines

### DIFF
--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -24,7 +24,6 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     if GobiertoBudgets::FunctionalArea.area_name == @area_name
       @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
     elsif GobiertoBudgets::CustomArea.area_name == @area_name
-      debugger
       @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, custom_code: @code, year: @year, kind: @kind, area_name: @area_name).all
     else
       @budget_line_composition = []

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -21,9 +21,10 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     end
     @budget_line_stats = GobiertoBudgets::BudgetLineStats.new(site: @site, budget_line: @budget_line)
     @budget_line_descendants = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, parent_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-    if GobiertoBudgets::FunctionalArea.area_name  == @area_name
+    if GobiertoBudgets::FunctionalArea.area_name == @area_name
       @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-    elsif GobiertoBudgets::CustomArea.area_name  == @area_name
+    elsif GobiertoBudgets::CustomArea.area_name == @area_name
+      debugger
       @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, custom_code: @code, year: @year, kind: @kind, area_name: @area_name).all
     else
       @budget_line_composition = []

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -21,7 +21,13 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     end
     @budget_line_stats = GobiertoBudgets::BudgetLineStats.new(site: @site, budget_line: @budget_line)
     @budget_line_descendants = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, parent_code: @code, year: @year, kind: @kind, area_name: @area_name).all
-    @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
+    if GobiertoBudgets::FunctionalArea.area_name  == @area_name
+      @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, functional_code: @code, year: @year, kind: @kind, area_name: @area_name).all
+    elsif GobiertoBudgets::CustomArea.area_name  == @area_name
+      @budget_line_composition = GobiertoBudgets::BudgetLine.where(site: current_site, place: @place, custom_code: @code, year: @year, kind: @kind, area_name: @area_name).all
+    else
+      @budget_line_composition = []
+    end
 
     respond_to do |format|
       format.html

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -275,7 +275,11 @@ module GobiertoBudgets
                 must_not: {
                   exists: {
                     field: "functional_code",
-                    field: "custom_code"
+                  },
+                },
+                must_not: {
+                  exists: {
+                    field: "custom_code",
                   }
                 }
               }

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -25,6 +25,7 @@ module GobiertoBudgets
         {term: { year: @conditions[:year] }},
         {term: { code: @conditions[:code] }},
         {missing: { field: 'functional_code'}},
+        {missing: { field: 'custom_code'}},
         {term: { ine_code: @conditions[:place].id }}
       ]
 
@@ -122,8 +123,17 @@ module GobiertoBudgets
           @conditions[:area_name] = FunctionalArea.area_name
           return functional_codes_for_economic_budget_line(@conditions)
         end
+      elsif @conditions[:custom_code]
+        if @conditions[:area_name] == CustomArea.area_name
+          @conditions[:area_name] = EconomicArea.area_name
+          terms.push({term: { custom_code: @conditions[:custom_code] }})
+        # else
+        #   @conditions[:area_name] = CustomArea.area_name
+        #   return functional_codes_for_economic_budget_line(@conditions)
+        end
       else
         terms.push({missing: { field: 'functional_code'}})
+        terms.push({missing: { field: 'custom_code'}})
       end
 
       query = {
@@ -264,7 +274,8 @@ module GobiertoBudgets
                 must: terms,
                 must_not: {
                   exists: {
-                    field: "functional_code"
+                    field: "functional_code",
+                    field: "custom_code"
                   }
                 }
               }

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -152,8 +152,8 @@
 
         <% end %>
 
+        <h2><%= t('.budget_lines_distribution') %></h2>
         <% if @budget_line_composition.any? %>
-          <h2><%= t('.budget_lines_distribution') %></h2>
           <table>
             <% @budget_line_composition.each do |budget_line| %>
               <tr>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -152,21 +152,19 @@
 
         <% end %>
 
-        <% if @kind != GobiertoBudgets::BudgetLine::INCOME %>
+        <% if @budget_line_composition.any? %>
           <h2><%= t('.budget_lines_distribution') %></h2>
-          <% if @budget_line_composition.any? %>
-            <table>
-              <% @budget_line_composition.each do |budget_line| %>
-                <tr>
-                  <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
-                  <td class="qty"><%= number_with_precision(budget_line.percentage_compared_with(@budget_line.amount) * 100, precision: 2) + '%' %></td>
-                  <td class="amount"><%= format_currency(budget_line.amount) %></td>
-                </tr>
-              <% end %>
-            </table>
-          <% else %>
-            <p><%= t('.no_distribution') %></p>
-          <% end %>
+          <table>
+            <% @budget_line_composition.each do |budget_line| %>
+              <tr>
+                <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
+                <td class="qty"><%= number_with_precision(budget_line.percentage_compared_with(@budget_line.amount) * 100, precision: 2) + '%' %></td>
+                <td class="amount"><%= format_currency(budget_line.amount) %></td>
+              </tr>
+            <% end %>
+          </table>
+        <% else %>
+          <p><%= t('.no_distribution') %></p>
         <% end %>
 
       </div>

--- a/lib/tasks/gobierto_budgets/categories.yml
+++ b/lib/tasks/gobierto_budgets/categories.yml
@@ -134,3 +134,51 @@ functional_3_g:
   parent_code:
   level: 1
   kind: expense
+
+custom_0_g:
+  area: custom
+  code: '0'
+  name: Custom cat 0 gasto
+  parent_code:
+  level: 1
+  kind: expense
+
+custom_1_g:
+  area: custom
+  code: '1'
+  name: Custom cat 1 gasto
+  parent_code:
+  level: 1
+  kind: expense
+
+custom_13_g:
+  area: custom
+  code: '13'
+  name: Custom cat 13 gasto
+  parent_code: 1
+  level: 2
+  kind: expense
+
+custom_0_i:
+  area: custom
+  code: '0'
+  name: Custom cat 0 ingreso
+  parent_code:
+  level: 1
+  kind: income
+
+custom_1_i:
+  area: custom
+  code: '1'
+  name: Custom cat 1 ingreso
+  parent_code:
+  level: 1
+  kind: income
+
+custom_13_i:
+  area: custom
+  code: '13'
+  name: Custom cat 13 ingreso
+  parent_code: 1
+  level: 2
+  kind: income

--- a/test/support/populate_data_helpers.rb
+++ b/test/support/populate_data_helpers.rb
@@ -57,6 +57,7 @@ module PopulateDataHelpers
       "code" => "151",
       "parent_code" => "15",
       "functional_code" => nil,
+      "custom_code" => nil,
       "area" => "functional",
       "level" => 3,
       "_id" => "9208.0/2016-01-01/p/e/f/151"


### PR DESCRIPTION
#763

### What does this PR do?

This PR allows to show the economic budget lines that compose a custom budget line.

It also adds custom budget lines to the fixtures for the shake of completeness.
