### PR TITLE
772 - Permits searching for budget lines in Algolia

### DIFF
--- a/app/assets/javascripts/module-search.js
+++ b/app/assets/javascripts/module-search.js
@@ -44,7 +44,11 @@ $(document).on('turbolinks:load', function() {
       case 'GobiertoCms::Page':
         return I18n.t("layouts.search.page_item");
       case 'GobiertoBudgets::BudgetLine':
-        return I18n.t("layouts.search.budget_line_item");
+        if (d['kind'] === 'I') {
+          return I18n.t("layouts.search.budget_line_item_income");
+        } else {
+          return I18n.t("layouts.search.budget_line_item_expense");
+        }
     }
   }
 

--- a/app/assets/javascripts/module-search.js
+++ b/app/assets/javascripts/module-search.js
@@ -90,7 +90,7 @@ $(document).on('turbolinks:load', function() {
         params: {
           hitsPerPage: 10,
           filters: window.searchClient.filters
-          }
+        }
       });
     });
 

--- a/app/assets/javascripts/module-search.js
+++ b/app/assets/javascripts/module-search.js
@@ -43,6 +43,8 @@ $(document).on('turbolinks:load', function() {
         return I18n.t("layouts.search.person_statement_item");
       case 'GobiertoCms::Page':
         return I18n.t("layouts.search.page_item");
+      case 'GobiertoBudgets::BudgetLine':
+        return I18n.t("layouts.search.budget_line_item");
     }
   }
 
@@ -64,8 +66,8 @@ $(document).on('turbolinks:load', function() {
             '<h2><a href="'+d.resource_path+'">' + (d['title'] || d['name'] || d['title_' + I18n.locale] || d['name_' + I18n.locale]) + '</a></h2>' +
             '<div class="description">' +
               '<div>' + itemDescription(d) + '</div>' +
-              '<span class="soft item_type">' + itemType(d) + '</span> · ' +
-              '<span class="soft updated_at">' + itemUpdatedAt(d) + '</span>' +
+              '<span class="soft item_type">' + itemType(d) + '</span>' +
+              (itemUpdatedAt(d) ? ' · <span class="soft updated_at">' + itemUpdatedAt(d) + '</span>' : '') +
             '</div>' +
           '</div>';
 

--- a/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
@@ -33,22 +33,33 @@ module GobiertoBudgets
           ine_code: ine_code,
           year: year,
           code: code,
-          kind: kind
-        }.merge(translated_attributes_hash)
+          kind: kind,
+          resource_path: resource_path,
+          class_name: self.class.name
+        }.merge(translated_attributes)
       end
 
-      def translated_attributes_hash
+      def translated_attributes
         current_locale = I18n.locale
-        attributes_translations = {}
+        translations = {}
 
         I18n.available_locales.each do |locale|
           I18n.locale = locale
-          attributes_translations["name_#{locale}"] = get_name
-          attributes_translations["description_#{locale}"] = get_description
+          translations["name_#{locale}"] = get_name
+          translations["description_#{locale}"] = get_description
         end
 
         I18n.locale = current_locale
-        attributes_translations
+        translations
+      end
+
+      def resource_path
+        Rails.application.routes.url_helpers.gobierto_budgets_budget_line_path(
+          area_name: area.area_name,
+          kind: kind,
+          year: year,
+          id: code
+        )
       end
 
     end

--- a/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
@@ -1,0 +1,57 @@
+module GobiertoBudgets
+  module BudgetLineAlgoliaHelpers
+    extend ActiveSupport::Concern
+
+    class_methods do
+
+      def search_index_name
+        "#{APP_CONFIG["site"]["name"]}_#{Rails.env}_#{self.name}"
+      end
+
+      def algolia_index
+        @algolia_index ||= begin
+          index = Algolia::Index.new(search_index_name)
+          index.set_settings({ attributesForFaceting: [ 'site_id' ] })
+          index
+        end
+      end
+
+    end
+
+    included do
+
+      def algolia_id
+        "#{index}/#{area.area_name}/#{ine_code}/#{year}/#{code}/#{kind}"
+      end
+
+      def algolia_as_json
+        {
+          objectID: algolia_id,
+          index: index,
+          type: area.area_name,
+          site_id: site.id,
+          ine_code: ine_code,
+          year: year,
+          code: code,
+          kind: kind
+        }.merge(translated_attributes_hash)
+      end
+
+      def translated_attributes_hash
+        current_locale = I18n.locale
+        attributes_translations = {}
+
+        I18n.available_locales.each do |locale|
+          I18n.locale = locale
+          attributes_translations["name_#{locale}"] = get_name
+          attributes_translations["description_#{locale}"] = get_description
+        end
+
+        I18n.locale = current_locale
+        attributes_translations
+      end
+
+    end
+
+  end
+end

--- a/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
@@ -16,6 +16,15 @@ module GobiertoBudgets
         end
       end
 
+      def algolia_reindex_collection(budget_lines)
+        objects = budget_lines.map { |bl| bl.algolia_as_json }
+        algolia_index.add_objects(objects)
+      end
+
+      def algolia_destroy_records(site)
+        algolia_index.delete_by_query('', filters: "site_id:#{site.id}")
+      end
+
     end
 
     included do

--- a/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
@@ -1,0 +1,409 @@
+module GobiertoBudgets
+  module BudgetLineElasticsearchHelpers
+    extend ActiveSupport::Concern
+
+    class_methods do
+
+      def where(conditions)
+        validate_conditions(conditions)
+        @conditions = conditions
+        self
+      end
+
+      def first
+        terms = [
+          {term: { kind: @conditions[:kind] }},
+          {term: { year: @conditions[:year] }},
+          {term: { code: @conditions[:code] }},
+          {missing: { field: 'functional_code'}},
+          {missing: { field: 'custom_code'}},
+          {term: { ine_code: @conditions[:place].id }}
+        ]
+
+        query = {
+          sort: [
+            { @sort_attribute => { order: @sort_order } }
+          ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms
+                }
+              }
+            }
+          },
+          size: 10_000
+        }
+
+        area     = BudgetArea.klass_for(@conditions[:area_name])
+
+        response = SearchEngine.client.search(
+          index: SearchEngineConfiguration::BudgetLine.index_forecast,
+          type: area.area_name,
+          body: query
+        )
+
+        hits = response['hits']['hits']
+
+        raise BudgetLine::RecordNotFound if hits.empty?
+
+        BudgetLinePresenter.new(hits.first['_source'].merge(
+          site: @conditions[:site],
+          kind: @conditions[:kind],
+          area: area
+        ))
+      end
+
+      def functional_codes_for_economic_budget_line(conditions)
+        terms = [
+          {term: { kind: conditions[:kind] }},
+          {term: { year: conditions[:year] }},
+          {term: { code: conditions[:functional_code] }},
+          {exists: { field: 'functional_code'}},
+          {term: { ine_code: conditions[:place].id }}
+        ]
+
+        query = {
+          sort: [
+            { @sort_attribute => { order: @sort_order } }
+          ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms
+                }
+              }
+            }
+          },
+          aggs: {
+            total_budget: { sum: { field: 'amount' } },
+            total_budget_per_inhabitant: { sum: { field: 'amount_per_inhabitant' } },
+          },
+          size: 10_000
+        }
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_forecast,
+                                                               type: EconomicArea.area_name, body: query
+
+        response['hits']['hits'].map{ |h| h['_source'] }.map do |row|
+          next if row['functional_code'].length != 1
+          area = FunctionalArea
+          row['code'] = row['functional_code']
+
+          BudgetLinePresenter.new(row.merge(kind: EXPENSE, area: area, site: @conditions[:site]))
+        end.compact.sort{|b,a| a.amount <=> b.amount }
+      end
+
+      def all
+        terms = [
+          {term: { kind: @conditions[:kind] }},
+          {term: { ine_code: @conditions[:place].id }}
+        ]
+
+        terms.push({term: { year: @conditions[:year] }}) if @conditions[:year]
+        terms.push({term: { code: @conditions[:code] }}) if @conditions[:code]
+        terms.push({term: { level: @conditions[:level] }}) if @conditions[:level]
+        terms.push({term: { parent_code: @conditions[:parent_code] }}) if @conditions[:parent_code]
+        if @conditions[:functional_code]
+          if @conditions[:area_name] == FunctionalArea.area_name
+            @conditions[:area_name] = EconomicArea.area_name
+            terms.push({term: { functional_code: @conditions[:functional_code] }})
+          else
+            @conditions[:area_name] = FunctionalArea.area_name
+            return functional_codes_for_economic_budget_line(@conditions)
+          end
+        elsif @conditions[:custom_code]
+          if @conditions[:area_name] == CustomArea.area_name
+            @conditions[:area_name] = EconomicArea.area_name
+            terms.push({term: { custom_code: @conditions[:custom_code] }})
+          # else
+          #   @conditions[:area_name] = CustomArea.area_name
+          #   return functional_codes_for_economic_budget_line(@conditions)
+          end
+        else
+          terms.push({missing: { field: 'functional_code'}})
+          terms.push({missing: { field: 'custom_code'}})
+        end
+
+        query = {
+          sort: [
+            { @sort_attribute => { order: @sort_order } }
+          ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms
+                }
+              }
+            }
+          },
+          aggs: {
+            total_budget: { sum: { field: 'amount' } },
+            total_budget_per_inhabitant: { sum: { field: 'amount_per_inhabitant' } },
+          },
+          size: 10_000
+        }
+
+        area = BudgetArea.klass_for(@conditions[:area_name])
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_forecast,
+                                                               type: area.area_name, body: query
+
+        response['hits']['hits'].map{ |h| h['_source'] }.map do |row|
+          BudgetLinePresenter.new(row.merge(
+            site: @conditions[:site],
+            kind: @conditions[:kind],
+            area: area,
+            total: response['aggregations']['total_budget']['value'],
+            total_budget_per_inhabitant: response['aggregations']['total_budget_per_inhabitant']['value']
+          ))
+        end
+      end
+
+      def search(options)
+
+        terms = [{term: { kind: options[:kind] }},
+                {term: { year: options[:year] }}]
+
+        terms << {term: { ine_code: options[:ine_code] }} if options[:ine_code].present?
+        terms << {term: { parent_code: options[:parent_code] }} if options[:parent_code].present?
+        terms << {term: { level: options[:level] }} if options[:level].present?
+        terms << {term: { code: options[:code] }} if options[:code].present?
+        if options[:range_hash].present?
+          options[:range_hash].each_key do |range_key|
+            terms << {range: { range_key => options[:range_hash][range_key] }}
+          end
+        end
+
+        query = {
+          sort: [
+            { code: { order: 'asc' } }
+          ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms
+                }
+              }
+            }
+          },
+          aggs: {
+            total_budget: { sum: { field: 'amount' } },
+            total_budget_per_inhabitant: { sum: { field: 'amount_per_inhabitant' } },
+          },
+          size: 10_000
+        }
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_forecast, type: (options[:type] || EconomicArea.area_name), body: query
+
+        return {
+          'hits' => response['hits']['hits'].map{ |h| h['_source'] },
+          'aggregations' => response['aggregations']
+        }
+      end
+
+      def for_ranking(options)
+        response = budget_line_query(options)
+        results = response['hits']['hits'].map{|h| h['_source']}
+        total_elements = response['hits']['total']
+
+        return results, total_elements
+      end
+
+      def place_position_in_ranking(options)
+        id = %w{ine_code year code kind}.map {|f| options[f.to_sym]}.join('/')
+
+        response = budget_line_query(options.merge(to_rank: true))
+        buckets = response['hits']['hits'].map{|h| h['_id']}
+        position = buckets.index(id) ? buckets.index(id) + 1 : 0;
+        return position
+      end
+
+      def budget_line_query(options)
+
+        terms = [
+          {term: { year: options[:year] }},
+          {term: { kind: options[:kind] }},
+          {term: { code: options[:code] }}
+        ]
+
+        if options[:filters].present?
+          population_filter =  options[:filters][:population]
+          total_filter = options[:filters][:total]
+          per_inhabitant_filter = options[:filters][:per_inhabitant]
+          aarr_filter = options[:filters][:aarr]
+        end
+
+        if (population_filter && (population_filter[:from].to_i > Population::FILTER_MIN || population_filter[:to].to_i < Population::FILTER_MAX))
+          reduced_filter = {population: population_filter}
+          reduced_filter.merge!(aarr: aarr_filter) if aarr_filter
+          results,total_elements = Population.for_ranking(options[:year], 0, nil, reduced_filter)
+          ine_codes = results.map{|p| p['ine_code']}
+          terms << [{terms: { ine_code: ine_codes }}] if ine_codes.any?
+        end
+
+        if (total_filter && (total_filter[:from].to_i > BudgetTotal::TOTAL_FILTER_MIN || total_filter[:to].to_i < BudgetTotal::TOTAL_FILTER_MAX))
+          terms << {range: { amount: { gte: total_filter[:from].to_i, lte: total_filter[:to].to_i} }}
+        end
+
+        if (per_inhabitant_filter && (per_inhabitant_filter[:from].to_i > BudgetTotal::PER_INHABITANT_FILTER_MIN || per_inhabitant_filter[:to].to_i < BudgetTotal::PER_INHABITANT_FILTER_MAX))
+          terms << {range: { amount_per_inhabitant: { gte: per_inhabitant_filter[:from].to_i, lte: per_inhabitant_filter[:to].to_i} }}
+        end
+
+        terms << {term: { autonomy_id: aarr_filter }}  unless aarr_filter.blank?
+
+        query = {
+          sort: [ { options[:variable].to_sym => { order: 'desc' } } ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms,
+                  must_not: {
+                    exists: {
+                      field: "functional_code",
+                    },
+                  },
+                  must_not: {
+                    exists: {
+                      field: "custom_code",
+                    }
+                  }
+                }
+              }
+            }
+          },
+          size: 10_000
+        }
+
+        query.merge!(size: options[:per_page]) if options[:per_page].present?
+        query.merge!(from: options[:offset]) if options[:offset].present?
+        query.merge!(_source: false) if options[:to_rank]
+
+        SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_forecast, type: options[:area_name], body: query
+      end
+
+      def find(options)
+        return self.search(options)['hits'].detect{|h| h['code'] == options[:code] }
+      end
+
+      def compare(options)
+        terms = [{terms: { ine_code: options[:ine_codes] }},
+                 {term: { level: options[:level] }},
+                 {term: { kind: options[:kind] }},
+                 {term: { year: options[:year] }}]
+
+        terms << {term: { parent_code: options[:parent_code] }} if options[:parent_code].present?
+        terms << {term: { code: options[:code] }} if options[:code].present?
+
+        query = {
+          sort: [
+            { code: { order: 'asc' } },
+            { ine_code: { order: 'asc' }}
+          ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms
+                }
+              }
+            }
+          },
+          size: 10_000
+        }
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_forecast, type: options[:type] , body: query
+        response['hits']['hits'].map{ |h| h['_source'] }
+      end
+
+      def has_children?(options)
+        options.symbolize_keys!
+        conditions = { parent_code: options[:code], level: options[:level].to_i + 1, type: options[:area] }
+        conditions.merge! options.slice(:ine_code,:kind,:year)
+
+        return search(conditions)['hits'].length > 0
+      end
+
+      def top_differences(options)
+        terms = [{term: { kind: options[:kind] }}, {term: { year: options[:year] }}, {term: { level: 3 }}]
+        terms << {term: { ine_code: options[:ine_code] }} if options[:ine_code].present?
+        terms << {term: { code: options[:code] }} if options[:code].present?
+
+        query = {
+          sort: [
+            { code: { order: 'asc' } }
+          ],
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: terms
+                }
+              }
+            }
+          },
+          size: 10_000
+        }
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_forecast, type: (options[:type] || EconomicArea.area_name), body: query
+
+        planned_results = response['hits']['hits'].map{ |h| h['_source'] }
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::BudgetLine.index_executed, type: (options[:type] || EconomicArea.area_name), body: query
+
+        executed_results = response['hits']['hits'].map{ |h| h['_source'] }
+
+        results = {}
+        planned_results.each do |p|
+          if e = executed_results.detect{|e| e['code'] == p['code']}
+            results[p['code']] = [p['amount'], e['amount'], ((e['amount'].to_f - p['amount'].to_f)/p['amount'].to_f) * 100]
+          end
+        end
+
+        return results.sort{ |b, a| a[1][2] <=> b[1][2] }[0..15], results.sort{ |a, b| a[1][2] <=> b[1][2] }[0..15]
+      end
+
+      def validate_conditions(conditions)
+        if conditions.has_key?(:kind)
+          raise BudgetLine::InvalidSearchConditions unless all_kinds.include?(conditions[:kind])
+        end
+        if conditions.has_key?(:area_name)
+          raise BudgetLine::InvalidSearchConditions unless BudgetArea.all_areas_names.include?(conditions[:area_name])
+        end
+      end
+
+    end
+
+    included do
+
+      private_class_method :validate_conditions
+
+      def elastic_search_index
+        SearchEngineConfiguration::BudgetLine.send(index)
+      end
+
+      def elasticsearch_as_json
+        {
+          ine_code: ine_code,
+          province_id: province_id,
+          autonomy_id: autonomy_id,
+          year: year,
+          population: population,
+          amount: amount,
+          code: code,
+          level: level,
+          kind: kind,
+          amount_per_inhabitant: amount_per_inhabitant,
+          parent_code: parent_code
+        }
+      end
+
+    end
+
+  end
+end

--- a/app/models/gobierto_budgets.rb
+++ b/app/models/gobierto_budgets.rb
@@ -4,4 +4,8 @@ module GobiertoBudgets
     'gb_'
   end
 
+  def self.searchable_models
+    [ GobiertoBudgets::BudgetLine ]
+  end
+
 end

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -4,29 +4,31 @@ module GobiertoBudgets
     class InvalidSearchConditions < StandardError; end
 
     include ActiveModel::Model
+    include BudgetLineElasticsearchHelpers
+    include BudgetLineAlgoliaHelpers
 
     INCOME  = 'I'
     EXPENSE = 'G'
 
     attr_reader(
-      :type,
       :id,
+      :index,
+      :type,
+      :site,
+      :area,
+      :kind,
+      :code,
       :ine_code,
       :place,
       :province_id,
       :autonomy_id,
       :year,
       :amount,
-      :code,
-      :level,
-      :kind,
-      :category,
-      :site,
-      :area,
       :amount_per_inhabitant,
+      :level,
       :parent_code,
+      :category,
       :name,
-      :index,
       :description
     )
 
@@ -35,392 +37,6 @@ module GobiertoBudgets
 
     def self.all_kinds
       [INCOME, EXPENSE]
-    end
-
-    def self.where(conditions)
-      validate_conditions(conditions)
-      @conditions = conditions
-      self
-    end
-
-    def self.first
-      terms = [
-        {term: { kind: @conditions[:kind] }},
-        {term: { year: @conditions[:year] }},
-        {term: { code: @conditions[:code] }},
-        {missing: { field: 'functional_code'}},
-        {missing: { field: 'custom_code'}},
-        {term: { ine_code: @conditions[:place].id }}
-      ]
-
-      query = {
-        sort: [
-          { @sort_attribute => { order: @sort_order } }
-        ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms
-              }
-            }
-          }
-        },
-        size: 10_000
-      }
-
-      area     = BudgetArea.klass_for(@conditions[:area_name])
-
-      response = GobiertoBudgets::SearchEngine.client.search(
-        index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
-        type: area.area_name,
-        body: query
-      )
-
-      hits = response['hits']['hits']
-
-      raise GobiertoBudgets::BudgetLine::RecordNotFound if hits.empty?
-
-      GobiertoBudgets::BudgetLinePresenter.new(hits.first['_source'].merge(
-        site: @conditions[:site],
-        kind: @conditions[:kind],
-        area: area
-      ))
-    end
-
-    def self.functional_codes_for_economic_budget_line(conditions)
-      terms = [
-        {term: { kind: conditions[:kind] }},
-        {term: { year: conditions[:year] }},
-        {term: { code: conditions[:functional_code] }},
-        {exists: { field: 'functional_code'}},
-        {term: { ine_code: conditions[:place].id }}
-      ]
-
-      query = {
-        sort: [
-          { @sort_attribute => { order: @sort_order } }
-        ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms
-              }
-            }
-          }
-        },
-        aggs: {
-          total_budget: { sum: { field: 'amount' } },
-          total_budget_per_inhabitant: { sum: { field: 'amount_per_inhabitant' } },
-        },
-        size: 10_000
-      }
-
-      response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
-                                                             type: EconomicArea.area_name, body: query
-
-      response['hits']['hits'].map{ |h| h['_source'] }.map do |row|
-        next if row['functional_code'].length != 1
-        area = GobiertoBudgets::FunctionalArea
-        row['code'] = row['functional_code']
-
-        GobiertoBudgets::BudgetLinePresenter.new(row.merge(kind: EXPENSE, area: area, site: @conditions[:site]))
-      end.compact.sort{|b,a| a.amount <=> b.amount }
-    end
-
-    def self.all
-      terms = [
-        {term: { kind: @conditions[:kind] }},
-        {term: { ine_code: @conditions[:place].id }}
-      ]
-
-      terms.push({term: { year: @conditions[:year] }}) if @conditions[:year]
-      terms.push({term: { code: @conditions[:code] }}) if @conditions[:code]
-      terms.push({term: { level: @conditions[:level] }}) if @conditions[:level]
-      terms.push({term: { parent_code: @conditions[:parent_code] }}) if @conditions[:parent_code]
-      if @conditions[:functional_code]
-        if @conditions[:area_name] == FunctionalArea.area_name
-          @conditions[:area_name] = EconomicArea.area_name
-          terms.push({term: { functional_code: @conditions[:functional_code] }})
-        else
-          @conditions[:area_name] = FunctionalArea.area_name
-          return functional_codes_for_economic_budget_line(@conditions)
-        end
-      elsif @conditions[:custom_code]
-        if @conditions[:area_name] == CustomArea.area_name
-          @conditions[:area_name] = EconomicArea.area_name
-          terms.push({term: { custom_code: @conditions[:custom_code] }})
-        # else
-        #   @conditions[:area_name] = CustomArea.area_name
-        #   return functional_codes_for_economic_budget_line(@conditions)
-        end
-      else
-        terms.push({missing: { field: 'functional_code'}})
-        terms.push({missing: { field: 'custom_code'}})
-      end
-
-      query = {
-        sort: [
-          { @sort_attribute => { order: @sort_order } }
-        ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms
-              }
-            }
-          }
-        },
-        aggs: {
-          total_budget: { sum: { field: 'amount' } },
-          total_budget_per_inhabitant: { sum: { field: 'amount_per_inhabitant' } },
-        },
-        size: 10_000
-      }
-
-      area = BudgetArea.klass_for(@conditions[:area_name])
-
-      response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
-                                                             type: area.area_name, body: query
-
-      response['hits']['hits'].map{ |h| h['_source'] }.map do |row|
-        GobiertoBudgets::BudgetLinePresenter.new(row.merge(
-          site: @conditions[:site],
-          kind: @conditions[:kind],
-          area: area,
-          total: response['aggregations']['total_budget']['value'],
-          total_budget_per_inhabitant: response['aggregations']['total_budget_per_inhabitant']['value']
-        ))
-      end
-    end
-
-    def self.search(options)
-
-      terms = [{term: { kind: options[:kind] }},
-              {term: { year: options[:year] }}]
-
-      terms << {term: { ine_code: options[:ine_code] }} if options[:ine_code].present?
-      terms << {term: { parent_code: options[:parent_code] }} if options[:parent_code].present?
-      terms << {term: { level: options[:level] }} if options[:level].present?
-      terms << {term: { code: options[:code] }} if options[:code].present?
-      if options[:range_hash].present?
-        options[:range_hash].each_key do |range_key|
-          terms << {range: { range_key => options[:range_hash][range_key] }}
-        end
-      end
-
-      query = {
-        sort: [
-          { code: { order: 'asc' } }
-        ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms
-              }
-            }
-          }
-        },
-        aggs: {
-          total_budget: { sum: { field: 'amount' } },
-          total_budget_per_inhabitant: { sum: { field: 'amount_per_inhabitant' } },
-        },
-        size: 10_000
-      }
-
-      response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: (options[:type] || EconomicArea.area_name), body: query
-
-      return {
-        'hits' => response['hits']['hits'].map{ |h| h['_source'] },
-        'aggregations' => response['aggregations']
-      }
-    end
-
-    def self.for_ranking(options)
-      response = budget_line_query(options)
-      results = response['hits']['hits'].map{|h| h['_source']}
-      total_elements = response['hits']['total']
-
-      return results, total_elements
-    end
-
-    def self.place_position_in_ranking(options)
-      id = %w{ine_code year code kind}.map {|f| options[f.to_sym]}.join('/')
-
-      response = budget_line_query(options.merge(to_rank: true))
-      buckets = response['hits']['hits'].map{|h| h['_id']}
-      position = buckets.index(id) ? buckets.index(id) + 1 : 0;
-      return position
-    end
-
-    def self.budget_line_query(options)
-
-      terms = [
-        {term: { year: options[:year] }},
-        {term: { kind: options[:kind] }},
-        {term: { code: options[:code] }}
-      ]
-
-      if options[:filters].present?
-        population_filter =  options[:filters][:population]
-        total_filter = options[:filters][:total]
-        per_inhabitant_filter = options[:filters][:per_inhabitant]
-        aarr_filter = options[:filters][:aarr]
-      end
-
-      if (population_filter && (population_filter[:from].to_i > GobiertoBudgets::Population::FILTER_MIN || population_filter[:to].to_i < GobiertoBudgets::Population::FILTER_MAX))
-        reduced_filter = {population: population_filter}
-        reduced_filter.merge!(aarr: aarr_filter) if aarr_filter
-        results,total_elements = GobiertoBudgets::Population.for_ranking(options[:year], 0, nil, reduced_filter)
-        ine_codes = results.map{|p| p['ine_code']}
-        terms << [{terms: { ine_code: ine_codes }}] if ine_codes.any?
-      end
-
-      if (total_filter && (total_filter[:from].to_i > GobiertoBudgets::BudgetTotal::TOTAL_FILTER_MIN || total_filter[:to].to_i < GobiertoBudgets::BudgetTotal::TOTAL_FILTER_MAX))
-        terms << {range: { amount: { gte: total_filter[:from].to_i, lte: total_filter[:to].to_i} }}
-      end
-
-      if (per_inhabitant_filter && (per_inhabitant_filter[:from].to_i > GobiertoBudgets::BudgetTotal::PER_INHABITANT_FILTER_MIN || per_inhabitant_filter[:to].to_i < GobiertoBudgets::BudgetTotal::PER_INHABITANT_FILTER_MAX))
-        terms << {range: { amount_per_inhabitant: { gte: per_inhabitant_filter[:from].to_i, lte: per_inhabitant_filter[:to].to_i} }}
-      end
-
-      terms << {term: { autonomy_id: aarr_filter }}  unless aarr_filter.blank?
-
-      query = {
-        sort: [ { options[:variable].to_sym => { order: 'desc' } } ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms,
-                must_not: {
-                  exists: {
-                    field: "functional_code",
-                  },
-                },
-                must_not: {
-                  exists: {
-                    field: "custom_code",
-                  }
-                }
-              }
-            }
-          }
-        },
-        size: 10_000
-      }
-
-      query.merge!(size: options[:per_page]) if options[:per_page].present?
-      query.merge!(from: options[:offset]) if options[:offset].present?
-      query.merge!(_source: false) if options[:to_rank]
-
-      GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: options[:area_name], body: query
-    end
-
-    def self.find(options)
-      return self.search(options)['hits'].detect{|h| h['code'] == options[:code] }
-    end
-
-    def self.compare(options)
-      terms = [{terms: { ine_code: options[:ine_codes] }},
-               {term: { level: options[:level] }},
-               {term: { kind: options[:kind] }},
-               {term: { year: options[:year] }}]
-
-      terms << {term: { parent_code: options[:parent_code] }} if options[:parent_code].present?
-      terms << {term: { code: options[:code] }} if options[:code].present?
-
-      query = {
-        sort: [
-          { code: { order: 'asc' } },
-          { ine_code: { order: 'asc' }}
-        ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms
-              }
-            }
-          }
-        },
-        size: 10_000
-      }
-
-      response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: options[:type] , body: query
-      response['hits']['hits'].map{ |h| h['_source'] }
-    end
-
-    def self.has_children?(options)
-      options.symbolize_keys!
-      conditions = { parent_code: options[:code], level: options[:level].to_i + 1, type: options[:area] }
-      conditions.merge! options.slice(:ine_code,:kind,:year)
-
-      return search(conditions)['hits'].length > 0
-    end
-
-    def self.top_differences(options)
-      terms = [{term: { kind: options[:kind] }}, {term: { year: options[:year] }}, {term: { level: 3 }}]
-      terms << {term: { ine_code: options[:ine_code] }} if options[:ine_code].present?
-      terms << {term: { code: options[:code] }} if options[:code].present?
-
-      query = {
-        sort: [
-          { code: { order: 'asc' } }
-        ],
-        query: {
-          filtered: {
-            filter: {
-              bool: {
-                must: terms
-              }
-            }
-          }
-        },
-        size: 10_000
-      }
-
-      response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: (options[:type] || EconomicArea.area_name), body: query
-
-      planned_results = response['hits']['hits'].map{ |h| h['_source'] }
-
-      response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, type: (options[:type] || EconomicArea.area_name), body: query
-
-      executed_results = response['hits']['hits'].map{ |h| h['_source'] }
-
-      results = {}
-      planned_results.each do |p|
-        if e = executed_results.detect{|e| e['code'] == p['code']}
-          results[p['code']] = [p['amount'], e['amount'], ((e['amount'].to_f - p['amount'].to_f)/p['amount'].to_f) * 100]
-        end
-      end
-
-      return results.sort{ |b, a| a[1][2] <=> b[1][2] }[0..15], results.sort{ |a, b| a[1][2] <=> b[1][2] }[0..15]
-    end
-
-    def self.algolia_index
-      @algolia_index ||= begin
-        index = Algolia::Index.new(search_index_name)
-        index.set_settings({ attributesForFaceting: [ 'site_id' ] })
-        index
-      end
-    end
-
-    def self.validate_conditions(conditions)
-      if conditions.has_key?(:kind)
-        raise GobiertoBudgets::BudgetLine::InvalidSearchConditions unless all_kinds.include?(conditions[:kind])
-      end
-      if conditions.has_key?(:area_name)
-        raise GobiertoBudgets::BudgetLine::InvalidSearchConditions unless BudgetArea.all_areas_names.include?(conditions[:area_name])
-      end
-    end
-    private_class_method :validate_conditions
-
-    def self.search_index_name
-      "#{APP_CONFIG["site"]["name"]}_#{Rails.env}_#{self.name}"
     end
 
     def self.get_level(code)
@@ -446,8 +62,7 @@ module GobiertoBudgets
       result['_source']['value']
     end
 
-    # Example:
-    # bl = GobiertoBudgets::BudgetLine.new(area_name: 'economic', site: Site.second, year: 2015, amount: 123.45, code: '1', kind: 'G', index: 'index_forecast')
+    # BudgetLine.new(site: Site.second, index: 'index_forecast', area_name: 'economic', kind: 'G', code: '1', year: 2015, amount: 123.45)
     def initialize(params = {})
       @site     = params[:site]
       @index    = params[:index]
@@ -470,14 +85,6 @@ module GobiertoBudgets
       @amount_per_inhabitant = (amount / population).round(2)
     end
 
-    def elastic_search_index
-      GobiertoBudgets::SearchEngineConfiguration::BudgetLine.send(index)
-    end
-
-    def algolia_id
-      "#{index}/#{area.area_name}/#{ine_code}/#{year}/#{code}/#{kind}"
-    end
-
     def population
       @population ||= self.class.get_population(ine_code, year)
     end
@@ -485,51 +92,6 @@ module GobiertoBudgets
     def to_param
       { place_id: place_id, year: year, code: code, area_name: area.area_name, kind: kind }
     end
-
-    def elasticsearch_as_json
-      {
-        ine_code: ine_code,
-        province_id: province_id,
-        autonomy_id: autonomy_id,
-        year: year,
-        population: population,
-        amount: amount,
-        code: code,
-        level: level,
-        kind: kind,
-        amount_per_inhabitant: amount_per_inhabitant,
-        parent_code: parent_code
-      }
-    end
-
-    def algolia_as_json
-      current_locale = I18n.locale
-      attributes_translations = {}
-
-      I18n.available_locales.each do |locale|
-        I18n.locale = locale
-        attributes_translations["name_#{locale}"] = get_name
-        attributes_translations["description_#{locale}"] = get_description
-      end
-
-      I18n.locale = current_locale
-
-      {
-        objectID: algolia_id,
-        index: index,
-        type: area.area_name,
-        site_id: site.id,
-        ine_code: ine_code,
-        year: year,
-        code: code,
-        kind: kind
-      }.merge(attributes_translations)
-    end
-
-    # def category
-    #   area = BudgetArea.klass_for(area_name)
-    #   area.all_items[self.kind][self.code]
-    # end
 
     def save
       result = GobiertoBudgets::SearchEngine.client.index(index: elastic_search_index, type: area.area_name, id: id, body: elasticsearch_as_json.to_json)

--- a/app/models/gobierto_budgets/category.rb
+++ b/app/models/gobierto_budgets/category.rb
@@ -23,7 +23,7 @@ module GobiertoBudgets
     end
 
     def self.default_name(area, kind, code)
-      area.all_items[kind][code]
+      area.all_items[I18n.locale][kind][code]
     end
 
     def self.default_description(area, kind, code)

--- a/app/models/gobierto_budgets/category.rb
+++ b/app/models/gobierto_budgets/category.rb
@@ -23,7 +23,7 @@ module GobiertoBudgets
     end
 
     def self.default_name(area, kind, code)
-      area.all_items[I18n.locale][kind][code]
+      area.all_items[kind][code]
     end
 
     def self.default_description(area, kind, code)

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -24,10 +24,6 @@
         <%#%>
         </h2>
       </div>
-      <div class="pure-u-1 pure-u-md-10-24 right slim_search">
-        <label><%= t('.search_for_a_budget_line') %></label>
-        <input type="text" placeholder="<%= t('gobierto_budgets.budget_lines.explorer.search') %>..." data-autocomplete="<%= gobierto_budgets_search_all_categories_path(@place.slug, @year, format: :json) %>">
-      </div>
     </div>
 
     <div class="pure-g metric_boxes">

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -86,7 +86,6 @@ ca:
         per_person: Per habitant
         planned_vs_executed: Despesa real vs. el plà
         planned_vs_executed_other_year_html: En %{year} va ser un %{link}
-        search_for_a_budget_line: Busca una partida
         see_all: Veure tots
         title: Pressupostos municipals el %{year}
         top_expense_category: Categoria

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -84,7 +84,6 @@ en:
         per_person: Per person
         planned_vs_executed: Real expenses vs the plan
         planned_vs_executed_other_year_html: In %{year} it was %{link}
-        search_for_a_budget_line: Search a budget line
         see_all: view all
         title: Local municipality budgets in %{year}
         top_expense_category: Category

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -86,7 +86,6 @@ es:
         per_person: Por habitante
         planned_vs_executed: Gasto real vs. el plan
         planned_vs_executed_other_year_html: En %{year} fue un %{link}
-        search_for_a_budget_line: Busca una partida
         see_all: ver todos
         title: Presupuestos municipales en %{year}
         top_expense_category: Categoría

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -90,6 +90,7 @@ ca:
       person_item: Biografia
       person_post_item: Post
       person_statement_item: Declaració
+      budget_line_item: Partida pressupostària
       powered_by: Gobierto utilitza <a href="https://www.algolia.com" target="_blank">Algolia</a>
         per a buscar
       updated: Actualitat

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -90,7 +90,8 @@ ca:
       person_item: Biografia
       person_post_item: Post
       person_statement_item: Declaració
-      budget_line_item: Partida pressupostària
+      budget_line_item_income: Partida pressupostària - Ingrés
+      budget_line_item_expense: Partida pressupostària - Despesa
       powered_by: Gobierto utilitza <a href="https://www.algolia.com" target="_blank">Algolia</a>
         per a buscar
       updated: Actualitat

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -85,6 +85,7 @@ en:
       person_item: Biography
       person_post_item: Post
       person_statement_item: Statement
+      budget_line_item: Budget line
       powered_by: Search powered by <a href="https://www.algolia.com" target="_blank">Algolia</a>
       updated: Updated
   sites:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -85,7 +85,8 @@ en:
       person_item: Biography
       person_post_item: Post
       person_statement_item: Statement
-      budget_line_item: Budget line
+      budget_line_item_income: Budget line - Income
+      budget_line_item_expense: Budget line - Expense
       powered_by: Search powered by <a href="https://www.algolia.com" target="_blank">Algolia</a>
       updated: Updated
   sites:

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -90,7 +90,8 @@ es:
       person_item: Biografía
       person_post_item: Post
       person_statement_item: Declaración
-      budget_line_item: Partida presupuestaria
+      budget_line_item_income: Partida presupuestaria - Ingreso
+      budget_line_item_expense: Partida presupuestaria - Gasto
       powered_by: Gobierto utiliza <a href="https://www.algolia.com" target="_blank">Algolia</a>
         para buscar
       updated: Actualizado

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -90,6 +90,7 @@ es:
       person_item: Biografía
       person_post_item: Post
       person_statement_item: Declaración
+      budget_line_item: Partida presupuestaria
       powered_by: Gobierto utiliza <a href="https://www.algolia.com" target="_blank">Algolia</a>
         para buscar
       updated: Actualizado

--- a/lib/tasks/gobierto_budgets/algolia_indices.rake
+++ b/lib/tasks/gobierto_budgets/algolia_indices.rake
@@ -1,0 +1,90 @@
+namespace :gobierto_budgets do
+  namespace :algolia do
+
+    desc 'Reindex records'
+    task :reindex, [:site_domain, :year] => [:environment] do |t, args|
+      site = Site.find_by!(domain: args[:site_domain])
+      year = args[:year].to_i
+      ine_code = site.place.id
+
+      puts "== Reindexing records for site #{site.domain}=="
+
+      # Delete all Algolia Budget Line records within this site
+      GobiertoBudgets::BudgetLine.algolia_destroy_records(site)
+
+      GobiertoBudgets::BudgetArea.all_areas.each do |area|
+        area.available_kinds.each do |kind|
+
+          puts "\n[INFO] area = '#{area.area_name}' kind = '#{kind}'"
+          puts "---------------------------------------------------"
+
+          forecast_hits = request_budget_lines_from_elasticsearch(
+            GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
+            area,
+            ine_code,
+            year
+          )
+
+          puts "[INFO] Found #{forecast_hits.size} forecast #{area.area_name} #{kind} BudgetLine records"
+
+          execution_hits = request_budget_lines_from_elasticsearch(
+            GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed,
+            area,
+            ine_code,
+            year
+          )
+
+          puts "[INFO] Found #{execution_hits.size} execution #{area.area_name} #{kind} BudgetLine records"
+
+          forecast_budget_lines = forecast_hits.map do |h|
+            create_budget_line(site, 'index_forecast', h)
+          end
+
+          execution_budget_lines = execution_hits.map do |h|
+            create_budget_line(site, 'index_executed', h)
+          end
+
+          GobiertoBudgets::BudgetLine.algolia_reindex_collection(forecast_budget_lines + execution_budget_lines)
+        end
+      end
+
+    end
+
+    def create_budget_line(site, index, elasticsearch_hit)
+      GobiertoBudgets::BudgetLine.new(
+             site: site,
+            index: index,
+        area_name: elasticsearch_hit['_type'],
+             kind: elasticsearch_hit['_source']['kind'],
+             code: elasticsearch_hit['_source']['code'],
+             year: elasticsearch_hit['_source']['year'],
+           amount: elasticsearch_hit['_source']['amount']
+      )
+    end
+
+    def request_budget_lines_from_elasticsearch(index, area, ine_code, year)
+      query = {
+        query: {
+          filtered: {
+            filter: {
+              bool: {
+                must: [
+                  { term: { ine_code: ine_code } },
+                  { term: { year: year } }
+                ]
+              }
+            }
+          }
+        },
+        size: 10_000
+      }
+
+      GobiertoBudgets::SearchEngine.client.search(
+        index: index,
+        type: area.area_name,
+        body: query
+      )['hits']['hits']
+    end
+
+  end
+end

--- a/lib/tasks/gobierto_budgets/algolia_indices.rake
+++ b/lib/tasks/gobierto_budgets/algolia_indices.rake
@@ -27,24 +27,11 @@ namespace :gobierto_budgets do
 
           puts "[INFO] Found #{forecast_hits.size} forecast #{area.area_name} #{kind} BudgetLine records"
 
-          execution_hits = request_budget_lines_from_elasticsearch(
-            GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed,
-            area,
-            ine_code,
-            year
-          )
-
-          puts "[INFO] Found #{execution_hits.size} execution #{area.area_name} #{kind} BudgetLine records"
-
           forecast_budget_lines = forecast_hits.map do |h|
             create_budget_line(site, 'index_forecast', h)
           end
 
-          execution_budget_lines = execution_hits.map do |h|
-            create_budget_line(site, 'index_executed', h)
-          end
-
-          GobiertoBudgets::BudgetLine.algolia_reindex_collection(forecast_budget_lines + execution_budget_lines)
+          GobiertoBudgets::BudgetLine.algolia_reindex_collection(forecast_budget_lines)
         end
       end
 

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class GobiertoBudgets::BudgetLineTest < ActionDispatch::IntegrationTest
+class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     super
     @path = gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::EconomicArea.area_name, GobiertoBudgets::BudgetLine::EXPENSE)

--- a/test/models/gobierto_budgets/budget_line_test.rb
+++ b/test/models/gobierto_budgets/budget_line_test.rb
@@ -111,6 +111,8 @@ module GobiertoBudgets
         year: budget_line.year,
         code: budget_line.code,
         kind: budget_line.kind,
+        resource_path: budget_line.resource_path,
+        class_name: budget_line.class.name,
         'name_es'        => 'Gastos de personal (custom, translated)',
         'description_es' => 'Los gastos de personal son... (custom, translated)',
         'name_en'        => 'Personal expenses (custom, translated)',


### PR DESCRIPTION
Connects to #772 

### What does this PR do?

* Permits indexing instances of `BudgetLine` in Algolia.
* Refactors `BudgetLine` model, moving Elasticsearch-specific behavior to `budget_line_elasticsearch_helpers.rb` and Algolia-specific behavior to `budget_line_algolia_helpers.rb`.
* Provides a Rake task to destroy and reindex all of the `BudgetLine` records indexed in Algolia for a specific site, and reindexes them again.

### How should this be manually tested?

Budget lines should be searchable by name and description.