### PR TITLE
769 - BudgetLine datasetet timestamps

### DIFF
--- a/app/pub_sub/publishers/gobierto_budgets_budget_line_activity.rb
+++ b/app/pub_sub/publishers/gobierto_budgets_budget_line_activity.rb
@@ -1,0 +1,7 @@
+module Publishers
+  class GobiertoBudgetsBudgetLineActivity
+    include Publisher
+
+    self.pub_sub_namespace = 'activities/gobierto_budgets_budget_line'
+  end
+end

--- a/app/pub_sub/subscribers/gobierto_budgets_budget_line_activity.rb
+++ b/app/pub_sub/subscribers/gobierto_budgets_budget_line_activity.rb
@@ -1,0 +1,47 @@
+module Subscribers
+  class GobiertoBudgetsBudgetLineActivity < ::Subscribers::Base
+
+    def budgets_forecast_economic_updated(event)
+      create_activity_from_event(event, action_name_for('forecast', GobiertoBudgets::EconomicArea))
+    end
+
+    def budgets_forecast_functional_updated(event)
+      create_activity_from_event(event, action_name_for('forecast', GobiertoBudgets::FunctionalArea))
+    end
+
+    def budgets_forecast_custom_updated(event)
+      create_activity_from_event(event, action_name_for('forecast', GobiertoBudgets::CustomArea))
+    end
+
+    def budgets_execution_economic_updated(event)
+      create_activity_from_event(event, action_name_for('execution', GobiertoBudgets::EconomicArea))
+    end
+
+    def budgets_execution_functional_updated(event)
+      create_activity_from_event(event, action_name_for('execution', GobiertoBudgets::FunctionalArea))
+    end
+
+    def budgets_execution_custom_updated(event)
+      create_activity_from_event(event, action_name_for('execution', GobiertoBudgets::CustomArea))
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      site = Site.find(event.payload[:site_id])
+
+      Activity.create!(
+        action: action,
+        subject: site,
+        subject_ip: '127.0.0.1',
+        admin_activity: false,
+        site_id: site.id
+      )
+    end
+
+    def action_name_for(index, area)
+      "gobierto_budgets.budgets_#{index}_#{area.area_name}_updated"
+    end
+
+  end
+end

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -6,6 +6,7 @@
 ::Subscribers::GobiertoBudgetConsultationsActivity.attach_to('trackable')
 ::Subscribers::GobiertoBudgetConsultationsConsultationResponseActivity.attach_to('activities/gobierto_budget_consultations_consultation_response')
 ::Subscribers::GobiertoCmsPageActivity.attach_to('activities/gobierto_cms_pages')
+::Subscribers::GobiertoBudgetsBudgetLineActivity.attach_to('activities/gobierto_budgets_budget_line')
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -1,6 +1,13 @@
 ---
 ca:
   gobierto_budgets:
+    events:
+      gobierto_budgets_budgets_forecast_economic_updated: 'Pressupostos actualitzats: àrea econòmica'
+      gobierto_budgets_budgets_forecast_functional_updated: 'Pressupostos actualitzats: àrea funcional'
+      gobierto_budgets_budgets_forecast_custom_updated: 'Pressupostos actualitzats: àrea personalitzada'
+      gobierto_budgets_budgets_execution_economic_updated: 'Execució pressupostària actualitzada: àrea econòmica'
+      gobierto_budgets_budgets_execution_functional_updated: 'Execució pressupostària actualitzada: àrea funcional'
+      gobierto_budgets_budgets_execution_custom_updated: 'Execució pressupostària actualitzada: àrea personalitzada'
     budget_lines:
       explorer:
         examples: Exemples

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -1,6 +1,13 @@
 ---
 en:
   gobierto_budgets:
+    events:
+      gobierto_budgets_budgets_forecast_economic_updated: 'Budgets updated: economic area'
+      gobierto_budgets_budgets_forecast_functional_updated: 'Budgets updated: functional area'
+      gobierto_budgets_budgets_forecast_custom_updated: 'Budgets updated: custom area'
+      gobierto_budgets_budgets_execution_economic_updated: 'Budgets execution updated: economic area'
+      gobierto_budgets_budgets_execution_functional_updated: 'Budgets execution updated: functional area'
+      gobierto_budgets_budgets_execution_custom_updated: 'Budgets execution updated: custom area'
     budget_lines:
       explorer:
         examples: Examples

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -1,6 +1,13 @@
 ---
 es:
   gobierto_budgets:
+    events:
+      gobierto_budgets_budgets_forecast_economic_updated: 'Presupuestos actualizados: área económica'
+      gobierto_budgets_budgets_forecast_functional_updated: 'Presupuestos actualizados: área funcional'
+      gobierto_budgets_budgets_forecast_custom_updated: 'Presupuestos actualizados: área personalizada'
+      gobierto_budgets_budgets_execution_economic_updated: 'Ejecución presupuestaria actualizada: área económica'
+      gobierto_budgets_budgets_execution_functional_updated: 'Ejecución presupuestaria actualizada: área funcional'
+      gobierto_budgets_budgets_execution_custom_updated: 'Ejecución presupuestaria actualizada: área personalizada'
     budget_lines:
       explorer:
         examples: Ejemplos

--- a/test/pub_sub/subscribers/gobierto_budgets_budget_line_test.rb
+++ b/test/pub_sub/subscribers/gobierto_budgets_budget_line_test.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+class Subscribers::GobiertoBudgetsBudgetLineActivityTest < ActiveSupport::TestCase
+  class Event < OpenStruct; end
+
+  LOCALHOST = '127.0.0.1'
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def subject
+    @subject ||= Subscribers::GobiertoBudgetsBudgetLineActivity.new('activities')
+  end
+
+  def ip_address
+    @ip_address ||= IPAddr.new(LOCALHOST)
+  end
+
+  def create_event(index, area)
+    Event.new(name: "gobierto_budgets.budgets_#{index}_#{area.area_name}_updated",
+      payload: {
+        subject: site,
+        ip: LOCALHOST,
+        site_id: site.id
+      }
+    )
+  end
+
+  def test_budgets_forecast_economic_updated_handling
+    assert_difference 'Activity.count' do
+      subject.budgets_forecast_economic_updated(
+        create_event('forecast', GobiertoBudgets::EconomicArea)
+      )
+    end
+
+    activity = Activity.last
+
+    assert_equal site, activity.subject
+    assert_equal ip_address, activity.subject_ip
+    assert_equal 'gobierto_budgets.budgets_forecast_economic_updated', activity.action
+    assert_equal site.id, activity.site_id
+    refute activity.admin_activity
+  end
+
+  def test_budgets_forecast_functional_updated_handling
+    assert_difference 'Activity.count' do
+      subject.budgets_forecast_functional_updated(
+        create_event('forecast', GobiertoBudgets::FunctionalArea)
+      )
+    end
+
+    activity = Activity.last
+
+    assert_equal site, activity.subject
+    assert_equal 'gobierto_budgets.budgets_forecast_functional_updated', activity.action
+  end
+
+  def test_budgets_forecast_custom_updated_handling
+    assert_difference 'Activity.count' do
+      subject.budgets_forecast_custom_updated(
+        create_event('forecast', GobiertoBudgets::CustomArea)
+      )
+    end
+
+    activity = Activity.last
+
+    assert_equal site, activity.subject
+    assert_equal 'gobierto_budgets.budgets_forecast_custom_updated', activity.action
+  end
+
+  def test_budgets_execution_economic_updated_handling
+    assert_difference 'Activity.count' do
+      subject.budgets_execution_economic_updated(
+        create_event('execution', GobiertoBudgets::EconomicArea)
+      )
+    end
+
+    activity = Activity.last
+
+    assert_equal site, activity.subject
+    assert_equal 'gobierto_budgets.budgets_execution_economic_updated', activity.action
+  end
+
+  def test_budgets_execution_functional_updated_handling
+    assert_difference 'Activity.count' do
+      subject.budgets_execution_functional_updated(
+        create_event('execution', GobiertoBudgets::FunctionalArea)
+      )
+    end
+
+    activity = Activity.last
+
+    assert_equal site, activity.subject
+    assert_equal 'gobierto_budgets.budgets_execution_functional_updated', activity.action
+  end
+
+  def test_budgets_execution_custom_updated_handling
+    assert_difference 'Activity.count' do
+      subject.budgets_execution_custom_updated(
+        create_event('execution', GobiertoBudgets::CustomArea)
+      )
+    end
+
+    activity = Activity.last
+
+    assert_equal site, activity.subject
+    assert_equal 'gobierto_budgets.budgets_execution_custom_updated', activity.action
+  end
+
+end


### PR DESCRIPTION
Connects to #769 

### What does this PR do?

Adds new publisher and subscriber to use when `BudgetLine` data is updated.

Related PR in Populate Data [#58](https://github.com/PopulateTools/populate-data-indicators/pull/58)

### How should this be manually tested?

After re-executing the budgets import scripts available at Populate Data (after merging the related PR), the corresponding `Activity` records should had been instantiated.
