### PR TITLE
43, 44 - Fix both evolution and context graphs

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
@@ -126,6 +126,28 @@ var VisLineasJ = Class.extend({
 
       this.data = jsonData;
 
+      var years_with_data = this.data["budgets"]["per_person"].map(function(x) {
+        var dates = x["values"].map(function(value) {
+          return value["date"];
+        });
+        return dates;
+      });
+
+      years_with_data = [].concat.apply([], years_with_data); // Flatten array
+
+      var unique_years = []
+      years_with_data.forEach(function(year) {
+          if (unique_years.indexOf(year) === -1) {
+            unique_years.push(year);
+          }
+      });
+
+      if (unique_years.length < 2) {
+        $('#lines_chart_wrapper').html('');
+        $('#lines_chart_wrapper_separator').remove();
+        return;
+      }
+
       this.data.budgets[this.measure].forEach(function(d) {
         d.values.forEach(function(v) {
           v.date = this.parseDate(v.date);

--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
@@ -92,7 +92,13 @@ var VisLineasJ = Class.extend({
 
     // Chart dimensions
     this.containerWidth = parseInt(d3.select(this.container).style('width'), 10);
-    this.tableWidth = parseInt(d3.select(this.tableContainer).style('width'), 10);
+
+    if (d3.select(this.tableContainer).size() !== 0) {
+      this.tableWidth = parseInt(d3.select(this.tableContainer).style('width'), 10);
+    } else {
+      this.tableWidth = 0;
+    }
+
     this.margin.right = this.measure == 'per_person' ? this.containerWidth * .07 : this.containerWidth * .15;
 
     this.width = this.containerWidth - this.margin.left - this.margin.right;
@@ -126,23 +132,24 @@ var VisLineasJ = Class.extend({
 
       this.data = jsonData;
 
-      var years_with_data = this.data["budgets"]["per_person"].map(function(x) {
+      var budgetsData = (this.data["budgets"]["per_person"] || this.data["budgets"]["total_budget"]);
+      var yearsWithData = budgetsData.map(function(x) {
         var dates = x["values"].map(function(value) {
           return value["date"];
         });
         return dates;
       });
 
-      years_with_data = [].concat.apply([], years_with_data); // Flatten array
+      yearsWithData = [].concat.apply([], yearsWithData); // Flatten array
 
-      var unique_years = []
-      years_with_data.forEach(function(year) {
-          if (unique_years.indexOf(year) === -1) {
-            unique_years.push(year);
+      var uniqueYears = []
+      yearsWithData.forEach(function(year) {
+          if (uniqueYears.indexOf(year) === -1) {
+            uniqueYears.push(year);
           }
       });
 
-      if (unique_years.length < 2) {
+      if (uniqueYears.length < 2) {
         $('#lines_chart_wrapper').html('');
         $('#lines_chart_wrapper_separator').remove();
         return;

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -112,7 +112,11 @@
       <div class="pure-u-1 pure-u-md-9-24 line_description">
 
         <h2><%= t('.about_this_line') %></h2>
-        <%= simple_format budget_line_description(@budget_line) %>
+        <% if @budget_line.description %>
+          <%= simple_format budget_line_description(@budget_line) %>
+        <% else %>
+          <%= t('.no_description') %>
+        <% end %>
       </div>
 
       <div class="pure-u-md-3-24"></div>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -166,7 +166,7 @@
       </div>
     </div>
 
-    <div class="separator"></div>
+    <div id="lines_chart_wrapper_separator" class="separator"></div>
 
     <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
       <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -174,13 +174,15 @@
         <div id="lines_chart"></div>
       </div>
 
-      <div class="pure-u-1 pure-u-md-1-2 p_h_r_1">
-        <h2><%= t('gobierto_budgets.budgets.index.context') %></h2>
-        <div id="lines_tooltip"></div>
-        <div class="help">
-          <%= link_to t('gobierto_budgets.budgets.index.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], title: t('gobierto_budgets.budgets.index.note_about_the_data_title'), class: 'tipsit' %>
+      <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name %>
+        <div class="pure-u-1 pure-u-md-1-2 p_h_r_1">
+          <h2><%= t('gobierto_budgets.budgets.index.context') %></h2>
+          <div id="lines_tooltip"></div>
+          <div class="help">
+            <%= link_to t('gobierto_budgets.budgets.index.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], title: t('gobierto_budgets.budgets.index.note_about_the_data_title'), class: 'tipsit' %>
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <div class="pure-u-1">
         <div class="filter m_v_2" role="tablist" aria-label="<%= t('gobierto_budgets.budgets.index.visualize') %>">

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -221,7 +221,7 @@
   <div class="featured_b_l block m_v_3" data-featured-budget-line="<%= gobierto_budgets_featured_budget_line_path(@site.place.slug, year: @year, template: 'gobierto_site_template') %>">
   </div>
 
-  <div class="separator"></div>
+  <div id="lines_chart_wrapper_separator" class="separator"></div>
 
   <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
     <div class=" pure-u-1 pure-u-md-1-2 block" >

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -39,6 +39,7 @@ ca:
         evolution: Evolució
         last_year: L'any passat
         no_distribution: No hi ha distribució associada a aquesta partida.
+        no_description: No hi ha una descripció associada a aquesta partida.
         no_more_descendants: No hi ha més sub-partides
         not_available: No disp.
         percentage: "% sobre el total del press."

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -37,7 +37,8 @@ en:
         budget_lines_distribution: Expense budget lines distribution
         evolution: Evolution
         last_year: Last year
-        no_distribution: There are related budget lines.
+        no_distribution: There aren't any related budget lines.
+        no_description: There's no description for this budget line.
         no_more_descendants: There are no more descendants
         not_available: Not avail.
         percentage: "% over the total"

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -39,6 +39,7 @@ es:
         evolution: Evolución
         last_year: El año pasado
         no_distribution: No hay distribución asociada a esta partida.
+        no_description: No hay una descripción asociada a esta partida.
         no_more_descendants: No hay más sub-partidas
         not_available: No disp.
         percentage: "% sobre el total del pres."


### PR DESCRIPTION
Connects to [#43](https://github.com/PopulateTools/issues/issues/43) and [#44](https://github.com/PopulateTools/issues/issues/44)

### What does this PR do?

* Hides evolution graph when there is only one year of data available.
* Hides context graph for `CustomArea` budget lines #show
