### PR TITLE
Stop overlapping lines with the same name

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_bubbles.js
@@ -109,7 +109,7 @@ var VisBubbles = Class.extend({
       .duration(500);
 
     this.nodes = this.createNodes(this.data, year);
-    this.bubbles.data(this.nodes, function (d) { return d.name; })
+    this.bubbles.data(this.nodes, function (d) { return d.id; })
 
     d3.selectAll('.bubble')
       .data(this.nodes, function (d) { return d.name; })


### PR DESCRIPTION
Unexpected.

Connects to #810.

### What does this PR do?
This PR improves the handling of lines with the same name in the bubbles vis.

### How should this be manually tested?
Load Mataró data and go to to 2014. Lines named 'D'entitats locals' shouldn't be overlapping anymore.
