### PR TITLE
Test normalized i18n files

### DIFF
--- a/config/locales/gobierto_admin/controllers/census_imports/ca.yml
+++ b/config/locales/gobierto_admin/controllers/census_imports/ca.yml
@@ -4,6 +4,6 @@ ca:
     census:
       imports:
         create:
-          error: Hi ha hagut un error al importar el teu arxiu. Per favor, tria
-            de nou.
+          error: Hi ha hagut un error al importar el teu arxiu. Per favor, tria de
+            nou.
           success: S'ha importat %{record_count} registres

--- a/config/locales/gobierto_admin/controllers/user_welcome_messages/ca.yml
+++ b/config/locales/gobierto_admin/controllers/user_welcome_messages/ca.yml
@@ -4,6 +4,6 @@ ca:
     users:
       welcome_messages:
         create:
-          error: El missatge de benvinguda no s'ha pogut enviar. Per favor, tria
-            de nou.
+          error: El missatge de benvinguda no s'ha pogut enviar. Per favor, tria de
+            nou.
           success: El missatge de benvinguda s'ha enviat

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/ca.yml
@@ -4,6 +4,8 @@ ca:
     gobierto_budget_consultations:
       consultations:
         create:
-          success_html: "La consulta s'ha creat correctament. <a href='%{link}'>Veure-la consulta</a>"
+          success_html: La consulta s'ha creat correctament. <a href='%{link}'>Veure-la
+            consulta</a>
         update:
-          success_html: "La consulta s'ha actualitzat correctament. <a href='%{link}'>Veure-la consulta</a>"
+          success_html: La consulta s'ha actualitzat correctament. <a href='%{link}'>Veure-la
+            consulta</a>

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/en.yml
@@ -4,6 +4,8 @@ en:
     gobierto_budget_consultations:
       consultations:
         create:
-          success_html: "Consultation was successfully created. <a href='%{link}'>View the consultation</a>"
+          success_html: Consultation was successfully created. <a href='%{link}'>View
+            the consultation</a>
         update:
-          success_html: "Consultation was successfully updated. <a href='%{link}'>View the consultation</a>"
+          success_html: Consultation was successfully updated. <a href='%{link}'>View
+            the consultation</a>

--- a/config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/es.yml
@@ -4,6 +4,8 @@ es:
     gobierto_budget_consultations:
       consultations:
         create:
-          success_html: "La consulta ha sido creada correctamente. <a href='%{link}'>Ver la consulta</a>"
+          success_html: La consulta ha sido creada correctamente. <a href='%{link}'>Ver
+            la consulta</a>
         update:
-          success_html: "La consulta ha sido actualizada. <a href='%{link}'>Ver la consulta</a>"
+          success_html: La consulta ha sido actualizada. <a href='%{link}'>Ver la
+            consulta</a>

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/issues/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/issues/ca.yml
@@ -4,6 +4,6 @@ ca:
     gobierto_participation:
       issues:
         create:
-          success: "El tema s'ha creat correctament."
+          success: El tema s'ha creat correctament.
         update:
-          success: "El tema s'ha actualitzat correctament."
+          success: El tema s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/issues/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/issues/en.yml
@@ -4,6 +4,6 @@ en:
     gobierto_participation:
       issues:
         create:
-          success: "Theme was successfully created."
+          success: Theme was successfully created.
         update:
-          success: "Theme was successfully updated."
+          success: Theme was successfully updated.

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/issues/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/issues/es.yml
@@ -4,6 +4,6 @@ es:
     gobierto_participation:
       issues:
         create:
-          success: "El tema se ha creado correctamente."
+          success: El tema se ha creado correctamente.
         update:
-          success: "El tema se ha actualizado correctamente."
+          success: El tema se ha actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/ca.yml
@@ -4,7 +4,8 @@ ca:
     gobierto_people:
       people:
         create:
-          success_html: "El perfil s'ha creat correctament. <a href=\"%{link}\">Veure la persona</a>."
+          success_html: El perfil s'ha creat correctament. <a href="%{link}">Veure
+            la persona</a>.
         update:
-          success_html: "El perfil s'ha actualitzat correctament. <a href=\"%{link}\">Veure la persona</a>."
-
+          success_html: El perfil s'ha actualitzat correctament. <a href="%{link}">Veure
+            la persona</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/en.yml
@@ -4,7 +4,8 @@ en:
     gobierto_people:
       people:
         create:
-          success_html: "Person was successfully created. <a href=\"%{link}\">See the person</a>."
+          success_html: Person was successfully created. <a href="%{link}">See the
+            person</a>.
         update:
-          success_html: "Person was successfully updated. <a href=\"%{link}\">See the person</a>."
-
+          success_html: Person was successfully updated. <a href="%{link}">See the
+            person</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/es.yml
@@ -4,7 +4,7 @@ es:
     gobierto_people:
       people:
         create:
-          success_html: "El perfil ha sido creado correctamente. <a href=\"%{link}\">Ver la persona</a>."
+          success_html: El perfil ha sido creado correctamente. <a href="%{link}">Ver
+            la persona</a>.
         update:
-          success_html: "El perfil ha sido actualizado. <a href=\"%{link}\">Ver la persona</a>."
-
+          success_html: El perfil ha sido actualizado. <a href="%{link}">Ver la persona</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/ca.yml
@@ -5,7 +5,8 @@ ca:
       people:
         person_events:
           create:
-            success_html: "El esdeveniment s'ha creat correctament. <a href=\"%{link}\">Veure el esdeveniment</a>."
+            success_html: El esdeveniment s'ha creat correctament. <a href="%{link}">Veure
+              el esdeveniment</a>.
           update:
-            success_html: "El esdeveniment s'ha actualitzat correctament. <a href=\"%{link}\">Veure el esdeveniment</a>."
-
+            success_html: El esdeveniment s'ha actualitzat correctament. <a href="%{link}">Veure
+              el esdeveniment</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/en.yml
@@ -5,7 +5,8 @@ en:
       people:
         person_events:
           create:
-            success_html: "Event was successfully created. <a href=\"%{link}\">See the event</a>."
+            success_html: Event was successfully created. <a href="%{link}">See the
+              event</a>.
           update:
-            success_html: "Event was successfully updated. <a href=\"%{link}\">See the event</a>."
-
+            success_html: Event was successfully updated. <a href="%{link}">See the
+              event</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/es.yml
@@ -5,7 +5,8 @@ es:
       people:
         person_events:
           create:
-            success_html: "El evento ha sido creado correctamente. <a href=\"%{link}\">Ver el evento</a>."
+            success_html: El evento ha sido creado correctamente. <a href="%{link}">Ver
+              el evento</a>.
           update:
-            success_html: "El evento ha sido actualizado. <a href=\"%{link}\">Ver el evento</a>."
-
+            success_html: El evento ha sido actualizado. <a href="%{link}">Ver el
+              evento</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/ca.yml
@@ -5,7 +5,8 @@ ca:
       people:
         person_posts:
           create:
-            success_html: "El post s'ha creat correctament. <a href=\"%{link}\">Veure el post</a>."
+            success_html: El post s'ha creat correctament. <a href="%{link}">Veure
+              el post</a>.
           update:
-            success_html: "El post s'ha actualitzat correctament. <a href=\"%{link}\">Veure el post</a>."
-
+            success_html: El post s'ha actualitzat correctament. <a href="%{link}">Veure
+              el post</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/en.yml
@@ -5,7 +5,8 @@ en:
       people:
         person_posts:
           create:
-            success_html: "Post was successfully created. <a href=\"%{link}\">See the post</a>."
+            success_html: Post was successfully created. <a href="%{link}">See the
+              post</a>.
           update:
-            success_html: "Post was successfully updated. <a href=\"%{link}\">See the post</a>."
-
+            success_html: Post was successfully updated. <a href="%{link}">See the
+              post</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/es.yml
@@ -5,7 +5,7 @@ es:
       people:
         person_posts:
           create:
-            success_html: "El post ha sido creado correctamente. <a href=\"%{link}\">Ver el post</a>."
+            success_html: El post ha sido creado correctamente. <a href="%{link}">Ver
+              el post</a>.
           update:
-            success_html: "El post ha sido actualizado. <a href=\"%{link}\">Ver el post</a>."
-
+            success_html: El post ha sido actualizado. <a href="%{link}">Ver el post</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/ca.yml
@@ -5,6 +5,8 @@ ca:
       people:
         person_statements:
           create:
-            success_html: "La declaració s'ha creat correctament. <a href=\"%{link}\">Veure la declaració</a>."
+            success_html: La declaració s'ha creat correctament. <a href="%{link}">Veure
+              la declaració</a>.
           update:
-            success_html: "La declaració s'ha actualitzat correctament. <a href=\"%{link}\">Veure la declaració</a>."
+            success_html: La declaració s'ha actualitzat correctament. <a href="%{link}">Veure
+              la declaració</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/en.yml
@@ -5,6 +5,8 @@ en:
       people:
         person_statements:
           create:
-            success_html: "Statement was successfully created. <a href=\"%{link}\">See the statement</a>."
+            success_html: Statement was successfully created. <a href="%{link}">See
+              the statement</a>.
           update:
-            success_html: "Statement was successfully updated. <a href=\"%{link}\">See the statement</a>."
+            success_html: Statement was successfully updated. <a href="%{link}">See
+              the statement</a>.

--- a/config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/es.yml
@@ -5,6 +5,8 @@ es:
       people:
         person_statements:
           create:
-            success_html: "La declaración ha sido creada correctamente. <a href=\"%{link}\">Ver la declaración</a>."
+            success_html: La declaración ha sido creada correctamente. <a href="%{link}">Ver
+              la declaración</a>.
           update:
-            success_html: "La declaración ha sido actualizada. <a href=\"%{link}\">Ver la declaración</a>."
+            success_html: La declaración ha sido actualizada. <a href="%{link}">Ver
+              la declaración</a>.

--- a/config/locales/gobierto_admin/gobierto_people/views/political_groups/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/political_groups/ca.yml
@@ -4,4 +4,3 @@ ca:
     gobierto_people:
       political_groups:
         title: Grups polítics
-

--- a/config/locales/gobierto_admin/gobierto_people/views/political_groups/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/political_groups/en.yml
@@ -4,4 +4,3 @@ en:
     gobierto_people:
       political_groups:
         title: Political groups
-

--- a/config/locales/gobierto_admin/gobierto_people/views/political_groups/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/political_groups/es.yml
@@ -4,4 +4,3 @@ es:
     gobierto_people:
       political_groups:
         title: Grupos políticos
-

--- a/config/locales/gobierto_admin/gobierto_people/views/settings/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/settings/ca.yml
@@ -4,4 +4,3 @@ ca:
     gobierto_people:
       settings:
         title: Preferencies
-

--- a/config/locales/gobierto_admin/gobierto_people/views/settings/en.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/settings/en.yml
@@ -4,4 +4,3 @@ en:
     gobierto_people:
       settings:
         title: Settings
-

--- a/config/locales/gobierto_admin/gobierto_people/views/settings/es.yml
+++ b/config/locales/gobierto_admin/gobierto_people/views/settings/es.yml
@@ -4,4 +4,3 @@ es:
     gobierto_people:
       settings:
         title: Preferencias
-

--- a/config/locales/gobierto_admin/views/census_imports/ca.yml
+++ b/config/locales/gobierto_admin/views/census_imports/ca.yml
@@ -6,14 +6,14 @@ ca:
         file_format_notes:
           instructions: 'El arxiu a carregar deu de ser un CSV, sense fila de capcalera,
             amb les columnes de dades que vulguem que el usuari hagi de verificar.
-            Per exemple, si volem validar DNI, data de naixement i codi postal,
-            deurem preparar un arxiu com aquest:'
+            Per exemple, si volem validar DNI, data de naixement i codi postal, deurem
+            preparar un arxiu com aquest:'
         form:
           disable_with: Carregant...
           submit: Carregant archiu de cens
         new:
           final_notes: es sustituiràn tots els registres, i si algún DNI d'usuari
             verificat deixa d'estar present, el usuari deixará de tindre accés
-          import_status: El cens ha sigut actualitzat per última volta el %{created_at} per %{admin_name}
-            (%{admin_email}). El arxiu té %{imported_records} registres.
+          import_status: El cens ha sigut actualitzat per última volta el %{created_at}
+            per %{admin_name} (%{admin_email}). El arxiu té %{imported_records} registres.
           title: Configuració de cens

--- a/config/locales/gobierto_admin/views/census_imports/es.yml
+++ b/config/locales/gobierto_admin/views/census_imports/es.yml
@@ -14,6 +14,7 @@ es:
         new:
           final_notes: se sustituirán todos los registros, y si algún DNI de usuario
             verificado deja de estar presente, el usuario dejará de tener acceso
-          import_status: El censo ha sido cargado por última vez el %{created_at} por %{admin_name}
-            (%{admin_email}). El archivo tiene %{imported_records} registros.
+          import_status: El censo ha sido cargado por última vez el %{created_at}
+            por %{admin_name} (%{admin_email}). El archivo tiene %{imported_records}
+            registros.
           title: Configuración de censo

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -25,4 +25,3 @@ ca:
         visibility_level:
           active: Públic
           draft: Borrador
-

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -25,4 +25,3 @@ en:
         visibility_level:
           active: Published
           draft: Draft
-

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -25,4 +25,3 @@ es:
         visibility_level:
           active: Público
           draft: Borrador
-

--- a/config/locales/gobierto_budget_consultations/controllers/consultation_responses/ca.yml
+++ b/config/locales/gobierto_budget_consultations/controllers/consultation_responses/ca.yml
@@ -4,4 +4,6 @@ ca:
     consultations:
       consultation_responses:
         new:
-          user_not_signed_in_html: "La participació en aquesta consulta està reservada als empadronats/des a %{place_name}.<br><br>Registra't o fes login si ja tens compte (i verifica que ja estàs empadronat) per poder participar."
+          user_not_signed_in_html: La participació en aquesta consulta està reservada
+            als empadronats/des a %{place_name}.<br><br>Registra't o fes login si
+            ja tens compte (i verifica que ja estàs empadronat) per poder participar.

--- a/config/locales/gobierto_budget_consultations/controllers/consultation_responses/en.yml
+++ b/config/locales/gobierto_budget_consultations/controllers/consultation_responses/en.yml
@@ -4,5 +4,6 @@ en:
     consultations:
       consultation_responses:
         new:
-          user_not_signed_in_html: "The participation in this consultation is reserved to people registered in %{place_name}.<br><br>Signup or login if you already have an account (and verify you are registered) to participate."
-
+          user_not_signed_in_html: The participation in this consultation is reserved
+            to people registered in %{place_name}.<br><br>Signup or login if you already
+            have an account (and verify you are registered) to participate.

--- a/config/locales/gobierto_budget_consultations/controllers/consultation_responses/es.yml
+++ b/config/locales/gobierto_budget_consultations/controllers/consultation_responses/es.yml
@@ -4,5 +4,6 @@ es:
     consultations:
       consultation_responses:
         new:
-          user_not_signed_in_html: "La participación en esta consulta está reservada a empadronados/as en %{place_name}.<br><br>Regístrate o haz login si ya tienes cuenta (y verifica que ya estás empadronado) para poder participar."
-
+          user_not_signed_in_html: La participación en esta consulta está reservada
+            a empadronados/as en %{place_name}.<br><br>Regístrate o haz login si ya
+            tienes cuenta (y verifica que ya estás empadronado) para poder participar.

--- a/config/locales/user/controllers/subscriptions/ca.yml
+++ b/config/locales/user/controllers/subscriptions/ca.yml
@@ -4,6 +4,7 @@ ca:
     subscriptions:
       create:
         create_success: S'ha realitzat la suscripció
-        error: "Ha ocorregut un problema en subscriure't: %{details}. Si ja estàs registrat, identifica't <a href=\"%{sign_in_path}\">açí</a>."
+        error: 'Ha ocorregut un problema en subscriure''t: %{details}. Si ja estàs
+          registrat, identifica''t <a href="%{sign_in_path}">açí</a>.'
       destroy:
         success: S'ha cancel·lat aquesta suscripció

--- a/config/locales/user/controllers/subscriptions/en.yml
+++ b/config/locales/user/controllers/subscriptions/en.yml
@@ -4,6 +4,7 @@ en:
     subscriptions:
       create:
         create_success: Subscription was successfully created
-        error: "There was a problem when subscribing to this resource: %{details}. If you are already registered, sign in <a href=\"%{sign_in_path}\">here</a>."
+        error: 'There was a problem when subscribing to this resource: %{details}.
+          If you are already registered, sign in <a href="%{sign_in_path}">here</a>.'
       destroy:
         success: Subscription was successfully canceled

--- a/config/locales/user/controllers/subscriptions/es.yml
+++ b/config/locales/user/controllers/subscriptions/es.yml
@@ -4,6 +4,7 @@ es:
     subscriptions:
       create:
         create_success: Se ha realizado la suscripción
-        error: "Ha ocurrido un problema al suscribirte: %{details}. Si ya estás registrado, identifícate <a href=\"%{sign_in_path}\">aquí</a>."
+        error: 'Ha ocurrido un problema al suscribirte: %{details}. Si ya estás registrado,
+          identifícate <a href="%{sign_in_path}">aquí</a>.'
       destroy:
         success: Se ha cancelado esta suscripción

--- a/config/locales/user/views/passwords/ca.yml
+++ b/config/locales/user/views/passwords/ca.yml
@@ -3,6 +3,6 @@ ca:
   user:
     passwords:
       edit:
-        title: "Estableix la teva nova contrasenya:"
+        title: 'Estableix la teva nova contrasenya:'
       edit_form:
         submit: Canviar

--- a/config/locales/user/views/passwords/en.yml
+++ b/config/locales/user/views/passwords/en.yml
@@ -3,6 +3,6 @@ en:
   user:
     passwords:
       edit:
-        title: "Set your new password:"
+        title: 'Set your new password:'
       edit_form:
         submit: Change

--- a/config/locales/user/views/passwords/es.yml
+++ b/config/locales/user/views/passwords/es.yml
@@ -3,6 +3,6 @@ es:
   user:
     passwords:
       edit:
-        title: "Establece tu nueva contraseña:"
+        title: 'Establece tu nueva contraseña:'
       edit_form:
         submit: Cambiar

--- a/config/locales/user/views/sessions/ca.yml
+++ b/config/locales/user/views/sessions/ca.yml
@@ -3,7 +3,7 @@ ca:
   user:
     sessions:
       new:
-        password_title: "No recordes la teva contrasenya? T'ajudem:"
+        password_title: 'No recordes la teva contrasenya? T''ajudem:'
         registration_title: 'Nou per aquí? Crea un compte gratis:'
         session_title: Ja tens compte? Fes login
       new_password_form:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20170712103453) do
 
   # These are extensions that must be enabled in order to support this database

--- a/test/misc/i18n_test.rb
+++ b/test/misc/i18n_test.rb
@@ -8,11 +8,15 @@ module Misc
     end
 
     def missing_keys
-      i18n.missing_keys
+      @missing_keys ||= i18n.missing_keys
     end
 
     def unused_keys
-      i18n.unused_keys
+      @unused_keys ||= i18n.unused_keys
+    end
+
+    def non_normalized_paths
+      @non_normalized_paths ||= i18n.non_normalized_paths
     end
 
     def test_no_missing_keys
@@ -21,6 +25,12 @@ module Misc
 
     def test_no_unused_keys
       assert_empty unused_keys, "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+    end
+
+    def test_normalized
+      assert_empty non_normalized_paths, "The following files need to be normalized:\n" \
+        "#{non_normalized_paths.map { |path| "  #{path}" }.join("\n")}\n" \
+        'Please run `i18n-tasks normalize` to fix'
     end
   end
 end


### PR DESCRIPTION
Improvement 💪 

### What does this PR do?

This PR introduces a new feature from i18n-tasks: testing normalized files. See the [Changelog here](https://github.com/glebm/i18n-tasks/blob/master/CHANGES.md#v0917).

From now on, there's a test in `test/misc/i18n` to check if the i18n files are normalized.

This is how the failure looks like:

```ruby
Failure:
Misc::I18nTest#test_normalized [/Users/fernando/proyectos/gobierto/test/misc/i18n_test.rb:31]
Minitest::Assertion: The following files need to be normalized:
  config/locales/gobierto_admin/views/census_imports/es.yml
  config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/es.yml
  config/locales/gobierto_admin/gobierto_participation/controllers/issues/es.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/es.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/es.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/es.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/es.yml
  config/locales/gobierto_admin/gobierto_people/views/political_groups/es.yml
  config/locales/gobierto_admin/gobierto_people/views/settings/es.yml
  config/locales/gobierto_admin/views/shared/es.yml
  config/locales/gobierto_budget_consultations/controllers/consultation_responses/es.yml
  config/locales/user/views/passwords/es.yml
  config/locales/user/controllers/subscriptions/es.yml
  config/locales/gobierto_admin/controllers/census_imports/ca.yml
  config/locales/gobierto_admin/views/census_imports/ca.yml
  config/locales/gobierto_admin/controllers/user_welcome_messages/ca.yml
  config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/ca.yml
  config/locales/gobierto_admin/gobierto_participation/controllers/issues/ca.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/ca.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/ca.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/ca.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/ca.yml
  config/locales/gobierto_admin/gobierto_people/views/political_groups/ca.yml
  config/locales/gobierto_admin/gobierto_people/views/settings/ca.yml
  config/locales/gobierto_admin/views/shared/ca.yml
  config/locales/gobierto_budget_consultations/controllers/consultation_responses/ca.yml
  config/locales/user/views/passwords/ca.yml
  config/locales/user/views/sessions/ca.yml
  config/locales/user/controllers/subscriptions/ca.yml
  config/locales/gobierto_admin/gobierto_budget_consultations/controllers/consultations/en.yml
  config/locales/gobierto_admin/gobierto_participation/controllers/issues/en.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/en.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_events/en.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_posts/en.yml
  config/locales/gobierto_admin/gobierto_people/controllers/people/person_statements/en.yml
  config/locales/gobierto_admin/gobierto_people/views/political_groups/en.yml
  config/locales/gobierto_admin/gobierto_people/views/settings/en.yml
  config/locales/gobierto_admin/views/shared/en.yml
  config/locales/gobierto_budget_consultations/controllers/consultation_responses/en.yml
  config/locales/user/views/passwords/en.yml
  config/locales/user/controllers/subscriptions/en.yml
Please run `i18n-tasks normalize` to fix.
```

Then, just run `$ i18n-tasks normalize` and the test will be green again.
