### PR TITLE
New Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,1249 @@
+# Common configuration.
 AllCops:
-  TargetRubyVersion: 2.4
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
   Exclude:
-    - db/schema.rb
-    - 'config/**/*'
-    - 'script/**/*'
-Documentation:
+    - '**/vendor/**/*'
+  # Default formatter will be used if no -f/--format option is given.
+  DefaultFormatter: progress
+  # Cop names are not displayed in offense messages by default. Change behavior
+  # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
+  # option.
+  DisplayCopNames: false
+  # Style guide URLs are not displayed in offense messages by default. Change
+  # behavior by overriding DisplayStyleGuide, or by giving the
+  # -S/--display-style-guide option.
+  DisplayStyleGuide: false
+  # Extra details are not displayed in offense messages by default. Change
+  # behavior by overriding ExtraDetails, or by giving the
+  # -E/--extra-details option.
+  ExtraDetails: false
+  # Additional cops that do not reference a style guide rule may be enabled by
+  # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
+  # the --only-guide-cops option.
+  StyleGuideCopsOnly: false
+  # All cops except the ones in disabled.yml are enabled by default. Change
+  # this behavior by overriding DisabledByDefault. When DisabledByDefault is
+  # true, all cops in the default configuration are disabled, and and only cops
+  # in user configuration are enabled. This makes cops opt-in instead of
+  # opt-out. Note that when DisabledByDefault is true, cops in user
+  # configuration will be enabled even if they don't set the Enabled parameter.
+  DisabledByDefault: false
+  # Enables the result cache if true. Can be overridden by the --cache command
+  # line option.
+  UseCache: true
+  # Threshold for how many files can be stored in the result cache before some
+  # of the files are automatically removed.
+  MaxFilesInCache: 20000
+  # The cache will be stored in "rubocop_cache" under this directory. The name
+  # "/tmp" is special and will be converted to the system temporary directory,
+  # which is "/tmp" on Unix-like systems, but could be something else on other
+  # systems.
+  CacheRootDirectory: /tmp
+  # The default cache root directory is /tmp, which on most systems is
+  # writable by any system user. This means that it is possible for a
+  # malicious user to anticipate the location of Rubocop's cache directory,
+  # and create a symlink in its place that could cause Rubocop to overwrite
+  # unintended files, or read malicious input. If you are certain that your
+  # cache location is secure from this kind of attack, and wish to use a
+  # symlinked cache location, set this value to "true".
+  AllowSymlinksInCacheRootDirectory: false
+  # What MRI version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  TargetRubyVersion: 2.4
+
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: when_needed
+  SupportedStyles:
+    # `when_needed` will add the frozen string literal comment to files
+    # only when the `TargetRubyVersion` is set to 2.3+.
+    - when_needed
+    # `always` will always add the frozen string literal comment to a file
+    # regardless of the Ruby version or if `freeze` or `<<` are called on a
+    # string literal. If you run code against multiple versions of Ruby, it is
+    # possible that this will create errors in Ruby 2.3.0+.
+    - always
+
+# Indent private/protected/public as deep as method definitions
+Style/AccessModifierIndentation:
+  EnforcedStyle: indent
+  SupportedStyles:
+    - outdent
+    - indent
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Alias:
+  EnforcedStyle: prefer_alias
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
+
+# Align the elements of a hash literal if they span more than one line.
+Style/AlignHash:
+  # Alignment of entries using hash rocket as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   'a' => 2
+  #   'bb' => 3
+  # separator - alignment of hash rockets, keys are right aligned
+  #    'a' => 2
+  #   'bb' => 3
+  # table - left alignment of keys, hash rockets, and values
+  #   'a'  => 2
+  #   'bb' => 3
+  EnforcedHashRocketStyle: key
+  # Alignment of entries using colon as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   a: 0
+  #   bb: 1
+  # separator - alignment of colons, keys are right aligned
+  #    a: 0
+  #   bb: 1
+  # table - left alignment of keys and values
+  #   a:  0
+  #   bb: 1
+  EnforcedColonStyle: key
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ignore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ignore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
+
+Style/AlignParameters:
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/AndOr:
+  # Whether `and` and `or` are banned only in conditionals (conditionals)
+  # or completely (always).
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - conditionals
+
+Style/AsciiComments:
   Enabled: false
-Rails:
+
+# Checks if usage of %() or %Q() matches configuration.
+Style/BarePercentLiterals:
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+    - percent_q
+    - bare_percent
+
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+    # The `line_count_based` style enforces braces around single line blocks and
+    # do..end around multi-line blocks.
+    - line_count_based
+    # The `semantic` style enforces braces around functional blocks, where the
+    # primary purpose of the block is to return a value and do..end for
+    # procedural blocks, where the primary purpose of the block is its
+    # side-effects.
+    #
+    # This looks at the usage of a block's method to determine its type (e.g. is
+    # the result of a `map` assigned to a variable or passed to another
+    # method) but exceptions are permitted in the `ProceduralMethods`,
+    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
+
+Style/BracesAroundHashParameters:
+  EnforcedStyle: no_braces
+  SupportedStyles:
+    # The `braces` style enforces braces around all method parameters that are
+    # hashes.
+    - braces
+    # The `no_braces` style checks that the last parameter doesn't have braces
+    # around it.
+    - no_braces
+    # The `context_dependent` style checks that the last parameter doesn't have
+    # braces around it, but requires braces if the second to last parameter is
+    # also a hash literal.
+    - context_dependent
+
+# Indentation of `when`.
+Style/CaseIndentation:
+  EnforcedStyle: case
+  SupportedStyles:
+    - case
+    - end
+  IndentOneStep: false
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # This only matters if IndentOneStep is true
+  IndentationWidth: ~
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+  # Checks the style of children definitions at classes and modules.
+  #
+  # Basically there are two different styles:
+  #
+  # `nested` - have each child on a separate line
+  #   class Foo
+  #     class Bar
+  #     end
+  #   end
+  #
+  # `compact` - combine definitions as much as possible
+  #   class Foo::Bar
+  #   end
+  #
+  # The compact style is only forced, for classes / modules with one child.
+  EnforcedStyle: nested
+  SupportedStyles:
+    - nested
+    - compact
+
+Style/ClassCheck:
+  EnforcedStyle: is_a?
+  SupportedStyles:
+    - is_a?
+    - kind_of?
+
+# Align with the style guide.
+Style/CollectionMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `detect` over `find`:
+  #
+  # CollectionMethods:
+  #   PreferredMethods:
+  #     find: detect
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+
+# Use ` or %x around command literals.
+Style/CommandLiteral:
+  EnforcedStyle: backticks
+  # backticks: Always use backticks.
+  # percent_x: Always use %x.
+  # mixed: Use backticks on single-line commands, and %x on multi-line commands.
+  SupportedStyles:
+    - backticks
+    - percent_x
+    - mixed
+  # If false, the cop will always recommend using %x if one or more backticks
+  # are found in the command string.
+  AllowInnerBackticks: false
+
+# Checks formatting of special comments
+Style/CommentAnnotation:
+  Keywords:
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+    - assign_to_condition
+    - assign_inside_condition
+  # When configured to `assign_to_condition`, `SingleLineConditionsOnly`
+  # will only register an offense when all branches of a condition are
+  # a single line.
+  # When configured to `assign_inside_condition`, `SingleLineConditionsOnly`
+  # will only register an offense for assignment to a condition that has
+  # at least one multiline branch.
+  SingleLineConditionsOnly: true
+
+# Checks that you have put a copyright in a comment before any code.
+#
+# You can override the default Notice in your .rubocop.yml file.
+#
+# In order to use autocorrect, you must supply a value for the
+# AutocorrectNotice key that matches the regexp Notice.  A blank
+# AutocorrectNotice will cause an error during autocorrect.
+#
+# Autocorrect will add a copyright notice in a comment at the top
+# of the file immediately after any shebang or encoding comments.
+#
+# Example rubocop.yml:
+#
+# Style/Copyright:
+#   Enabled: true
+#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
+#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
+#
+Style/Copyright:
+  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  AutocorrectNotice: ''
+
+Style/DocumentationMethod:
+  RequireForNonPublicMethods: false
+
+# Multi-line method chaining should be done with leading dots.
+Style/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+    - leading
+    - trailing
+
+# Warn on empty else statements
+# empty - warn only on empty else
+# nil - warn on else with nil in it
+# both - warn on empty else and else with nil in it
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    - empty
+    - nil
+    - both
+
+# Use empty lines between defs.
+Style/EmptyLineBetweenDefs:
+  # If true, this parameter means that single line method definitions don't
+  # need an empty line between them.
+  AllowAdjacentOneLineDefs: false
+
+Style/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Style/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Style/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+# Checks whether the source file has a utf-8 encoding comment or not
+# AutoCorrectEncodingComment must match the regex
+# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+Style/Encoding:
   Enabled: true
+  EnforcedStyle: never
+  SupportedStyles:
+    - when_needed
+    - always
+    - never
+  AutoCorrectEncodingComment: '# encoding: utf-8'
+
+Style/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+  # When true, forces the alignment of = in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
+
+Style/FileName:
+  # File names listed in AllCops:Include are excluded by default. Add extra
+  # excludes here.
+  Exclude: []
+  # When true, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
+  ExpectMatchingDefinition: false
+  # If non-nil, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
+
+Style/FirstParameterIndentation:
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+    - consistent
+    # The first parameter should normally be indented one step more than the
+    # preceding line, but if it's a parameter for a method call that is itself
+    # a parameter in a method call, then the inner parameter should be indented
+    # relative to the inner method.
+    - special_for_inner_method_call
+    # Same as special_for_inner_method_call except that the special rule only
+    # applies if the outer method call encloses its arguments in parentheses.
+    - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks use of for or each in multiline loops.
+Style/For:
+  EnforcedStyle: each
+  SupportedStyles:
+    - for
+    - each
+
+# Enforce the method used for string formatting.
+Style/FormatString:
+  EnforcedStyle: format
+  SupportedStyles:
+    - format
+    - sprintf
+    - percent
+
+# Built-in global variables are allowed by default.
+Style/GlobalVars:
+  AllowedVariables: []
+
+# `MinBodyLength` defines the number of lines of the a body of an if / unless
+# needs to have to trigger this cop
+Style/GuardClause:
+  MinBodyLength: 6
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  SupportedStyles:
+    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
+    - ruby19
+    # checks for hash rocket syntax for all hashes
+    - hash_rockets
+    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
+    - no_mixed_keys
+    # enforces both ruby19 and no_mixed_keys styles
+    - ruby19_no_mixed_keys
+  # Force hashes that have a symbol value to use hash rockets
+  UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Style/IfUnlessModifier:
+  MaxLineLength: 80
+
+Style/IndentationConsistency:
+  # The difference between `rails` and `normal` is that the `rails` style
+  # prescribes that in classes and modules the `protected` and `private`
+  # modifier keywords shall be indented the same as public methods and that
+  # protected and private members shall be indented one step more than the
+  # modifiers. Other than that, both styles mean that entities on the same
+  # logical depth shall have the same indentation.
+  EnforcedStyle: normal
+  SupportedStyles:
+    - normal
+    - rails
+
+Style/IndentationWidth:
+  # Number of spaces for each indentation level.
+  Width: 2
+
+# Checks the indentation of the first element in an array literal.
+Style/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of assignment RHS, when on a different line from LHS
+Style/IndentAssignment:
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of the first key in a hash literal.
+Style/IndentHash:
+  # The value `special_inside_parentheses` means that hash literals with braces
+  # that have their opening brace on the same line as a surrounding opening
+  # round parenthesis, shall have their first key indented relative to the
+  # first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first key shall
+  # always be relative to the first position of the line where the opening
+  # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_braces
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Lambda:
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+
+Style/LambdaCall:
+  EnforcedStyle: call
+  SupportedStyles:
+    - call
+    - braces
+
+Style/Next:
+  # With `always` all conditions at the end of an iteration needs to be
+  # replaced by next - with `skip_modifier_ifs` the modifier if like this one
+  # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
+  EnforcedStyle: skip_modifier_ifs
+  # `MinBodyLength` defines the number of lines of the a body of an if / unless
+  # needs to have to trigger this cop
+  MinBodyLength: 3
+  SupportedStyles:
+    - skip_modifier_ifs
+    - always
+
+Style/NonNilCheck:
+  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
+  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
+  # **usually** OK, but might change behavior.
+  #
+  # With `IncludeSemanticChanges` set to `false`, this cop does not report
+  # offenses for `!x.nil?` and does no changes that might change behavior.
+  IncludeSemanticChanges: false
+
+Style/NumericPredicate:
+  EnforcedStyle: predicate
+  SupportedStyles:
+    - predicate
+    - comparison
+
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+    - require_no_parentheses_except_multiline
+
+Style/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Style/ModuleFunction:
+  EnforcedStyle: module_function
+  SupportedStyles:
+    - module_function
+    - extend_self
+
+Style/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineAssignmentLayout:
+  # The types of assignments which are subject to this rule.
+  SupportedTypes:
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
+
+Style/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+    - indented_relative_to_receiver
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/NumericLiterals:
+  MinDigits: 5
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_with_o
+  SupportedOctalStyles:
+    - zero_with_o
+    - zero_only
+
+Style/OptionHash:
+  # A list of parameter names that will be flagged by this cop.
+  SuspiciousParamNames:
+    - options
+    - opts
+    - args
+    - params
+    - parameters
+
+# Allow safe assignment in conditions.
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  ()
+    '%i': ()
+    '%q': ()
+    '%Q': ()
+    '%r': '{}'
+    '%s': ()
+    '%w': ()
+    '%W': ()
+    '%x': ()
+
+Style/PercentQLiterals:
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+    - lower_case_q # Use %q when possible, %Q when necessary
+    - upper_case_q # Always use %Q
+
+Style/PredicateName:
+  # Predicate name prefixes.
+  NamePrefix:
+    - is_
+    - has_
+    - have_
+  # Predicate name prefixes that should be removed.
+  NamePrefixBlacklist:
+    - is_
+    - have_
+  # Predicate names which, despite having a blacklisted prefix, or no ?,
+  # should still be accepted
+  NameWhitelist:
+    - is_a?
+  # Exclude Rspec specs because there is a strong convetion to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - '**/spec/**/*'
+    - '**/test/**/*'
+
+Style/PreferredHashMethods:
+  Enabled: true
+  EnforcedStyle: verbose
+
+Style/Documentation:
+  Enabled: false
+
+Style/RaiseArgs:
+  EnforcedStyle: exploded
+  SupportedStyles:
+    - compact # raise Exception.new(msg)
+    - exploded # raise Exception, msg
+
+Style/RedundantReturn:
+  # When true allows code like `return x, y`.
+  AllowMultipleReturnValues: false
+
+# Use / or %r around regular expressions.
+Style/RegexpLiteral:
+  EnforcedStyle: slashes
+  # slashes: Always use slashes.
+  # percent_r: Always use %r.
+  # mixed: Use slashes on single-line regexes, and %r on multi-line regexes.
+  SupportedStyles:
+    - slashes
+    - percent_r
+    - mixed
+  # If false, the cop will always recommend using %r if one or more slashes
+  # are found in the regexp string.
+  AllowInnerSlashes: false
+
+Style/Semicolon:
+  # Allow ; to separate several expressions on the same line.
+  AllowAsExpressionSeparator: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+  SupportedStyles:
+    - only_raise
+    - only_fail
+    - semantic
+
+Style/SingleLineBlockParams:
+  Methods:
+    - reduce:
+        - a
+        - e
+    - inject:
+        - a
+        - e
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: true
+
+Style/SpaceBeforeFirstArg:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+    - use_perl_names
+    - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+  # If true, strings which span multiple lines using \ for continuation must
+  # use the same type of quotes on each line.
+  ConsistentQuotesInMultiline: false
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+
+Style/StringMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `to_sym` over `intern`:
+  #
+  # StringMethods:
+  #   PreferredMethods:
+  #     intern: to_sym
+  PreferredMethods:
+    intern: to_sym
+
+Style/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+
+Style/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceAroundOperators:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
+
+Style/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+  # Valid values are: space, no_space
+  EnforcedStyleForEmptyBraces: no_space
+  # Space between { and |. Overrides EnforcedStyle if there is a conflict.
+  SpaceBeforeBlockParameters: true
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+    - space
+    - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
+
+Style/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+  SupportedStyles:
+    - percent
+    - brackets
+
+Style/SymbolProc:
+  # A list of method names to be ignored by the check.
+  # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
+  IgnoredMethods:
+    - respond_to
+    - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+  AllowSafeAssignment: true
+
+Style/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+    - final_newline
+    - final_blank_line
+
+Style/TrailingCommaInArguments:
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
+  EnforcedStyleForMultiline: no_comma
+
+# TrivialAccessors requires exact name matches and doesn't allow
+# predicated methods by default.
+Style/TrivialAccessors:
+  # When set to false the cop will suggest the use of accessor methods
+  # in situations like:
+  #
+  # def name
+  #   @other_name
+  # end
+  #
+  # This way you can uncover "hidden" attributes in your code.
+  ExactNameMatch: true
+  AllowPredicates: true
+  # Allows trivial writers that don't end in an equal sign. e.g.
+  #
+  # def on_exception(action)
+  #   @on_exception=action
+  # end
+  # on_exception :restart
+  #
+  # Commonly used in DSLs
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  Whitelist:
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
+
+Style/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Style/VariableNumber:
+  EnforcedStyle: normalcase
+  SupportedStyles:
+    - snake_case
+    - normalcase
+    - non_integer
+
+Style/WhileUntilModifier:
+  MaxLineLength: 80
+
+# WordArray enforces how array literals of word-like strings should be expressed.
+Style/WordArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    # percent style: %w(word1 word2)
+    - percent
+    # bracket style: ['word1', 'word2']
+    - brackets
+  # The MinSize option causes the WordArray rule to be ignored for arrays
+  # smaller than a certain size.  The rule is only applied to arrays
+  # whose element count is greater than or equal to MinSize.
+  MinSize: 0
+  # The regular expression WordRegex decides what is considered a word.
+  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
+
+##################### Metrics ##################################
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
+  # a Float.
+  Max: 15
+  Enabled: false
+
+Metrics/BlockNesting:
+  Max: 3
+
+Metrics/ClassLength:
+  CountComments: false  # count full line comments?
+  Max: 100
+  Enabled: false
+
+Metrics/ModuleLength:
+  CountComments: false  # count full line comments?
+  Max: 100
+  Enabled: false
+
+# Avoid complex methods.
+Metrics/CyclomaticComplexity:
+  Max: 9
+
 Metrics/LineLength:
-  Max: 140
+  Max: 180
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+
+Metrics/MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 15
+  Enabled: false
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: true
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+##################### Lint ##################################
+
+# TODO: This cop was buggy in 0.48.1. Reenable when upgrading to 0.49.0
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+# Allow safe assignment in conditions.
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: true
+
+# checks whether the end keywords are aligned properly for `do` `end` blocks.
+Lint/BlockAlignment:
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole
+  # expression's starting line.
+  # The value `either` means both are allowed.
+  EnforcedStyleAlignWith: either
+
+# Align ends correctly.
+Lint/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
+  EnforcedStyleAlignWith: keyword
+  AutoCorrect: false
+
+Lint/DefEndAlignment:
+  # The value `def` means that `end` should be aligned with the def keyword.
+  # The value `start_of_line` means that `end` should be aligned with method
+  # calls like `private`, `public`, etc, if present in front of the `def`
+  # keyword on the same line.
+  EnforcedStyleAlignWith: start_of_line
+  AutoCorrect: false
+
+Lint/InheritException:
+  # The default base class in favour of `Exception`.
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+    - runtime_error
+    - standard_error
+
+# Checks for unused block arguments
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+# Checks for unused method arguments.
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+
+##################### Performance ############################
+
+Performance/RedundantMerge:
+  # Max number of key-value pairs to consider an offense
+  MaxKeyValuePairs: 2
+
+##################### Rails ##################################
+
+Rails/ActionFilter:
+  EnforcedStyle: action
+  SupportedStyles:
+    - action
+    - filter
+  Include:
+    - app/controllers/**/*.rb
+
+Rails/Date:
+  # The value `strict` disallows usage of `Date.today`, `Date.current`,
+  # `Date#to_time` etc.
+  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
+  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
+  # time zone.
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Rails/Exit:
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
+
+Rails/FindBy:
+  Include:
+    - app/models/**/*.rb
+
+Rails/FindEach:
+  Include:
+    - app/models/**/*.rb
+
+Rails/HasAndBelongsToMany:
+  Include:
+    - app/models/**/*.rb
+
+Rails/NotNullColumn:
+  Include:
+    - db/migrate/*.rb
+
+Rails/Output:
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - db/**/*.rb
+    - lib/**/*.rb
+
+Rails/ReadWriteAttribute:
+  Include:
+    - app/models/**/*.rb
+
+Rails/RequestReferer:
+  EnforcedStyle: referer
+  SupportedStyles:
+    - referer
+    - referrer
+
+Rails/SafeNavigation:
+  # This will convert usages of `try` to use safe navigation as well as `try!`.
+  # `try` and `try!` work slighly differently. `try!` and safe navigation will
+  # both raise a `NoMethodError` if the receiver of the method call does not
+  # implement the intended method. `try` will not raise an exception for this.
+  ConvertTry: false
+
+Rails/ScopeArgs:
+  Include:
+    - app/models/**/*.rb
+
+Rails/TimeZone:
+  # The value `strict` means that `Time` should be used with `zone`.
+  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Rails/UniqBeforePluck:
+  EnforcedStyle: conservative
+  AutoCorrect: false
+
+Rails/Validation:
+  Include:
+    - app/models/**/*.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - '**/*.gemspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,33 +1,35 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
-gem "rails", "~> 5.1.1"
-gem "pg", "~> 0.19"
-gem "redcarpet", require: true
-gem "bcrypt", '~> 3.1.0'
-gem 'jbuilder', '~> 2.5'
-gem "rollbar"
-gem "meta-tags"
-gem "ine-places", '0.2.0'
-gem "ruby_px"
-gem "responders"
-gem "dalli"
-gem "cookies_eu"
 gem "actionpack-action_caching", git: "https://github.com/rails/actionpack-action_caching.git", ref: "9044141824650138bf27741e8f0ed95ccd9ef26d"
 gem "active_model_serializers"
+gem "bcrypt", "~> 3.1.0"
+gem "cookies_eu"
+gem "dalli"
+gem "ine-places", "0.2.0"
+gem "jbuilder", "~> 2.5"
 gem "mechanize"
+gem "meta-tags"
 gem "paper_trail"
+gem "pg", "~> 0.19"
+gem "rails", "~> 5.1.1"
+gem "redcarpet", require: true
+gem "responders"
+gem "rollbar"
+gem "ruby_px"
 
 # Frontend
-gem "sass-rails", "~> 5.0.0"
-gem "uglifier", ">= 1.3.0"
-gem "jquery-rails"
 gem "bourbon"
-gem "turbolinks"
-gem "therubyracer"
-gem "flight-for-rails"
 gem "cocoon"
-gem "i18n-js", ">= 3.0.0.rc11"
 gem "d3-rails", "~> 4.8"
+gem "flight-for-rails"
+gem "i18n-js", ">= 3.0.0.rc11"
+gem "jquery-rails"
+gem "sass-rails", "~> 5.0.0"
+gem "therubyracer"
+gem "turbolinks"
+gem "uglifier", ">= 1.3.0"
 
 # Elasticsearch
 gem "elasticsearch"
@@ -60,8 +62,8 @@ gem "invisible_captcha"
 gem "redis", "~> 3.3"
 
 # Translations
+gem "i18n-active_record", require: "i18n/active_record"
 gem "json_translate", "~> 3.0"
-gem "i18n-active_record", :require => "i18n/active_record"
 
 # Liquid
 gem "liquid", "~> 4.0"
@@ -77,22 +79,22 @@ group :development, :test do
 end
 
 group :test do
+  gem "capybara"
+  gem "capybara-email"
+  gem "codecov", "~> 0.1.9", require: false
+  gem "database_cleaner"
+  gem "launchy"
   gem "minitest-rails"
   gem "minitest-rails-capybara"
   gem "minitest-reporters"
-  gem "minitest-stub_any_instance"
-  gem "spy"
-  gem "capybara"
-  gem "poltergeist"
-  gem "database_cleaner"
-  gem "launchy"
-  gem "codecov", "~> 0.1.9", require: false
-  gem "webmock"
   gem "minitest-retry"
-  gem "capybara-email"
-  gem "vcr"
-  gem "timecop"
+  gem "minitest-stub_any_instance"
   gem "mocha"
+  gem "poltergeist"
+  gem "spy"
+  gem "timecop"
+  gem "vcr"
+  gem "webmock"
 end
 
 group :development do

--- a/app/repositories/census_repository.rb
+++ b/app/repositories/census_repository.rb
@@ -85,13 +85,10 @@ class CensusRepository
   end
 
   def parse_document_number(document_number)
-    parsed_document_number = document_number
-
-    parsed_document_number.delete!(' ')
-    parsed_document_number.gsub!(/\W/, '')
-    parsed_document_number.upcase!
-
-    parsed_document_number
+    document_number.
+      gsub(/\s+/, '').
+      gsub(/\W/, '').
+      upcase
   end
 
   def build_alternatives(document_number)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,6 @@
-require_relative 'boot'
+# frozen_string_literal: true
+
+require_relative "boot"
 
 require "rails"
 require "active_model/railtie"
@@ -21,7 +23,7 @@ Bundler.require(*Rails.groups)
 
 module Gobierto
   class Application < Rails::Application
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
     config.i18n.default_locale = :es
     config.i18n.available_locales = [:es, :en, :ca]
 
@@ -29,10 +31,8 @@ module Gobierto
       g.test_framework :minitest, spec: false, fixture: true
     end
 
-    config.action_dispatch.default_headers.merge!({
-      'Access-Control-Allow-Origin' => '*',
-      'Access-Control-Request-Method' => '*'
-    })
+    config.action_dispatch.default_headers.merge!("Access-Control-Allow-Origin" => "*",
+                                                  "Access-Control-Request-Method" => "*")
 
     config.active_job.queue_adapter = :async
 
@@ -49,9 +49,8 @@ module Gobierto
     ]
 
     # Do not add wrapper .field_with_errors around form fields with validation errors
-    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
+    config.action_view.field_error_proc = proc { |html_tag, _instance| html_tag }
 
-    config.time_zone = 'Madrid'
+    config.time_zone = "Madrid"
   end
 end
-

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+# frozen_string_literal: true
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -13,12 +15,12 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
+      "Cache-Control" => "public, max-age=172800"
     }
   else
     config.action_controller.perform_caching = false
@@ -56,7 +58,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::FileUpdateChecker
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -11,12 +13,12 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -32,7 +34,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
@@ -47,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -75,7 +77,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
@@ -83,5 +85,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: ENV.fetch("HOST"), protocol: 'https' }
+  config.action_mailer.default_url_options = { host: ENV.fetch("HOST"), protocol: "https" }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -11,12 +13,12 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -32,7 +34,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
@@ -47,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -75,7 +77,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -15,11 +17,11 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => 'public, max-age=3600'
+    "Cache-Control" => "public, max-age=3600"
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
@@ -43,5 +45,5 @@ Rails.application.configure do
   # Increase log level to speed up the test suite
   config.log_level = ENV["CI"] ? :fatal : :debug
 
-  config.action_mailer.default_url_options = { host: 'gobierto.dev' }
+  config.action_mailer.default_url_options = { host: "gobierto.dev" }
 end

--- a/config/initializers/action_mailer_settings.rb
+++ b/config/initializers/action_mailer_settings.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 if Rails.application.secrets.mailer_delivery_method == "ses"
   Rails.application.config.action_mailer.delivery_method = :ses
 
   ActionMailer::Base.add_delivery_method :ses, AWS::SES::Base,
-    :access_key_id     => ENV.fetch("AWS_ACCESS_KEY_ID") { "" },
-    :secret_access_key => ENV.fetch("AWS_SECRET_ACCESS_KEY") { "" },
-    :server => 'email.eu-west-1.amazonaws.com'
+                                         access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID") { "" },
+                                         secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY") { "" },
+                                         server: "email.eu-west-1.amazonaws.com"
 end
 
 if Rails.application.secrets.mailer_delivery_method == "smtp"

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 AlgoliaSearch.configuration = {
-  application_id: Rails.application.secrets.algolia_application_id || '',
-  api_key: Rails.application.secrets.algolia_api_key || '',
+  application_id: Rails.application.secrets.algolia_application_id || "",
+  api_key: Rails.application.secrets.algolia_api_key || "",
   connect_timeout: 2,
   receive_timeout: 30,
   send_timeout: 30,

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 APP_CONFIG = Rails.application.config_for(:application).with_indifferent_access
 
 SITE_MODULES = APP_CONFIG["site_modules"].map do |site_module|

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ApplicationController.renderer.defaults.merge!(

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( trix_es.js trix_ca.js trix_en.js gobierto_consultations/application_desktop.js )
+Rails.application.config.assets.precompile += %w(trix_es.js trix_ca.js trix_en.js gobierto_consultations/application_desktop.js)

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 ActionController::Renderers.add :csv do |obj, options|
-  filename = options[:filename] || 'data'
+  filename = options[:filename] || "data"
   str = obj.respond_to?(:to_csv) ? obj.to_csv : obj.to_s
   send_data str, type: Mime[:csv],
-    disposition: "attachment; filename=#{filename}.csv"
+                 disposition: "attachment; filename=#{filename}.csv"
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/gobierto_modules.rb
+++ b/config/initializers/gobierto_modules.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
+
 SITE_MODULES.each do |gobierto_module|
   file_name = gobierto_module.underscore
   file_path = Rails.root.join("app/models/#{file_name}.rb")
-  if File.file?(file_path)
-    require_dependency(file_name)
-  end
+  require_dependency(file_name) if File.file?(file_path)
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Liquid::Template.error_mode = :lax
 
 require "liquid/tags/page_url"

--- a/config/initializers/load_data.rb
+++ b/config/initializers/load_data.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 INE::Places.preload

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 MetaTags.configure do |c|
-  c.title_limit        = 200
+  c.title_limit = 200
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 PaperTrail.config.track_associations = false

--- a/config/initializers/redis_client.rb
+++ b/config/initializers/redis_client.rb
@@ -1,4 +1,4 @@
-$redis = Redis.new({
-  url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/0" },
-  namespace: APP_CONFIG["site"]["name"]
-})
+# frozen_string_literal: true
+
+$redis = Redis.new(url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/0" },
+                   namespace: APP_CONFIG["site"]["name"])

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,16 +1,13 @@
-require 'rollbar/rails'
+# frozen_string_literal: true
+
+require "rollbar/rails"
 
 Rollbar.configure do |config|
   config.access_token = Rails.application.secrets.rollbar_access_token
 
-  if Rails.env.development? || Rails.env.test?
-    config.enabled = false
-  end
+  config.enabled = false if Rails.env.development? || Rails.env.test?
 
-  config.exception_level_filters.merge!({
-    'ActionController::InvalidCrossOriginRequest' => 'ignore',
-    'ActionController::RoutingError' => 'ignore',
-    'ActionController::UnknownFormat' => 'ignore'
-  })
-
+  config.exception_level_filters.merge!("ActionController::InvalidCrossOriginRequest" => "ignore",
+                                        "ActionController::RoutingError" => "ignore",
+                                        "ActionController::UnknownFormat" => "ignore")
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store,
-  key: "_gobierto_session",
-  domain: :all,
-  tld_length: ENV.fetch("TLD_LENGTH") { "2" }.to_i
+                                       key: "_gobierto_session",
+                                       domain: :all,
+                                       tld_length: ENV.fetch("TLD_LENGTH") { "2" }.to_i

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Sidekiq::Logging.logger.level = Rails.logger.level
 
 Sidekiq.configure_server do |config|

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -1,17 +1,19 @@
-::Subscribers::AdminActivity.attach_to('activities/admins')
-::Subscribers::CensusActivity.attach_to('activities/census')
-::Subscribers::GobiertoPeopleActivity.attach_to('trackable')
-::Subscribers::GobiertoBudgetConsultationsActivity.attach_to('trackable')
-::Subscribers::GobiertoCalendarsActivity.attach_to('trackable')
-::Subscribers::GobiertoBudgetConsultationsConsultationResponseActivity.attach_to('activities/gobierto_budget_consultations_consultation_response')
-::Subscribers::GobiertoCmsPageActivity.attach_to('activities/gobierto_cms_pages')
-::Subscribers::GobiertoBudgetsBudgetLineActivity.attach_to('activities/gobierto_budgets_budget_line')
-::Subscribers::GobiertoCommonCollectionActivity.attach_to('activities/gobierto_common_collections')
-::Subscribers::GobiertoAttachmentsAttachmentActivity.attach_to('activities/gobierto_attachments_attachments')
-::Subscribers::IssueActivity.attach_to('activities/issues')
-::Subscribers::GobiertoParticipationProcessActivity.attach_to('activities/gobierto_participation_processes')
-::Subscribers::UserActivity.attach_to('activities/users')
-::Subscribers::SiteActivity.attach_to('activities/sites')
+# frozen_string_literal: true
+
+::Subscribers::AdminActivity.attach_to("activities/admins")
+::Subscribers::CensusActivity.attach_to("activities/census")
+::Subscribers::GobiertoPeopleActivity.attach_to("trackable")
+::Subscribers::GobiertoBudgetConsultationsActivity.attach_to("trackable")
+::Subscribers::GobiertoCalendarsActivity.attach_to("trackable")
+::Subscribers::GobiertoBudgetConsultationsConsultationResponseActivity.attach_to("activities/gobierto_budget_consultations_consultation_response")
+::Subscribers::GobiertoCmsPageActivity.attach_to("activities/gobierto_cms_pages")
+::Subscribers::GobiertoBudgetsBudgetLineActivity.attach_to("activities/gobierto_budgets_budget_line")
+::Subscribers::GobiertoCommonCollectionActivity.attach_to("activities/gobierto_common_collections")
+::Subscribers::GobiertoAttachmentsAttachmentActivity.attach_to("activities/gobierto_attachments_attachments")
+::Subscribers::IssueActivity.attach_to("activities/issues")
+::Subscribers::GobiertoParticipationProcessActivity.attach_to("activities/gobierto_participation_processes")
+::Subscribers::UserActivity.attach_to("activities/users")
+::Subscribers::SiteActivity.attach_to("activities/sites")
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|

--- a/config/initializers/translations.rb
+++ b/config/initializers/translations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "i18n/backend/active_record"
 require "i18n/backend/fallbacks"
 
@@ -8,7 +10,7 @@ end
 module I18n
   module JS
     def self.translations
-     ::I18n::Backend::Simple.new.instance_eval do
+      ::I18n::Backend::Simple.new.instance_eval do
         init_translations unless initialized?
         Private::HashWithSymbolKeys.new(translations)
                                    .slice(*::I18n.available_locales)
@@ -18,7 +20,7 @@ module I18n
   end
 end
 
-Translation  = I18n::Backend::ActiveRecord::Translation
+Translation = I18n::Backend::ActiveRecord::Translation
 
 if Translation.table_exists?
   I18n.backend = I18n::Backend::ActiveRecord.new
@@ -31,6 +33,6 @@ if Translation.table_exists?
   I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
 end
 
-I18n.fallbacks.map(:ca => :es)
-I18n.fallbacks.map(:es => :ca)
-I18n.fallbacks.map(:en => :es)
+I18n.fallbacks.map(ca: :es)
+I18n.fallbacks.map(es: :ca)
+I18n.fallbacks.map(en: :es)

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
@@ -9,7 +11,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # The root page is kind of dynamic
   constraints GobiertoSiteConstraint.new do
-    root 'meta_welcome#index'
+    root "meta_welcome#index"
   end
 
   if Rails.env.development?
-    get '/sandbox' => 'sandbox#index'
-    get '/sandbox/*template' => 'sandbox#show'
+    get "/sandbox" => "sandbox#index"
+    get "/sandbox/*template" => "sandbox#show"
   end
 
   # Admin module
   namespace :gobierto_admin, as: :admin, path: :admin do
-    get '/' => 'welcome#index', as: :root
+    get "/" => "welcome#index", as: :root
 
     resource :sessions, only: [:new, :create, :destroy]
     resources :sites, only: [:index, :new, :create, :edit, :update, :destroy]
@@ -78,7 +80,7 @@ Rails.application.routes.draw do
     end
 
     namespace :gobierto_participation, as: :participation, path: :participation do
-      get '/' => 'welcome#index'
+      get "/" => "welcome#index"
 
       resources :processes, only: [:index, :new, :edit, :create, :update] do
         resources :file_attachments, only: [:index], controller: "processes/process_file_attachments", as: :file_attachments, path: :file_attachments
@@ -100,8 +102,8 @@ Rails.application.routes.draw do
       resources :file_attachments, only: [:index, :create, :new, :edit, :update]
       namespace :api do
         resources :attachments, only: [:index, :show, :create, :update, :destroy]
-        post   '/attachings' => 'attachings#create'
-        delete '/attachings' => 'attachings#destroy'
+        post "/attachings" => "attachings#create"
+        delete "/attachings" => "attachings#destroy"
       end
     end
 
@@ -114,7 +116,7 @@ Rails.application.routes.draw do
   # User module
   namespace :user do
     constraints GobiertoSiteConstraint.new do
-      get '/' => 'welcome#index', as: :root
+      get "/" => "welcome#index", as: :root
 
       resource :sessions, only: [:new, :create, :destroy]
       resource :registrations, only: [:create]
@@ -130,68 +132,68 @@ Rails.application.routes.draw do
   end
 
   # Gobierto Budget Consultations module
-  namespace :gobierto_budget_consultations, path: 'consultas-presupuestos' do
+  namespace :gobierto_budget_consultations, path: "consultas-presupuestos" do
     constraints GobiertoSiteConstraint.new do
-      resources :consultations, only: [:index, :show], path: '' do
-        get 'partidas', to: 'consultations/consultation_items#index', as: :item_summary
-        get 'participa', to: 'consultations/consultation_responses#new', as: :new_response
-        post 'participa', to: 'consultations/consultation_responses#create', as: :response, via: [:post]
-        get 'terminado', to: 'consultations/consultation_confirmations#show', as: :show_confirmation
+      resources :consultations, only: [:index, :show], path: "" do
+        get "partidas", to: "consultations/consultation_items#index", as: :item_summary
+        get "participa", to: "consultations/consultation_responses#new", as: :new_response
+        post "participa", to: "consultations/consultation_responses#create", as: :response, via: [:post]
+        get "terminado", to: "consultations/consultation_confirmations#show", as: :show_confirmation
       end
 
-      resources :consultation_participations, only: [:show], path: 'participaciones'
+      resources :consultation_participations, only: [:show], path: "participaciones"
     end
   end
 
   # Gobierto People module
-  namespace :gobierto_people, path: '/' do
+  namespace :gobierto_people, path: "/" do
     constraints GobiertoSiteConstraint.new do
-      get 'cargos-y-agendas' => 'welcome#index', as: :root
+      get "cargos-y-agendas" => "welcome#index", as: :root
 
       # Agendas
-      resources :person_events, only: [:index], as: :events, path: 'agendas'
-      resources :government_party_person_events, only: [:index], as: :government_party_events, path: 'agendas/gobierno'
-      resources :opposition_party_person_events, only: [:index], as: :opposition_party_events, path: 'agendas/oposicion'
-      resources :executive_category_person_events, only: [:index], as: :executive_category_events, path: 'agendas/directivos'
+      resources :person_events, only: [:index], as: :events, path: "agendas"
+      resources :government_party_person_events, only: [:index], as: :government_party_events, path: "agendas/gobierno"
+      resources :opposition_party_person_events, only: [:index], as: :opposition_party_events, path: "agendas/oposicion"
+      resources :executive_category_person_events, only: [:index], as: :executive_category_events, path: "agendas/directivos"
 
-      resources :past_person_events, only: [:index], as: :past_events, path: 'agendas/eventos-pasados'
-      resources :government_party_past_person_events, only: [:index], as: :government_party_past_events, path: 'agendas/gobierno/eventos-pasados'
-      resources :opposition_party_past_person_events, only: [:index], as: :opposition_party_past_events, path: 'agendas/oposicion/eventos-pasados'
-      resources :executive_category_past_person_events, only: [:index], as: :executive_category_past_events, path: 'agendas/directivos/eventos-pasados'
+      resources :past_person_events, only: [:index], as: :past_events, path: "agendas/eventos-pasados"
+      resources :government_party_past_person_events, only: [:index], as: :government_party_past_events, path: "agendas/gobierno/eventos-pasados"
+      resources :opposition_party_past_person_events, only: [:index], as: :opposition_party_past_events, path: "agendas/oposicion/eventos-pasados"
+      resources :executive_category_past_person_events, only: [:index], as: :executive_category_past_events, path: "agendas/directivos/eventos-pasados"
 
-      resources :people_past_person_events, only: [:index], controller: "people/past_person_events", as: :person_past_events, path: 'agendas/:container_slug/eventos-pasados'
-      resources :people_person_events, only: [:index, :show], controller: "people/person_events", as: :person_events, path: 'agendas/:container_slug', param: :slug
+      resources :people_past_person_events, only: [:index], controller: "people/past_person_events", as: :person_past_events, path: "agendas/:container_slug/eventos-pasados"
+      resources :people_person_events, only: [:index, :show], controller: "people/person_events", as: :person_events, path: "agendas/:container_slug", param: :slug
 
       # Blogs
-      resources :person_posts, only: [:index], as: :posts, path: 'blogs/posts'
-      resources :person_post_tags, only: [:show], as: :post_tags, path: 'blogs/tags'
+      resources :person_posts, only: [:index], as: :posts, path: "blogs/posts"
+      resources :person_post_tags, only: [:show], as: :post_tags, path: "blogs/tags"
 
-      resources :people_person_post_tags, only: [:show], controller: "people/person_post_tags", as: :person_post_tags, path: 'blogs/:person_slug/tags'
-      resources :people_person_posts, only: [:index, :show], controller: "people/person_posts", as: :person_posts, path: 'blogs/:person_slug', param: :slug
+      resources :people_person_post_tags, only: [:show], controller: "people/person_post_tags", as: :person_post_tags, path: "blogs/:person_slug/tags"
+      resources :people_person_posts, only: [:index, :show], controller: "people/person_posts", as: :person_posts, path: "blogs/:person_slug", param: :slug
 
       # Statements
-      resources :person_statements, only: [:index], as: :statements, path: 'declaraciones'
-      resources :person_gifts, only: [:index], as: :gifts, path: 'obsequios-y-regalos'
-      resources :person_travels, only: [:index], as: :travels, path: 'viajes-y-desplazamientos'
-      resources :people_person_statements, only: [:index, :show], controller: "people/person_statements", as: :person_statements, path: 'declaraciones/:person_slug', param: :slug
+      resources :person_statements, only: [:index], as: :statements, path: "declaraciones"
+      resources :person_gifts, only: [:index], as: :gifts, path: "obsequios-y-regalos"
+      resources :person_travels, only: [:index], as: :travels, path: "viajes-y-desplazamientos"
+      resources :people_person_statements, only: [:index, :show], controller: "people/person_statements", as: :person_statements, path: "declaraciones/:person_slug", param: :slug
 
       # Officials
-      resources :people, only: [:index], path: 'personas'
-      resources :government_party_people, only: [:index], path: 'personas/gobierno'
-      resources :opposition_party_people, only: [:index], path: 'personas/oposicion'
-      resources :executive_category_people, only: [:index], path: 'personas/directivos'
+      resources :people, only: [:index], path: "personas"
+      resources :government_party_people, only: [:index], path: "personas/gobierno"
+      resources :opposition_party_people, only: [:index], path: "personas/oposicion"
+      resources :executive_category_people, only: [:index], path: "personas/directivos"
 
       # Political Groups
-      resources :political_group, only: [:show], path: 'personas/grupos-politicos', param: :slug do
-        resources :people, only: [:index], controller: 'political_groups/people', path: '/'
+      resources :political_group, only: [:show], path: "personas/grupos-politicos", param: :slug do
+        resources :people, only: [:index], controller: "political_groups/people", path: "/"
       end
 
       # People
-      resources :people, only: [:show], path: 'personas', param: :slug do
-        resource :person_bio, only: [:show], controller: "people/person_bio", as: :bio, path: 'biografia'
-        resources :person_messages, only: [:create], controller: "people/person_messages", as: :messages, path: 'contacto', param: :slug do
+      resources :people, only: [:show], path: "personas", param: :slug do
+        resource :person_bio, only: [:show], controller: "people/person_bio", as: :bio, path: "biografia"
+        resources :person_messages, only: [:create], controller: "people/person_messages", as: :messages, path: "contacto", param: :slug do
           collection do
-            get '/' => 'people/person_messages#new', as: :new
+            get "/" => "people/person_messages#new", as: :new
           end
         end
         resource :google_calendar_calendars, only: [:edit, :update], controller: "people/google_calendar/calendars", as: :google_calendar_calendars
@@ -205,52 +207,52 @@ Rails.application.routes.draw do
   # Gobierto Budgets module
   namespace :gobierto_budgets, path: nil do
     constraints GobiertoSiteConstraint.new do
-      get 'site' => 'sites#show'
+      get "site" => "sites#show"
 
       resources :featured_budget_lines, only: [:show]
 
-      get 'presupuestos/resumen(/:year)' => 'budgets#index', as: :budgets
-      get 'presupuestos/partidas/:year/:area_name/:kind' => 'budget_lines#index', as: :budget_lines
-      get 'presupuestos/partidas/:id/:year/:area_name/:kind' => 'budget_lines#show', as: :budget_line
-      get 'budget_line_descendants/:year/:area_name/:kind' => 'budget_line_descendants#index', as: :budget_line_descendants
-      get 'presupuestos/ejecucion(/:year)' => 'budgets_execution#index', as: :budgets_execution
-      get 'presupuestos/guia' => 'budgets#guide', as: :budgets_guide
-      get 'budgets/treemap(/:year)' => 'budget_lines#treemap', as: :budget_lines_treemap
+      get "presupuestos/resumen(/:year)" => "budgets#index", as: :budgets
+      get "presupuestos/partidas/:year/:area_name/:kind" => "budget_lines#index", as: :budget_lines
+      get "presupuestos/partidas/:id/:year/:area_name/:kind" => "budget_lines#show", as: :budget_line
+      get "budget_line_descendants/:year/:area_name/:kind" => "budget_line_descendants#index", as: :budget_line_descendants
+      get "presupuestos/ejecucion(/:year)" => "budgets_execution#index", as: :budgets_execution
+      get "presupuestos/guia" => "budgets#guide", as: :budgets_guide
+      get "budgets/treemap(/:year)" => "budget_lines#treemap", as: :budget_lines_treemap
 
       # TODO: move to an API > move to the big indexer
-      get 'all_categories/:slug/:year' => 'search#all_categories', as: :search_all_categories
+      get "all_categories/:slug/:year" => "search#all_categories", as: :search_all_categories
 
       namespace :api do
-        get '/categories' => 'categories#index'
-        get '/categories/:area/:kind' => 'categories#index'
-        get '/data/widget/budget/:ine_code/:year/:code/:area/:kind' => 'data#budget', as: :data_budget
-        get '/data/widget/budget_per_inhabitant/:ine_code/:year/:code/:area/:kind' => 'data#budget_per_inhabitant', as: :data_budget_per_inhabitant
-        get '/data/lines/:ine_code/:year/:what' => 'data#lines', as: :data_lines
-        get '/data/lines/budget_line/:ine_code/:year/:what/:kind/:code/:area' => 'data#lines', as: :data_lines_budget_line
-        get '/data/widget/budget_execution_deviation/:ine_code/:year/:kind' => 'data#budget_execution_deviation', as: :data_budget_execution_deviation
-        get '/data/widget/budget_execution_comparison/:ine_code/:year/:kind/:area' => 'data#budget_execution_comparison', as: :data_budget_execution_comparison
+        get "/categories" => "categories#index"
+        get "/categories/:area/:kind" => "categories#index"
+        get "/data/widget/budget/:ine_code/:year/:code/:area/:kind" => "data#budget", as: :data_budget
+        get "/data/widget/budget_per_inhabitant/:ine_code/:year/:code/:area/:kind" => "data#budget_per_inhabitant", as: :data_budget_per_inhabitant
+        get "/data/lines/:ine_code/:year/:what" => "data#lines", as: :data_lines
+        get "/data/lines/budget_line/:ine_code/:year/:what/:kind/:code/:area" => "data#lines", as: :data_lines_budget_line
+        get "/data/widget/budget_execution_deviation/:ine_code/:year/:kind" => "data#budget_execution_deviation", as: :data_budget_execution_deviation
+        get "/data/widget/budget_execution_comparison/:ine_code/:year/:kind/:area" => "data#budget_execution_comparison", as: :data_budget_execution_comparison
       end
     end
   end
 
   # Gobierto Indicators module
-  namespace :gobierto_indicators, path: 'indicadores' do
+  namespace :gobierto_indicators, path: "indicadores" do
     constraints GobiertoSiteConstraint.new do
-      root 'indicators#index'
+      root "indicators#index"
     end
   end
 
   # Gobierto CMS module
-  namespace :gobierto_cms, path: 'paginas' do
+  namespace :gobierto_cms, path: "paginas" do
     constraints GobiertoSiteConstraint.new do
-      resources :pages, only: [:index, :show], path: ''
+      resources :pages, only: [:index, :show], path: ""
     end
   end
 
   # Gobierto Participation module
-  namespace :gobierto_participation, path: '/' do
+  namespace :gobierto_participation, path: "/" do
     constraints GobiertoSiteConstraint.new do
-      get 'participacion' => 'welcome#index', as: :root
+      get "participacion" => "welcome#index", as: :root
 
       resources :processes, only: [:index, :show] do
         resources :pages, only: [:index, :show]
@@ -261,9 +263,9 @@ Rails.application.routes.draw do
   end
 
   # Gobierto Exports module
-  namespace :gobierto_exports, path: 'datos' do
+  namespace :gobierto_exports, path: "datos" do
     constraints GobiertoSiteConstraint.new do
-      root 'exports#index'
+      root "exports#index"
     end
   end
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 %w(
   .ruby-version
   .rbenv-vars

--- a/db/migrate/20150411144654_create_sites.rb
+++ b/db/migrate/20150411144654_create_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSites < ActiveRecord::Migration[5.0]
   def change
     create_table :sites do |t|

--- a/db/migrate/20161103165835_create_admins.rb
+++ b/db/migrate/20161103165835_create_admins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAdmins < ActiveRecord::Migration[5.0]
   def change
     create_table :admins do |t|
@@ -11,8 +13,8 @@ class CreateAdmins < ActiveRecord::Migration[5.0]
       t.timestamps
     end
 
-    add_index :admins, :email,                unique: true
+    add_index :admins, :email, unique: true
     add_index :admins, :reset_password_token, unique: true
-    add_index :admins, :confirmation_token,   unique: true
+    add_index :admins, :confirmation_token, unique: true
   end
 end

--- a/db/migrate/20161107174757_create_admin_sites.rb
+++ b/db/migrate/20161107174757_create_admin_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAdminSites < ActiveRecord::Migration[5.0]
   def change
     create_table :admin_sites do |t|

--- a/db/migrate/20161109071501_add_title_to_sites.rb
+++ b/db/migrate/20161109071501_add_title_to_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTitleToSites < ActiveRecord::Migration[5.0]
   def change
     add_column :sites, :title, :string, null: false, default: ""

--- a/db/migrate/20161109104606_add_visibility_level_to_sites.rb
+++ b/db/migrate/20161109104606_add_visibility_level_to_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddVisibilityLevelToSites < ActiveRecord::Migration[5.0]
   def change
     add_column :sites, :visibility_level, :integer, null: false, default: 0

--- a/db/migrate/20161109160427_add_creation_ip_to_sites.rb
+++ b/db/migrate/20161109160427_add_creation_ip_to_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCreationIpToSites < ActiveRecord::Migration[5.0]
   def change
     add_column :sites, :creation_ip, :inet

--- a/db/migrate/20161110071134_create_activities.rb
+++ b/db/migrate/20161110071134_create_activities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActivities < ActiveRecord::Migration[5.0]
   def change
     create_table :activities do |t|

--- a/db/migrate/20161111060645_add_last_sign_in_fields_to_admins.rb
+++ b/db/migrate/20161111060645_add_last_sign_in_fields_to_admins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLastSignInFieldsToAdmins < ActiveRecord::Migration[5.0]
   def change
     add_column :admins, :last_sign_in_at, :datetime

--- a/db/migrate/20161111060751_add_creation_ip_to_admins.rb
+++ b/db/migrate/20161111060751_add_creation_ip_to_admins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCreationIpToAdmins < ActiveRecord::Migration[5.0]
   def change
     add_column :admins, :creation_ip, :inet

--- a/db/migrate/20161111111116_create_admin_permissions.rb
+++ b/db/migrate/20161111111116_create_admin_permissions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAdminPermissions < ActiveRecord::Migration[5.0]
   def change
     create_table :admin_permissions do |t|

--- a/db/migrate/20161114111038_add_god_to_admins.rb
+++ b/db/migrate/20161114111038_add_god_to_admins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGodToAdmins < ActiveRecord::Migration[5.0]
   def change
     add_column :admins, :god, :boolean, null: false, default: false

--- a/db/migrate/20161114161441_add_timestamp_to_activities.rb
+++ b/db/migrate/20161114161441_add_timestamp_to_activities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTimestampToActivities < ActiveRecord::Migration[5.0]
   def change
     add_column :activities, :created_at, :timestamp, null: false

--- a/db/migrate/20161114174131_add_invitation_token_to_admins.rb
+++ b/db/migrate/20161114174131_add_invitation_token_to_admins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddInvitationTokenToAdmins < ActiveRecord::Migration[5.0]
   def change
     add_column :admins, :invitation_token, :string

--- a/db/migrate/20161116054442_create_users.rb
+++ b/db/migrate/20161116054442_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[5.0]
   def change
     create_table :users do |t|
@@ -14,8 +16,8 @@ class CreateUsers < ActiveRecord::Migration[5.0]
       t.timestamps
     end
 
-    add_index :users, :email,                unique: true
+    add_index :users, :email, unique: true
     add_index :users, :reset_password_token, unique: true
-    add_index :users, :confirmation_token,   unique: true
+    add_index :users, :confirmation_token, unique: true
   end
 end

--- a/db/migrate/20161117070200_add_source_site_to_users.rb
+++ b/db/migrate/20161117070200_add_source_site_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSourceSiteToUsers < ActiveRecord::Migration[5.0]
   def change
     add_reference :users, :source_site

--- a/db/migrate/20161118063635_create_census_items.rb
+++ b/db/migrate/20161118063635_create_census_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCensusItems < ActiveRecord::Migration[5.0]
   def change
     create_table :census_items do |t|

--- a/db/migrate/20161121133131_create_admin_census_imports.rb
+++ b/db/migrate/20161121133131_create_admin_census_imports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAdminCensusImports < ActiveRecord::Migration[5.0]
   def change
     create_table :admin_census_imports do |t|

--- a/db/migrate/20161122111248_create_user_verifications.rb
+++ b/db/migrate/20161122111248_create_user_verifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUserVerifications < ActiveRecord::Migration[5.0]
   def change
     create_table :user_verifications do |t|

--- a/db/migrate/20161122115920_add_census_verified_field_to_users.rb
+++ b/db/migrate/20161122115920_add_census_verified_field_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCensusVerifiedFieldToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :census_verified, :boolean, null: false, default: false

--- a/db/migrate/20161124065317_add_municipality_id_to_sites.rb
+++ b/db/migrate/20161124065317_add_municipality_id_to_sites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMunicipalityIdToSites < ActiveRecord::Migration[5.0]
   def change
     add_column :sites, :municipality_id, :integer

--- a/db/migrate/20161125113234_create_gobierto_budget_consultations_consultations.rb
+++ b/db/migrate/20161125113234_create_gobierto_budget_consultations_consultations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoBudgetConsultationsConsultations < ActiveRecord::Migration[5.0]
   def change
     create_table :gbc_consultations do |t|

--- a/db/migrate/20161125160905_create_gobierto_budget_consultations_consultation_items.rb
+++ b/db/migrate/20161125160905_create_gobierto_budget_consultations_consultation_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoBudgetConsultationsConsultationItems < ActiveRecord::Migration[5.0]
   def change
     create_table :gbc_consultation_items do |t|

--- a/db/migrate/20161125170030_create_gobierto_budget_consultations_consultation_responses.rb
+++ b/db/migrate/20161125170030_create_gobierto_budget_consultations_consultation_responses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoBudgetConsultationsConsultationResponses < ActiveRecord::Migration[5.0]
   def change
     create_table :gbc_consultation_responses do |t|

--- a/db/migrate/20161127123102_gobierto_admin_prefix_table_names.rb
+++ b/db/migrate/20161127123102_gobierto_admin_prefix_table_names.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GobiertoAdminPrefixTableNames < ActiveRecord::Migration[5.0]
   def change
     rename_table :admins, :admin_admins

--- a/db/migrate/20161203085646_increase_numeric_precision_in_amount_fields.rb
+++ b/db/migrate/20161203085646_increase_numeric_precision_in_amount_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class IncreaseNumericPrecisionInAmountFields < ActiveRecord::Migration[5.0]
   def change
     change_column :gbc_consultation_items, :budget_line_amount, :decimal, precision: 12, scale: 2, null: false, default: 0.0

--- a/db/migrate/20161206065440_add_sharing_token_to_consultation_responses.rb
+++ b/db/migrate/20161206065440_add_sharing_token_to_consultation_responses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSharingTokenToConsultationResponses < ActiveRecord::Migration[5.0]
   def change
     add_column :gbc_consultation_responses, :sharing_token, :string

--- a/db/migrate/20161208114958_add_budget_line_name_to_consultation_items.rb
+++ b/db/migrate/20161208114958_add_budget_line_name_to_consultation_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddBudgetLineNameToConsultationItems < ActiveRecord::Migration[5.0]
   def change
     add_column :gbc_consultation_items, :budget_line_name, :string, null: false, default: ""

--- a/db/migrate/20161214101235_add_year_of_birth_to_users.rb
+++ b/db/migrate/20161214101235_add_year_of_birth_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddYearOfBirthToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :year_of_birth, :integer

--- a/db/migrate/20161214101300_add_gender_to_users.rb
+++ b/db/migrate/20161214101300_add_gender_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGenderToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :gender, :integer

--- a/db/migrate/20161214104309_change_name_constraint_in_users.rb
+++ b/db/migrate/20161214104309_change_name_constraint_in_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeNameConstraintInUsers < ActiveRecord::Migration[5.0]
   def change
     change_column_null :users, :name, true

--- a/db/migrate/20161214104508_change_password_constraint_in_users.rb
+++ b/db/migrate/20161214104508_change_password_constraint_in_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangePasswordConstraintInUsers < ActiveRecord::Migration[5.0]
   def change
     change_column_null :users, :password_digest, true

--- a/db/migrate/20161216132408_create_user_subscriptions.rb
+++ b/db/migrate/20161216132408_create_user_subscriptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUserSubscriptions < ActiveRecord::Migration[5.0]
   def change
     create_table :user_subscriptions do |t|

--- a/db/migrate/20161219132627_create_user_notifications.rb
+++ b/db/migrate/20161219132627_create_user_notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUserNotifications < ActiveRecord::Migration[5.0]
   def change
     create_table :user_notifications do |t|

--- a/db/migrate/20161221062928_add_notification_frequency_to_users.rb
+++ b/db/migrate/20161221062928_add_notification_frequency_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNotificationFrequencyToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :notification_frequency, :integer, null: false, default: 0

--- a/db/migrate/20161221101641_add_sent_flag_to_user_notifications.rb
+++ b/db/migrate/20161221101641_add_sent_flag_to_user_notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSentFlagToUserNotifications < ActiveRecord::Migration[5.0]
   def change
     add_column :user_notifications, :sent, :boolean, null: false, default: false

--- a/db/migrate/20161222054737_add_seen_flag_to_user_notifications.rb
+++ b/db/migrate/20161222054737_add_seen_flag_to_user_notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSeenFlagToUserNotifications < ActiveRecord::Migration[5.0]
   def change
     add_column :user_notifications, :is_seen, :boolean, null: false, default: false

--- a/db/migrate/20161222064115_rename_sent_flag_in_user_notifications.rb
+++ b/db/migrate/20161222064115_rename_sent_flag_in_user_notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameSentFlagInUserNotifications < ActiveRecord::Migration[5.0]
   def change
     rename_column :user_notifications, :sent, :is_sent

--- a/db/migrate/20161222064233_add_sent_flag_index_in_user_notifications.rb
+++ b/db/migrate/20161222064233_add_sent_flag_index_in_user_notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSentFlagIndexInUserNotifications < ActiveRecord::Migration[5.0]
   def change
     add_index :user_notifications, :is_sent

--- a/db/migrate/20161222173006_create_gobierto_people_people.rb
+++ b/db/migrate/20161222173006_create_gobierto_people_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePeople < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_people do |t|

--- a/db/migrate/20161222191256_create_gobierto_common_content_blocks.rb
+++ b/db/migrate/20161222191256_create_gobierto_common_content_blocks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonContentBlocks < ActiveRecord::Migration[5.0]
   def change
     create_table :content_blocks do |t|

--- a/db/migrate/20161222192816_create_gobierto_common_content_block_fields.rb
+++ b/db/migrate/20161222192816_create_gobierto_common_content_block_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonContentBlockFields < ActiveRecord::Migration[5.0]
   def change
     create_table :content_block_fields do |t|

--- a/db/migrate/20161222193212_create_gobierto_common_content_block_records.rb
+++ b/db/migrate/20161222193212_create_gobierto_common_content_block_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonContentBlockRecords < ActiveRecord::Migration[5.0]
   def change
     create_table :content_block_records do |t|

--- a/db/migrate/20161229184441_add_gobierto_people_avatar_url_to_people.rb
+++ b/db/migrate/20161229184441_add_gobierto_people_avatar_url_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGobiertoPeopleAvatarUrlToPeople < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_people, :avatar_url, :string

--- a/db/migrate/20170103172918_create_gobierto_people_person_events.rb
+++ b/db/migrate/20170103172918_create_gobierto_people_person_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePersonEvents < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_person_events do |t|

--- a/db/migrate/20170104151011_create_gobierto_people_person_event_locations.rb
+++ b/db/migrate/20170104151011_create_gobierto_people_person_event_locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePersonEventLocations < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_person_event_locations do |t|

--- a/db/migrate/20170105080037_create_gobierto_people_person_event_attendees.rb
+++ b/db/migrate/20170105080037_create_gobierto_people_person_event_attendees.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePersonEventAttendees < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_person_event_attendees do |t|

--- a/db/migrate/20170109052231_create_gobierto_people_person_statements.rb
+++ b/db/migrate/20170109052231_create_gobierto_people_person_statements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePersonStatements < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_person_statements do |t|

--- a/db/migrate/20170109110351_create_gobierto_people_person_posts.rb
+++ b/db/migrate/20170109110351_create_gobierto_people_person_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePersonPosts < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_person_posts do |t|

--- a/db/migrate/20170109162309_add_gobierto_people_counter_cache_fields_to_people.rb
+++ b/db/migrate/20170109162309_add_gobierto_people_counter_cache_fields_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGobiertoPeopleCounterCacheFieldsToPeople < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_people, :events_count, :integer, null: false, default: 0

--- a/db/migrate/20170113100956_add_gobierto_people_attachment_fields_to_person_statements.rb
+++ b/db/migrate/20170113100956_add_gobierto_people_attachment_fields_to_person_statements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGobiertoPeopleAttachmentFieldsToPersonStatements < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_person_statements, :attachment_url, :string

--- a/db/migrate/20170113111030_create_gobierto_people_political_groups.rb
+++ b/db/migrate/20170113111030_create_gobierto_people_political_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePoliticalGroups < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_political_groups do |t|

--- a/db/migrate/20170113111154_add_gobierto_people_political_group_reference_to_people.rb
+++ b/db/migrate/20170113111154_add_gobierto_people_political_group_reference_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGobiertoPeoplePoliticalGroupReferenceToPeople < ActiveRecord::Migration[5.0]
   def change
     add_reference :gp_people, :political_group

--- a/db/migrate/20170113111816_add_gobierto_people_classification_fields_to_people.rb
+++ b/db/migrate/20170113111816_add_gobierto_people_classification_fields_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGobiertoPeopleClassificationFieldsToPeople < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_people, :category, :integer, null: false, default: 0

--- a/db/migrate/20170114153207_gobierto_common_change_content_blocks_title_field_type.rb
+++ b/db/migrate/20170114153207_gobierto_common_change_content_blocks_title_field_type.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class GobiertoCommonChangeContentBlocksTitleFieldType < ActiveRecord::Migration[5.0]
   def up
-    enable_extension 'hstore' unless extension_enabled?('hstore')
+    enable_extension "hstore" unless extension_enabled?("hstore")
 
     add_column :content_blocks, :title_hstore, :hstore
 
     ActiveRecord::Base.transaction do
       GobiertoCommon::ContentBlock.select(:id, :title).find_each do |content_block|
-        content_block.update_columns(title_hstore: YAML::load(content_block.title))
+        content_block.update_columns(title_hstore: YAML.safe_load(content_block.title))
       end
     end
 
@@ -19,7 +21,7 @@ class GobiertoCommonChangeContentBlocksTitleFieldType < ActiveRecord::Migration[
 
     ActiveRecord::Base.transaction do
       GobiertoCommon::ContentBlock.select(:id, :title).find_each do |content_block|
-        content_block.update_columns(title_text: YAML::dump(content_block.title))
+        content_block.update_columns(title_text: YAML.dump(content_block.title))
       end
     end
 

--- a/db/migrate/20170116072555_add_gobierto_people_classifying_fields_indexes_to_people.rb
+++ b/db/migrate/20170116072555_add_gobierto_people_classifying_fields_indexes_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGobiertoPeopleClassifyingFieldsIndexesToPeople < ActiveRecord::Migration[5.0]
   def change
     add_index :gp_people, :category

--- a/db/migrate/20170131144344_create_gobierto_people_settings.rb
+++ b/db/migrate/20170131144344_create_gobierto_people_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeopleSettings < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_settings do |t|

--- a/db/migrate/20170201120912_add_position_to_gobierto_people_people.rb
+++ b/db/migrate/20170201120912_add_position_to_gobierto_people_people.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddPositionToGobiertoPeoplePeople < ActiveRecord::Migration[5.0]
   def change
-    add_column :gp_people, :position, :integer, default: 999999, null: false
+    add_column :gp_people, :position, :integer, default: 999_999, null: false
   end
 end

--- a/db/migrate/20170213134054_add_internal_id_to_content_blocks.rb
+++ b/db/migrate/20170213134054_add_internal_id_to_content_blocks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddInternalIdToContentBlocks < ActiveRecord::Migration[5.0]
   def change
     add_column :content_blocks, :internal_id, :string

--- a/db/migrate/20170215091438_add_email_to_gobierto_people_person.rb
+++ b/db/migrate/20170215091438_add_email_to_gobierto_people_person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddEmailToGobiertoPeoplePerson < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_people, :email, :string

--- a/db/migrate/20170216114700_add_configuration_flags_to_gobierto_budgets_consultations.rb
+++ b/db/migrate/20170216114700_add_configuration_flags_to_gobierto_budgets_consultations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfigurationFlagsToGobiertoBudgetsConsultations < ActiveRecord::Migration[5.0]
   def change
     add_column :gbc_consultations, :show_figures, :boolean, default: true

--- a/db/migrate/20170216114836_add_configuration_flags_to_gobierto_budgets_consultations_items.rb
+++ b/db/migrate/20170216114836_add_configuration_flags_to_gobierto_budgets_consultations_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfigurationFlagsToGobiertoBudgetsConsultationsItems < ActiveRecord::Migration[5.0]
   def change
     add_column :gbc_consultation_items, :block_reduction, :boolean, default: false

--- a/db/migrate/20170222070916_change_gobierto_budget_consultations_consultation_responses_link_to_user.rb
+++ b/db/migrate/20170222070916_change_gobierto_budget_consultations_consultation_responses_link_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeGobiertoBudgetConsultationsConsultationResponsesLinkToUser < ActiveRecord::Migration[5.0]
   def up
     remove_index :gbc_consultation_responses, name: "index_gbc_consultation_responses_on_user_id"

--- a/db/migrate/20170222144905_create_gcms_pages_table.rb
+++ b/db/migrate/20170222144905_create_gcms_pages_table.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class CreateGcmsPagesTable < ActiveRecord::Migration[5.0]
   def change
     create_table :gcms_pages do |t|
-      t.string :title, null: false, default: ''
-      t.text :body, null: false, default: ''
-      t.string :slug, null: false, default: ''
+      t.string :title, null: false, default: ""
+      t.text :body, null: false, default: ""
+      t.string :slug, null: false, default: ""
       t.references :site
       t.integer :visibility_level, null: false, default: 0
 

--- a/db/migrate/20170224090622_forece_internal_id_to_be_empty_string.rb
+++ b/db/migrate/20170224090622_forece_internal_id_to_be_empty_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ForeceInternalIdToBeEmptyString < ActiveRecord::Migration[5.0]
   def up
     remove_index :content_blocks, name: "index_content_blocks_on_site_id_and_internal_id"

--- a/db/migrate/20170301120456_create_gobierto_common_custom_user_fields.rb
+++ b/db/migrate/20170301120456_create_gobierto_common_custom_user_fields.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonCustomUserFields < ActiveRecord::Migration[5.0]
   def change
-    enable_extension 'hstore' unless extension_enabled?('hstore')
+    enable_extension "hstore" unless extension_enabled?("hstore")
 
     create_table :custom_user_fields do |t|
       t.references :site

--- a/db/migrate/20170301120504_create_gobierto_common_custom_user_field_records.rb
+++ b/db/migrate/20170301120504_create_gobierto_common_custom_user_field_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonCustomUserFieldRecords < ActiveRecord::Migration[5.0]
   def change
     create_table :custom_user_field_records do |t|

--- a/db/migrate/20170302100518_replace_users_year_of_birth.rb
+++ b/db/migrate/20170302100518_replace_users_year_of_birth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReplaceUsersYearOfBirth < ActiveRecord::Migration[5.0]
   def up
     remove_column :users, :year_of_birth

--- a/db/migrate/20170302154209_add_user_information_to_consultation_responses.rb
+++ b/db/migrate/20170302154209_add_user_information_to_consultation_responses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserInformationToConsultationResponses < ActiveRecord::Migration[5.0]
   def change
     add_column :gbc_consultation_responses, :user_information, :jsonb

--- a/db/migrate/20170304172933_add_referrer_url_to_users.rb
+++ b/db/migrate/20170304172933_add_referrer_url_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReferrerUrlToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :referrer_url, :string

--- a/db/migrate/20170312182331_add_position_to_political_groups.rb
+++ b/db/migrate/20170312182331_add_position_to_political_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPositionToPoliticalGroups < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_political_groups, :position, :integer, default: 0, null: false

--- a/db/migrate/20170322144939_add_gcms_pages_translations.rb
+++ b/db/migrate/20170322144939_add_gcms_pages_translations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGcmsPagesTranslations < ActiveRecord::Migration[5.0]
   def change
     remove_index :gcms_pages, name: "index_gcms_pages_on_slug_and_site_id", unique: true

--- a/db/migrate/20170410082426_add_initial_submodule_settings.rb
+++ b/db/migrate/20170410082426_add_initial_submodule_settings.rb
@@ -1,18 +1,17 @@
-class AddInitialSubmoduleSettings < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddInitialSubmoduleSettings < ActiveRecord::Migration[5.0]
   def up
     Site.all.each do |site|
-      if site.configuration.gobierto_people_enabled?
-        GobiertoPeople::Setting.create site: site, key: "agendas_submodule_active", value: "true"
-        GobiertoPeople::Setting.create site: site, key: "officials_submodule_active", value: "true"
-        GobiertoPeople::Setting.create site: site, key: "blog_submodule_active", value: "true"
-        GobiertoPeople::Setting.create site: site, key: "statements_submodule_active", value: "true"
-      end
+      next unless site.configuration.gobierto_people_enabled?
+      GobiertoPeople::Setting.create site: site, key: "agendas_submodule_active", value: "true"
+      GobiertoPeople::Setting.create site: site, key: "officials_submodule_active", value: "true"
+      GobiertoPeople::Setting.create site: site, key: "blog_submodule_active", value: "true"
+      GobiertoPeople::Setting.create site: site, key: "statements_submodule_active", value: "true"
     end
   end
 
   def down
     GobiertoPeople::Setting.where("key ~* ?", ".*_submodule_active").destroy_all
   end
-
 end

--- a/db/migrate/20170410112608_add_external_id_to_gobierto_people_person_event.rb
+++ b/db/migrate/20170410112608_add_external_id_to_gobierto_people_person_event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddExternalIdToGobiertoPeoplePersonEvent < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_person_events, :external_id, :string

--- a/db/migrate/20170411101428_add_person_id_not_null_constraint_to_gobierto_people_person_event.rb
+++ b/db/migrate/20170411101428_add_person_id_not_null_constraint_to_gobierto_people_person_event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPersonIdNotNullConstraintToGobiertoPeoplePersonEvent < ActiveRecord::Migration[5.0]
   def change
     change_column :gp_person_events, :person_id, :integer, null: false

--- a/db/migrate/20170411163634_add_sites_translations.rb
+++ b/db/migrate/20170411163634_add_sites_translations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSitesTranslations < ActiveRecord::Migration[5.0]
   def change
     add_column :sites, :name_translations, :jsonb

--- a/db/migrate/20170412092128_add_gp_person_translations.rb
+++ b/db/migrate/20170412092128_add_gp_person_translations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGpPersonTranslations < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_people, :charge_translations, :jsonb

--- a/db/migrate/20170412092257_add_gp_person_event_translations.rb
+++ b/db/migrate/20170412092257_add_gp_person_event_translations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGpPersonEventTranslations < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_person_events, :title_translations, :jsonb

--- a/db/migrate/20170412092307_add_gp_person_statement_translations.rb
+++ b/db/migrate/20170412092307_add_gp_person_statement_translations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGpPersonStatementTranslations < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_person_statements, :title_translations, :jsonb

--- a/db/migrate/20170412125156_create_gobierto_people_person_calendar_configuration.rb
+++ b/db/migrate/20170412125156_create_gobierto_people_person_calendar_configuration.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class CreateGobiertoPeoplePersonCalendarConfiguration < ActiveRecord::Migration[5.0]
   def change
     create_table :gp_person_calendar_configurations do |t|
       t.integer :person_id, null: false
-      t.jsonb :data, null: false, default: '{}'
+      t.jsonb :data, null: false, default: "{}"
     end
   end
 end

--- a/db/migrate/20170417094657_create_table_gobierto_module_settings.rb
+++ b/db/migrate/20170417094657_create_table_gobierto_module_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTableGobiertoModuleSettings < ActiveRecord::Migration[5.0]
   def change
     create_table :gobierto_module_settings do |t|

--- a/db/migrate/20170418145507_remove_deprecated_columns_after_globalization.rb
+++ b/db/migrate/20170418145507_remove_deprecated_columns_after_globalization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveDeprecatedColumnsAfterGlobalization < ActiveRecord::Migration[5.0]
   def change
     remove_column :sites, :name

--- a/db/migrate/20170419153124_change_gobierto_people_person_calendar_configuration_data_default_value.rb
+++ b/db/migrate/20170419153124_change_gobierto_people_person_calendar_configuration_data_default_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeGobiertoPeoplePersonCalendarConfigurationDataDefaultValue < ActiveRecord::Migration[5.0]
   def change
     change_column_default :gp_person_calendar_configurations, :data, {}

--- a/db/migrate/20170420072054_create_translations.rb
+++ b/db/migrate/20170420072054_create_translations.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class CreateTranslations < ActiveRecord::Migration[5.0]
   def change
     create_table :translations do |t|
       t.string :locale
       t.string :key
-      t.text   :value
-      t.text   :interpolations
+      t.text :value
+      t.text :interpolations
       t.boolean :is_proc, default: false
 
       t.timestamps

--- a/db/migrate/20170420132633_add_unique_contraint_to_person_calendar_configuration_person_id.rb
+++ b/db/migrate/20170420132633_add_unique_contraint_to_person_calendar_configuration_person_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniqueContraintToPersonCalendarConfigurationPersonId < ActiveRecord::Migration[5.0]
   def change
     add_index :gp_person_calendar_configurations, :person_id, unique: true

--- a/db/migrate/20170424104048_migrate_ibm_notes_settings_to_gobierto_module_settings.rb
+++ b/db/migrate/20170424104048_migrate_ibm_notes_settings_to_gobierto_module_settings.rb
@@ -1,7 +1,8 @@
-class MigrateIbmNotesSettingsToGobiertoModuleSettings < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class MigrateIbmNotesSettingsToGobiertoModuleSettings < ActiveRecord::Migration[5.0]
   def migrate_ibm_notes_users
-    ibm_notes_users_settings = GobiertoPeople::Setting.where(key: 'IBM_NOTES_ENDPOINT_USR')
+    ibm_notes_users_settings = GobiertoPeople::Setting.where(key: "IBM_NOTES_ENDPOINT_USR")
 
     ibm_notes_users_settings.each do |setting|
       gobierto_module_settings = GobiertoModuleSettings.find_or_create_by(
@@ -17,7 +18,7 @@ class MigrateIbmNotesSettingsToGobiertoModuleSettings < ActiveRecord::Migration[
   end
 
   def migrate_ibm_notes_passwords
-    ibm_notes_pwd_settings = GobiertoPeople::Setting.where(key: 'IBM_NOTES_ENDPOINT_PWD')
+    ibm_notes_pwd_settings = GobiertoPeople::Setting.where(key: "IBM_NOTES_ENDPOINT_PWD")
 
     ibm_notes_pwd_settings.each do |setting|
       gobierto_module_settings = GobiertoModuleSettings.find_or_create_by(
@@ -38,28 +39,26 @@ class MigrateIbmNotesSettingsToGobiertoModuleSettings < ActiveRecord::Migration[
   end
 
   def down
-
     GobiertoModuleSettings.where(module_name: "GobiertoPeople").each do |module_settings|
-      if module_settings.settings['ibm_notes_usr'].present?
+      if module_settings.settings["ibm_notes_usr"].present?
         GobiertoPeople::Setting.create!(
           site: module_settings.site,
-          key: 'IBM_NOTES_ENDPOINT_USR',
-          value: module_settings.settings['ibm_notes_usr']
+          key: "IBM_NOTES_ENDPOINT_USR",
+          value: module_settings.settings["ibm_notes_usr"]
         )
-        module_settings.settings.delete('ibm_notes_usr')
+        module_settings.settings.delete("ibm_notes_usr")
       end
 
-      if module_settings.settings['ibm_notes_pwd'].present?
+      if module_settings.settings["ibm_notes_pwd"].present?
         GobiertoPeople::Setting.create!(
           site: module_settings.site,
-          key: 'IBM_NOTES_ENDPOINT_PWD',
-          value: module_settings.settings['ibm_notes_pwd']
+          key: "IBM_NOTES_ENDPOINT_PWD",
+          value: module_settings.settings["ibm_notes_pwd"]
         )
-        module_settings.settings.delete('ibm_notes_pwd')
+        module_settings.settings.delete("ibm_notes_pwd")
       end
 
       module_settings.save!
     end
-
   end
 end

--- a/db/migrate/20170428081148_fix_content_block_fields_data.rb
+++ b/db/migrate/20170428081148_fix_content_block_fields_data.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 class FixContentBlockFieldsData < ActiveRecord::Migration[5.0]
   def change
     GobiertoCommon::ContentBlockField.where("name = ''").each do |cbf|
-      if cbf.name.blank?
-        cbf.name = SecureRandom.uuid
-        cbf.save!
-        puts " - Updated ContentBlockField #{cbf.id}"
-      end
+      next unless cbf.name.blank?
+      cbf.name = SecureRandom.uuid
+      cbf.save!
+      puts " - Updated ContentBlockField #{cbf.id}"
     end
   end
 end

--- a/db/migrate/20170509075454_add_not_null_constraint_to_person_event_attendees_event_id.rb
+++ b/db/migrate/20170509075454_add_not_null_constraint_to_person_event_attendees_event_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNotNullConstraintToPersonEventAttendeesEventId < ActiveRecord::Migration[5.0]
   def up
     change_column :gp_person_event_attendees, :person_event_id, :integer, null: false

--- a/db/migrate/20170509082436_add_not_null_constraint_to_person_event_locations_event_id.rb
+++ b/db/migrate/20170509082436_add_not_null_constraint_to_person_event_locations_event_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNotNullConstraintToPersonEventLocationsEventId < ActiveRecord::Migration[5.0]
   def up
     change_column :gp_person_event_locations, :person_event_id, :integer, null: false

--- a/db/migrate/20170509082437_add_site_id_to_gp_events_statements_and_posts.rb
+++ b/db/migrate/20170509082437_add_site_id_to_gp_events_statements_and_posts.rb
@@ -1,5 +1,6 @@
-class AddSiteIdToGpEventsStatementsAndPosts < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddSiteIdToGpEventsStatementsAndPosts < ActiveRecord::Migration[5.0]
   def up
     add_site_id_to_person_events
     add_site_id_to_person_statements
@@ -41,5 +42,4 @@ class AddSiteIdToGpEventsStatementsAndPosts < ActiveRecord::Migration[5.0]
     add_foreign_key :gp_person_posts, :sites
     change_column :gp_person_posts, :site_id, :integer, null: false
   end
-
 end

--- a/db/migrate/20170509154856_add_slug_to_gobierto_people_person.rb
+++ b/db/migrate/20170509154856_add_slug_to_gobierto_people_person.rb
@@ -1,5 +1,6 @@
-class AddSlugToGobiertoPeoplePerson < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddSlugToGobiertoPeoplePerson < ActiveRecord::Migration[5.0]
   def up
     add_column :gp_people, :slug, :string
     ::GobiertoPeople::Person.reset_column_information
@@ -20,5 +21,4 @@ class AddSlugToGobiertoPeoplePerson < ActiveRecord::Migration[5.0]
       person.save!
     end
   end
-
 end

--- a/db/migrate/20170509163252_add_slug_to_gobierto_people_person_event.rb
+++ b/db/migrate/20170509163252_add_slug_to_gobierto_people_person_event.rb
@@ -1,5 +1,6 @@
-class AddSlugToGobiertoPeoplePersonEvent < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddSlugToGobiertoPeoplePersonEvent < ActiveRecord::Migration[5.0]
   def up
     add_column :gp_person_events, :slug, :string
     change_column :gp_person_events, :slug, :string, null: false
@@ -13,5 +14,4 @@ class AddSlugToGobiertoPeoplePersonEvent < ActiveRecord::Migration[5.0]
     change_column :gp_person_events, :starts_at, :datetime
     change_column :gp_person_events, :ends_at, :datetime
   end
-
 end

--- a/db/migrate/20170509163345_add_slug_to_gobierto_people_person_statement.rb
+++ b/db/migrate/20170509163345_add_slug_to_gobierto_people_person_statement.rb
@@ -1,5 +1,6 @@
-class AddSlugToGobiertoPeoplePersonStatement < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddSlugToGobiertoPeoplePersonStatement < ActiveRecord::Migration[5.0]
   def up
     add_column :gp_person_statements, :slug, :string
     ::GobiertoPeople::PersonStatement.reset_column_information
@@ -23,5 +24,4 @@ class AddSlugToGobiertoPeoplePersonStatement < ActiveRecord::Migration[5.0]
       statement.save!
     end
   end
-
 end

--- a/db/migrate/20170510091709_add_slug_to_gobierto_people_person_posts.rb
+++ b/db/migrate/20170510091709_add_slug_to_gobierto_people_person_posts.rb
@@ -1,5 +1,6 @@
-class AddSlugToGobiertoPeoplePersonPosts < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddSlugToGobiertoPeoplePersonPosts < ActiveRecord::Migration[5.0]
   def up
     add_column :gp_person_posts, :slug, :string
     ::GobiertoPeople::PersonPost.reset_column_information
@@ -20,5 +21,4 @@ class AddSlugToGobiertoPeoplePersonPosts < ActiveRecord::Migration[5.0]
       post.save!
     end
   end
-
 end

--- a/db/migrate/20170516111435_add_slug_to_gobierto_people_political_group.rb
+++ b/db/migrate/20170516111435_add_slug_to_gobierto_people_political_group.rb
@@ -1,5 +1,6 @@
-class AddSlugToGobiertoPeoplePoliticalGroup < ActiveRecord::Migration[5.0]
+# frozen_string_literal: true
 
+class AddSlugToGobiertoPeoplePoliticalGroup < ActiveRecord::Migration[5.0]
   def up
     add_column :gp_political_groups, :slug, :string
     ::GobiertoPeople::PoliticalGroup.reset_column_information
@@ -20,5 +21,4 @@ class AddSlugToGobiertoPeoplePoliticalGroup < ActiveRecord::Migration[5.0]
       political_group.save!
     end
   end
-
 end

--- a/db/migrate/20170519070559_add_google_calendar_token_to_gp_people_people.rb
+++ b/db/migrate/20170519070559_add_google_calendar_token_to_gp_people_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGoogleCalendarTokenToGpPeoplePeople < ActiveRecord::Migration[5.0]
   def change
     add_column :gp_people, :google_calendar_token, :string

--- a/db/migrate/20170522103406_add_attachment_url_to_content_block_record.rb
+++ b/db/migrate/20170522103406_add_attachment_url_to_content_block_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAttachmentUrlToContentBlockRecord < ActiveRecord::Migration[5.0]
   def change
     add_column :content_block_records, :attachment_url, :string

--- a/db/migrate/20170530144711_add_preview_token_to_admins.rb
+++ b/db/migrate/20170530144711_add_preview_token_to_admins.rb
@@ -1,5 +1,6 @@
-class AddPreviewTokenToAdmins < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class AddPreviewTokenToAdmins < ActiveRecord::Migration[5.1]
   def up
     add_column :admin_admins, :preview_token, :string
     GobiertoAdmin::Admin.reset_column_information
@@ -21,5 +22,4 @@ class AddPreviewTokenToAdmins < ActiveRecord::Migration[5.1]
       admin.save!
     end
   end
-
 end

--- a/db/migrate/20170602084501_create_gobierto_attachments_attachment.rb
+++ b/db/migrate/20170602084501_create_gobierto_attachments_attachment.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class CreateGobiertoAttachmentsAttachment < ActiveRecord::Migration[5.1]
   def change
     create_table :ga_attachments do |t|
       t.integer :site_id, null: false
-      t.string  :name, null: false
-      t.text    :description
-      t.string  :file_name, null: false
-      t.string  :file_digest, null: false
-      t.string  :url, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :file_name, null: false
+      t.string :file_digest, null: false
+      t.string :url, null: false
       t.integer :file_size, null: false
       t.integer :current_version, null: false, default: 0
     end

--- a/db/migrate/20170602140913_create_versions.rb
+++ b/db/migrate/20170602140913_create_versions.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
 class CreateVersions < ActiveRecord::Migration[5.1]
-
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
   # so that MySQL will use `longtext` instead of `text`.  Otherwise,
@@ -10,11 +11,11 @@ class CreateVersions < ActiveRecord::Migration[5.1]
 
   def change
     create_table :versions do |t|
-      t.string   :item_type, {:null=>false}
-      t.integer  :item_id,   null: false
-      t.string   :event,     null: false
-      t.string   :whodunnit
-      t.text     :object, limit: TEXT_BYTES
+      t.string :item_type, null: false
+      t.integer :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.text :object, limit: TEXT_BYTES
 
       # Known issue in MySQL: fractional second precision
       # -------------------------------------------------
@@ -31,6 +32,6 @@ class CreateVersions < ActiveRecord::Migration[5.1]
       #
       t.datetime :created_at
     end
-    add_index :versions, %i(item_type item_id)
+    add_index :versions, [:item_type, :item_id]
   end
 end

--- a/db/migrate/20170605103424_create_attachings.rb
+++ b/db/migrate/20170605103424_create_attachings.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class CreateAttachings < ActiveRecord::Migration[5.1]
   def change
     create_table :ga_attachings do |t|
       t.integer :site_id, null: false
       t.integer :attachment_id, null: false
       t.integer :attachable_id, null: false
-      t.string  :attachable_type, null: false
+      t.string :attachable_type, null: false
     end
 
-    add_index :ga_attachings, [:site_id, :attachment_id, :attachable_id, :attachable_type], unique: true,  name: 'record_unique_index'
+    add_index :ga_attachings, [:site_id, :attachment_id, :attachable_id, :attachable_type], unique: true, name: "record_unique_index"
   end
 end

--- a/db/migrate/20170622125313_create_gobierto_budgets_category.rb
+++ b/db/migrate/20170622125313_create_gobierto_budgets_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoBudgetsCategory < ActiveRecord::Migration[5.1]
   def change
     create_table :gb_categories do |t|
@@ -9,6 +11,6 @@ class CreateGobiertoBudgetsCategory < ActiveRecord::Migration[5.1]
       t.jsonb :custom_description_translations
     end
 
-    add_index :gb_categories, [:site_id, :area_name, :kind, :code], unique: true,  name: 'gb_categories_record_unique_index'
+    add_index :gb_categories, [:site_id, :area_name, :kind, :code], unique: true, name: "gb_categories_record_unique_index"
   end
 end

--- a/db/migrate/20170703101643_create_gpart_processes.rb
+++ b/db/migrate/20170703101643_create_gpart_processes.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class CreateGpartProcesses < ActiveRecord::Migration[5.1]
   def change
     create_table :gpart_processes do |t|
       t.references :site
-      t.string :slug, null: false, default: ''
+      t.string :slug, null: false, default: ""
       t.integer :visibility_level, null: false, default: 0
       t.jsonb :title_translations
       t.jsonb :body_translations

--- a/db/migrate/20170703134510_create_gobierto_participation_process_stages.rb
+++ b/db/migrate/20170703134510_create_gobierto_participation_process_stages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoParticipationProcessStages < ActiveRecord::Migration[5.1]
   def change
     create_table :gpart_process_stages do |t|

--- a/db/migrate/20170703145524_create_gobierto_participation_issues.rb
+++ b/db/migrate/20170703145524_create_gobierto_participation_issues.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoParticipationIssues < ActiveRecord::Migration[5.1]
   def change
     create_table :gpart_issues do |t|

--- a/db/migrate/20170703152748_create_gobierto_participation_areas.rb
+++ b/db/migrate/20170703152748_create_gobierto_participation_areas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoParticipationAreas < ActiveRecord::Migration[5.1]
   def change
     create_table :gpart_areas do |t|

--- a/db/migrate/20170703154336_create_gobierto_common_collection_item.rb
+++ b/db/migrate/20170703154336_create_gobierto_common_collection_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonCollectionItem < ActiveRecord::Migration[5.1]
   def change
     create_table :collection_items do |t|

--- a/db/migrate/20170703154337_update_gobierto_common_collection_item.rb
+++ b/db/migrate/20170703154337_update_gobierto_common_collection_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateGobiertoCommonCollectionItem < ActiveRecord::Migration[5.1]
   def change
     remove_column :collection_items, :site_id

--- a/db/migrate/20170711143932_add_position_to_gobierto_participation_issues.rb
+++ b/db/migrate/20170711143932_add_position_to_gobierto_participation_issues.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPositionToGobiertoParticipationIssues < ActiveRecord::Migration[5.1]
   def change
     add_column :gpart_issues, :position, :integer, default: 0, null: false

--- a/db/migrate/20170712103453_attachment_name_can_be_null.rb
+++ b/db/migrate/20170712103453_attachment_name_can_be_null.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AttachmentNameCanBeNull < ActiveRecord::Migration[5.1]
   def change
     change_column :ga_attachments, :name, :string, null: true

--- a/db/migrate/20170713101934_create_gobierto_common_collection.rb
+++ b/db/migrate/20170713101934_create_gobierto_common_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonCollection < ActiveRecord::Migration[5.1]
   def change
     create_table :collections do |t|

--- a/db/migrate/20170718094412_add_container_and_type_to_gobierto_common_collection.rb
+++ b/db/migrate/20170718094412_add_container_and_type_to_gobierto_common_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddContainerAndTypeToGobiertoCommonCollection < ActiveRecord::Migration[5.1]
   def change
     add_reference :collections, :container, polymorphic: true, index: true

--- a/db/migrate/20170718132239_replace_process_and_process_stage_localized_slug.rb
+++ b/db/migrate/20170718132239_replace_process_and_process_stage_localized_slug.rb
@@ -1,12 +1,13 @@
-class ReplaceProcessAndProcessStageLocalizedSlug < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class ReplaceProcessAndProcessStageLocalizedSlug < ActiveRecord::Migration[5.1]
   def change
     update_processes_table_slug
     update_process_stages_table_slug
   end
 
   def update_processes_table_slug
-    remove_index :gpart_processes, name: 'index_gpart_processes_on_slug_translations'
+    remove_index :gpart_processes, name: "index_gpart_processes_on_slug_translations"
     remove_column :gpart_processes, :slug_translations
     add_index :gpart_processes, :slug, unique: true
   end
@@ -15,8 +16,7 @@ class ReplaceProcessAndProcessStageLocalizedSlug < ActiveRecord::Migration[5.1]
     add_column :gpart_process_stages, :slug, :string, null: false
     add_index :gpart_process_stages, :slug, unique: true
 
-    remove_index :gpart_process_stages, name: 'index_gpart_process_stages_on_slug_translations'
+    remove_index :gpart_process_stages, name: "index_gpart_process_stages_on_slug_translations"
     remove_column :gpart_process_stages, :slug_translations
   end
-
 end

--- a/db/migrate/20170718145219_add_header_image_url_to_process.rb
+++ b/db/migrate/20170718145219_add_header_image_url_to_process.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
+
 class AddHeaderImageUrlToProcess < ActiveRecord::Migration[5.1]
-  
   def change
     add_column :gpart_processes, :header_image_url, :string
   end
-
 end

--- a/db/migrate/20170719065428_change_gobierto_common_collection_slug.rb
+++ b/db/migrate/20170719065428_change_gobierto_common_collection_slug.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class ChangeGobiertoCommonCollectionSlug < ActiveRecord::Migration[5.1]
   def change
     remove_column :collections, :slug_translations
-    add_column :collections, :slug, :string, null: false, default: ''
+    add_column :collections, :slug, :string, null: false, default: ""
   end
 end

--- a/db/migrate/20170719091606_add_type_to_processes.rb
+++ b/db/migrate/20170719091606_add_type_to_processes.rb
@@ -1,7 +1,7 @@
-class AddTypeToProcesses < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class AddTypeToProcesses < ActiveRecord::Migration[5.1]
   def change
     add_column :gpart_processes, :process_type, :integer, default: GobiertoParticipation::Process.process_types[:group_process], null: false
   end
-
 end

--- a/db/migrate/20170719141421_add_stage_type_to_process_stage.rb
+++ b/db/migrate/20170719141421_add_stage_type_to_process_stage.rb
@@ -1,7 +1,7 @@
-class AddStageTypeToProcessStage < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class AddStageTypeToProcessStage < ActiveRecord::Migration[5.1]
   def change
     add_column :gpart_process_stages, :stage_type, :integer, default: 0, null: false
   end
-
 end

--- a/db/migrate/20170720154418_add_description_to_process_stage.rb
+++ b/db/migrate/20170720154418_add_description_to_process_stage.rb
@@ -1,7 +1,7 @@
-class AddDescriptionToProcessStage < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class AddDescriptionToProcessStage < ActiveRecord::Migration[5.1]
   def change
     add_column :gpart_process_stages, :description_translations, :jsonb
   end
-  
 end

--- a/db/migrate/20170720162142_create_gobierto_common_collection_default_and_add_pages.rb
+++ b/db/migrate/20170720162142_create_gobierto_common_collection_default_and_add_pages.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonCollectionDefaultAndAddPages < ActiveRecord::Migration[5.1]
   def change
     Site.all.each do |site|
       collection = GobiertoCommon::Collection.create! site: site,
-                                                      slug: 'site-' + site.name.downcase.delete(' '),
-                                                      title_translations: {'es' => 'Sitio' },
+                                                      slug: "site-" + site.name.downcase.delete(" "),
+                                                      title_translations: { "es" => "Sitio" },
                                                       container: site,
-                                                      item_type: 'GobiertoCms::Page'
+                                                      item_type: "GobiertoCms::Page"
 
       site.pages.all.each do |page|
         collection.append(page)

--- a/db/migrate/20170721101608_relax_constraint_on_process_stage_slug.rb
+++ b/db/migrate/20170721101608_relax_constraint_on_process_stage_slug.rb
@@ -1,8 +1,8 @@
-class RelaxConstraintOnProcessStageSlug < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class RelaxConstraintOnProcessStageSlug < ActiveRecord::Migration[5.1]
   def change
-    remove_index :gpart_process_stages, name: 'index_gpart_process_stages_on_slug'
+    remove_index :gpart_process_stages, name: "index_gpart_process_stages_on_slug"
     add_index :gpart_process_stages, [:process_id, :slug], unique: true
   end
-
 end

--- a/db/migrate/20170721104628_gobierto_common_update_title_translations.rb
+++ b/db/migrate/20170721104628_gobierto_common_update_title_translations.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class GobiertoCommonUpdateTitleTranslations < ActiveRecord::Migration[5.1]
   def change
     Site.all.each do |site|
       site.collections.each do |collection|
-        collection.title_translations = {"ca": "Lloc", "en": "Site", "es": "Sitio"}
+        collection.title_translations = { "ca": "Lloc", "en": "Site", "es": "Sitio" }
         collection.save
       end
     end

--- a/db/migrate/20170725101331_add_issue_to_process.rb
+++ b/db/migrate/20170725101331_add_issue_to_process.rb
@@ -1,7 +1,7 @@
-class AddIssueToProcess < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class AddIssueToProcess < ActiveRecord::Migration[5.1]
   def change
     add_column :gpart_processes, :issue_id, :integer
   end
-
 end

--- a/db/migrate/20170725131230_add_information_text_tranlsations_to_process.rb
+++ b/db/migrate/20170725131230_add_information_text_tranlsations_to_process.rb
@@ -1,7 +1,7 @@
-class AddInformationTextTranlsationsToProcess < ActiveRecord::Migration[5.1]
+# frozen_string_literal: true
 
+class AddInformationTextTranlsationsToProcess < ActiveRecord::Migration[5.1]
   def change
     add_column :gpart_processes, :information_text_translations, :jsonb
   end
-
 end

--- a/db/migrate/20170726122503_add_timestamps_gobierto_attachments_attachment.rb
+++ b/db/migrate/20170726122503_add_timestamps_gobierto_attachments_attachment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTimestampsGobiertoAttachmentsAttachment < ActiveRecord::Migration[5.1]
   def change
     add_timestamps :ga_attachments, default: DateTime.current

--- a/db/migrate/20170728075853_rename_gp_person_events_to_gobierto_calendars_events.rb
+++ b/db/migrate/20170728075853_rename_gp_person_events_to_gobierto_calendars_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameGpPersonEventsToGobiertoCalendarsEvents < ActiveRecord::Migration[5.1]
   def change
     rename_table :gp_person_events, :gobierto_calendars_events

--- a/db/migrate/20170729075853_rename_rest_of_gp_person_events_to_gobierto_calendarss.rb
+++ b/db/migrate/20170729075853_rename_rest_of_gp_person_events_to_gobierto_calendarss.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameRestOfGpPersonEventsToGobiertoCalendarss < ActiveRecord::Migration[5.1]
   def change
     rename_table :gp_person_event_attendees, :gobierto_calendars_event_attendees

--- a/db/migrate/20170729084620_remove_person_id_from_gobierto_calendars_events.rb
+++ b/db/migrate/20170729084620_remove_person_id_from_gobierto_calendars_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemovePersonIdFromGobiertoCalendarsEvents < ActiveRecord::Migration[5.1]
   def up
     add_column :gobierto_calendars_events, :collection_id, :integer
@@ -9,13 +11,12 @@ class RemovePersonIdFromGobiertoCalendarsEvents < ActiveRecord::Migration[5.1]
     end.size
 
     GobiertoCalendars::Event.all.each do |e|
-      if p = GobiertoPeople::Person.find_by(id: e.person_id)
-        collection = p.events_collection
-        e.collection = collection
-        e.save!
+      next unless p = GobiertoPeople::Person.find_by(id: e.person_id)
+      collection = p.events_collection
+      e.collection = collection
+      e.save!
 
-        collection.append(e)
-      end
+      collection.append(e)
     end
 
     remove_column :gobierto_calendars_events, :person_id

--- a/db/migrate/20170729093045_remove_events_count_from_people.rb
+++ b/db/migrate/20170729093045_remove_events_count_from_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveEventsCountFromPeople < ActiveRecord::Migration[5.1]
   def change
     remove_column :gp_people, :events_count

--- a/db/migrate/20170731151716_migrate_activities_and_subscriptions_to_calendars_events.rb
+++ b/db/migrate/20170731151716_migrate_activities_and_subscriptions_to_calendars_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MigrateActivitiesAndSubscriptionsToCalendarsEvents < ActiveRecord::Migration[5.1]
   def change
     Activity.where(subject_type: "GobiertoPeople::PersonEvent").update_all(subject_type: "GobiertoCalendars::Event")

--- a/db/migrate/20170802094032_change_gobierto_participation_issues.rb
+++ b/db/migrate/20170802094032_change_gobierto_participation_issues.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeGobiertoParticipationIssues < ActiveRecord::Migration[5.1]
   def change
     rename_table :gpart_issues, :issues

--- a/db/migrate/20170802134830_migrate_activities_and_subscriptions_to_issues.rb
+++ b/db/migrate/20170802134830_migrate_activities_and_subscriptions_to_issues.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class MigrateActivitiesAndSubscriptionsToIssues < ActiveRecord::Migration[5.1]
   def change
-    Activity.where(subject_type: 'GobiertoParticipation::Issue').update_all(subject_type: 'Issue')
-    Activity.where(action: 'gobierto_participation.issue_created').update_all(action: 'issues.issue_created')
-    Activity.where(action: 'gobierto_participation.issue_updated').update_all(action: 'issues.issue_updated')
-    User::Subscription.where(subscribable_type: 'GobiertoParticipation::Issue').update_all(subscribable_type: 'Issue')
+    Activity.where(subject_type: "GobiertoParticipation::Issue").update_all(subject_type: "Issue")
+    Activity.where(action: "gobierto_participation.issue_created").update_all(action: "issues.issue_created")
+    Activity.where(action: "gobierto_participation.issue_updated").update_all(action: "issues.issue_updated")
+    User::Subscription.where(subscribable_type: "GobiertoParticipation::Issue").update_all(subscribable_type: "Issue")
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,8 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170802134830) do
-
+ActiveRecord::Schema.define(version: 20_170_802_134_830) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
@@ -29,17 +30,17 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.integer "site_id"
     t.datetime "created_at", null: false
     t.index ["admin_activity"], name: "index_activities_on_admin_activity"
-    t.index ["author_type", "author_id"], name: "index_activities_on_author_type_and_author_id"
-    t.index ["recipient_type", "recipient_id"], name: "index_activities_on_recipient_type_and_recipient_id"
+    t.index %w(author_type author_id), name: "index_activities_on_author_type_and_author_id"
+    t.index %w(recipient_type recipient_id), name: "index_activities_on_recipient_type_and_recipient_id"
     t.index ["site_id"], name: "index_activities_on_site_id"
-    t.index ["subject_id", "subject_type"], name: "index_activities_on_subject_id_and_subject_type"
-    t.index ["subject_type", "subject_id"], name: "index_activities_on_subject_type_and_subject_id"
+    t.index %w(subject_id subject_type), name: "index_activities_on_subject_id_and_subject_type"
+    t.index %w(subject_type subject_id), name: "index_activities_on_subject_type_and_subject_id"
   end
 
   create_table "admin_admin_sites", id: :serial, force: :cascade do |t|
     t.integer "admin_id"
     t.integer "site_id"
-    t.index ["admin_id", "site_id"], name: "index_admin_admin_sites_on_admin_id_and_site_id"
+    t.index %w(admin_id site_id), name: "index_admin_admin_sites_on_admin_id_and_site_id"
     t.index ["admin_id"], name: "index_admin_admin_sites_on_admin_id"
     t.index ["site_id"], name: "index_admin_admin_sites_on_site_id"
   end
@@ -83,7 +84,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "namespace", default: "", null: false
     t.string "resource_name", default: "", null: false
     t.string "action_name", default: "", null: false
-    t.index ["admin_id", "namespace", "resource_name", "action_name"], name: "index_admin_permissions_on_admin_id_and_fields"
+    t.index %w(admin_id namespace resource_name action_name), name: "index_admin_permissions_on_admin_id_and_fields"
     t.index ["admin_id"], name: "index_admin_permissions_on_admin_id"
   end
 
@@ -93,9 +94,9 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "date_of_birth", default: "", null: false
     t.integer "import_reference"
     t.boolean "verified", default: false, null: false
-    t.index ["site_id", "document_number_digest", "date_of_birth", "verified"], name: "index_census_items_on_site_id_and_doc_number_and_birth_verified"
-    t.index ["site_id", "document_number_digest", "date_of_birth"], name: "index_census_items_on_site_id_and_doc_number_and_date_of_birth"
-    t.index ["site_id", "import_reference"], name: "index_census_items_on_site_id_and_import_reference"
+    t.index %w(site_id document_number_digest date_of_birth verified), name: "index_census_items_on_site_id_and_doc_number_and_birth_verified"
+    t.index %w(site_id document_number_digest date_of_birth), name: "index_census_items_on_site_id_and_doc_number_and_date_of_birth"
+    t.index %w(site_id import_reference), name: "index_census_items_on_site_id_and_import_reference"
     t.index ["site_id"], name: "index_census_items_on_site_id"
   end
 
@@ -108,8 +109,8 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.datetime "updated_at", null: false
     t.bigint "collection_id"
     t.index ["collection_id"], name: "index_collection_items_on_collection_id"
-    t.index ["container_type", "container_id"], name: "index_collection_items_on_container_type_and_container_id"
-    t.index ["item_type", "item_id"], name: "index_collection_items_on_item_type_and_item_id"
+    t.index %w(container_type container_id), name: "index_collection_items_on_container_type_and_container_id"
+    t.index %w(item_type item_id), name: "index_collection_items_on_item_type_and_item_id"
   end
 
   create_table "collections", force: :cascade do |t|
@@ -121,7 +122,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.bigint "container_id"
     t.string "item_type"
     t.string "slug", default: "", null: false
-    t.index ["container_type", "container_id"], name: "index_collections_on_container_type_and_container_id"
+    t.index %w(container_type container_id), name: "index_collections_on_container_type_and_container_id"
     t.index ["site_id"], name: "index_collections_on_site_id"
   end
 
@@ -143,7 +144,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.datetime "updated_at", null: false
     t.string "attachment_url"
     t.index ["content_block_id"], name: "index_content_block_records_on_content_block_id"
-    t.index ["content_context_type", "content_context_id"], name: "index_content_block_records_on_content_context"
+    t.index %w(content_context_type content_context_id), name: "index_content_block_records_on_content_context"
     t.index ["payload"], name: "index_content_block_records_on_payload", using: :gin
   end
 
@@ -177,7 +178,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["site_id", "name"], name: "index_custom_user_fields_on_site_id_and_name", unique: true
+    t.index %w(site_id name), name: "index_custom_user_fields_on_site_id_and_name", unique: true
     t.index ["site_id"], name: "index_custom_user_fields_on_site_id"
   end
 
@@ -186,7 +187,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.integer "attachment_id", null: false
     t.integer "attachable_id", null: false
     t.string "attachable_type", null: false
-    t.index ["site_id", "attachment_id", "attachable_id", "attachable_type"], name: "record_unique_index", unique: true
+    t.index %w(site_id attachment_id attachable_id attachable_type), name: "record_unique_index", unique: true
   end
 
   create_table "ga_attachments", force: :cascade do |t|
@@ -209,7 +210,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "code", null: false
     t.jsonb "custom_name_translations"
     t.jsonb "custom_description_translations"
-    t.index ["site_id", "area_name", "kind", "code"], name: "gb_categories_record_unique_index", unique: true
+    t.index %w(site_id area_name kind code), name: "gb_categories_record_unique_index", unique: true
   end
 
   create_table "gbc_consultation_items", id: :serial, force: :cascade do |t|
@@ -236,7 +237,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "sharing_token"
     t.string "document_number_digest"
     t.jsonb "user_information"
-    t.index ["consultation_id", "document_number_digest"], name: "index_gbc_consultation_responses_on_document_number_digest", unique: true
+    t.index %w(consultation_id document_number_digest), name: "index_gbc_consultation_responses_on_document_number_digest", unique: true
     t.index ["consultation_id"], name: "index_gbc_consultation_responses_on_consultation_id"
     t.index ["sharing_token"], name: "index_gbc_consultation_responses_on_sharing_token", unique: true
     t.index ["user_information"], name: "index_gbc_consultation_responses_on_user_information", using: :gin
@@ -319,7 +320,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.jsonb "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["site_id", "module_name"], name: "index_gobierto_module_settings_on_site_id_and_module_name", unique: true
+    t.index %w(site_id module_name), name: "index_gobierto_module_settings_on_site_id_and_module_name", unique: true
     t.index ["site_id"], name: "index_gobierto_module_settings_on_site_id"
   end
 
@@ -337,7 +338,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.integer "political_group_id"
     t.integer "category", default: 0, null: false
     t.integer "party"
-    t.integer "position", default: 999999, null: false
+    t.integer "position", default: 999_999, null: false
     t.string "email"
     t.jsonb "charge_translations"
     t.jsonb "bio_translations"
@@ -345,7 +346,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "google_calendar_token"
     t.index ["admin_id"], name: "index_gp_people_on_admin_id"
     t.index ["bio_translations"], name: "index_gp_people_on_bio_translations", using: :gin
-    t.index ["category", "party"], name: "index_gp_people_on_category_and_party"
+    t.index %w(category party), name: "index_gp_people_on_category_and_party"
     t.index ["category"], name: "index_gp_people_on_category"
     t.index ["charge_translations"], name: "index_gp_people_on_charge_translations", using: :gin
     t.index ["google_calendar_token"], name: "index_gp_people_on_google_calendar_token", unique: true
@@ -436,7 +437,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "slug", null: false
     t.integer "stage_type", default: 0, null: false
     t.jsonb "description_translations"
-    t.index ["process_id", "slug"], name: "index_gpart_process_stages_on_process_id_and_slug", unique: true
+    t.index %w(process_id slug), name: "index_gpart_process_stages_on_process_id_and_slug", unique: true
     t.index ["process_id"], name: "index_gpart_process_stages_on_process_id"
     t.index ["title_translations"], name: "index_gpart_process_stages_on_title_translations", using: :gin
   end
@@ -521,9 +522,9 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.index ["is_seen"], name: "index_user_notifications_on_is_seen"
     t.index ["is_sent"], name: "index_user_notifications_on_is_sent"
     t.index ["site_id"], name: "index_user_notifications_on_site_id"
-    t.index ["subject_type", "subject_id", "site_id", "user_id"], name: "index_user_notifications_on_subject_and_site_id_and_user_id"
-    t.index ["subject_type", "subject_id", "site_id"], name: "index_user_notifications_on_subject_and_site_id"
-    t.index ["user_id", "site_id"], name: "index_user_notifications_on_user_id_and_site_id"
+    t.index %w(subject_type subject_id site_id user_id), name: "index_user_notifications_on_subject_and_site_id_and_user_id"
+    t.index %w(subject_type subject_id site_id), name: "index_user_notifications_on_subject_and_site_id"
+    t.index %w(user_id site_id), name: "index_user_notifications_on_user_id_and_site_id"
     t.index ["user_id"], name: "index_user_notifications_on_user_id"
   end
 
@@ -535,10 +536,10 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["site_id"], name: "index_user_subscriptions_on_site_id"
-    t.index ["subscribable_type", "site_id"], name: "index_user_subscriptions_on_subscribable_type_and_site_id"
-    t.index ["subscribable_type", "subscribable_id", "site_id", "user_id"], name: "index_user_subscriptions_on_type_and_id_and_user_id", unique: true
-    t.index ["subscribable_type", "subscribable_id", "site_id"], name: "index_user_subscriptions_on_type_and_id"
-    t.index ["user_id", "site_id"], name: "index_user_subscriptions_on_user_id_and_site_id"
+    t.index %w(subscribable_type site_id), name: "index_user_subscriptions_on_subscribable_type_and_site_id"
+    t.index %w(subscribable_type subscribable_id site_id user_id), name: "index_user_subscriptions_on_type_and_id_and_user_id", unique: true
+    t.index %w(subscribable_type subscribable_id site_id), name: "index_user_subscriptions_on_type_and_id"
+    t.index %w(user_id site_id), name: "index_user_subscriptions_on_user_id_and_site_id"
     t.index ["user_id"], name: "index_user_subscriptions_on_user_id"
   end
 
@@ -589,7 +590,7 @@ ActiveRecord::Schema.define(version: 20170802134830) do
     t.string "whodunnit"
     t.text "object"
     t.datetime "created_at"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index %w(item_type item_id), name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "gobierto_calendars_events", "collections", on_delete: :cascade

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 fixtures_to_load = [
   "sites",
   "users",
@@ -42,6 +44,6 @@ GobiertoPeople::PoliticalGroup.reset_position!
 Site.all.each do |site|
   if site.configuration.gobierto_people_enabled?
     GobiertoCommon::GobiertoSeeder::ModuleSeeder.seed("GobiertoPeople", site)
-    GobiertoCommon::GobiertoSeeder::ModuleSiteSeeder.seed(APP_CONFIG['site']['name'], "GobiertoPeople", site)
+    GobiertoCommon::GobiertoSeeder::ModuleSiteSeeder.seed(APP_CONFIG["site"]["name"], "GobiertoPeople", site)
   end
 end

--- a/db/seeds/modules/gobierto_people/seeds.rb
+++ b/db/seeds/modules/gobierto_people/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoSeeds
   class Recipe
     def self.run(site)
@@ -16,80 +18,69 @@ module GobiertoSeeds
       ## Contact block
       contact_block = GobiertoCommon::ContentBlock.find_by(site_id: site.id, internal_id: GobiertoCommon::DynamicContent::CONTACT_BLOCK_ID)
       if contact_block.nil?
-        contact_block = GobiertoCommon::ContentBlock.create!({
-          internal_id: GobiertoCommon::DynamicContent::CONTACT_BLOCK_ID,
-          site: site,
-          content_model_name: "GobiertoPeople::Person",
-          title: { "ca" => "Formes de contacte", "es" => "Formas de contacto" }
-        })
+        contact_block = GobiertoCommon::ContentBlock.create!(internal_id: GobiertoCommon::DynamicContent::CONTACT_BLOCK_ID,
+                                                             site: site,
+                                                             content_model_name: "GobiertoPeople::Person",
+                                                             title: { "ca" => "Formes de contacte", "es" => "Formas de contacto" })
       end
 
       ## Contact block fields
       contact_block_field = GobiertoCommon::ContentBlockField.find_by content_block: contact_block, name: "service_name"
       if contact_block_field.nil?
-        GobiertoCommon::ContentBlockField.create!({content_block: contact_block,
-          name: "service_name",
-          field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
-          label: { "ca" => "Servei", "es" => "Servicio" }
-        })
+        GobiertoCommon::ContentBlockField.create!(content_block: contact_block,
+                                                  name: "service_name",
+                                                  field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
+                                                  label: { "ca" => "Servei", "es" => "Servicio" })
       end
 
       contact_block_field = GobiertoCommon::ContentBlockField.find_by content_block: contact_block, name: "service_url"
       if contact_block_field.nil?
-        GobiertoCommon::ContentBlockField.create!({content_block: contact_block,
-          name: "service_url",
-          field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
-          label: { "ca" => "URL", "es" => "URL" }
-        })
+        GobiertoCommon::ContentBlockField.create!(content_block: contact_block,
+                                                  name: "service_url",
+                                                  field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
+                                                  label: { "ca" => "URL", "es" => "URL" })
       end
 
       contact_block_field = GobiertoCommon::ContentBlockField.find_by content_block: contact_block, name: "service_handle"
       if contact_block_field.nil?
-        GobiertoCommon::ContentBlockField.create!({content_block: contact_block,
-          name: "service_handle",
-          field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
-          label: { "ca" => "Nom d'usuari", "es" => "Nombre de usuario" }
-        })
+        GobiertoCommon::ContentBlockField.create!(content_block: contact_block,
+                                                  name: "service_handle",
+                                                  field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
+                                                  label: { "ca" => "Nom d'usuari", "es" => "Nombre de usuario" })
       end
 
       contact_block_field = GobiertoCommon::ContentBlockField.find_by content_block: contact_block, name: "service_notes"
       if contact_block_field.nil?
-        GobiertoCommon::ContentBlockField.create!({content_block: contact_block,
-          name: "service_notes",
-          field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
-          label: { "ca" => "Notes", "es" => "Notas" }
-        })
+        GobiertoCommon::ContentBlockField.create!(content_block: contact_block,
+                                                  name: "service_notes",
+                                                  field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
+                                                  label: { "ca" => "Notes", "es" => "Notas" })
       end
 
       ## Seed loader
       seeds_filenames = Dir.glob(File.join(File.dirname(__FILE__), "*_seeds.yml"))
 
       seeds_filenames.each do |seeds_filename|
-        block_data = YAML.load File.read(seeds_filename)
+        block_data = YAML.safe_load File.read(seeds_filename)
 
-        block_data['blocks'].each do |content_block|
-          block = GobiertoCommon::ContentBlock.find_by(site_id: site.id, internal_id: content_block['internal_id'])
+        block_data["blocks"].each do |content_block|
+          block = GobiertoCommon::ContentBlock.find_by(site_id: site.id, internal_id: content_block["internal_id"])
           if block.nil?
-            block = GobiertoCommon::ContentBlock.create!({
-              internal_id: content_block['internal_id'],
-              site: site,
-              content_model_name: content_block['content_model_name'],
-              title: content_block['title']
-            })
+            block = GobiertoCommon::ContentBlock.create!(internal_id: content_block["internal_id"],
+                                                         site: site,
+                                                         content_model_name: content_block["content_model_name"],
+                                                         title: content_block["title"])
           end
 
-          content_block['fields'].each do |field|
-            block_field = GobiertoCommon::ContentBlockField.find_by content_block: block, name: field['name']
-            if block_field.nil?
-              GobiertoCommon::ContentBlockField.create!({content_block: block, name: field['name'],
-                field_type: ::GobiertoCommon::ContentBlockField.field_types[field['field_type']],
-                label: field['label']
-              })
-            end
+          content_block["fields"].each do |field|
+            block_field = GobiertoCommon::ContentBlockField.find_by content_block: block, name: field["name"]
+            next unless block_field.nil?
+            GobiertoCommon::ContentBlockField.create!(content_block: block, name: field["name"],
+                                                      field_type: ::GobiertoCommon::ContentBlockField.field_types[field["field_type"]],
+                                                      label: field["label"])
           end
         end
       end
-
     end
   end
 end

--- a/db/seeds/sites/gobierto_dival/gobierto_people/seeds.rb
+++ b/db/seeds/sites/gobierto_dival/gobierto_people/seeds.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module GobiertoSeeds
   class Recipe
-    def self.run(site)
-    end
+    def self.run(_site); end
   end
 end

--- a/db/seeds/sites/gobierto_populate/gobierto_people/seeds.rb
+++ b/db/seeds/sites/gobierto_populate/gobierto_people/seeds.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module GobiertoSeeds
   class Recipe
-    def self.run(site)
-    end
+    def self.run(_site); end
   end
 end

--- a/lib/constraints/gobierto_site_constraint.rb
+++ b/lib/constraints/gobierto_site_constraint.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class GobiertoSiteConstraint
   def matches?(request)
-    full_domain = (request.env['HTTP_HOST'] || request.env['SERVER_NAME'] || request.env['SERVER_ADDR']).split(':').first
+    full_domain = (request.env["HTTP_HOST"] || request.env["SERVER_NAME"] || request.env["SERVER_ADDR"]).split(":").first
 
     if site = Site.find_by_allowed_domain(full_domain)
-      request.env['gobierto_site'] = site
+      request.env["gobierto_site"] = site
       return true
     end
 
-    return false
+    false
   end
 end

--- a/lib/errors/not_authorized.rb
+++ b/lib/errors/not_authorized.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Errors
   class NotAuthorized < StandardError; end
 end

--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "file_uploader/s3"
 require_relative "file_uploader/local"
 

--- a/lib/file_uploader/local.rb
+++ b/lib/file_uploader/local.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module FileUploader
   class Local
-    FILE_PATH_PREFIX = "system/attachments".freeze
+    FILE_PATH_PREFIX = "system/attachments"
 
     attr_reader :file, :file_name
 
@@ -12,7 +14,7 @@ module FileUploader
     def call
       FileUtils.mkdir_p(file_base_path) unless File.exist?(file_base_path)
       FileUtils.mv(file.tempfile.path, file_path)
-      File.chmod(0664, file_path)
+      File.chmod(0o664, file_path)
       ObjectSpace.undefine_finalizer(file.tempfile)
 
       file_uri

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "aws-sdk"
 
 module FileUploader

--- a/lib/ibm_notes/api.rb
+++ b/lib/ibm_notes/api.rb
@@ -1,11 +1,12 @@
-require 'mechanize'
+# frozen_string_literal: true
+
+require "mechanize"
 
 module IbmNotes
   class InvalidCredentials < StandardError; end
   class ServiceUnavailable < StandardError; end
 
   class Api
-
     def self.get_person_events(params)
       make_request params
     end
@@ -56,10 +57,9 @@ module IbmNotes
 
     def self.agent
       agent = Mechanize.new
-      agent.user_agent_alias = 'Mac Safari'
+      agent.user_agent_alias = "Mac Safari"
       agent.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       agent
     end
-
   end
 end

--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -1,60 +1,59 @@
+# frozen_string_literal: true
+
 module IbmNotes
   class PersonEvent
-
     attr_accessor :id, :title, :description, :starts_at, :ends_at, :person, :location, :attendees
 
     def initialize(person, response_event)
-      @id          = set_id(response_event)
-      @title       = response_event['summary']
-      @description = response_event['description'] if response_event['description'].present?
-      @person      = person
-      @location    = response_event['location'] if response_event['location'].present?
-      @attendees   = set_attendees(response_event)
+      @id = set_id(response_event)
+      @title = response_event["summary"]
+      @description = response_event["description"] if response_event["description"].present?
+      @person = person
+      @location = response_event["location"] if response_event["location"].present?
+      @attendees = set_attendees(response_event)
       set_start_and_end_date(response_event)
     end
 
     private
 
     def set_id(event)
-      if event['recurrenceId'].present?
-        "#{event['id']}/#{event['recurrenceId']}"
+      if event["recurrenceId"].present?
+        "#{event["id"]}/#{event["recurrenceId"]}"
       else
-        event['id']
+        event["id"]
       end
     end
 
     def set_start_and_end_date(event)
-      if event['start']['tzid'].present? && event['start']['tzid'] == 'Romance Standard Time'
-        time_zone = ActiveSupport::TimeZone['Madrid']
-        @starts_at = time_zone.parse("#{event['start']['date']} #{event['start']['time']}").utc
-        @ends_at   = time_zone.parse("#{event['end']['date']} #{event['end']['time']}").utc || starts_at + 1.hour
+      if event["start"]["tzid"].present? && event["start"]["tzid"] == "Romance Standard Time"
+        time_zone = ActiveSupport::TimeZone["Madrid"]
+        @starts_at = time_zone.parse("#{event["start"]["date"]} #{event["start"]["time"]}").utc
+        @ends_at = time_zone.parse("#{event["end"]["date"]} #{event["end"]["time"]}").utc || starts_at + 1.hour
       else # assume UTC
-        @starts_at = parse_date event['start']
-        @ends_at   = parse_date(event['end']) || starts_at + 1.hour
+        @starts_at = parse_date event["start"]
+        @ends_at = parse_date(event["end"]) || starts_at + 1.hour
       end
     end
 
     def parse_date(date)
       unless date.nil?
-        d = Time.parse("#{date['date']} #{date['time']}")
+        d = Time.parse("#{date["date"]} #{date["time"]}")
         Time.utc(d.year, d.month, d.day, d.hour, d.min, d.sec)
       end
     end
 
     def set_attendees(event)
-      if event['attendees'].present?
-        event['attendees'].map do |attendee|
-          if (attendee['status'] == 'accepted' || attendee['role'] == 'req-participant') && attendee['displayName'].present?
-            {
-              name: attendee['displayName'].split('/').first,
-              email: attendee['email']
-            }
-          end
+      if event["attendees"].present?
+        event["attendees"].map do |attendee|
+          next unless (attendee["status"] == "accepted" || attendee["role"] == "req-participant") && attendee["displayName"].present?
+          {
+            name: attendee["displayName"].split("/").first,
+            email: attendee["email"]
+          }
         end.compact
       else
         []
       end
     end
-
   end
 end

--- a/lib/liquid/tags/page_title.rb
+++ b/lib/liquid/tags/page_title.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PageTitle < Liquid::Tag
   def initialize(tag_name, page_slug, tokens)
     super
@@ -5,7 +7,7 @@ class PageTitle < Liquid::Tag
   end
 
   def render(context)
-    current_site = context.environments.first['current_site']
+    current_site = context.environments.first["current_site"]
     page = current_site.pages.find_by_slug!(@page_slug)
     return page.title
   rescue ActiveRecord::RecordNotFound
@@ -13,4 +15,4 @@ class PageTitle < Liquid::Tag
   end
 end
 
-Liquid::Template.register_tag('page_title', PageTitle)
+Liquid::Template.register_tag("page_title", PageTitle)

--- a/lib/liquid/tags/page_url.rb
+++ b/lib/liquid/tags/page_url.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PageUrl < Liquid::Tag
   def initialize(tag_name, page_slug, tokens)
     super
@@ -5,7 +7,7 @@ class PageUrl < Liquid::Tag
   end
 
   def render(context)
-    current_site = context.environments.first['current_site']
+    current_site = context.environments.first["current_site"]
     page = current_site.pages.find_by_slug!(@page_slug)
     return url_helpers.gobierto_cms_page_path(page.slug)
   rescue ActiveRecord::RecordNotFound
@@ -17,7 +19,6 @@ class PageUrl < Liquid::Tag
   def url_helpers
     Rails.application.routes.url_helpers
   end
-
 end
 
-Liquid::Template.register_tag('page_url', PageUrl)
+Liquid::Template.register_tag("page_url", PageUrl)

--- a/lib/populate_data.rb
+++ b/lib/populate_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "populate_data/gobierto"
 
 module PopulateData

--- a/lib/populate_data/gobierto.rb
+++ b/lib/populate_data/gobierto.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "gobierto/logging"
 require_relative "gobierto/client"
 require_relative "gobierto/budget_line"

--- a/lib/populate_data/gobierto/budget_line.rb
+++ b/lib/populate_data/gobierto/budget_line.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 module PopulateData
   module Gobierto
     class BudgetLine < Client
-
-      ENDPOINT_URI = "/datasets/ds-presupuestos-municipales-partida.json".freeze
+      ENDPOINT_URI = "/datasets/ds-presupuestos-municipales-partida.json"
 
       attr_reader(
         :level,
@@ -36,7 +37,6 @@ module PopulateData
           filter_by_entity_id: @entity_id
         }.to_json
       end
-
     end
   end
 end

--- a/lib/populate_data/gobierto/category.rb
+++ b/lib/populate_data/gobierto/category.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 module PopulateData
   module Gobierto
     class Category < Client
-
-      ENDPOINT_URI = "/collections/c-categorias-presupuestos-municipales/items".freeze
+      ENDPOINT_URI = "/collections/c-categorias-presupuestos-municipales/items"
 
       attr_reader(
         :area,
@@ -35,7 +36,6 @@ module PopulateData
           level: @level
         }.to_json
       end
-
     end
   end
 end

--- a/lib/populate_data/gobierto/client.rb
+++ b/lib/populate_data/gobierto/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "uri"
 require "net/http"
 require "json"
@@ -68,7 +70,6 @@ module PopulateData
 
         http_client
       end
-
     end
   end
 end

--- a/lib/populate_data/gobierto/entity.rb
+++ b/lib/populate_data/gobierto/entity.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 module PopulateData
   module Gobierto
     class Entity < Client
-
-      ENDPOINT_URI = "/collections/c-entidades-presupuestos-municipales/items".freeze
+      ENDPOINT_URI = "/collections/c-entidades-presupuestos-municipales/items"
 
       attr_reader(
         :municipality_id
@@ -21,7 +22,6 @@ module PopulateData
           filter_by_municipality_id: @municipality_id
         }.to_json
       end
-
     end
   end
 end

--- a/lib/populate_data/gobierto/logging.rb
+++ b/lib/populate_data/gobierto/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PopulateData
   module Gobierto
     module Logging
@@ -14,7 +16,7 @@ module PopulateData
       def self.logger
         @logger ||= begin
           logger = Logger.new(STDOUT)
-          logger.formatter = proc do |severity, datetime, progname, msg|
+          logger.formatter = proc do |_severity, datetime, _progname, msg|
             "[PopulateData::Gobierto] #{datetime}: #{msg}\n"
           end
 

--- a/lib/secret_attribute.rb
+++ b/lib/secret_attribute.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require "digest/sha1"
 
 class SecretAttribute
   def self.digest(value)
-    Digest::SHA1.hexdigest(value+salt)
+    Digest::SHA1.hexdigest(value + salt)
   end
 
   def self.salt

--- a/lib/tasks/db/db.rake
+++ b/lib/tasks/db/db.rake
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 namespace :db do
   namespace :data do
-    desc 'Anonymize names and phone numbers'
+    desc "Anonymize names and phone numbers"
     task anonymize: :environment do
-      if ENV['RAILS_ENV'] == 'production'
+      if ENV["RAILS_ENV"] == "production"
         puts "Refusing to anonymize production data. You don't really want to do that."
       else
-        puts "Anonymizing all Users in the #{ENV['RAILS_ENV']} database."
+        puts "Anonymizing all Users in the #{ENV["RAILS_ENV"]} database."
 
         User.all.each do |user|
           seed = Digest::SHA1.hexdigest("#{Time.current}#{rand(100)}#{user.id}")[0..19]
@@ -13,27 +15,27 @@ namespace :db do
           user.name = "user #{seed}"
           user.email = "user-#{seed}@gobierto.tools"
           user.bio = nil
-          user.date_of_birth = '2000-07-06'
-          user.password = 'gobierto'
-          user.password_confirmation = 'gobierto'
+          user.date_of_birth = "2000-07-06"
+          user.password = "gobierto"
+          user.password_confirmation = "gobierto"
           puts "Saving #{user.name} (#{user.email})"
           user.save!
         end
 
-        puts "Anonymizing all Admins in the #{ENV['RAILS_ENV']} database."
+        puts "Anonymizing all Admins in the #{ENV["RAILS_ENV"]} database."
 
         GobiertoAdmin::Admin.all.each do |admin|
           seed = Digest::SHA1.hexdigest("#{Time.current}#{rand(100)}#{admin.id}")[0..19]
 
-          admin.name = "admin #{seed}" unless admin.email.include?('populate.tools')
-          admin.email = "admin-#{seed}@gobierto.tools" unless admin.email.include?('populate.tools')
-          admin.password = 'gobierto'
-          admin.password_confirmation = 'gobierto'
+          admin.name = "admin #{seed}" unless admin.email.include?("populate.tools")
+          admin.email = "admin-#{seed}@gobierto.tools" unless admin.email.include?("populate.tools")
+          admin.password = "gobierto"
+          admin.password_confirmation = "gobierto"
           puts "Saving #{admin.name} (#{admin.email})"
           admin.save!
         end
 
-        puts "Anonymizing all Persons in the #{ENV['RAILS_ENV']} database."
+        puts "Anonymizing all Persons in the #{ENV["RAILS_ENV"]} database."
 
         GobiertoPeople::Person.all.each do |person|
           seed = Digest::SHA1.hexdigest("#{Time.current}#{rand(100)}#{person.id}")[0..19]
@@ -45,14 +47,14 @@ namespace :db do
           person.save!
         end
 
-        puts "Changing all Sites to gobierto.dev in the #{ENV['RAILS_ENV']} database."
+        puts "Changing all Sites to gobierto.dev in the #{ENV["RAILS_ENV"]} database."
 
         Site.all.each do |site|
-          site.domain = site.domain.gsub('gobify.net', 'gobierto.dev')
+          site.domain = site.domain.gsub("gobify.net", "gobierto.dev")
           site.save
         end
 
-        puts 'Remember map site domains in /etc/hosts'
+        puts "Remember map site domains in /etc/hosts"
       end
     end
   end

--- a/lib/tasks/gobierto_admin/reset_preview_tokens.rake
+++ b/lib/tasks/gobierto_admin/reset_preview_tokens.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_admin do
   desc "Regenerates admins preview token"
   task regenerate_preview_tokens: :environment do

--- a/lib/tasks/gobierto_budgets/algolia_indices.rake
+++ b/lib/tasks/gobierto_budgets/algolia_indices.rake
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 namespace :gobierto_budgets do
   namespace :algolia do
-
-    desc 'Reindex records'
-    task :reindex, [:site_domain, :year] => [:environment] do |t, args|
+    desc "Reindex records"
+    task :reindex, [:site_domain, :year] => [:environment] do |_t, args|
       site = Site.find_by!(domain: args[:site_domain])
       year = args[:year].to_i
       ine_code = site.place.id
@@ -14,7 +15,6 @@ namespace :gobierto_budgets do
 
       GobiertoBudgets::BudgetArea.all_areas.each do |area|
         area.available_kinds.each do |kind|
-
           puts "\n[INFO] area = '#{area.area_name}' kind = '#{kind}'"
           puts "---------------------------------------------------"
 
@@ -28,24 +28,23 @@ namespace :gobierto_budgets do
           puts "[INFO] Found #{forecast_hits.size} forecast #{area.area_name} #{kind} BudgetLine records"
 
           forecast_budget_lines = forecast_hits.map do |h|
-            create_budget_line(site, 'index_forecast', h)
+            create_budget_line(site, "index_forecast", h)
           end
 
           GobiertoBudgets::BudgetLine.algolia_reindex_collection(forecast_budget_lines)
         end
       end
-
     end
 
     def create_budget_line(site, index, elasticsearch_hit)
       GobiertoBudgets::BudgetLine.new(
-             site: site,
-            index: index,
-        area_name: elasticsearch_hit['_type'],
-             kind: elasticsearch_hit['_source']['kind'],
-             code: elasticsearch_hit['_source']['code'],
-             year: elasticsearch_hit['_source']['year'],
-           amount: elasticsearch_hit['_source']['amount']
+        site: site,
+        index: index,
+        area_name: elasticsearch_hit["_type"],
+        kind: elasticsearch_hit["_source"]["kind"],
+        code: elasticsearch_hit["_source"]["code"],
+        year: elasticsearch_hit["_source"]["year"],
+        amount: elasticsearch_hit["_source"]["amount"]
       )
     end
 
@@ -70,8 +69,7 @@ namespace :gobierto_budgets do
         index: index,
         type: area.area_name,
         body: query
-      )['hits']['hits']
+      )["hits"]["hits"]
     end
-
   end
 end

--- a/lib/tasks/gobierto_budgets/data/bubbles.rake
+++ b/lib/tasks/gobierto_budgets/data/bubbles.rake
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 namespace :gobierto_budgets do
   namespace :data do
-    desc 'Dump bubbles data'
+    desc "Dump bubbles data"
     task bubbles: :environment do
       Site.all.each do |site|
         place = site.place

--- a/lib/tasks/gobierto_budgets/elasticsearch_indices.rake
+++ b/lib/tasks/gobierto_budgets/elasticsearch_indices.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_budgets do
   namespace :elasticsearch do
     desc "Create indices"

--- a/lib/tasks/gobierto_cms/migrate_pages_to_globalize.rake
+++ b/lib/tasks/gobierto_cms/migrate_pages_to_globalize.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_cms do
   namespace :globalize do
     desc "Migrates pages fields to globalize"

--- a/lib/tasks/gobierto_common/active_notifier.rake
+++ b/lib/tasks/gobierto_common/active_notifier.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :common do
   namespace :active_notifier do
     desc "Actively seeks for events to notify"

--- a/lib/tasks/gobierto_core/migrate_sites_to_globalize.rake
+++ b/lib/tasks/gobierto_core/migrate_sites_to_globalize.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_core do
   namespace :globalize do
     desc "Migrates sites fields to globalize"

--- a/lib/tasks/gobierto_people/counter_cache.rake
+++ b/lib/tasks/gobierto_people/counter_cache.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_people do
   namespace :counter_cache do
     desc "Resets Person-related counter cache fields"

--- a/lib/tasks/gobierto_people/migrate_people_to_globalize.rake
+++ b/lib/tasks/gobierto_people/migrate_people_to_globalize.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_people do
   namespace :globalize do
     desc "Migrates people fields to globalize"

--- a/lib/tasks/gobierto_people/sync_agendas.rake
+++ b/lib/tasks/gobierto_people/sync_agendas.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :gobierto_people do
   desc "Synchronizes sites agendas with selected calendar provider"
   task sync_agendas: :environment do

--- a/lib/tasks/user/notification_digest_agent.rake
+++ b/lib/tasks/user/notification_digest_agent.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :user do
   namespace :notification_digest_agent do
     desc "Delivers hourly notification digests"

--- a/lib/validators/domain_validator.rb
+++ b/lib/validators/domain_validator.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class DomainValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add attribute, :not_valid_format if value.present? && value.split('.').length < 2
+    record.errors.add attribute, :not_valid_format if value.present? && value.split(".").length < 2
   end
 end

--- a/test/controllers/gobierto_admin/admin/invitation_acceptances_controller_test.rb
+++ b/test/controllers/gobierto_admin/admin/invitation_acceptances_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/controllers/gobierto_admin/admin/invitations_controller_test.rb
+++ b/test/controllers/gobierto_admin/admin/invitations_controller_test.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   class Admin::InvitationsControllerTest < GobiertoControllerTest
-
     def site
       @site ||= sites(:madrid)
     end
@@ -31,8 +32,8 @@ module GobiertoAdmin
     def valid_invitation_params
       {
         admin_invitation: {
-          emails: 'email1@example.com,email2@example.com',
-          site_ids: ['', site.id]
+          emails: "email1@example.com,email2@example.com",
+          site_ids: ["", site.id]
         }
       }
     end

--- a/test/controllers/gobierto_admin/admins_controller_test.rb
+++ b/test/controllers/gobierto_admin/admins_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -33,8 +35,8 @@ module GobiertoAdmin
           name: admin.name,
           email: admin.email,
           password: "wadus",
-          site_modules: ["GobiertoBudgetConsultations", "GobiertoPeople"],
-          site_ids: ['', site.id]
+          site_modules: %w(GobiertoBudgetConsultations GobiertoPeople),
+          site_ids: ["", site.id]
         }
       }
     end
@@ -46,8 +48,8 @@ module GobiertoAdmin
           email: "newadmin@example.com",
           password: "wadus",
           password_confirmation: "wadus",
-          site_modules: ["GobiertoBudgetConsultations", "GobiertoPeople"],
-          site_ids: ['', site.id]
+          site_modules: %w(GobiertoBudgetConsultations GobiertoPeople),
+          site_ids: ["", site.id]
         }
       }
     end

--- a/test/controllers/gobierto_admin/census/imports_controller_test.rb
+++ b/test/controllers/gobierto_admin/census/imports_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -26,7 +28,7 @@ module GobiertoAdmin
     def valid_census_params
       {
         census_import: {
-          file: Rack::Test::UploadedFile.new(File.open(Rails.root.join('test/fixtures/files/census.csv')))
+          file: Rack::Test::UploadedFile.new(File.open(Rails.root.join("test/fixtures/files/census.csv")))
         }
       }
     end

--- a/test/controllers/gobierto_admin/gobierto_budget_consultations/consultations/consultation_reports_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_budget_consultations/consultations/consultation_reports_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -25,7 +27,7 @@ module GobiertoAdmin
         end
 
         def test_show
-          get admin_budget_consultation_consultation_reports_url(consultation), params: {format: :csv }
+          get admin_budget_consultation_consultation_reports_url(consultation), params: { format: :csv }
           assert_response :success
           assert exporter_spy.has_been_called?
         end

--- a/test/controllers/gobierto_admin/gobierto_budget_consultations/consultations_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_budget_consultations/consultations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/controllers/gobierto_admin/gobierto_participation/configuration/issues_sort_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_participation/configuration/issues_sort_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -29,8 +31,8 @@ module GobiertoAdmin
         def valid_sort_params
           {
             positions: {
-              '0' => { id: issue_1.id, position: 2 },
-              '1' => { id: issue_2.id, position: 1 }
+              "0" => { id: issue_1.id, position: 2 },
+              "1" => { id: issue_2.id, position: 1 }
             }
           }
         end

--- a/test/controllers/gobierto_admin/gobierto_people/configuration/political_groups_sort_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_people/configuration/political_groups_sort_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -29,8 +31,8 @@ module GobiertoAdmin
         def valid_sort_params
           {
             positions: {
-              '0' => { id: political_group_1.id, position: 2 },
-              '1' => { id: political_group_2.id, position: 1 }
+              "0" => { id: political_group_1.id, position: 2 },
+              "1" => { id: political_group_2.id, position: 1 }
             }
           }
         end

--- a/test/controllers/gobierto_admin/gobierto_people/people/people_sort_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_people/people/people_sort_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -29,8 +31,8 @@ module GobiertoAdmin
         def valid_sort_params
           {
             positions: {
-              '0' => { id: person1.id, position: 2 },
-              '1' => { id: person2.id, position: 1 }
+              "0" => { id: person1.id, position: 2 },
+              "1" => { id: person2.id, position: 1 }
             }
           }
         end

--- a/test/controllers/gobierto_admin/sites/sessions_controller_test.rb
+++ b/test/controllers/gobierto_admin/sites/sessions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/controllers/gobierto_admin/sites_controller_test.rb
+++ b/test/controllers/gobierto_admin/sites_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -23,12 +25,12 @@ module GobiertoAdmin
 
     def valid_site_params
       {
-        title_translations: { I18n.locale => 'Title'},
-        name_translations: { I18n.locale => 'Foo'},
-        location_name: 'Madrid',
+        title_translations: { I18n.locale => "Title" },
+        name_translations: { I18n.locale => "Foo" },
+        location_name: "Madrid",
         municipality_id: 1,
-        domain: 'test2.gobierto.dev',
-        visibility_level: 'active'
+        domain: "test2.gobierto.dev",
+        visibility_level: "active"
       }
     end
 
@@ -152,7 +154,7 @@ module GobiertoAdmin
 
     def test_update_site_with_invalid_params_doesnt_broadcasts_event
       with_signed_in_admin(admin) do
-        patch admin_site_url(site), params: { site: { name: '' } }
+        patch admin_site_url(site), params: { site: { name: "" } }
         assert_response :success
 
         refute notification_service_spy.has_been_called?

--- a/test/controllers/gobierto_admin/users_controller_test.rb
+++ b/test/controllers/gobierto_admin/users_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/controllers/gobierto_people/people/google_calendar_authorization_controller_test.rb
+++ b/test/controllers/gobierto_people/people/google_calendar_authorization_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoPeople::People::GoogleCalendar::AuthorizationControllerTest < ActionController::TestCase
@@ -16,19 +18,19 @@ class GobiertoPeople::People::GoogleCalendar::AuthorizationControllerTest < Acti
   end
 
   def test_new_request_with_code
-    client_secrets = mock()
-    auth_client = mock()
+    client_secrets = mock
+    auth_client = mock
 
     client_secrets.stubs(to_authorization: auth_client)
-    auth_client.stubs(update!: true, fetch_access_token!: true, to_json: 'json')
+    auth_client.stubs(update!: true, fetch_access_token!: true, to_json: "json")
     auth_client.stubs(:code=, true)
     auth_client.stubs(:client_secret=, true)
     Google::APIClient::ClientSecrets.stubs(:load).returns(client_secrets)
 
-    get :new, params: { code: 'foo'}, session: { google_calendar_person_id: person.id }
+    get :new, params: { code: "foo" }, session: { google_calendar_person_id: person.id }
     assert_response :redirect
 
     configuration = GobiertoPeople::PersonGoogleCalendarConfiguration.find_by person_id: person.id
-    assert configuration.data['google_calendar_credentials'].present?
+    assert configuration.data["google_calendar_credentials"].present?
   end
 end

--- a/test/controllers/gobierto_people/people/google_calendar_calendars_controller_test.rb
+++ b/test/controllers/gobierto_people/people/google_calendar_calendars_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoPeople::People::GoogleCalendar::CalendarsControllerTest < ActionController::TestCase
@@ -11,11 +13,11 @@ class GobiertoPeople::People::GoogleCalendar::CalendarsControllerTest < ActionCo
 
   def test_update
     ApplicationController.stub_any_instance(:current_site, site) do
-      put :update, params: { person_slug: person.slug, person_id: person.id, calendars_form: { calendars: ['foo', 'bar', '']}}, session: { google_calendar_person_id: person.id }
+      put :update, params: { person_slug: person.slug, person_id: person.id, calendars_form: { calendars: ["foo", "bar", ""] } }, session: { google_calendar_person_id: person.id }
       assert_response :redirect
 
       configuration = GobiertoPeople::PersonGoogleCalendarConfiguration.find_by person_id: person.id
-      assert_equal ['foo', 'bar'], configuration.calendars
+      assert_equal %w(foo bar), configuration.calendars
     end
   end
 end

--- a/test/controllers/gobierto_people/welcome_controller_test.rb
+++ b/test/controllers/gobierto_people/welcome_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoPeople::WelcomeControllerTest < GobiertoControllerTest

--- a/test/controllers/user/sessions_controller_test.rb
+++ b/test/controllers/user/sessions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SessionsControllerTest < GobiertoControllerTest

--- a/test/decorators/activity_decorator_test.rb
+++ b/test/decorators/activity_decorator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ActivityDecoratorTest < ActiveSupport::TestCase

--- a/test/decorators/gobierto_budget_consultations/consultation_decorator_test.rb
+++ b/test/decorators/gobierto_budget_consultations/consultation_decorator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
@@ -17,7 +19,7 @@ module GobiertoBudgetConsultations
       end
 
       assert_equal consultation.consultation_items.count * ConsultationDecorator::CONSULTATION_ITEM_COMPLETION_TIME_IN_SECONDS,
-        @subject.estimated_completion_time_in_seconds
+                   @subject.estimated_completion_time_in_seconds
     end
   end
 end

--- a/test/decorators/gobierto_people/person_decorator_test.rb
+++ b/test/decorators/gobierto_people/person_decorator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople

--- a/test/decorators/site_decorator_test.rb
+++ b/test/decorators/site_decorator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SiteDecoratorTest < ActiveSupport::TestCase

--- a/test/forms/gobierto_admin/admin_edit_password_form_test.rb
+++ b/test/forms/gobierto_admin/admin_edit_password_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/admin_form_test.rb
+++ b/test/forms/gobierto_admin/admin_form_test.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   class AdminFormTest < ActiveSupport::TestCase
     def valid_admin_form
       @valid_admin_form ||= AdminForm.new(
-        authorization_level: 'manager',
+        authorization_level: "manager",
         name: admin.name,
         email: new_admin_email, # To ensure uniqueness
         password: "gobierto",

--- a/test/forms/gobierto_admin/admin_invitation_form_test.rb
+++ b/test/forms/gobierto_admin/admin_invitation_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/admin_new_password_form_test.rb
+++ b/test/forms/gobierto_admin/admin_new_password_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/census_import_form_test.rb
+++ b/test/forms/gobierto_admin/census_import_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/file_attachment_form_test.rb
+++ b/test/forms/gobierto_admin/file_attachment_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/file_uploader_helpers"
 

--- a/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/extensions/gobierto_common/trackable_test"
 

--- a/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_item_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_item_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -68,10 +70,10 @@ module GobiertoAdmin
 
       def test_position
         assert_equal latest_consultation_item.position + 1,
-          valid_consultation_item_form.position
+                     valid_consultation_item_form.position
 
         assert_equal consultation_item.position,
-          valid_persisted_consultation_item_form.position
+                     valid_persisted_consultation_item_form.position
       end
     end
   end

--- a/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budget_consultations/consultation_response_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -67,8 +69,8 @@ module GobiertoAdmin
         user_information = valid_consultation_response_form.consultation_response.user_information
         assert_equal "male", user_information["gender"]
         assert_equal "1992-01-01", user_information["date_of_birth"]
-        assert_equal user_information["district"], {"raw_value"=>"randomstring1", "localized_value"=>"Center"}
-        assert_equal user_information["association"], {"raw_value"=>"Foo", "localized_value"=>"Foo"}
+        assert_equal user_information["district"], "raw_value" => "randomstring1", "localized_value" => "Center"
+        assert_equal user_information["association"], "raw_value" => "Foo", "localized_value" => "Foo"
       end
 
       def test_error_messages_with_invalid_attributes

--- a/test/forms/gobierto_admin/gobierto_calendars/event_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_calendars/event_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -6,8 +8,8 @@ module GobiertoAdmin
       def valid_event_form
         @valid_event_form ||= EventForm.new(
           collection_id: collection.id,
-          title_translations: {I18n.locale => event.title},
-          description_translations: {I18n.locale => event.description},
+          title_translations: { I18n.locale => event.title },
+          description_translations: { I18n.locale => event.description },
           attachment_url: event.attachment_url,
           starts_at: event.starts_at,
           ends_at: event.ends_at,

--- a/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -6,9 +8,9 @@ module GobiertoAdmin
       def valid_page_form
         @valid_page_form ||= PageForm.new(
           site_id: site.id,
-          title_translations: {I18n.locale => page.title},
-          body_translations: {I18n.locale => page.body},
-          slug_translations: {I18n.locale => page.slug},
+          title_translations: { I18n.locale => page.title },
+          body_translations: { I18n.locale => page.body },
+          slug_translations: { I18n.locale => page.slug },
           visibility_level: page.visibility_level
         )
       end

--- a/test/forms/gobierto_admin/gobierto_common/collection_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_common/collection_form_test.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCommon
     class CollectionFormTest < ActiveSupport::TestCase
-      def valid_form(file = nil)
+      def valid_form(_file = nil)
         @valid_form ||= CollectionForm.new(
           site_id: site.id,
-          title_translations: { 'en' => 'Collection', 'es' => 'Colección' },
-          slug: 'collection',
+          title_translations: { "en" => "Collection", "es" => "Colección" },
+          slug: "collection",
           container_global_id: container.to_global_id,
           item_type: item_type
         )
       end
 
-      def invalid_form(file = nil)
+      def invalid_form(_file = nil)
         @invalid_form ||= CollectionForm.new
       end
 
@@ -26,7 +28,7 @@ module GobiertoAdmin
       end
 
       def item_type
-        'GobiertoCms::Page'
+        "GobiertoCms::Page"
       end
 
       def test_save_with_valid_attributes

--- a/test/forms/gobierto_admin/gobierto_participation/process_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_participation/process_form_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class ProcessFormTest < ActiveSupport::TestCase
-
       def valid_process_form
         @valid_process_form ||= ProcessForm.new(
           site_id: site.id,
@@ -46,8 +47,8 @@ module GobiertoAdmin
           body_translations: nil,
           slug: nil,
           process_type: group.process_type,
-          starts: Date.parse('2017-01-02'),
-          ends: Date.parse('2017-01-03')
+          starts: Date.parse("2017-01-02"),
+          ends: Date.parse("2017-01-03")
         )
       end
 
@@ -98,7 +99,6 @@ module GobiertoAdmin
         assert_equal 0, invalid_group_form.errors.messages[:starts].size
         assert_equal 0, invalid_group_form.errors.messages[:ends].size
       end
-
     end
   end
 end

--- a/test/forms/gobierto_admin/gobierto_people/person_calendar_configuration_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_calendar_configuration_form_test.rb
@@ -1,10 +1,11 @@
-require 'test_helper'
-require 'support/calendar_integration_helpers'
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/calendar_integration_helpers"
 
 module GobiertoAdmin
   module GobiertoPeople
     class PersonCalendarConfigurationFormTest < ActiveSupport::TestCase
-
       include ::CalendarIntegrationHelpers
 
       def person
@@ -14,7 +15,7 @@ module GobiertoAdmin
       def valid_person_calendar_configuration_form
         @valid_person_calendar_configuration_form ||= PersonCalendarConfigurationForm.new(
           person_id: person.id,
-          ibm_notes_url: 'http://foo.com'
+          ibm_notes_url: "http://foo.com"
         )
       end
 
@@ -26,7 +27,7 @@ module GobiertoAdmin
         activate_ibm_notes_calendar_integration(person.site)
 
         assert valid_person_calendar_configuration_form.save
-        assert_equal({ 'endpoint' => 'http://foo.com'}, person.calendar_configuration.data)
+        assert_equal({ "endpoint" => "http://foo.com" }, person.calendar_configuration.data)
       end
     end
   end

--- a/test/forms/gobierto_admin/gobierto_people/person_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -8,8 +10,8 @@ module GobiertoAdmin
           admin_id: admin.id,
           site_id: site.id,
           name: person.name,
-          charge_translations: {I18n.locale => person.charge},
-          bio_translations: {I18n.locale => person.bio},
+          charge_translations: { I18n.locale => person.charge },
+          bio_translations: { I18n.locale => person.bio },
           bio_url: person.bio_url,
           visibility_level: person.visibility_level,
           category: person.category,
@@ -80,7 +82,6 @@ module GobiertoAdmin
 
         assert person_form.valid?
       end
-
     end
   end
 end

--- a/test/forms/gobierto_admin/gobierto_people/person_post_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_post_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -48,7 +50,7 @@ module GobiertoAdmin
       def test_tags_normalization
         valid_person_post_form.tags = "one, two, three"
 
-        assert_equal ["one", "two", "three"], valid_person_post_form.tags
+        assert_equal %w(one two three), valid_person_post_form.tags
       end
 
       def test_tags_initialization

--- a/test/forms/gobierto_admin/gobierto_people/person_statement_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_statement_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -7,7 +9,7 @@ module GobiertoAdmin
         @valid_person_statement_form ||= PersonStatementForm.new(
           person_id: person.id,
           site_id: site.id,
-          title_translations: {I18n.locale => person_statement.title},
+          title_translations: { I18n.locale => person_statement.title },
           published_on: person_statement.published_on,
           attachment_url: person_statement.attachment_url,
           attachment_size: person_statement.attachment_size,
@@ -71,7 +73,6 @@ module GobiertoAdmin
 
         assert person_statement_form.valid?
       end
-
     end
   end
 end

--- a/test/forms/gobierto_admin/gobierto_people/political_group_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/political_group_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/gobierto_people/settings_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/settings_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/issue_form_test.rb
+++ b/test/forms/gobierto_admin/issue_form_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   class IssueFormTest < ActiveSupport::TestCase

--- a/test/forms/gobierto_admin/site_form_test.rb
+++ b/test/forms/gobierto_admin/site_form_test.rb
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   class SiteFormTest < ActiveSupport::TestCase
     def valid_site_form
       @valid_site_form ||= SiteForm.new(
-        title_translations: {I18n.locale => site.title},
-        name_translations: {I18n.locale => new_site_name}, # To ensure uniqueness
+        title_translations: { I18n.locale => site.title },
+        name_translations: { I18n.locale => new_site_name }, # To ensure uniqueness
         domain: new_site_domain, # To ensure uniqueness
         location_name: site.location_name,
         municipality_id: 1,
         visibility_level: "active",
-        default_locale: 'es',
-        available_locales: ['es', 'ca'],
+        default_locale: "es",
+        available_locales: %w(es ca),
         privacy_page_id: privacy_page.id
       )
     end
@@ -30,17 +32,13 @@ module GobiertoAdmin
 
     def valid_google_analytics_id_site_form
       @valid_google_analytics_id_site_form ||= SiteForm.new(
-        valid_site_form.instance_values.merge({
-          google_analytics_id: "UA-000000-01"
-        })
+        valid_site_form.instance_values.merge(google_analytics_id: "UA-000000-01")
       )
     end
 
     def invalid_google_analytics_id_site_form
       @invalid_google_analytics_id_site_form ||= SiteForm.new(
-        valid_site_form.instance_values.merge({
-          google_analytics_id: "UA-WADUS"
-        })
+        valid_site_form.instance_values.merge(google_analytics_id: "UA-WADUS")
       )
     end
 

--- a/test/forms/gobierto_admin/user_form_test.rb
+++ b/test/forms/gobierto_admin/user_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/user_password_form_test.rb
+++ b/test/forms/gobierto_admin/user_password_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_admin/user_welcome_message_form_test.rb
+++ b/test/forms/gobierto_admin/user_welcome_message_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/forms/gobierto_budget_consultations/consultation_response_form_test.rb
+++ b/test/forms/gobierto_budget_consultations/consultation_response_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
@@ -22,13 +24,13 @@ module GobiertoBudgetConsultations
 
     def selected_options_params
       @selected_options_params ||= {
-        '0' => {
-          'item_id' => consultation_item_1.id,
-          'selected_option' => -5
+        "0" => {
+          "item_id" => consultation_item_1.id,
+          "selected_option" => -5
         },
-        '1' => {
-          'item_id' => consultation_item_2.id,
-          'selected_option' => 0
+        "1" => {
+          "item_id" => consultation_item_2.id,
+          "selected_option" => 0
         }
       }
     end
@@ -123,8 +125,8 @@ module GobiertoBudgetConsultations
       user_information = valid_consultation_response_form.consultation_response.user_information
       assert_equal "female", user_information["gender"]
       assert_equal "1990-01-01", user_information["date_of_birth"]
-      assert_equal user_information["district"], {"raw_value"=>"randomstring1", "localized_value"=>"Center"}
-      assert_equal user_information["association"], {"raw_value"=>"Asociación amigos perros", "localized_value"=>"Asociación amigos perros"}
+      assert_equal user_information["district"], "raw_value" => "randomstring1", "localized_value" => "Center"
+      assert_equal user_information["association"], "raw_value" => "Asociación amigos perros", "localized_value" => "Asociación amigos perros"
     end
   end
 end

--- a/test/forms/gobierto_people/person_event_form_test.rb
+++ b/test/forms/gobierto_people/person_event_form_test.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople
   class PersonEventFormTest < ActiveSupport::TestCase
     def valid_event_form
       @valid_event_form ||= PersonEventForm.new(
-        external_id: '123',
+        external_id: "123",
         site_id: site.id,
         person_id: person.id,
         title: event.title,

--- a/test/forms/gobierto_people/person_google_calendar_calendars_form_test.rb
+++ b/test/forms/gobierto_people/person_google_calendar_calendars_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople
@@ -5,7 +7,7 @@ module GobiertoPeople
     def valid_form
       @valid_form ||= GobiertoPeople::PersonGoogleCalendarCalendarsForm.new(
         person_id: person.id,
-        calendars: ['foo', 'bar']
+        calendars: %w(foo bar)
       )
     end
 
@@ -21,19 +23,18 @@ module GobiertoPeople
       assert valid_form.save
 
       configuration = ::GobiertoPeople::PersonGoogleCalendarConfiguration.find_by(person_id: person.id)
-      assert_equal ['foo', 'bar'], configuration.calendars
+      assert_equal %w(foo bar), configuration.calendars
     end
 
     def test_update_with_valid_attributes
       configuration = ::GobiertoPeople::PersonGoogleCalendarConfiguration.find_by(person_id: person.id)
-      configuration.calendars = ['foo']
+      configuration.calendars = ["foo"]
       configuration.save!
 
       assert valid_form.save
 
       configuration = ::GobiertoPeople::PersonGoogleCalendarConfiguration.find_by(person_id: person.id)
-      assert_equal ['foo', 'bar'], configuration.calendars
+      assert_equal %w(foo bar), configuration.calendars
     end
-
   end
 end

--- a/test/forms/user/census_verification_form_test.rb
+++ b/test/forms/user/census_verification_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::CensusVerificationFormTest < ActiveSupport::TestCase

--- a/test/forms/user/confirmation_form_site_without_verification_test.rb
+++ b/test/forms/user/confirmation_form_site_without_verification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::ConfirmationFormSiteWithoutVerificationTest < ActiveSupport::TestCase
@@ -23,7 +25,7 @@ class User::ConfirmationFormSiteWithoutVerificationTest < ActiveSupport::TestCas
       date_of_birth_year: nil,
       date_of_birth_month: nil,
       date_of_birth_day: nil,
-      gender: nil,
+      gender: nil
     )
   end
 

--- a/test/forms/user/confirmation_form_test.rb
+++ b/test/forms/user/confirmation_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::ConfirmationFormTest < ActiveSupport::TestCase
@@ -15,7 +17,7 @@ class User::ConfirmationFormTest < ActiveSupport::TestCase
         madrid_custom_user_field_district.name => { "custom_user_field_id" => madrid_custom_user_field_district.id, "value" => madrid_custom_user_field_district.options.keys.first },
         madrid_custom_user_field_association.name => { "custom_user_field_id" => madrid_custom_user_field_association.id, "value" => "Foo" }
       },
-      document_number: '00000000A'
+      document_number: "00000000A"
     )
   end
 

--- a/test/forms/user/edit_password_form_test.rb
+++ b/test/forms/user/edit_password_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::EditPasswordFormTest < ActiveSupport::TestCase

--- a/test/forms/user/new_password_form_test.rb
+++ b/test/forms/user/new_password_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NewPasswordFormTest < ActiveSupport::TestCase

--- a/test/forms/user/notification_form_test.rb
+++ b/test/forms/user/notification_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NotificationFormTest < ActiveSupport::TestCase

--- a/test/forms/user/registration_form_test.rb
+++ b/test/forms/user/registration_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::RegistrationFormTest < ActiveSupport::TestCase

--- a/test/forms/user/session_form_test.rb
+++ b/test/forms/user/session_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SessionFormTest < ActiveSupport::TestCase

--- a/test/forms/user/settings_form_test.rb
+++ b/test/forms/user/settings_form_test.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SettingsFormTest < ActiveSupport::TestCase
   def valid_user_settings_form
     @valid_user_settings_form ||= User::SettingsForm.new(
       user_id: user.id,
-      name: 'Fulano',
-      email: 'example@example.org',
+      name: "Fulano",
+      email: "example@example.org",
       date_of_birth_day: 1,
       date_of_birth_month: 1,
       date_of_birth_year: 1982,

--- a/test/forms/user/subscription_form_test.rb
+++ b/test/forms/user/subscription_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SubscriptionFormTest < ActiveSupport::TestCase

--- a/test/forms/user/subscription_preferences_form_test.rb
+++ b/test/forms/user/subscription_preferences_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SubscriptionPreferencesFormTest < ActiveSupport::TestCase

--- a/test/helpers/gobierto_admin/application_helper_test.rb
+++ b/test/helpers/gobierto_admin/application_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/helpers/gobierto_admin/site_helper_test.rb
+++ b/test/helpers/gobierto_admin/site_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -12,24 +14,24 @@ module GobiertoAdmin
 
     def test_site_visibility_level_badge_for_draft_site
       visibility_level_badge_markup =
-        '<span>' \
+        "<span>" \
           '<i class="fa fa-lock"></i>' \
-          'Draft' \
-        '</span>'
+          "Draft" \
+        "</span>"
 
       assert_equal visibility_level_badge_markup,
-        site_visibility_level_badge_for(draft_site)
+                   site_visibility_level_badge_for(draft_site)
     end
 
     def test_site_visibility_level_badge_for_active_site
       visibility_level_badge_markup =
-        '<span>' \
+        "<span>" \
           '<i class="fa fa-unlock"></i>' \
-          'Published' \
-        '</span>'
+          "Published" \
+        "</span>"
 
       assert_equal visibility_level_badge_markup,
-        site_visibility_level_badge_for(active_site)
+                   site_visibility_level_badge_for(active_site)
     end
   end
 end

--- a/test/helpers/gobierto_budget_consultations/consultations_helper_test.rb
+++ b/test/helpers/gobierto_budget_consultations/consultations_helper_test.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
   class ConsultationsHelperTest < ActionView::TestCase
     def test_budget_amount_to_human
-      assert_equal "123,567€", budget_amount_to_human(123567)
-      assert_equal "123,000€", budget_amount_to_human(123000)
-      assert_equal "123,000,000€", budget_amount_to_human(123000000)
-      assert_equal "1,240,000€", budget_amount_to_human(1240000)
+      assert_equal "123,567€", budget_amount_to_human(123_567)
+      assert_equal "123,000€", budget_amount_to_human(123_000)
+      assert_equal "123,000,000€", budget_amount_to_human(123_000_000)
+      assert_equal "1,240,000€", budget_amount_to_human(1_240_000)
     end
   end
 end

--- a/test/integration/gobierto_admin/activities_test.rb
+++ b/test/integration/gobierto_admin/activities_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/admin_create_test.rb
+++ b/test/integration/gobierto_admin/admin_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -70,19 +72,19 @@ module GobiertoAdmin
         end
 
         invite_email = ActionMailer::Base.deliveries.last
-        assert_equal 'admin@email.dev', invite_email.to[0]
+        assert_equal "admin@email.dev", invite_email.to[0]
       end
 
-      open_email('admin@email.dev')
-      current_email.click_link current_email.first('a').text
+      open_email("admin@email.dev")
+      current_email.click_link current_email.first("a").text
 
       assert has_message?("Signed in successfully")
 
       assert has_content?("Edit your data")
 
       assert has_field?("admin_email", with: "admin@email.dev")
-      fill_in :admin_password, with: 'gobierto'
-      fill_in :admin_password_confirmation, with: 'gobierto'
+      fill_in :admin_password, with: "gobierto"
+      fill_in :admin_password_confirmation, with: "gobierto"
       click_button "Update"
 
       assert has_message?("Data updated successfully")
@@ -133,6 +135,5 @@ module GobiertoAdmin
         assert has_content?("Sites is too short (minimum at least 1 element)")
       end
     end
-
   end
 end

--- a/test/integration/gobierto_admin/admin_invitation_acceptance_test.rb
+++ b/test/integration/gobierto_admin/admin_invitation_acceptance_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -22,8 +24,8 @@ module GobiertoAdmin
 
       assert has_content?("Edit your data")
 
-      fill_in :admin_password, with: 'gobierto'
-      fill_in :admin_password_confirmation, with: 'gobierto'
+      fill_in :admin_password, with: "gobierto"
+      fill_in :admin_password_confirmation, with: "gobierto"
       click_button "Update"
 
       assert has_message?("Data updated successfully")

--- a/test/integration/gobierto_admin/admin_invitation_create_test.rb
+++ b/test/integration/gobierto_admin/admin_invitation_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -38,6 +40,5 @@ module GobiertoAdmin
         assert has_content?("There was a problem sending the invitations")
       end
     end
-
   end
 end

--- a/test/integration/gobierto_admin/admin_password_reset_test.rb
+++ b/test/integration/gobierto_admin/admin_password_reset_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/admin_show_test.rb
+++ b/test/integration/gobierto_admin/admin_show_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/admin_update_test.rb
+++ b/test/integration/gobierto_admin/admin_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/create_issue_test.rb
+++ b/test/integration/gobierto_admin/create_issue_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/dirty_forms_test.rb
+++ b/test/integration/gobierto_admin/dirty_forms_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachings_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachings_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoAttachments
     class AttachingTest < ActionDispatch::IntegrationTest
-
       def site
         @site ||= sites(:madrid)
       end
@@ -29,7 +30,7 @@ module GobiertoAdmin
       end
 
       def attachment_attributes
-        @attachment_attributes ||= %w[ id site_id name description file_name file_digest url file_size current_version created_at ]
+        @attachment_attributes ||= %w(id site_id name description file_name file_digest url file_size current_version created_at)
       end
 
       def test_attachings_create_success
@@ -44,14 +45,14 @@ module GobiertoAdmin
         post admin_attachments_api_attachings_path(payload)
 
         response_body = JSON.parse(response.body)
-        attachment = response_body['attachment']
+        attachment = response_body["attachment"]
 
         assert_response :success
 
         assert array_match(attachment_attributes, attachment.keys)
 
-        assert_equal 'PDF Attachment Name',                            attachment['name']
-        assert_equal 'http://host.com/attachments/pdf-attachment.pdf', attachment['url']
+        assert_equal "PDF Attachment Name", attachment["name"]
+        assert_equal "http://host.com/attachments/pdf-attachment.pdf", attachment["url"]
         assert_equal 2, cms_page.reload.attachments.count
       end
 
@@ -104,7 +105,6 @@ module GobiertoAdmin
 
         assert_response :not_found
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
@@ -1,10 +1,11 @@
-require 'test_helper'
-require 'base64'
+# frozen_string_literal: true
+
+require "test_helper"
+require "base64"
 
 module GobiertoAdmin
   module GobiertoAttachments
     class AttachmentTest < ActionDispatch::IntegrationTest
-
       def site
         @site ||= sites(:madrid)
       end
@@ -14,19 +15,19 @@ module GobiertoAdmin
       end
 
       def attachment_attributes
-        @attachment_attributes ||= %w[ id site_id name description file_name file_digest url file_size current_version created_at ]
+        @attachment_attributes ||= %w(id site_id name description file_name file_digest url file_size current_version created_at)
       end
 
       def pdf_file
-        @pdf_file ||= file_fixture('gobierto_attachments/attachment/pdf-attachment.pdf')
+        @pdf_file ||= file_fixture("gobierto_attachments/attachment/pdf-attachment.pdf")
       end
 
       def new_pdf_file
-        @new_pdf_file ||= file_fixture('gobierto_attachments/attachment/new-pdf-attachment.pdf')
+        @new_pdf_file ||= file_fixture("gobierto_attachments/attachment/new-pdf-attachment.pdf")
       end
 
       def xlsx_file
-        @xlsx_file ||= file_fixture('gobierto_attachments/attachment/xlsx-attachment.xlsx')
+        @xlsx_file ||= file_fixture("gobierto_attachments/attachment/xlsx-attachment.xlsx")
       end
 
       def pdf_attachment
@@ -49,7 +50,7 @@ module GobiertoAdmin
         get admin_attachments_api_attachments_path
 
         json_response = JSON.parse(response.body)
-        attachments = json_response['attachments']
+        attachments = json_response["attachments"]
         attachment = attachments.first
 
         assert_response :success
@@ -57,14 +58,14 @@ module GobiertoAdmin
         assert_equal 5, attachments.size
         assert array_match(attachment_attributes, attachment.keys)
 
-        assert_equal 'Attachment Name',                             attachment['name']
-        assert_equal 49,                                            attachment['file_size']
-        assert_equal 'attachment',                                  attachment['file_name']
-        assert_equal 'b6db2818dffd2fb2fc20836bebd59b87',            attachment['file_digest']
-        assert_equal 'http://host.com/attachments/attachment',      attachment['url']
-        assert_equal 'Description of attachment without extension', attachment['description']
-        assert_equal 3,                                             attachment['current_version']
-        assert_equal site.id,                                       attachment['site_id']
+        assert_equal "Attachment Name", attachment["name"]
+        assert_equal 49, attachment["file_size"]
+        assert_equal "attachment", attachment["file_name"]
+        assert_equal "b6db2818dffd2fb2fc20836bebd59b87", attachment["file_digest"]
+        assert_equal "http://host.com/attachments/attachment", attachment["url"]
+        assert_equal "Description of attachment without extension", attachment["description"]
+        assert_equal 3, attachment["current_version"]
+        assert_equal site.id, attachment["site_id"]
       end
 
       def test_attachments_index_for_attachable
@@ -78,20 +79,20 @@ module GobiertoAdmin
         get admin_attachments_api_attachments_path(payload)
 
         json_response = JSON.parse(response.body)
-        attachments = json_response['attachments']
+        attachments = json_response["attachments"]
         attachment = attachments.first
 
         assert_response :success
 
         assert_equal 1, json_response.size
-        assert_equal 'XLSX Attachment Name', attachment['name']
+        assert_equal "XLSX Attachment Name", attachment["name"]
       end
 
       def test_attachment_index_search
         login_admin_for_api(admin)
 
         payload = {
-          search_string: 'PDF'
+          search_string: "PDF"
         }
 
         ::GobiertoAttachments::Attachment.stubs(:search).returns([pdf_attachment])
@@ -99,12 +100,12 @@ module GobiertoAdmin
         get admin_attachments_api_attachments_path(payload)
 
         json_response = JSON.parse(response.body)
-        attachments = json_response['attachments']
+        attachments = json_response["attachments"]
 
         assert_response :success
 
         assert_equal 1, attachments.size
-        assert_equal 'PDF Attachment Name', attachments.first['name']
+        assert_equal "PDF Attachment Name", attachments.first["name"]
       end
 
       def test_attachments_show_success
@@ -113,13 +114,13 @@ module GobiertoAdmin
         get admin_attachments_api_attachment_path(pdf_attachment.id)
 
         json_response = JSON.parse(response.body)
-        attachment = json_response['attachment']
+        attachment = json_response["attachment"]
 
         assert_response :success
 
         assert array_match(attachment_attributes, attachment.keys)
-        assert_equal 'PDF Attachment Name', attachment['name']
-        assert_equal 'http://host.com/attachments/pdf-attachment.pdf', attachment['url']
+        assert_equal "PDF Attachment Name", attachment["name"]
+        assert_equal "http://host.com/attachments/pdf-attachment.pdf", attachment["url"]
       end
 
       def test_attachments_show_error
@@ -137,35 +138,35 @@ module GobiertoAdmin
 
         payload = {
           attachment: {
-            name: 'New attachment name',
-            description: 'New attachment description',
-            file_name: 'new-pdf-attachment.pdf',
+            name: "New attachment name",
+            description: "New attachment description",
+            file_name: "new-pdf-attachment.pdf",
             file: ::Base64.strict_encode64(new_pdf_file.read)
           }
         }
 
-        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns('http://host.com/attachments/new-pdf-attachment.pdf')
+        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/new-pdf-attachment.pdf")
 
         post admin_attachments_api_attachments_path(payload)
 
         response_body = JSON.parse(response.body)
-        attachment = response_body['attachment']
+        attachment = response_body["attachment"]
 
         assert_response :success
 
         assert array_match(attachment_attributes, attachment.keys)
 
-        assert_equal 'New attachment name',                                attachment['name']
-        assert_equal 'new-pdf-attachment.pdf',                             attachment['file_name']
-        assert_equal 'http://host.com/attachments/new-pdf-attachment.pdf', attachment['url']
-        assert_equal 1,                                                    attachment['current_version']
+        assert_equal "New attachment name", attachment["name"]
+        assert_equal "new-pdf-attachment.pdf", attachment["file_name"]
+        assert_equal "http://host.com/attachments/new-pdf-attachment.pdf", attachment["url"]
+        assert_equal 1, attachment["current_version"]
       end
 
       def test_attachments_create_error
         login_admin_for_api(admin)
 
         payload = {
-          attachment: { name: 'Incomplete attachment info' }
+          attachment: { name: "Incomplete attachment info" }
         }
 
         post admin_attachments_api_attachments_path, params: payload
@@ -173,7 +174,7 @@ module GobiertoAdmin
         response_body = JSON.parse(response.body)
 
         assert_response :bad_request
-        assert_equal 'Invalid payload', response_body['error']
+        assert_equal "Invalid payload", response_body["error"]
       end
 
       def test_attachments_update_success
@@ -182,14 +183,14 @@ module GobiertoAdmin
         payload = {
           attachment: {
             id: pdf_attachment.id,
-            name: 'Replace with new PDF file',
+            name: "Replace with new PDF file",
             description: nil,
-            file_name: 'new-pdf-attachment.pdf',
+            file_name: "new-pdf-attachment.pdf",
             file: ::Base64.strict_encode64(new_pdf_file.read)
           }
         }
 
-        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns('http://host.com/attachments/new-pdf-attachment.pdf')
+        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/new-pdf-attachment.pdf")
 
         patch admin_attachments_api_attachment_path(pdf_attachment.id), params: payload
 
@@ -197,27 +198,27 @@ module GobiertoAdmin
 
         db_pdf_attachment = ::GobiertoAttachments::Attachment.find(pdf_attachment.id)
 
-        assert_equal 'Replace with new PDF file',                          db_pdf_attachment.name
-        assert_nil                                                         db_pdf_attachment.description
-        assert_equal 'new-pdf-attachment.pdf',                             db_pdf_attachment.file_name
-        assert_equal 'http://host.com/attachments/new-pdf-attachment.pdf', db_pdf_attachment.url
-        assert_equal 2,                                                    db_pdf_attachment.current_version
+        assert_equal "Replace with new PDF file", db_pdf_attachment.name
+        assert_nil db_pdf_attachment.description
+        assert_equal "new-pdf-attachment.pdf", db_pdf_attachment.file_name
+        assert_equal "http://host.com/attachments/new-pdf-attachment.pdf", db_pdf_attachment.url
+        assert_equal 2, db_pdf_attachment.current_version
 
         # Check HTTP response returns updated info
 
         response_body = JSON.parse(response.body)
-        attachment = response_body['attachment']
+        attachment = response_body["attachment"]
 
         assert_response :success
 
         assert array_match(attachment_attributes, attachment.keys)
 
-        assert_equal pdf_attachment.id,                                    attachment['id']
-        assert_equal 'Replace with new PDF file',                          attachment['name']
-        assert_nil                                                         attachment['description']
-        assert_equal 'new-pdf-attachment.pdf',                             attachment['file_name']
-        assert_equal 'http://host.com/attachments/new-pdf-attachment.pdf', attachment['url']
-        assert_equal 2,                                                    attachment['current_version']
+        assert_equal pdf_attachment.id, attachment["id"]
+        assert_equal "Replace with new PDF file", attachment["name"]
+        assert_nil attachment["description"]
+        assert_equal "new-pdf-attachment.pdf", attachment["file_name"]
+        assert_equal "http://host.com/attachments/new-pdf-attachment.pdf", attachment["url"]
+        assert_equal 2, attachment["current_version"]
       end
 
       def test_attachments_destroy_success
@@ -251,7 +252,6 @@ module GobiertoAdmin
 
         assert_response :not_found
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_attachments/create_file_attachment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/create_file_attachment_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoAttachments
@@ -21,12 +23,12 @@ module GobiertoAdmin
           with_signed_in_admin(admin) do
             with_current_site(site) do
               visit @path
-              click_link 'Files'
-              assert has_selector?('h1', text: 'Files')
+              click_link "Files"
+              assert has_selector?("h1", text: "Files")
 
-              click_link 'New'
-              assert has_selector?('h1', text: 'New document')
-              click_button 'Create'
+              click_link "New"
+              assert has_selector?("h1", text: "New document")
+              click_button "Create"
               assert has_alert?("File can't be blank")
             end
           end
@@ -39,28 +41,28 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
 
-              click_link 'Files'
-              assert has_selector?('h1', text: 'Files')
+              click_link "Files"
+              assert has_selector?("h1", text: "Files")
 
-              click_link 'New'
-              assert has_selector?('h1', text: 'New document')
+              click_link "New"
+              assert has_selector?("h1", text: "New document")
 
-              fill_in 'file_attachment_name', with: 'My file_attachment'
-              fill_in 'file_attachment_description', with: 'My file_attachment description'
-              attach_file('file_attachment_file', 'test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf')
+              fill_in "file_attachment_name", with: "My file_attachment"
+              fill_in "file_attachment_description", with: "My file_attachment description"
+              attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
 
               with_stubbed_s3_file_upload do
-                click_button 'Create'
+                click_button "Create"
               end
 
-              assert has_message?('Attachment created successfully.')
-              file_attachment = ::GobiertoAttachments::Attachment.find_by(name: 'My file_attachment',
-                                                                          description: 'My file_attachment description')
+              assert has_message?("Attachment created successfully.")
+              file_attachment = ::GobiertoAttachments::Attachment.find_by(name: "My file_attachment",
+                                                                          description: "My file_attachment description")
               activity = Activity.last
               assert_equal file_attachment, activity.subject
               assert_equal admin, activity.author
               assert_equal site.id, activity.site_id
-              assert_equal 'gobierto_attachments.attachment_created', activity.action
+              assert_equal "gobierto_attachments.attachment_created", activity.action
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_attachments/file_attachment_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/file_attachment_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -17,7 +19,7 @@ module GobiertoAdmin
       end
 
       def collections
-        @collections ||= site.collections.where(item_type: 'GobiertoAttachments::Attachment')
+        @collections ||= site.collections.where(item_type: "GobiertoAttachments::Attachment")
       end
 
       def test_attachments_index
@@ -25,14 +27,14 @@ module GobiertoAdmin
           with_current_site(site) do
             visit @path
 
-            within 'table tbody' do
-              assert has_selector?('tr', count: collections.size)
+            within "table tbody" do
+              assert has_selector?("tr", count: collections.size)
 
               collections.each do |collection|
                 assert has_selector?("tr#collection-item-#{collection.id}")
 
                 within "tr#collection-item-#{collection.id}" do
-                  assert has_link?("#{collection.title}")
+                  assert has_link?(collection.title.to_s)
                 end
               end
             end

--- a/test/integration/gobierto_admin/gobierto_attachments/update_file_attachment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/update_file_attachment_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoAttachments
@@ -25,18 +27,18 @@ module GobiertoAdmin
           with_signed_in_admin(admin) do
             with_current_site(site) do
               visit @path
-              click_link 'Files'
-              assert has_selector?('h1', text: 'Files')
-              click_link 'PDF Collection Attachment Name'
+              click_link "Files"
+              assert has_selector?("h1", text: "Files")
+              click_link "PDF Collection Attachment Name"
 
-              fill_in 'file_attachment_name', with: 'File attachment name updated'
-              fill_in 'file_attachment_description', with: 'File attachment description updated'
+              fill_in "file_attachment_name", with: "File attachment name updated"
+              fill_in "file_attachment_description", with: "File attachment description updated"
 
-              click_button 'Update'
+              click_button "Update"
 
-              assert has_message?('Attachment updated successfully.')
-              assert has_field?('file_attachment_name', with: 'File attachment name updated')
-              assert has_field?('file_attachment_description', with: 'File attachment description updated')
+              assert has_message?("Attachment updated successfully.")
+              assert has_field?("file_attachment_name", with: "File attachment name updated")
+              assert has_field?("file_attachment_description", with: "File attachment description updated")
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/populate_data_helpers"
 

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_item_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/populate_data_helpers"
 

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_preview_test.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
   class ConsultationPreviewTest < ActionDispatch::IntegrationTest
-
     def setup
       super
       @path = admin_budget_consultations_path
@@ -30,7 +31,6 @@ module GobiertoBudgetConsultations
           visit @path
 
           within "tr#consultation-item-#{active_consultation.id}" do
-
             preview_link = find("a", text: "View consultation")
 
             refute preview_link[:href].include?(admin.preview_token)
@@ -71,7 +71,6 @@ module GobiertoBudgetConsultations
 
     def test_preview_draft_page_if_not_admin
       with_current_site(site) do
-
         assert_raises ActiveRecord::RecordNotFound do
           visit gobierto_budget_consultations_consultation_path(draft_consultation)
         end
@@ -80,6 +79,5 @@ module GobiertoBudgetConsultations
         refute has_selector?("h2", text: draft_consultation.title)
       end
     end
-
   end
 end

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_responses_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_responses_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -102,19 +104,19 @@ module GobiertoAdmin
               select "1992", from: :consultation_response_date_of_birth_1i
               select "January", from: :consultation_response_date_of_birth_2i
               select "1", from: :consultation_response_date_of_birth_3i
-              page.find("#consultation_response_gender_male", visible: false).trigger('click')
+              page.find("#consultation_response_gender_male", visible: false).trigger("click")
               select "Center", from: "Districts"
               fill_in "Association", with: "Asociación Vecinos Arganzuela"
               fill_in "Bio", with: "My short bio"
 
-              page.find("#consultation_response_selected_options_#{item1.id}_5", visible: false).trigger('click')
-              page.find("#consultation_response_selected_options_#{item2.id}_5", visible: false).trigger('click')
+              page.find("#consultation_response_selected_options_#{item1.id}_5", visible: false).trigger("click")
+              page.find("#consultation_response_selected_options_#{item2.id}_5", visible: false).trigger("click")
               click_button "Create"
 
               assert has_alert?("Consultation couldn't be saved. Please, review the responses and try again")
 
-              page.find("#consultation_response_selected_options_#{item1.id}_0", visible: false).trigger('click')
-              page.find("#consultation_response_selected_options_#{item2.id}_-5", visible: false).trigger('click')
+              page.find("#consultation_response_selected_options_#{item1.id}_0", visible: false).trigger("click")
+              page.find("#consultation_response_selected_options_#{item2.id}_-5", visible: false).trigger("click")
               select "Center", from: "Districts"
               fill_in "Association", with: "Asociación Vecinos Arganzuela"
               fill_in "Bio", with: "My short bio"
@@ -157,14 +159,14 @@ module GobiertoAdmin
 
               # Don't fill user custom fields
 
-              page.find("#consultation_response_selected_options_#{item1.id}_5", visible: false).trigger('click')
-              page.find("#consultation_response_selected_options_#{item2.id}_5", visible: false).trigger('click')
+              page.find("#consultation_response_selected_options_#{item1.id}_5", visible: false).trigger("click")
+              page.find("#consultation_response_selected_options_#{item2.id}_5", visible: false).trigger("click")
               click_button "Create"
 
               assert has_alert?("Consultation couldn't be saved. Please, review the responses and try again")
 
-              page.find("#consultation_response_selected_options_#{item1.id}_0", visible: false).trigger('click')
-              page.find("#consultation_response_selected_options_#{item2.id}_-5", visible: false).trigger('click')
+              page.find("#consultation_response_selected_options_#{item1.id}_0", visible: false).trigger("click")
+              page.find("#consultation_response_selected_options_#{item2.id}_-5", visible: false).trigger("click")
               select "Center", from: "Districts"
               fill_in "Association", with: "Asociación Vecinos Arganzuela"
               fill_in "Bio", with: "My short bio"
@@ -185,7 +187,6 @@ module GobiertoAdmin
           end
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultations_list_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultations_list_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/file_uploader_helpers"
 
@@ -44,26 +46,26 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
 
-              click_link 'New'
+              click_link "New"
 
-              fill_in 'collection_title_translations_en', with: 'My collection'
-              fill_in 'collection_slug', with: 'my-collection'
-              find('select#collection_container_global_id').find("option[value='#{process.to_global_id}']").select_option
-              find('select#collection_item_type').find("option[value='GobiertoCalendars::Event']").select_option
+              fill_in "collection_title_translations_en", with: "My collection"
+              fill_in "collection_slug", with: "my-collection"
+              find("select#collection_container_global_id").find("option[value='#{process.to_global_id}']").select_option
+              find("select#collection_item_type").find("option[value='GobiertoCalendars::Event']").select_option
 
-              click_link 'ES'
-              fill_in 'collection_title_translations_es', with: 'Mi colección'
+              click_link "ES"
+              fill_in "collection_title_translations_es", with: "Mi colección"
 
-              click_button 'Create'
+              click_button "Create"
 
-              assert has_message?('Collection was successfully created.')
+              assert has_message?("Collection was successfully created.")
 
               collection = site.collections.last
               activity = Activity.last
               assert_equal collection, activity.subject
               assert_equal admin, activity.author
               assert_equal site.id, activity.site_id
-              assert_equal 'gobierto_common.collection_created', activity.action
+              assert_equal "gobierto_common.collection_created", activity.action
             end
           end
         end
@@ -75,21 +77,21 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
 
-              click_link 'New'
+              click_link "New"
 
-              fill_in 'collection_title_translations_en', with: 'My collection'
-              fill_in 'collection_slug', with: 'my-collection'
-              find('select#collection_container_global_id').find("option[value='#{person.to_global_id}']").select_option
-              find('select#collection_item_type').find("option[value='GobiertoCalendars::Event']").select_option
+              fill_in "collection_title_translations_en", with: "My collection"
+              fill_in "collection_slug", with: "my-collection"
+              find("select#collection_container_global_id").find("option[value='#{person.to_global_id}']").select_option
+              find("select#collection_item_type").find("option[value='GobiertoCalendars::Event']").select_option
 
-              click_link 'ES'
-              fill_in 'collection_title_translations_es', with: 'Mi colección'
+              click_link "ES"
+              fill_in "collection_title_translations_es", with: "Mi colección"
 
-              click_button 'Create'
+              click_button "Create"
 
-              assert has_message?('Collection was successfully created.')
+              assert has_message?("Collection was successfully created.")
 
-              assert has_selector?('h1', text: person.name)
+              assert has_selector?("h1", text: person.name)
               assert has_link?("< Back to agendas")
 
               within ".sub_filter ul", match: :first do
@@ -119,12 +121,11 @@ module GobiertoAdmin
               assert_equal collection, activity.subject
               assert_equal admin, activity.author
               assert_equal site.id, activity.site_id
-              assert_equal 'gobierto_common.collection_created', activity.action
+              assert_equal "gobierto_common.collection_created", activity.action
             end
           end
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_calendars/event_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -73,7 +75,7 @@ module GobiertoAdmin
                 end
 
                 within ".person-event-state-radio-buttons" do
-                  find("label", text: "Published").trigger('click')
+                  find("label", text: "Published").trigger("click")
                 end
 
                 with_stubbed_s3_file_upload do
@@ -103,7 +105,7 @@ module GobiertoAdmin
                   assert has_selector?(".content-block-record-value", text: "Location Address")
                 end
 
-                assert all(".content-block-record-value").any?{ |v| v.text.include?(attendee.name) }
+                assert all(".content-block-record-value").any? { |v| v.text.include?(attendee.name) }
 
                 within ".person-event-state-radio-buttons" do
                   with_hidden_elements do

--- a/test/integration/gobierto_admin/gobierto_calendars/event_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_preview_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   module GobiertoPeople
     class PersonEventPreviewTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         @path = admin_people_person_events_path(person)
@@ -35,7 +36,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-event-item-#{published_event.id}" do
-
               preview_link = find("a", text: "View event")
 
               refute preview_link[:href].include?(admin.preview_token)
@@ -76,7 +76,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-event-item-#{published_event.id}" do
-
               preview_link = find("a", text: "View event")
 
               assert preview_link[:href].include?(admin.preview_token)
@@ -113,7 +112,6 @@ module GobiertoAdmin
 
       def test_preview_pending_event_if_not_admin
         with_current_site(site) do
-
           assert_raises ActiveRecord::RecordNotFound do
             visit gobierto_people_person_event_path(person.slug, pending_event.slug)
           end
@@ -129,7 +127,6 @@ module GobiertoAdmin
           refute has_selector?("h2", text: pending_event.title)
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_calendars/event_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -113,8 +115,8 @@ module GobiertoAdmin
                   assert has_selector?(".content-block-record-value", text: "Location Address")
                 end
 
-                assert all(".content-block-record-value").any?{ |v| v.text.include?("Attendee Name") }
-                assert all(".content-block-record-value").any?{ |v| v.text.include?("Attendee Charge") }
+                assert all(".content-block-record-value").any? { |v| v.text.include?("Attendee Name") }
+                assert all(".content-block-record-value").any? { |v| v.text.include?("Attendee Charge") }
 
                 within ".person-event-state-radio-buttons" do
                   with_hidden_elements do

--- a/test/integration/gobierto_admin/gobierto_calendars/events_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/events_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_cms/create_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/create_page_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCms
@@ -27,14 +29,14 @@ module GobiertoAdmin
               visit @path
 
               within "tr#collection-item-#{collection.id}" do
-                click_link 'News'
+                click_link "News"
               end
 
-              assert has_selector?('h1', text: 'News')
+              assert has_selector?("h1", text: "News")
 
-              click_link 'New'
-              assert has_selector?('h1', text: 'New page')
-              click_button 'Create'
+              click_link "New"
+              assert has_selector?("h1", text: "New page")
+              click_button "Create"
               assert has_alert?("Title can't be blank")
               assert has_alert?("Body can't be blank")
               assert has_alert?("URL can't be blank")
@@ -50,48 +52,48 @@ module GobiertoAdmin
               visit @path
 
               within "tr#collection-item-#{collection.id}" do
-                click_link 'News'
+                click_link "News"
               end
 
-              assert has_selector?('h1', text: 'News')
+              assert has_selector?("h1", text: "News")
 
-              click_link 'New'
-              assert has_selector?('h1', text: 'New page')
+              click_link "New"
+              assert has_selector?("h1", text: "New page")
 
-              fill_in 'page_title_translations_en', with: 'My page'
-              find('#page_body_translations_en', visible: false).set('The content of the page')
-              fill_in 'page_slug_translations_en', with: 'new-page'
+              fill_in "page_title_translations_en", with: "My page"
+              find("#page_body_translations_en", visible: false).set("The content of the page")
+              fill_in "page_slug_translations_en", with: "new-page"
 
-              click_link 'ES'
-              fill_in 'page_title_translations_es', with: 'Mi página'
-              find('#page_body_translations_es', visible: false).set('Contenido de la página')
-              fill_in 'page_slug_translations_es', with: 'nueva-pagina'
+              click_link "ES"
+              fill_in "page_title_translations_es", with: "Mi página"
+              find("#page_body_translations_es", visible: false).set("Contenido de la página")
+              fill_in "page_slug_translations_es", with: "nueva-pagina"
 
-              click_button 'Create'
+              click_button "Create"
 
-              assert has_message?('Page created successfully')
-              assert has_field?('page_slug_translations_en', with: 'new-page')
-
-              assert_equal(
-                '<div>The content of the page</div>',
-                find('#page_body_translations_en', visible: false).value
-              )
-
-              click_link 'ES'
+              assert has_message?("Page created successfully")
+              assert has_field?("page_slug_translations_en", with: "new-page")
 
               assert_equal(
-                '<div>Contenido de la página</div>',
-                find('#page_body_translations_es', visible: false).value
+                "<div>The content of the page</div>",
+                find("#page_body_translations_en", visible: false).value
               )
 
-              assert has_field?('page_slug_translations_es', with: 'nueva-pagina')
+              click_link "ES"
+
+              assert_equal(
+                "<div>Contenido de la página</div>",
+                find("#page_body_translations_es", visible: false).value
+              )
+
+              assert has_field?("page_slug_translations_es", with: "nueva-pagina")
 
               page = site.pages.last
               activity = Activity.last
               assert_equal page, activity.subject
               assert_equal admin, activity.author
               assert_equal site.id, activity.site_id
-              assert_equal 'gobierto_cms.page_created', activity.action
+              assert_equal "gobierto_cms.page_created", activity.action
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_cms/page_attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/page_attachments_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -29,7 +31,7 @@ module GobiertoAdmin
               click_link cms_page.title
 
               refute has_content?("XLSX Attachment Name")
-              page.find('a.show-files').trigger('click')
+              page.find("a.show-files").trigger("click")
               assert has_content?("XLSX Attachment Name")
             end
           end
@@ -44,7 +46,7 @@ module GobiertoAdmin
 
               click_link cms_page.title
 
-              page.find('#show-modal').trigger('click')
+              page.find("#show-modal").trigger("click")
               assert has_content?("XLSX Attachment Name")
               assert has_content?("PDF Attachment Name")
             end

--- a/test/integration/gobierto_admin/gobierto_cms/page_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/page_index_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCms
@@ -17,21 +19,21 @@ module GobiertoAdmin
       end
 
       def collections
-        @collections ||= site.collections.where(item_type: 'GobiertoCms::Page')
+        @collections ||= site.collections.where(item_type: "GobiertoCms::Page")
       end
 
       def test_collections_index
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
-            within 'table tbody' do
-              assert has_selector?('tr', count: collections.size)
+            within "table tbody" do
+              assert has_selector?("tr", count: collections.size)
 
               collections.each do |collection|
                 assert has_selector?("tr#collection-item-#{collection.id}")
 
                 within "tr#collection-item-#{collection.id}" do
-                  assert has_link?('View collection')
+                  assert has_link?("View collection")
                 end
               end
             end

--- a/test/integration/gobierto_admin/gobierto_cms/page_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/page_preview_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCms
@@ -34,11 +36,11 @@ module GobiertoAdmin
             visit @path
 
             within "tr#collection-item-#{collection.id}" do
-              click_link 'News'
+              click_link "News"
             end
 
             within "tr#page-item-#{published_page.id}" do
-              preview_link = find('a', text: 'View page')
+              preview_link = find("a", text: "View page")
 
               refute preview_link[:href].include?(admin.preview_token)
 
@@ -46,7 +48,7 @@ module GobiertoAdmin
             end
 
             assert_equal gobierto_cms_page_path(published_page.slug), current_path
-            assert has_selector?('h1', text: published_page.title)
+            assert has_selector?("h1", text: published_page.title)
           end
         end
       end
@@ -57,11 +59,11 @@ module GobiertoAdmin
             visit @path
 
             within "tr#collection-item-#{collection.id}" do
-              click_link 'News'
+              click_link "News"
             end
 
             within "tr#page-item-#{draft_page.id}" do
-              preview_link = find('a', text: 'View page')
+              preview_link = find("a", text: "View page")
 
               assert preview_link[:href].include?(admin.preview_token)
 
@@ -69,7 +71,7 @@ module GobiertoAdmin
             end
 
             assert_equal gobierto_cms_page_path(draft_page.slug), current_path
-            assert has_selector?('h1', text: draft_page.title)
+            assert has_selector?("h1", text: draft_page.title)
           end
         end
       end
@@ -81,7 +83,7 @@ module GobiertoAdmin
           end
 
           # assert_response :not_found
-          refute has_selector?('h1', text: draft_page.title)
+          refute has_selector?("h1", text: draft_page.title)
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCms
@@ -31,36 +33,36 @@ module GobiertoAdmin
               visit @path
 
               within "tr#collection-item-#{collection.id}" do
-                click_link 'News'
+                click_link "News"
               end
 
-              assert has_selector?('h1', text: 'News')
+              assert has_selector?("h1", text: "News")
 
-              click_link 'Consultation page FAQ'
+              click_link "Consultation page FAQ"
 
-              fill_in 'page_title_translations_en', with: 'Consultation page FAQ updated'
-              fill_in 'page_slug_translations_en', with: 'consultation-faq-updated'
+              fill_in "page_title_translations_en", with: "Consultation page FAQ updated"
+              fill_in "page_slug_translations_en", with: "consultation-faq-updated"
 
-              click_button 'Update'
+              click_button "Update"
 
-              assert has_message?('Page updated successfully')
-              assert has_field?('page_slug_translations_en', with: 'consultation-faq-updated')
-              assert_equal('faq-consultas', find('#page_slug_translations_es', visible: false).value)
+              assert has_message?("Page updated successfully")
+              assert has_field?("page_slug_translations_en", with: "consultation-faq-updated")
+              assert_equal("faq-consultas", find("#page_slug_translations_es", visible: false).value)
 
               assert_equal(
-                '<div>This is the body of the page</div>',
-                find('#page_body_translations_en', visible: false).value
+                "<div>This is the body of the page</div>",
+                find("#page_body_translations_en", visible: false).value
               )
 
               activity = Activity.last
               assert_equal cms_page, activity.subject
               assert_equal admin, activity.author
               assert_equal site.id, activity.site_id
-              assert_equal 'gobierto_cms.page_updated', activity.action
+              assert_equal "gobierto_cms.page_updated", activity.action
 
-              click_link 'View the page'
+              click_link "View the page"
 
-              assert has_content?('This is the body of the page')
+              assert has_content?("This is the body of the page")
 
               visit @path
             end

--- a/test/integration/gobierto_admin/gobierto_common/content_block_record_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_block_record_test.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCommon
     module ContentBlockRecords
       class ContentBlockRecordTest < ActionDispatch::IntegrationTest
-
         def setup
           super
           @path = edit_admin_people_person_path(gobierto_people_people(:richard))
@@ -69,7 +70,6 @@ module GobiertoAdmin
                   assert has_text? "Accomplishment 2 Title"
                   assert has_content?("document-1.pdf", count: 1)
                 end
-
               end
             end
           end
@@ -125,7 +125,6 @@ module GobiertoAdmin
                   assert has_content? "Ate 33 meatballs in 45 minutes"
                   refute has_content? "meatballs_photo.png"
                 end
-
               end
             end
           end
@@ -155,12 +154,10 @@ module GobiertoAdmin
 
                   assert has_content? "Ate 33 meatballs in 45 minutes"
                 end
-
               end
             end
           end
         end
-
       end
     end
   end

--- a/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -68,7 +70,7 @@ module GobiertoAdmin
                     end
                   end
 
-                  all(".dynamic-content-record-wrapper").each do |content_block_field|
+                  all(".dynamic-content-record-wrapper").each do |_content_block_field|
                     assert has_select?("Field type", selected: "Date")
 
                     AVAILABLE_LOCALES.each do |locale|

--- a/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_delete_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_delete_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_blocks/content_block_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCommon
@@ -22,8 +24,8 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
 
-              click_link 'New'
-              click_button 'Create'
+              click_link "New"
+              click_button "Create"
 
               assert has_alert?("Title can't be blank")
               assert has_alert?("URL can't be blank")
@@ -40,28 +42,28 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
 
-              click_link 'New'
+              click_link "New"
 
-              fill_in 'collection_title_translations_en', with: 'My collection'
-              fill_in 'collection_slug', with: 'my-collection'
-              find('select#collection_container_global_id').find("option[value='#{site.to_global_id}']").select_option
-              find('select#collection_item_type').find("option[value='GobiertoCms::Page']").select_option
+              fill_in "collection_title_translations_en", with: "My collection"
+              fill_in "collection_slug", with: "my-collection"
+              find("select#collection_container_global_id").find("option[value='#{site.to_global_id}']").select_option
+              find("select#collection_item_type").find("option[value='GobiertoCms::Page']").select_option
 
-              click_link 'ES'
-              fill_in 'collection_title_translations_es', with: 'Mi colección'
+              click_link "ES"
+              fill_in "collection_title_translations_es", with: "Mi colección"
 
-              click_button 'Create'
+              click_button "Create"
 
-              assert has_message?('Collection was successfully created.')
+              assert has_message?("Collection was successfully created.")
 
-              assert has_selector?('h1', text: 'My collection')
+              assert has_selector?("h1", text: "My collection")
 
               collection = site.collections.last
               activity = Activity.last
               assert_equal collection, activity.subject
               assert_equal admin, activity.author
               assert_equal site.id, activity.site_id
-              assert_equal 'gobierto_common.collection_created', activity.action
+              assert_equal "gobierto_common.collection_created", activity.action
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/update_cms_pages_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/update_cms_pages_collection_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCommon
@@ -27,17 +29,17 @@ module GobiertoAdmin
               visit @path
 
               within "tr#collection-item-#{collection.id}" do
-                page.find('a.open_remote_modal').trigger('click')
+                page.find("a.open_remote_modal").trigger("click")
               end
 
-              within 'form.edit_collection' do
-                fill_in 'collection_title_translations_en', with: 'News updated'
-                fill_in 'collection_slug', with: 'news-updated'
+              within "form.edit_collection" do
+                fill_in "collection_title_translations_en", with: "News updated"
+                fill_in "collection_slug", with: "news-updated"
 
-                click_button 'Update'
+                click_button "Update"
               end
 
-              assert has_message?('Collection was successfully updated.')
+              assert has_message?("Collection was successfully updated.")
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_participation/processes/create_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/create_process_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class CreateProcessTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         @path = admin_participation_processes_path
@@ -22,68 +23,68 @@ module GobiertoAdmin
           with_current_site(site) do
             visit @path
 
-            click_link 'Nuevo proceso / grupo'
+            click_link "Nuevo proceso / grupo"
 
-            within 'form.new_process' do
-              fill_in 'process_title_translations_en', with: 'New process title'
-              fill_in 'process_body_translations_en',  with: 'New process body'
+            within "form.new_process" do
+              fill_in "process_title_translations_en", with: "New process title"
+              fill_in "process_body_translations_en", with: "New process body"
 
-              fill_in 'process_title_translations_es', with: 'Título del nuevo proceso'
-              fill_in 'process_body_translations_es',  with: 'Descripción del nuevo proceso'
+              fill_in "process_title_translations_es", with: "Título del nuevo proceso"
+              fill_in "process_body_translations_es", with: "Descripción del nuevo proceso"
 
-              fill_in 'process_slug', with: 'new-process'
+              fill_in "process_slug", with: "new-process"
 
-              select 'Culture', from: 'process_issue_id'
+              select "Culture", from: "process_issue_id"
 
-              fill_in 'process_starts', with: '2017-01-01'
-              fill_in 'process_ends',   with: '2017-01-30'
+              fill_in "process_starts", with: "2017-01-01"
+              fill_in "process_ends", with: "2017-01-30"
 
-              choose 'process_process_type_process'
+              choose "process_process_type_process"
 
               # Activate and edit Information stage
 
-              find('#process_stages_attributes_0_active').set(true)
+              find("#process_stages_attributes_0_active").set(true)
 
-              within '#edit_stage_0' do
-                fill_in 'process_stages_attributes_0_title_translations_en', with: 'New information stage title'
-                fill_in 'process_stages_attributes_0_description_translations_en', with: 'New information stage description'
-                fill_in 'process_stages_attributes_0_starts', with: '2017-01-02'
-                fill_in 'process_stages_attributes_0_ends',   with: '2017-01-14'
+              within "#edit_stage_0" do
+                fill_in "process_stages_attributes_0_title_translations_en", with: "New information stage title"
+                fill_in "process_stages_attributes_0_description_translations_en", with: "New information stage description"
+                fill_in "process_stages_attributes_0_starts", with: "2017-01-02"
+                fill_in "process_stages_attributes_0_ends", with: "2017-01-14"
               end
 
               # Activate and edit Ideas stage
 
-              find('#process_stages_attributes_2_active').set(true)
+              find("#process_stages_attributes_2_active").set(true)
 
-              within '#edit_stage_2' do
-                fill_in 'process_stages_attributes_2_title_translations_en', with: 'New ideas stage title'
-                fill_in 'process_stages_attributes_2_description_translations_en', with: 'New ideas stage description'
-                fill_in 'process_stages_attributes_2_starts', with: '2017-01-20'
-                fill_in 'process_stages_attributes_2_ends',   with: '2017-01-28'
+              within "#edit_stage_2" do
+                fill_in "process_stages_attributes_2_title_translations_en", with: "New ideas stage title"
+                fill_in "process_stages_attributes_2_description_translations_en", with: "New ideas stage description"
+                fill_in "process_stages_attributes_2_starts", with: "2017-01-20"
+                fill_in "process_stages_attributes_2_ends", with: "2017-01-28"
               end
 
-              click_button 'Create'
+              click_button "Create"
             end
 
-            assert has_message? 'Process was successfully created'
+            assert has_message? "Process was successfully created"
 
             visit @path
 
-            assert has_content? 'New process title'
+            assert has_content? "New process title"
 
             process = site.processes.process.last
 
-            assert_equal 'New process title', process.title
-            assert_equal 'New process body', process.body
-            assert_equal 'Título del nuevo proceso', process.title_es
-            assert_equal 'Descripción del nuevo proceso', process.body_es
-            assert_equal 'new-process', process.slug
-            assert_equal 'Culture', process.issue.name
+            assert_equal "New process title", process.title
+            assert_equal "New process body", process.body
+            assert_equal "Título del nuevo proceso", process.title_es
+            assert_equal "Descripción del nuevo proceso", process.body_es
+            assert_equal "new-process", process.slug
+            assert_equal "Culture", process.issue.name
 
             assert_equal 2, process.stages.size
 
-            assert_equal 'New information stage title', process.stages.first.title
-            assert_equal 'New ideas stage title', process.stages.last.title
+            assert_equal "New information stage title", process.stages.first.title
+            assert_equal "New ideas stage title", process.stages.last.title
           end
         end
       end
@@ -93,38 +94,37 @@ module GobiertoAdmin
           with_current_site(site) do
             visit @path
 
-            click_link 'Nuevo proceso / grupo'
+            click_link "Nuevo proceso / grupo"
 
-            within 'form.new_process' do
-              fill_in 'process_title_translations_en', with: 'New group title'
-              fill_in 'process_body_translations_en',  with: 'New group body'
+            within "form.new_process" do
+              fill_in "process_title_translations_en", with: "New group title"
+              fill_in "process_body_translations_en", with: "New group body"
 
-              fill_in 'process_slug', with: 'new-group'
+              fill_in "process_slug", with: "new-group"
 
-              select 'Culture', from: 'process_issue_id'
+              select "Culture", from: "process_issue_id"
 
-              choose 'process_process_type_group_process'
+              choose "process_process_type_group_process"
 
-              click_button 'Create'
+              click_button "Create"
             end
 
-            assert has_message? 'Process was successfully created'
+            assert has_message? "Process was successfully created"
 
             visit @path
 
-            assert has_content? 'New group title'
+            assert has_content? "New group title"
 
             group = site.processes.group_process.last
 
-            assert_equal 'New group title', group.title
-            assert_equal 'New group body', group.body
-            assert_equal 'Culture', group.issue.name
+            assert_equal "New group title", group.title
+            assert_equal "New group body", group.body
+            assert_equal "Culture", group.issue.name
             assert_nil group.starts
             assert_nil group.ends
           end
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_participation/processes/process_attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/process_attachments_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class ProcessAttachmentsTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         collection.append(attachment)
@@ -34,8 +35,8 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within '.tabs' do
-              click_link 'Documents'
+            within ".tabs" do
+              click_link "Documents"
             end
 
             assert has_content?(attachment.name)
@@ -48,31 +49,31 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within '.tabs' do
-              click_link 'Documents'
+            within ".tabs" do
+              click_link "Documents"
             end
 
-            click_link 'New'
+            click_link "New"
 
-            assert has_selector?('h1', text: process.title)
+            assert has_selector?("h1", text: process.title)
 
-            fill_in 'file_attachment_name', with: 'My file_attachment'
-            fill_in 'file_attachment_description', with: 'My file_attachment description'
-            attach_file('file_attachment_file', 'test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf')
+            fill_in "file_attachment_name", with: "My file_attachment"
+            fill_in "file_attachment_description", with: "My file_attachment description"
+            attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
 
             with_stubbed_s3_file_upload do
-              click_button 'Create'
+              click_button "Create"
             end
 
-            assert has_message?('Attachment created successfully.')
+            assert has_message?("Attachment created successfully.")
 
-            assert has_selector?('h1', text: process.title)
+            assert has_selector?("h1", text: process.title)
 
-            within '.tabs' do
-              click_link 'Documents'
+            within ".tabs" do
+              click_link "Documents"
             end
 
-            assert has_content?('My file_attachment')
+            assert has_content?("My file_attachment")
           end
         end
       end
@@ -82,31 +83,31 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within '.tabs' do
-              click_link 'Documents'
+            within ".tabs" do
+              click_link "Documents"
             end
 
             click_link attachment.name
 
-            assert has_selector?('h1', text: process.title)
+            assert has_selector?("h1", text: process.title)
 
-            fill_in 'file_attachment_name', with: 'My file_attachment'
-            fill_in 'file_attachment_description', with: 'My file_attachment description'
-            attach_file('file_attachment_file', 'test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf')
+            fill_in "file_attachment_name", with: "My file_attachment"
+            fill_in "file_attachment_description", with: "My file_attachment description"
+            attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
 
             with_stubbed_s3_file_upload do
-              click_button 'Update'
+              click_button "Update"
             end
 
-            assert has_message?('Attachment updated successfully.')
+            assert has_message?("Attachment updated successfully.")
 
-            assert has_selector?('h1', text: process.title)
+            assert has_selector?("h1", text: process.title)
 
-            within '.tabs' do
-              click_link 'Documents'
+            within ".tabs" do
+              click_link "Documents"
             end
 
-            assert has_content?('My file_attachment')
+            assert has_content?("My file_attachment")
             refute has_content?(attachment.name)
           end
         end

--- a/test/integration/gobierto_admin/gobierto_participation/processes/process_events_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/process_events_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class ProcessEventsTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         collection.append(event)
@@ -34,8 +35,8 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within '.tabs' do
-              click_link 'Agenda'
+            within ".tabs" do
+              click_link "Agenda"
             end
 
             assert has_content?(event.title)
@@ -49,30 +50,30 @@ module GobiertoAdmin
             with_current_site(site) do
               visit edit_admin_participation_process_path(process)
 
-              within '.tabs' do
-                click_link 'Agenda'
+              within ".tabs" do
+                click_link "Agenda"
               end
 
-              click_link 'New event'
+              click_link "New event"
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
               fill_in "event_title_translations_en", with: "Event Title"
               fill_in "event_starts_at", with: "2017-01-01 00:00"
               fill_in "event_ends_at", with: "2017-01-01 00:01"
               find("#event_description_translations_en", visible: false).set("Event Description")
 
-              click_button 'Create'
+              click_button "Create"
 
-              assert has_message?('Event was successfully created.')
+              assert has_message?("Event was successfully created.")
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
-              within '.tabs' do
-                click_link 'Agenda'
+              within ".tabs" do
+                click_link "Agenda"
               end
 
-              assert has_content?('Event Title')
+              assert has_content?("Event Title")
             end
           end
         end
@@ -84,26 +85,26 @@ module GobiertoAdmin
             with_current_site(site) do
               visit edit_admin_participation_process_path(process)
 
-              within '.tabs' do
-                click_link 'Agenda'
+              within ".tabs" do
+                click_link "Agenda"
               end
 
               click_link event.title
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
-              fill_in 'event_title_translations_en', with: 'My event updated'
-              click_button 'Update'
+              fill_in "event_title_translations_en", with: "My event updated"
+              click_button "Update"
 
-              assert has_message?('Event was successfully updated')
+              assert has_message?("Event was successfully updated")
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
-              within '.tabs' do
-                click_link 'Agenda'
+              within ".tabs" do
+                click_link "Agenda"
               end
 
-              assert has_content?('My event updated')
+              assert has_content?("My event updated")
               refute has_content?(event.title)
             end
           end

--- a/test/integration/gobierto_admin/gobierto_participation/processes/process_pages_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/process_pages_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class ProcessPagesTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         collection.append(cms_page)
@@ -34,8 +35,8 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within '.tabs' do
-              click_link 'News'
+            within ".tabs" do
+              click_link "News"
             end
 
             assert has_content?(cms_page.title)
@@ -49,30 +50,30 @@ module GobiertoAdmin
             with_current_site(site) do
               visit edit_admin_participation_process_path(process)
 
-              within '.tabs' do
-                click_link 'News'
+              within ".tabs" do
+                click_link "News"
               end
 
-              within '.admin_tools' do
-                click_link 'New'
+              within ".admin_tools" do
+                click_link "New"
               end
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
               fill_in "page_title_translations_en", with: "News Title"
-              find('#page_body_translations_en', visible: false).set('The content of the page')
-              fill_in 'page_slug_translations_en', with: 'new-page'
-              click_button 'Create'
+              find("#page_body_translations_en", visible: false).set("The content of the page")
+              fill_in "page_slug_translations_en", with: "new-page"
+              click_button "Create"
 
-              assert has_message?('Page created successfully')
+              assert has_message?("Page created successfully")
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
-              within '.tabs' do
-                click_link 'News'
+              within ".tabs" do
+                click_link "News"
               end
 
-              assert has_content?('News Title')
+              assert has_content?("News Title")
             end
           end
         end
@@ -84,26 +85,26 @@ module GobiertoAdmin
             with_current_site(site) do
               visit edit_admin_participation_process_path(process)
 
-              within '.tabs' do
-                click_link 'News'
+              within ".tabs" do
+                click_link "News"
               end
 
               click_link cms_page.title
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
-              fill_in 'page_title_translations_en', with: 'My page updated'
-              click_button 'Update'
+              fill_in "page_title_translations_en", with: "My page updated"
+              click_button "Update"
 
-              assert has_message?('Page updated successfully')
+              assert has_message?("Page updated successfully")
 
-              assert has_selector?('h1', text: process.title)
+              assert has_selector?("h1", text: process.title)
 
-              within '.tabs' do
-                click_link 'News'
+              within ".tabs" do
+                click_link "News"
               end
 
-              assert has_content?('My page updated')
+              assert has_content?("My page updated")
               refute has_content?(cms_page.title)
             end
           end

--- a/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
@@ -1,9 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class CreateProcessTest < ActionDispatch::IntegrationTest
-
       def admin
         @admin ||= gobierto_admin_admins(:nick)
       end
@@ -25,21 +26,21 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within 'form.edit_process' do
-              fill_in 'process_title_translations_en', with: 'Edited process title'
-              select 'Women', from: 'process_issue_id'
+            within "form.edit_process" do
+              fill_in "process_title_translations_en", with: "Edited process title"
+              select "Women", from: "process_issue_id"
 
-              click_button 'Update'
+              click_button "Update"
             end
 
-            assert has_message? 'Process was successfully updated'
+            assert has_message? "Process was successfully updated"
 
             visit admin_participation_processes_path
 
-            assert has_content? 'Edited process title'
+            assert has_content? "Edited process title"
 
-            assert_equal 'Edited process title', process.title
-            assert_equal 'Women', process.issue.name
+            assert_equal "Edited process title", process.title
+            assert_equal "Women", process.issue.name
           end
         end
       end
@@ -49,21 +50,21 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(group)
 
-            within 'form.edit_process' do
-              fill_in 'process_title_translations_en', with: 'Edited group title'
-              select 'Women', from: 'process_issue_id'
+            within "form.edit_process" do
+              fill_in "process_title_translations_en", with: "Edited group title"
+              select "Women", from: "process_issue_id"
 
-              click_button 'Update'
+              click_button "Update"
             end
 
-            assert has_message? 'Process was successfully updated'
+            assert has_message? "Process was successfully updated"
 
             visit admin_participation_processes_path
 
-            assert has_content? 'Edited group title'
+            assert has_content? "Edited group title"
 
-            assert_equal 'Edited group title', group.title
-            assert_equal 'Women', group.issue.name
+            assert_equal "Edited group title", group.title
+            assert_equal "Women", group.issue.name
           end
         end
       end
@@ -74,19 +75,19 @@ module GobiertoAdmin
             visit edit_admin_participation_process_path(process)
 
             # Add Results stage
-            within 'form.edit_process' do
-              find('#process_stages_attributes_4_active').set(true)
+            within "form.edit_process" do
+              find("#process_stages_attributes_4_active").set(true)
 
-              within '#edit_stage_4' do
-                fill_in 'process_stages_attributes_4_title_translations_en', with: 'Results stage title'
-                fill_in 'process_stages_attributes_4_starts', with: '2017-01-02'
-                fill_in 'process_stages_attributes_4_ends',   with: '2017-01-14'
+              within "#edit_stage_4" do
+                fill_in "process_stages_attributes_4_title_translations_en", with: "Results stage title"
+                fill_in "process_stages_attributes_4_starts", with: "2017-01-02"
+                fill_in "process_stages_attributes_4_ends", with: "2017-01-14"
               end
 
-              click_button 'Update'
+              click_button "Update"
             end
 
-            assert has_message? 'Process was successfully updated'
+            assert has_message? "Process was successfully updated"
 
             visit admin_participation_processes_path
 
@@ -100,12 +101,12 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within 'form.edit_process' do
-              find('#process_stages_attributes_0_active').set(false)  # disable Information stage
-              click_button 'Update'
+            within "form.edit_process" do
+              find("#process_stages_attributes_0_active").set(false) # disable Information stage
+              click_button "Update"
             end
 
-            assert has_message? 'Process was successfully updated'
+            assert has_message? "Process was successfully updated"
 
             visit admin_participation_processes_path
 
@@ -119,45 +120,43 @@ module GobiertoAdmin
           with_current_site(site) do
             visit edit_admin_participation_process_path(process)
 
-            within 'form.edit_process' do
-
+            within "form.edit_process" do
               # Update Information stage
-              within '#edit_stage_0' do
-                fill_in 'process_stages_attributes_0_title_translations_en', with: 'Edited information stage title'
-                fill_in 'process_stages_attributes_0_starts', with: '2017-07-15'
-                fill_in 'process_stages_attributes_0_ends',   with: '2017-07-16'
+              within "#edit_stage_0" do
+                fill_in "process_stages_attributes_0_title_translations_en", with: "Edited information stage title"
+                fill_in "process_stages_attributes_0_starts", with: "2017-07-15"
+                fill_in "process_stages_attributes_0_ends", with: "2017-07-16"
               end
 
               # Update Meetings stage
-              within '#edit_stage_1' do
-                fill_in 'process_stages_attributes_1_title_translations_en', with: 'Edited meetings stage title'
-                fill_in 'process_stages_attributes_1_starts', with: '2017-08-17'
-                fill_in 'process_stages_attributes_1_ends',   with: '2017-08-18'
+              within "#edit_stage_1" do
+                fill_in "process_stages_attributes_1_title_translations_en", with: "Edited meetings stage title"
+                fill_in "process_stages_attributes_1_starts", with: "2017-08-17"
+                fill_in "process_stages_attributes_1_ends", with: "2017-08-18"
               end
 
-              click_button 'Update'
+              click_button "Update"
             end
 
-            assert has_message? 'Process was successfully updated'
+            assert has_message? "Process was successfully updated"
 
             visit admin_participation_processes_path
 
-            information_stage = process.stages.find_by(stage_type: 'information')
-            meetings_stage    = process.stages.find_by(stage_type: 'meetings')
+            information_stage = process.stages.find_by(stage_type: "information")
+            meetings_stage = process.stages.find_by(stage_type: "meetings")
 
             assert array_match %w(information meetings ideas), process.stages.pluck(:stage_type)
 
-            assert_equal 'Edited information stage title', information_stage.title
-            assert_equal Date.parse('2017-07-15'), information_stage.starts
-            assert_equal Date.parse('2017-07-16'), information_stage.ends
+            assert_equal "Edited information stage title", information_stage.title
+            assert_equal Date.parse("2017-07-15"), information_stage.starts
+            assert_equal Date.parse("2017-07-16"), information_stage.ends
 
-            assert_equal 'Edited meetings stage title', meetings_stage.title
-            assert_equal Date.parse('2017-08-17'), meetings_stage.starts
-            assert_equal Date.parse('2017-08-18'), meetings_stage.ends
+            assert_equal "Edited meetings stage title", meetings_stage.title
+            assert_equal Date.parse("2017-08-17"), meetings_stage.starts
+            assert_equal Date.parse("2017-08-18"), meetings_stage.ends
           end
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
@@ -1,34 +1,35 @@
-require 'test_helper'
-require 'support/calendar_integration_helpers'
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/calendar_integration_helpers"
 
 module GobiertoAdmin
   module GobiertoPeople
     class PersonCalendarConfigurationTest < ActionDispatch::IntegrationTest
-
       include ::CalendarIntegrationHelpers
 
       def google_calendar_id
-        'richard@google-calendar.com'
+        "richard@google-calendar.com"
       end
 
-     def setup
+      def setup
         super
         @person_events_path = admin_people_person_events_path(person)
 
         ## Mocks
-        calendar1 = mock()
-        calendar1.stubs(id: google_calendar_id, primary?: true, summary: 'Calendar 1')
+        calendar1 = mock
+        calendar1.stubs(id: google_calendar_id, primary?: true, summary: "Calendar 1")
 
-        calendar2 = mock()
-        calendar2.stubs(id: 2, primary?: false, summary: 'Calendar 2')
+        calendar2 = mock
+        calendar2.stubs(id: 2, primary?: false, summary: "Calendar 2")
 
-        calendar3 = mock()
-        calendar3.stubs(id: 3, primary?: false, summary: 'Calendar 3')
+        calendar3 = mock
+        calendar3.stubs(id: 3, primary?: false, summary: "Calendar 3")
 
-        calendars_mock = mock()
+        calendars_mock = mock
         calendars_mock.stubs(:calendars).returns([calendar1, calendar2, calendar3])
         ::GobiertoPeople::GoogleCalendar::CalendarIntegration.stubs(:new).returns(calendars_mock)
-      end
+       end
 
       def person
         @person ||= gobierto_people_people(:richard)
@@ -46,28 +47,28 @@ module GobiertoAdmin
         with_signed_in_admin(admin) do
           with_current_site(site) do
             activate_ibm_notes_calendar_integration(site)
-            set_ibm_notes_calendar_endpoint(person, 'http://calendar/richard')
+            set_ibm_notes_calendar_endpoint(person, "http://calendar/richard")
 
             visit @person_events_path
 
-            click_link 'Agenda'
-            click_link 'Configuration'
+            click_link "Agenda"
+            click_link "Configuration"
 
-            assert has_field?('calendar_configuration[ibm_notes_url]', with: 'http://calendar/richard')
+            assert has_field?("calendar_configuration[ibm_notes_url]", with: "http://calendar/richard")
 
-            fill_in 'calendar_configuration_ibm_notes_url', with: 'http://calendar/richard/new'
+            fill_in "calendar_configuration_ibm_notes_url", with: "http://calendar/richard/new"
 
-            click_button 'Update'
+            click_button "Update"
 
-            assert has_field?('calendar_configuration[ibm_notes_url]', with: 'http://calendar/richard/new')
-            refute has_field?('calendar_configuration[ibm_notes_url]', with: 'http://calendar/richard')
+            assert has_field?("calendar_configuration[ibm_notes_url]", with: "http://calendar/richard/new")
+            refute has_field?("calendar_configuration[ibm_notes_url]", with: "http://calendar/richard")
 
             assert_enqueued_with(job: ::GobiertoPeople::ClearImportedPersonEventsJob, args: [person], queue: "default") do
-              fill_in 'calendar_configuration_ibm_notes_url', with: ''
-              click_button 'Update'
+              fill_in "calendar_configuration_ibm_notes_url", with: ""
+              click_button "Update"
             end
 
-            assert has_field?('calendar_configuration[ibm_notes_url]')
+            assert has_field?("calendar_configuration[ibm_notes_url]")
           end
         end
       end
@@ -79,10 +80,10 @@ module GobiertoAdmin
 
             visit @person_events_path
 
-            click_link 'Agenda'
-            click_link 'Configuration'
+            click_link "Agenda"
+            click_link "Configuration"
 
-            assert has_field?('google_calendar_invitation_url')
+            assert has_field?("google_calendar_invitation_url")
           end
         end
       end
@@ -91,37 +92,35 @@ module GobiertoAdmin
         with_signed_in_admin(admin) do
           with_current_site(site) do
             activate_google_calendar_calendar_integration(site)
-            configure_google_calendar_integration(person, {
-              'google_calendar_credentials' => 'person credentials',
-            })
+            configure_google_calendar_integration(person, "google_calendar_credentials" => "person credentials")
 
             visit @person_events_path
 
-            click_link 'Agenda'
-            click_link 'Configuration'
+            click_link "Agenda"
+            click_link "Configuration"
 
-            refute has_field?('google_calendar_invitation_url')
-            assert has_field?('calendar_configuration[clear_google_calendar_configuration]')
+            refute has_field?("google_calendar_invitation_url")
+            assert has_field?("calendar_configuration[clear_google_calendar_configuration]")
 
-            refute has_checked_field?('Calendar 1')
-            refute has_checked_field?('Calendar 2')
-            refute has_checked_field?('Calendar 3')
+            refute has_checked_field?("Calendar 1")
+            refute has_checked_field?("Calendar 2")
+            refute has_checked_field?("Calendar 3")
 
-            check 'Calendar 1'
+            check "Calendar 1"
 
             click_button "Update"
 
-            assert has_checked_field?('Calendar 1')
-            refute has_checked_field?('Calendar 2')
-            refute has_checked_field?('Calendar 3')
+            assert has_checked_field?("Calendar 1")
+            refute has_checked_field?("Calendar 2")
+            refute has_checked_field?("Calendar 3")
 
             assert_enqueued_with(job: ::GobiertoPeople::ClearImportedPersonEventsJob, args: [person], queue: "default") do
-              check 'calendar_configuration[clear_google_calendar_configuration]'
+              check "calendar_configuration[clear_google_calendar_configuration]"
               click_button "Update"
             end
 
-            assert has_field?('google_calendar_invitation_url')
-            refute has_field?('calendar_configuration[clear_google_calendar_configuration]')
+            assert has_field?("google_calendar_invitation_url")
+            refute has_field?("calendar_configuration[clear_google_calendar_configuration]")
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/integration/dynamic_content_helpers"
 

--- a/test/integration/gobierto_admin/gobierto_people/person_post_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   module GobiertoPeople
     class PersonPostPreviewTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         @path = admin_people_person_posts_path(richard)
@@ -35,7 +36,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-post-item-#{active_post.id}" do
-
               preview_link = find("a", text: "View post")
 
               refute preview_link[:href].include?(admin.preview_token)
@@ -76,7 +76,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-post-item-#{active_post.id}" do
-
               preview_link = find("a", text: "View post")
 
               assert preview_link[:href].include?(admin.preview_token)
@@ -113,7 +112,6 @@ module GobiertoAdmin
 
       def test_preview_draft_post_if_not_admin
         with_current_site(site) do
-
           assert_raises ActiveRecord::RecordNotFound do
             visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
           end
@@ -129,7 +127,6 @@ module GobiertoAdmin
           refute has_selector?("h1", text: draft_post.title)
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_people/person_post_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/person_posts_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_posts_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/person_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_preview_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   module GobiertoPeople
     class PersonPreviewTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         @path = admin_people_people_path
@@ -31,7 +32,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-item-#{published_person.id}" do
-
               preview_link = find("a", text: "View person")
 
               refute preview_link[:href].include?(admin.preview_token)
@@ -66,7 +66,6 @@ module GobiertoAdmin
 
       def test_preview_draft_page_if_not_admin
         with_current_site(site) do
-
           assert_raises ActiveRecord::RecordNotFound do
             visit gobierto_people_person_path(draft_person.slug)
           end
@@ -75,7 +74,6 @@ module GobiertoAdmin
           refute has_selector?("h2", text: draft_person.name)
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/integration/dynamic_content_helpers"
 

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
   module GobiertoPeople
     class PersonStatementPreviewTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         @path = admin_people_person_statements_path(richard)
@@ -35,7 +36,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-statement-item-#{active_statement.id}" do
-
               preview_link = find("a", text: "View statement")
 
               refute preview_link[:href].include?(admin.preview_token)
@@ -76,7 +76,6 @@ module GobiertoAdmin
             visit @path
 
             within "tr#person-statement-item-#{active_statement.id}" do
-
               preview_link = find("a", text: "View statement")
 
               assert preview_link[:href].include?(admin.preview_token)
@@ -113,7 +112,6 @@ module GobiertoAdmin
 
       def test_preview_draft_statement_if_not_admin
         with_current_site(site) do
-
           assert_raises ActiveRecord::RecordNotFound do
             visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
           end
@@ -129,7 +127,6 @@ module GobiertoAdmin
           refute has_selector?("h3", text: draft_statement.title)
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/integration/dynamic_content_helpers"
 

--- a/test/integration/gobierto_admin/gobierto_people/person_statements_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statements_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/person_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/integration/dynamic_content_helpers"
 

--- a/test/integration/gobierto_admin/gobierto_people/political_group_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/political_group_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/political_group_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/political_group_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/gobierto_people/settings_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/settings_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -95,7 +97,6 @@ module GobiertoAdmin
           end
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/issue_index_test.rb
+++ b/test/integration/gobierto_admin/issue_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -31,7 +33,7 @@ module GobiertoAdmin
               assert has_selector?("tr#issue-item-#{issue.id}")
 
               within "tr#issue-item-#{issue.id}" do
-                assert has_link?("#{issue.name}")
+                assert has_link?(issue.name.to_s)
               end
             end
           end

--- a/test/integration/gobierto_admin/session_test.rb
+++ b/test/integration/gobierto_admin/session_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin
@@ -12,55 +14,54 @@ module GobiertoAdmin
     end
 
     def test_site_create
-        with_signed_in_admin(admin) do
-          visit @path
+      with_signed_in_admin(admin) do
+        visit @path
 
-          within "form.new_site" do
-            fill_in "site_title_translations_en", with: "Site Title"
-            fill_in "site_name_translations_en", with: "Site Name"
+        within "form.new_site" do
+          fill_in "site_title_translations_en", with: "Site Title"
+          fill_in "site_name_translations_en", with: "Site Name"
 
+          fill_in "site_title_translations_es", with: "Site Title"
+          fill_in "site_name_translations_es", with: "Site Name"
 
-            fill_in "site_title_translations_es", with: "Site Title"
-            fill_in "site_name_translations_es", with: "Site Name"
+          fill_in "site_location_name", with: "Site Location"
+          fill_in "site_domain", with: "test.gobierto.dev"
+          fill_in "site_head_markup", with: "Site Head markup"
+          fill_in "site_foot_markup", with: "Site Foot markup"
+          fill_in "site_links_markup", with: "Site Links markup"
+          fill_in "site_google_analytics_id", with: "UA-000000-01"
+          fill_in "site_populate_data_api_token", with: "APITOKEN"
 
-            fill_in "site_location_name", with: "Site Location"
-            fill_in "site_domain", with: "test.gobierto.dev"
-            fill_in "site_head_markup", with: "Site Head markup"
-            fill_in "site_foot_markup", with: "Site Foot markup"
-            fill_in "site_links_markup", with: "Site Links markup"
-            fill_in "site_google_analytics_id", with: "UA-000000-01"
-            fill_in "site_populate_data_api_token", with: "APITOKEN"
-
-            within ".site-check-boxes" do
-              check "site_available_locales_es"
-              choose "site_default_locale_es"
-            end
-
-            # Simulate Location selection in user control
-            find("#site_municipality_id", visible: false).set("1")
-
-            attach_file "site_logo_file", "test/fixtures/files/sites/logo-madrid.png"
-
-            within ".site-module-check-boxes" do
-              check "Gobierto Development"
-            end
-
-            within ".widget_save" do
-              choose "Published"
-            end
-
-            with_stubbed_s3_file_upload do
-              click_button "Create"
-            end
+          within ".site-check-boxes" do
+            check "site_available_locales_es"
+            choose "site_default_locale_es"
           end
 
-          assert has_message?("Site was successfully created")
+          # Simulate Location selection in user control
+          find("#site_municipality_id", visible: false).set("1")
 
-          within "table.site-list tbody tr", match: :first do
-            assert has_content?("Site Title")
-            assert has_content?("Site Name")
-            assert has_content?("Published")
+          attach_file "site_logo_file", "test/fixtures/files/sites/logo-madrid.png"
+
+          within ".site-module-check-boxes" do
+            check "Gobierto Development"
           end
+
+          within ".widget_save" do
+            choose "Published"
+          end
+
+          with_stubbed_s3_file_upload do
+            click_button "Create"
+          end
+        end
+
+        assert has_message?("Site was successfully created")
+
+        within "table.site-list tbody tr", match: :first do
+          assert has_content?("Site Title")
+          assert has_content?("Site Name")
+          assert has_content?("Published")
+        end
       end
     end
   end

--- a/test/integration/gobierto_admin/site_html_templates_test.rb
+++ b/test/integration/gobierto_admin/site_html_templates_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/file_uploader_helpers"
 
 module GobiertoAdmin
   class SiteHtmlTemplatesTest < ActionDispatch::IntegrationTest
-
     def setup
       super
       @path = edit_admin_site_path(site)
@@ -22,7 +23,7 @@ module GobiertoAdmin
     end
 
     def template
-      %Q{<a href="{% page_url #{privacy_page.slug} %}">{% page_title #{privacy_page.slug} %}</a>}
+      %(<a href="{% page_url #{privacy_page.slug} %}">{% page_title #{privacy_page.slug} %}</a>)
     end
 
     def test_site_render_liquid_html_blocks

--- a/test/integration/gobierto_admin/site_session_test.rb
+++ b/test/integration/gobierto_admin/site_session_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/update_issue_test.rb
+++ b/test/integration/gobierto_admin/update_issue_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/user_list_test.rb
+++ b/test/integration/gobierto_admin/user_list_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/user_password_change_test.rb
+++ b/test/integration/gobierto_admin/user_password_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/user_show_test.rb
+++ b/test/integration/gobierto_admin/user_show_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/user_update_test.rb
+++ b/test/integration/gobierto_admin/user_update_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_admin/user_welcome_message_create_test.rb
+++ b/test/integration/gobierto_admin/user_welcome_message_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/integration/gobierto_budget_consultations/consultation_index_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
@@ -11,7 +13,7 @@ module GobiertoBudgetConsultations
       @active_consultations ||= begin
         [
           gobierto_budget_consultations_consultations(:madrid_open),
-          gobierto_budget_consultations_consultations(:madrid_open_attached),
+          gobierto_budget_consultations_consultations(:madrid_open_attached)
         ]
       end
     end

--- a/test/integration/gobierto_budget_consultations/consultation_response_create_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_response_create_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
@@ -46,7 +48,7 @@ module GobiertoBudgetConsultations
       with_current_site(site) do
         with_signed_in_user(unverified_user) do
           # Force referer detection
-          Capybara.current_session.driver.header 'Referer', @path
+          Capybara.current_session.driver.header "Referer", @path
           visit @path
 
           assert has_content?("The process in which you want to participate requires to verify your register in")
@@ -84,15 +86,15 @@ module GobiertoBudgetConsultations
           with_signed_in_user(user) do
             visit @path
 
-            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger('click')
-            page.find("button", text: "Reduce").trigger('click')
+            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
+            page.find("button", text: "Reduce").trigger("click")
             assert_equal "Surplus", page.all(".budget-figure").last.text
             sleep 2
-            page.find("button", text: "Increase").trigger('click')
+            page.find("button", text: "Increase").trigger("click")
             assert_equal "Balanced", page.all(".budget-figure").last.text
 
-            assert page.find("a.budget-next i")['class'].include?("fa-check")
-            page.find("a.budget-next").trigger('click')
+            assert page.find("a.budget-next i")["class"].include?("fa-check")
+            page.find("a.budget-next").trigger("click")
 
             assert has_content?("Thanks for your response")
           end
@@ -106,15 +108,15 @@ module GobiertoBudgetConsultations
           with_signed_in_user(user) do
             visit @path
 
-            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger('click')
-            page.find("button", text: "Increase").trigger('click')
+            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
+            page.find("button", text: "Increase").trigger("click")
             assert_equal "Deficit", page.all(".budget-figure").last.text
             sleep 2
-            page.find("button", text: "Increase").trigger('click')
+            page.find("button", text: "Increase").trigger("click")
             assert_equal "Deficit", page.all(".budget-figure").last.text
 
-            assert page.find("a.budget-next i")['class'].include?("fa-times")
-            page.find("a.budget-next").trigger('click')
+            assert page.find("a.budget-next i")["class"].include?("fa-times")
+            page.find("a.budget-next").trigger("click")
 
             refute has_content?("Estupendo, muchas gracias por tu aportación")
           end
@@ -128,15 +130,15 @@ module GobiertoBudgetConsultations
           with_signed_in_user(user) do
             visit gobierto_budget_consultations_consultation_new_response_path(consultation_not_requiring_balance)
 
-            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger('click')
-            page.find("button", text: "Increase").trigger('click')
+            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
+            page.find("button", text: "Increase").trigger("click")
             assert_equal "Deficit", page.all(".budget-figure").last.text
             sleep 2
-            page.find("button", text: "Increase").trigger('click')
+            page.find("button", text: "Increase").trigger("click")
             assert_equal "Deficit", page.all(".budget-figure").last.text
             sleep 2
-            assert page.find("a.budget-next i")['class'].include?("fa-check")
-            page.find("a.budget-next").trigger('click')
+            assert page.find("a.budget-next i")["class"].include?("fa-check")
+            page.find("a.budget-next").trigger("click")
 
             assert has_content?("Thanks for your response")
           end
@@ -147,7 +149,7 @@ module GobiertoBudgetConsultations
     def test_consultation_response_creation_with_login
       with_current_site(site) do
         # Force referer detection
-        Capybara.current_session.driver.header 'Referer', @path
+        Capybara.current_session.driver.header "Referer", @path
         visit @path
 
         assert has_content?("The participation in this consultation is reserved to people registered in Madrid.")
@@ -166,7 +168,7 @@ module GobiertoBudgetConsultations
     def test_consultation_response_creation_with_signup_and_verification
       with_current_site(site) do
         # Force referer detection
-        Capybara.current_session.driver.header 'Referer', @path
+        Capybara.current_session.driver.header "Referer", @path
         visit @path
 
         assert has_content?("The participation in this consultation is reserved to people registered in Madrid.")

--- a/test/integration/gobierto_budget_consultations/consultation_show_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_show_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
@@ -70,7 +72,6 @@ module GobiertoBudgetConsultations
 
       with_current_site(site) do
         with_signed_in_user(user) do
-
           assert_raises(ActiveRecord::RecordNotFound) do
             visit @path
           end
@@ -93,8 +94,8 @@ module GobiertoBudgetConsultations
         assert has_selector?(".consultation-title", text: "Inversión en Bomberos y Protección Civil")
         assert has_content?("40€")
 
-        within '.consultation-step' do
-          click_link 'Start'
+        within ".consultation-step" do
+          click_link "Start"
         end
 
         assert has_message?("The participation in this consultation is reserved to people registered in Madrid.")
@@ -125,8 +126,8 @@ module GobiertoBudgetConsultations
           assert has_selector?(".consultation-title", text: "Inversión en Bomberos y Protección Civil")
           assert has_content?("40€")
 
-          within '.consultation-step' do
-            click_link 'Start'
+          within ".consultation-step" do
+            click_link "Start"
           end
 
           assert has_message?("The process in which you want to participate requires to verify your register in")

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -1,9 +1,11 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     super
-    @path = gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::EconomicArea.area_name, GobiertoBudgets::BudgetLine::EXPENSE)
+    @path = gobierto_budgets_budget_line_path("1", last_year, GobiertoBudgets::EconomicArea.area_name, GobiertoBudgets::BudgetLine::EXPENSE)
   end
 
   def site
@@ -18,8 +20,8 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
     with_current_site(site) do
       visit @path
 
-      assert has_content?('Personal expenses (custom, translated)')
-      assert has_content?('Órganos de gobierno y personal directivo')
+      assert has_content?("Personal expenses (custom, translated)")
+      assert has_content?("Órganos de gobierno y personal directivo")
     end
   end
 
@@ -27,18 +29,18 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
     with_current_site(site) do
       visit @path
 
-      assert has_css?('.metric_box h3', text: 'Expense plan. / inh.')
-      assert has_css?('.metric_box h3', text: 'Expense planned')
-      assert has_css?('.metric_box h3', text: 'Expense real vs. plan.')
-      assert has_css?('.metric_box h3', text: '% over the total')
-      assert has_css?('.metric_box h3', text: 'Avg. expense in the province')
-      assert page.all(".metric_box .metric").all?{ |e| e.text =~ /(\d+)|Not avail./}
+      assert has_css?(".metric_box h3", text: "Expense plan. / inh.")
+      assert has_css?(".metric_box h3", text: "Expense planned")
+      assert has_css?(".metric_box h3", text: "Expense real vs. plan.")
+      assert has_css?(".metric_box h3", text: "% over the total")
+      assert has_css?(".metric_box h3", text: "Avg. expense in the province")
+      assert page.all(".metric_box .metric").all? { |e| e.text =~ /(\d+)|Not avail./ }
     end
   end
 
   def test_invalid_budget_line_url
     with_current_site(site) do
-      visit gobierto_budgets_budget_line_path('1', last_year, GobiertoBudgets::EconomicArea.area_name, 'foo')
+      visit gobierto_budgets_budget_line_path("1", last_year, GobiertoBudgets::EconomicArea.area_name, "foo")
 
       assert_equal 400, status_code
     end

--- a/test/integration/gobierto_budgets/budget_lines_test.rb
+++ b/test/integration/gobierto_budgets/budget_lines_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoBudgets::BudgetLinesTest < ActionDispatch::IntegrationTest

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest

--- a/test/integration/gobierto_budgets/guide_test.rb
+++ b/test/integration/gobierto_budgets/guide_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoBudgets::GuideTest < ActionDispatch::IntegrationTest

--- a/test/integration/gobierto_budgets/home_page_test.rb
+++ b/test/integration/gobierto_budgets/home_page_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   def setup
@@ -18,7 +20,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
     with_current_site(site) do
       visit @path
 
-      assert has_content?('Budgets')
+      assert has_content?("Budgets")
       assert has_content?(last_year)
     end
   end
@@ -27,12 +29,12 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
     with_current_site(site) do
       visit @path
 
-      assert has_css?('.metric_box h3', text: 'Expenses per inhabitant')
-      assert has_css?('.metric_box h3', text: 'Total expenses')
-      assert has_css?('.metric_box h3', text: 'Executed')
-      assert has_css?('.metric_box h3', text: 'Inhabitants')
-      assert has_css?('.metric_box h3', text: 'Debt')
-      assert page.all('.metric_box .metric').all? { |e| e.text =~ /(\d+)|Not avail./ }
+      assert has_css?(".metric_box h3", text: "Expenses per inhabitant")
+      assert has_css?(".metric_box h3", text: "Total expenses")
+      assert has_css?(".metric_box h3", text: "Executed")
+      assert has_css?(".metric_box h3", text: "Inhabitants")
+      assert has_css?(".metric_box h3", text: "Debt")
+      assert page.all(".metric_box .metric").all? { |e| e.text =~ /(\d+)|Not avail./ }
     end
   end
 end

--- a/test/integration/gobierto_cms/page_index_test.rb
+++ b/test/integration/gobierto_cms/page_index_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoCms
   class PageIndexTest < ActionDispatch::IntegrationTest

--- a/test/integration/gobierto_cms/visit_page_test.rb
+++ b/test/integration/gobierto_cms/visit_page_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoCms

--- a/test/integration/gobierto_exports/exports_page_test.rb
+++ b/test/integration/gobierto_exports/exports_page_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoExports
@@ -25,29 +27,26 @@ module GobiertoExports
     end
 
     def test_index_hides_disabled_submodules
-
-      gp_enabled_submodules.delete('statements')
+      gp_enabled_submodules.delete("statements")
 
       with_current_site(site) do
         visit @path
 
-        assert has_selector?('h3', text: 'Agendas')
-        refute has_selector?('h3', text: 'Statements')
+        assert has_selector?("h3", text: "Agendas")
+        refute has_selector?("h3", text: "Statements")
       end
     end
 
     def test_index_without_any_submodules
-
-      gp_enabled_submodules.delete('officials')
-      gp_enabled_submodules.delete('agendas')
-      gp_enabled_submodules.delete('blogs')
-      gp_enabled_submodules.delete('statements')
+      gp_enabled_submodules.delete("officials")
+      gp_enabled_submodules.delete("agendas")
+      gp_enabled_submodules.delete("blogs")
+      gp_enabled_submodules.delete("statements")
 
       with_current_site(site) do
         visit @path
         assert has_content? "There aren't any active submodules"
       end
     end
-
   end
 end

--- a/test/integration/gobierto_participation/pages/page_index_test.rb
+++ b/test/integration/gobierto_participation/pages/page_index_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class PageIndexTest < ActionDispatch::IntegrationTest
-
     def setup
       super
       @path = gobierto_participation_process_path(gender_violence_process.slug)
@@ -24,9 +25,9 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
-          assert has_link? 'Processes'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
+          assert has_link? "Processes"
           assert has_link? gender_violence_process.title
         end
       end
@@ -36,12 +37,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.sub_sections' do
-          assert has_content? 'Information'
-          assert has_content? 'Meetings'
-          assert has_content? 'Polls'
-          assert has_content? 'Contributions'
-          assert has_content? 'Results'
+        within "menu.sub_sections" do
+          assert has_content? "Information"
+          assert has_content? "Meetings"
+          assert has_content? "Polls"
+          assert has_content? "Contributions"
+          assert has_content? "Results"
         end
       end
     end
@@ -50,13 +51,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
-
       end
     end
 
@@ -64,11 +64,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        assert_equal gender_violence_process.news.size, all('.place_news-item').size
+        assert_equal gender_violence_process.news.size, all(".place_news-item").size
 
-        news_titles = gender_violence_process.news.map { |notice| notice.title }
+        news_titles = gender_violence_process.news.map(&:title)
 
-        assert array_match ['Notice 1 title', 'Notice 2 title'], news_titles
+        assert array_match ["Notice 1 title", "Notice 2 title"], news_titles
       end
     end
 
@@ -76,7 +76,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit gobierto_participation_process_path(green_city_group.slug)
 
-        assert has_content? 'There are no related news'
+        assert has_content? "There are no related news"
       end
     end
 
@@ -84,14 +84,14 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        click_link 'News'
+        click_link "News"
 
-        assert has_selector?('h2', text: 'News')
+        assert has_selector?("h2", text: "News")
 
         green_city_group.news.each do |page|
-          assert has_selector?('news_teaser')
+          assert has_selector?("news_teaser")
 
-          within 'news_teaser' do
+          within "news_teaser" do
             assert has_link?(page.title)
           end
         end

--- a/test/integration/gobierto_participation/pages/page_show_test.rb
+++ b/test/integration/gobierto_participation/pages/page_show_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class PageShowTest < ActionDispatch::IntegrationTest
@@ -23,9 +25,9 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
-          assert has_link? 'Processes'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
+          assert has_link? "Processes"
           assert has_link? gender_violence_process.title
         end
       end
@@ -35,12 +37,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.sub_sections' do
-          assert has_content? 'Information'
-          assert has_content? 'Meetings'
-          assert has_content? 'Polls'
-          assert has_content? 'Contributions'
-          assert has_content? 'Results'
+        within "menu.sub_sections" do
+          assert has_content? "Information"
+          assert has_content? "Meetings"
+          assert has_content? "Polls"
+          assert has_content? "Contributions"
+          assert has_content? "Results"
         end
       end
     end
@@ -49,11 +51,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
       end
     end
@@ -62,11 +64,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        assert_equal gender_violence_process.news.size, all('.place_news-item').size
+        assert_equal gender_violence_process.news.size, all(".place_news-item").size
 
         news_titles = gender_violence_process.news.map(&:title)
 
-        assert array_match ['Notice 1 title', 'Notice 2 title'], news_titles
+        assert array_match ["Notice 1 title", "Notice 2 title"], news_titles
       end
     end
 
@@ -74,7 +76,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit gobierto_participation_process_path(green_city_group.slug)
 
-        assert has_content? 'There are no related news'
+        assert has_content? "There are no related news"
       end
     end
 
@@ -82,12 +84,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        click_link 'News'
+        click_link "News"
 
-        assert has_selector?('h2', text: 'News')
-        click_link 'Notice 1 title'
-        assert has_selector?('h1', text: 'Notice 1 title')
-        assert has_content? 'Notice 1 body'
+        assert has_selector?("h2", text: "News")
+        click_link "Notice 1 title"
+        assert has_selector?("h1", text: "Notice 1 title")
+        assert has_content? "Notice 1 body"
       end
     end
   end

--- a/test/integration/gobierto_participation/processes/process_events_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_events_index_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class ProcessEventsIndexTest < ActionDispatch::IntegrationTest
-
     def site
       @site ||= sites(:madrid)
     end
@@ -26,9 +27,9 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_events_path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
-          assert has_link? 'Processes'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
+          assert has_link? "Processes"
           assert has_link? process.title
         end
       end
@@ -38,12 +39,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_events_path
 
-        within 'menu.sub_sections' do
-          assert has_link? 'About'
-          assert has_link? 'Issues'
-          assert has_link? 'Processes'
-          assert has_link? 'Ask'
-          assert has_link? 'Ideas'
+        within "menu.sub_sections" do
+          assert has_link? "About"
+          assert has_link? "Issues"
+          assert has_link? "Processes"
+          assert has_link? "Ask"
+          assert has_link? "Ideas"
         end
       end
     end
@@ -52,13 +53,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_events_path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
-
       end
     end
 
@@ -66,8 +66,8 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_events_path
 
-        within '.site_header' do
-          skip 'Not yet defined'
+        within ".site_header" do
+          skip "Not yet defined"
         end
       end
     end
@@ -76,24 +76,22 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_events_path
 
-        within '.events_list' do
-          assert_equal process_events.size, all('.person_event-item').size
+        within ".events_list" do
+          assert_equal process_events.size, all(".person_event-item").size
 
-          assert has_content? 'Swimming lessons for elders'
-          assert has_link? 'Instalaciones Deportivas Canal de Isabel II'
+          assert has_content? "Swimming lessons for elders"
+          assert has_link? "Instalaciones Deportivas Canal de Isabel II"
 
-          assert has_content? 'Intensive reading club in english'
+          assert has_content? "Intensive reading club in english"
         end
 
-        within '.content_side' do
-          assert has_content? 'Agenda'
+        within ".content_side" do
+          assert has_content? "Agenda"
           # TODO: refute has_content? "Agenda for #{process.title}"
 
-          assert_equal process_events.size, all('.has-events').size
+          assert_equal process_events.size, all(".has-events").size
         end
-
       end
     end
-
   end
 end

--- a/test/integration/gobierto_participation/processes/process_events_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_events_show_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class ProcessEventsShowTest < ActionDispatch::IntegrationTest
-
     def site
       @site ||= sites(:madrid)
     end
@@ -27,9 +28,9 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_event_path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
-          assert has_link? 'Processes'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
+          assert has_link? "Processes"
           assert has_link? process.title
         end
       end
@@ -39,12 +40,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_event_path
 
-        within 'menu.sub_sections' do
-          assert has_link? 'About'
-          assert has_link? 'Issues'
-          assert has_link? 'Processes'
-          assert has_link? 'Ask'
-          assert has_link? 'Ideas'
+        within "menu.sub_sections" do
+          assert has_link? "About"
+          assert has_link? "Issues"
+          assert has_link? "Processes"
+          assert has_link? "Ask"
+          assert has_link? "Ideas"
         end
       end
     end
@@ -53,11 +54,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_event_path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
 
         # TODO: check that these links redirect to their corresponding pages
@@ -69,8 +70,8 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_event_path
 
-        within '.site_header' do
-          assert has_content? 'Follow this process'
+        within ".site_header" do
+          assert has_content? "Follow this process"
         end
       end
     end
@@ -79,18 +80,16 @@ module GobiertoParticipation
       with_current_site(site) do
         visit process_event_path
 
-        within '.event_wrapper' do
-          assert has_content? 'Swimming lessons for elders'
-          assert has_link? 'Instalaciones Deportivas Canal de Isabel II'
+        within ".event_wrapper" do
+          assert has_content? "Swimming lessons for elders"
+          assert has_link? "Instalaciones Deportivas Canal de Isabel II"
         end
 
-        assert has_content? 'Agenda'
+        assert has_content? "Agenda"
         # TODO: refute has_content? "Agenda for #{process.title}"
 
-        assert_equal process.events.size, all('.has-events').size
-
+        assert_equal process.events.size, all(".has-events").size
       end
     end
-
   end
 end

--- a/test/integration/gobierto_participation/processes/process_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_index_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class ProcessIndexTest < ActionDispatch::IntegrationTest
-
     def setup
       super
       @path = gobierto_participation_processes_path
@@ -16,9 +17,9 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
-          assert has_link? 'Processes'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
+          assert has_link? "Processes"
         end
       end
     end
@@ -27,12 +28,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.sub_sections' do
-          assert has_link? 'About'
-          assert has_link? 'Issues'
-          assert has_link? 'Processes'
-          assert has_link? 'Ask'
-          assert has_link? 'Ideas'
+        within "menu.sub_sections" do
+          assert has_link? "About"
+          assert has_link? "Issues"
+          assert has_link? "Processes"
+          assert has_link? "Ask"
+          assert has_link? "Ideas"
         end
       end
     end
@@ -41,11 +42,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
 
         # TODO: check that these links redirect to their corresponding pages
@@ -57,11 +58,10 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.site_header' do
-          skip 'Not yet defined'
+        within ".site_header" do
+          skip "Not yet defined"
         end
       end
     end
-
   end
 end

--- a/test/integration/gobierto_participation/processes/process_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_show_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class ProcessShowTest < ActionDispatch::IntegrationTest
-
     def setup
       super
       @path = gobierto_participation_process_path(gender_violence_process.slug)
@@ -24,9 +25,9 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
-          assert has_link? 'Processes'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
+          assert has_link? "Processes"
           assert has_link? gender_violence_process.title
         end
       end
@@ -36,12 +37,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.sub_sections' do
-          assert has_link? 'Information'
-          assert has_link? 'Meetings'
-          assert has_link? 'Polls'
-          assert has_link? 'Contributions'
-          assert has_link? 'Results'
+        within "menu.sub_sections" do
+          assert has_link? "Information"
+          assert has_link? "Meetings"
+          assert has_link? "Polls"
+          assert has_link? "Contributions"
+          assert has_link? "Results"
         end
       end
     end
@@ -50,11 +51,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
 
         # TODO: check that these links redirect to their corresponding pages
@@ -66,8 +67,8 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.site_header' do
-          assert has_content? 'Follow this process'
+        within ".site_header" do
+          assert has_content? "Follow this process"
         end
       end
     end
@@ -76,16 +77,16 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.container' do
+        within ".container" do
           assert has_content? gender_violence_process.title
           assert has_content? gender_violence_process.body
 
-          assert has_content? 'Interesting information'
+          assert has_content? "Interesting information"
 
-          process_duration_text = "#{gender_violence_process.starts.strftime('%e/%m/%y')} to #{gender_violence_process.ends.strftime('%e/%m/%y')}"
+          process_duration_text = "#{gender_violence_process.starts.strftime("%e/%m/%y")} to #{gender_violence_process.ends.strftime("%e/%m/%y")}"
 
           assert has_content? process_duration_text
-          assert has_content? 'Women'
+          assert has_content? "Women"
           # TODO: assert has_content? 'Strategic' (~Ámbito)
         end
       end
@@ -95,11 +96,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        assert_equal gender_violence_process.news.size, all('.place_news-item').size
+        assert_equal gender_violence_process.news.size, all(".place_news-item").size
 
-        news_titles = gender_violence_process.news.map { |notice| notice.title }
+        news_titles = gender_violence_process.news.map(&:title)
 
-        assert array_match ['Notice 1 title', 'Notice 2 title'], news_titles
+        assert array_match ["Notice 1 title", "Notice 2 title"], news_titles
       end
     end
 
@@ -107,7 +108,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit gobierto_participation_process_path(green_city_group.slug)
 
-        assert has_content? 'There are no related news'
+        assert has_content? "There are no related news"
       end
     end
 
@@ -115,11 +116,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        assert_equal gender_violence_process.events.size, all('.place_event-item').size
+        assert_equal gender_violence_process.events.size, all(".place_event-item").size
 
-        events_titles = gender_violence_process.events.map { |event| event.title }
+        events_titles = gender_violence_process.events.map(&:title)
 
-        assert array_match ['Intensive reading club in english', 'Swimming lessons for elders'], events_titles
+        assert array_match ["Intensive reading club in english", "Swimming lessons for elders"], events_titles
       end
     end
 
@@ -127,7 +128,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit gobierto_participation_process_path(green_city_group.slug)
 
-        assert has_content? 'There are no related events'
+        assert has_content? "There are no related events"
       end
     end
 
@@ -135,7 +136,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        skip 'Not yet defined'
+        skip "Not yet defined"
       end
     end
 
@@ -143,8 +144,8 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.timeline' do
-          assert_equal gender_violence_process.stages.size, all('.timeline_row').size
+        within ".timeline" do
+          assert_equal gender_violence_process.stages.size, all(".timeline_row").size
         end
       end
     end
@@ -153,9 +154,8 @@ module GobiertoParticipation
       with_current_site(site) do
         visit gobierto_participation_process_path(green_city_group.slug)
 
-        refute has_content? 'Process stages'
+        refute has_content? "Process stages"
       end
     end
-
   end
 end

--- a/test/integration/gobierto_participation/welcome/welcome_index_test.rb
+++ b/test/integration/gobierto_participation/welcome/welcome_index_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoParticipation
   class WelcomeIndexTest < ActionDispatch::IntegrationTest
-
     def setup
       super
       @path = gobierto_participation_root_path
@@ -16,8 +17,8 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.global_breadcrumb' do
-          assert has_link? 'Participation'
+        within ".global_breadcrumb" do
+          assert has_link? "Participation"
         end
       end
     end
@@ -26,12 +27,12 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.sub_sections' do
-          assert has_link? 'About'
-          assert has_link? 'Issues'
-          assert has_link? 'Processes'
-          assert has_link? 'Ask'
-          assert has_link? 'Ideas'
+        within "menu.sub_sections" do
+          assert has_link? "About"
+          assert has_link? "Issues"
+          assert has_link? "Processes"
+          assert has_link? "Ask"
+          assert has_link? "Ideas"
         end
       end
     end
@@ -40,11 +41,11 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within 'menu.secondary_nav' do
-          assert has_link? 'News'
-          assert has_link? 'Agenda'
-          assert has_link? 'Documents'
-          assert has_link? 'Activity'
+        within "menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
         end
 
         # TODO: check that these links redirect to their corresponding pages
@@ -56,11 +57,10 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        within '.site_header' do
-          skip 'Not yet defined'
+        within ".site_header" do
+          skip "Not yet defined"
         end
       end
     end
-
   end
 end

--- a/test/integration/gobierto_people/people/base.rb
+++ b/test/integration/gobierto_people/people/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoPeople
   module People
     module Base

--- a/test/integration/gobierto_people/people/person_bio_test.rb
+++ b/test/integration/gobierto_people/people/person_bio_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 

--- a/test/integration/gobierto_people/people/person_event_show_test.rb
+++ b/test/integration/gobierto_people/people/person_event_show_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 require "support/event_helpers"
@@ -53,11 +55,10 @@ module GobiertoPeople
       end
 
       def test_events_summary_upcoming_and_past_filters
-        past_event    = create_event(title: "Past event title", starts_at: "2014-02-15", person: person)
-        future_event  = create_event(title: "Future event title", starts_at: "2014-04-15", person: person)
+        past_event = create_event(title: "Past event title", starts_at: "2014-02-15", person: person)
+        future_event = create_event(title: "Future event title", starts_at: "2014-04-15", person: person)
 
         Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
           with_current_site(site) do
             visit gobierto_people_person_events_path(person.slug)
 
@@ -104,12 +105,11 @@ module GobiertoPeople
       end
 
       def test_calendar_navigation_arrows
-        past_event    = create_event(starts_at: "2014-02-15", person: person)
+        past_event = create_event(starts_at: "2014-02-15", person: person)
         present_event = create_event(starts_at: "2014-03-15", person: person)
-        future_event  = create_event(starts_at: "2014-04-15", person: person)
+        future_event = create_event(starts_at: "2014-04-15", person: person)
 
         Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
           with_current_site(site) do
             visit gobierto_people_person_events_path(person.slug)
 
@@ -131,16 +131,14 @@ module GobiertoPeople
               assert has_link?(past_event.starts_at.day)
             end
           end
-
         end
       end
 
       def test_filter_events_by_calendar_date_link
-        past_event    = create_event(title: "Past event title", starts_at: "2014-03-10 11:00", person: person)
-        future_event  = create_event(title: "Future event title", starts_at: "2014-03-20 11:00", person: person)
+        past_event = create_event(title: "Past event title", starts_at: "2014-03-10 11:00", person: person)
+        future_event = create_event(title: "Future event title", starts_at: "2014-03-20 11:00", person: person)
 
         Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
           with_current_site(site) do
             visit gobierto_people_person_events_path(person.slug)
 
@@ -162,7 +160,6 @@ module GobiertoPeople
           end
         end
       end
-
     end
   end
 end

--- a/test/integration/gobierto_people/people/person_message_test.rb
+++ b/test/integration/gobierto_people/people/person_message_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 

--- a/test/integration/gobierto_people/people/person_post_show_test.rb
+++ b/test/integration/gobierto_people/people/person_post_show_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 

--- a/test/integration/gobierto_people/people/person_posts_index_test.rb
+++ b/test/integration/gobierto_people/people/person_posts_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 

--- a/test/integration/gobierto_people/people/person_statement_show_test.rb
+++ b/test/integration/gobierto_people/people/person_statement_show_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "base"
 

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople

--- a/test/integration/gobierto_people/people_submodules_test.rb
+++ b/test/integration/gobierto_people/people_submodules_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople
@@ -30,39 +32,38 @@ module GobiertoPeople
       with_current_site(site) do
         visit @path
 
-        within '#main_menu' do
-          assert has_selector? 'h2', text: 'Officials and Agendas'
-          assert has_content? 'Agendas'
-          assert has_content? 'Officials'
-          assert has_content? 'Statements'
-          assert has_content? 'Blogs'
+        within "#main_menu" do
+          assert has_selector? "h2", text: "Officials and Agendas"
+          assert has_content? "Agendas"
+          assert has_content? "Officials"
+          assert has_content? "Statements"
+          assert has_content? "Blogs"
         end
 
-        disable_submodule('blogs')
+        disable_submodule("blogs")
 
         visit @path
 
-        within '#main_menu' do
-          assert has_selector? 'h2', text: 'Officials and Agendas'
-          assert has_content? 'Agendas'
-          assert has_content? 'Officials'
-          assert has_content? 'Statements'
-          refute has_content? 'Blogs'
+        within "#main_menu" do
+          assert has_selector? "h2", text: "Officials and Agendas"
+          assert has_content? "Agendas"
+          assert has_content? "Officials"
+          assert has_content? "Statements"
+          refute has_content? "Blogs"
         end
 
-        disable_submodule('officials')
-        disable_submodule('statements')
+        disable_submodule("officials")
+        disable_submodule("statements")
 
         visit @path
 
-        within '#main_menu' do
-          refute has_content? 'Officials and Agendas'
-          assert has_selector? 'h2', text: 'Agendas'
-          refute has_content? 'Officials'
-          refute has_content? 'Statements'
-          refute has_content? 'Blogs'
+        within "#main_menu" do
+          refute has_content? "Officials and Agendas"
+          assert has_selector? "h2", text: "Agendas"
+          refute has_content? "Officials"
+          refute has_content? "Statements"
+          refute has_content? "Blogs"
         end
-
       end
     end
 
@@ -72,12 +73,12 @@ module GobiertoPeople
 
         assert_equal current_path, gobierto_people_people_path
 
-        disable_submodules ['blogs', 'statements']
+        disable_submodules %w(blogs statements)
         visit @path
 
         assert_equal current_path, gobierto_people_people_path
 
-        disable_submodule 'officials'
+        disable_submodule "officials"
         visit @path
 
         assert_equal current_path, gobierto_people_events_path
@@ -88,25 +89,24 @@ module GobiertoPeople
       with_current_site(site) do
         visit gobierto_people_person_path(richard.slug)
 
-        within '.people-navigation' do
-          assert has_link? 'Agenda'
-          assert has_link? 'Goods and Activities'
+        within ".people-navigation" do
+          assert has_link? "Agenda"
+          assert has_link? "Goods and Activities"
         end
 
-        assert has_selector? 'div .upcoming-events'
+        assert has_selector? "div .upcoming-events"
 
-        disable_submodules ['agendas', 'statements']
+        disable_submodules %w(agendas statements)
 
         visit gobierto_people_person_path(richard.slug)
 
-        within '.people-navigation' do
-          refute has_link? 'Agenda'
-          refute has_link? 'Goods and Activities'
+        within ".people-navigation" do
+          refute has_link? "Agenda"
+          refute has_link? "Goods and Activities"
         end
 
-        refute has_selector? 'div .upcoming-events'
+        refute has_selector? "div .upcoming-events"
       end
     end
-
   end
 end

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/event_helpers"
 
@@ -125,16 +127,15 @@ module GobiertoPeople
           refute has_link? government_member.name
           refute has_link? executive_member.name
         end
-
       end
     end
 
     def test_person_events_filter_for_calendar_widget
       government_event = create_event(person: government_member, starts_at: "2014-03-16")
-      executive_event  = create_event(person: executive_member,  starts_at: "2014-03-17")
+      executive_event = create_event(person: executive_member, starts_at: "2014-03-17")
 
       government_event_day = government_event.starts_at.day
-      executive_event_day  = executive_event.starts_at.day
+      executive_event_day = executive_event.starts_at.day
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
@@ -160,14 +161,13 @@ module GobiertoPeople
             refute has_link? government_event_day
             refute has_link? executive_event_day
           end
-
         end
       end
     end
 
     def test_person_events_filter_for_events_list
       government_event = create_event(person: government_member, title: "Government event", starts_at: "2014-03-16")
-      executive_event  = create_event(person: executive_member,  title: "Executive event",  starts_at: "2014-03-16")
+      executive_event = create_event(person: executive_member, title: "Executive event", starts_at: "2014-03-16")
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
@@ -253,11 +253,10 @@ module GobiertoPeople
     end
 
     def test_future_and_past_events_filter
-      past_event   = create_event(title: "Past event title",   starts_at: "2014-02-15")
+      past_event = create_event(title: "Past event title", starts_at: "2014-02-15")
       future_event = create_event(title: "Future event title", starts_at: "2014-04-15")
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
         with_current_site(site) do
           visit @path
 
@@ -273,7 +272,6 @@ module GobiertoPeople
             refute has_content?(future_event.title)
           end
         end
-
       end
     end
 
@@ -319,11 +317,10 @@ module GobiertoPeople
     end
 
     def test_calendar_navigation_arrows
-      past_event   = create_event(starts_at: "2014-02-15")
+      past_event = create_event(starts_at: "2014-02-15")
       future_event = create_event(starts_at: "2014-04-15")
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
         with_current_site(site) do
           visit gobierto_people_events_path
 
@@ -341,7 +338,6 @@ module GobiertoPeople
             assert has_link?(past_event.starts_at.day)
           end
         end
-
       end
     end
 
@@ -351,7 +347,6 @@ module GobiertoPeople
       end
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
         with_current_site(site) do
           visit gobierto_people_events_path
 
@@ -360,18 +355,15 @@ module GobiertoPeople
               assert has_link?(event.starts_at.day)
             end
           end
-
         end
-
       end
     end
 
     def test_filter_events_by_calendar_date_link
-      past_event    = create_event(title: "Past event title", starts_at: "2014-03-10 11:00")
-      future_event  = create_event(title: "Future event title", starts_at: "2014-03-20 11:00")
+      past_event = create_event(title: "Past event title", starts_at: "2014-03-10 11:00")
+      future_event = create_event(title: "Future event title", starts_at: "2014-03-20 11:00")
 
       Timecop.freeze(Time.zone.parse("2014-03-15")) do
-
         with_current_site(site) do
           visit @path
 

--- a/test/integration/gobierto_people/person_posts_index_test.rb
+++ b/test/integration/gobierto_people/person_posts_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople

--- a/test/integration/gobierto_people/person_profile_test.rb
+++ b/test/integration/gobierto_people/person_profile_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "people/base"
 

--- a/test/integration/gobierto_people/person_statements_index_test.rb
+++ b/test/integration/gobierto_people/person_statements_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople

--- a/test/integration/gobierto_people/welcome_index_test.rb
+++ b/test/integration/gobierto_people/welcome_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople

--- a/test/integration/home_page_test.rb
+++ b/test/integration/home_page_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class HomePageTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/census_verification_test.rb
+++ b/test/integration/user/census_verification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::CensusVerificationTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/confirmation_test.rb
+++ b/test/integration/user/confirmation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::ConfirmationTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/confirmation_with_custom_fields_test.rb
+++ b/test/integration/user/confirmation_with_custom_fields_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::ConfirmationWithCustomFieldsTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/notification_index_test.rb
+++ b/test/integration/user/notification_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NotificationIndexTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/password_reset_test.rb
+++ b/test/integration/user/password_reset_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::PasswordResetTest < ActionDispatch::IntegrationTest
@@ -104,5 +106,4 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
       assert has_message?("Please check your inbox to get instructions")
     end
   end
-
 end

--- a/test/integration/user/registration_test.rb
+++ b/test/integration/user/registration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::RegistrationTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/session_test.rb
+++ b/test/integration/user/session_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SessionTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/settings_test.rb
+++ b/test/integration/user/settings_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SettingsTest < ActionDispatch::IntegrationTest

--- a/test/integration/user/subscription_index_test.rb
+++ b/test/integration/user/subscription_index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SubscriptionIndexTest < ActionDispatch::IntegrationTest
@@ -45,7 +47,7 @@ class User::SubscriptionIndexTest < ActionDispatch::IntegrationTest
         with_signed_in_user(user) do
           visit @path
 
-          page.find('#user_subscription_preferences_site_to_subscribe', visible: false).trigger('click')
+          page.find("#user_subscription_preferences_site_to_subscribe", visible: false).trigger("click")
 
           click_button "Save"
 

--- a/test/jobs/gobierto_people/clear_imported_person_events_job_test.rb
+++ b/test/jobs/gobierto_people/clear_imported_person_events_job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoPeople::ClearImportedPersonEventsJobTest < ActiveSupport::TestCase
@@ -7,7 +9,7 @@ class GobiertoPeople::ClearImportedPersonEventsJobTest < ActiveSupport::TestCase
 
   def test_perform
     event1 = gobierto_calendars_events(:richard_published)
-    event1.update_column(:external_id, 'richard_published')
+    event1.update_column(:external_id, "richard_published")
 
     GobiertoPeople::ClearImportedPersonEventsJob.new.perform(person)
 

--- a/test/lib/file_uploader/local_test.rb
+++ b/test/lib/file_uploader/local_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module FileUploader

--- a/test/lib/ibm_notes/api_test.rb
+++ b/test/lib/ibm_notes/api_test.rb
@@ -1,90 +1,90 @@
-require 'test_helper'
-require_relative '../../../lib/ibm_notes/api'
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../lib/ibm_notes/api"
 
 class ApiTest < ActiveSupport::TestCase
-
   def test_get_person_events
-    VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+    VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
       response_data = IbmNotes::Api.get_person_events(
-        endpoint: 'https://host.wadus.com/mail/foo.nsf/api/calendar/events',
-        username: 'username',
-        password: 'password'
+        endpoint: "https://host.wadus.com/mail/foo.nsf/api/calendar/events",
+        username: "username",
+        password: "password"
       )
 
-      events = response_data['events']
+      events = response_data["events"]
 
       assert_equal events.size, 3
-      assert_equal "/mail/foo.nsf/api/calendar/events/BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated", events[0]['href']
-      assert_equal "/mail/foo.nsf/api/calendar/events/3C1E302CAC131891C12580F90044239B-Lotus_Notes_Generated", events[1]['href']
-      assert_equal "/mail/foo.nsf/api/calendar/events/D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z", events[2]['href']
+      assert_equal "/mail/foo.nsf/api/calendar/events/BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated", events[0]["href"]
+      assert_equal "/mail/foo.nsf/api/calendar/events/3C1E302CAC131891C12580F90044239B-Lotus_Notes_Generated", events[1]["href"]
+      assert_equal "/mail/foo.nsf/api/calendar/events/D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z", events[2]["href"]
     end
   end
 
   def test_get_event
-    VCR.use_cassette('ibm_notes/non_recurrent_event', decode_compressed_response: true) do
+    VCR.use_cassette("ibm_notes/non_recurrent_event", decode_compressed_response: true) do
       response_data = IbmNotes::Api.get_event(
-        endpoint: 'https://host.wadus.com/mail/foo.nsf/api/calendar/events/3C1E302CAC131891C12580F90044239B-Lotus_Notes_Generated',
-        username: 'username',
-        password: 'password'
+        endpoint: "https://host.wadus.com/mail/foo.nsf/api/calendar/events/3C1E302CAC131891C12580F90044239B-Lotus_Notes_Generated",
+        username: "username",
+        password: "password"
       )
 
-      event = response_data['events'][0]
+      event = response_data["events"][0]
 
-      assert_equal '3C1E302CAC131891C12580F90044239B-Lotus_Notes_Generated', event['id']
-      assert_equal 'Lliurament Premis Rac', event['summary']
-      assert_equal '2017-05-04', event['start']['date']
+      assert_equal "3C1E302CAC131891C12580F90044239B-Lotus_Notes_Generated", event["id"]
+      assert_equal "Lliurament Premis Rac", event["summary"]
+      assert_equal "2017-05-04", event["start"]["date"]
     end
   end
 
   def test_get_recurrent_event_instances
-    VCR.use_cassette('ibm_notes/recurrent_event_instances', decode_compressed_response: true) do
+    VCR.use_cassette("ibm_notes/recurrent_event_instances", decode_compressed_response: true) do
       response_data = IbmNotes::Api.get_recurrent_event_instances(
-        endpoint: 'https://host.wadus.com/mail/bar.nsf/api/calendar/events/646503F7F545D629C12580FB0030DC5E_0-Lotus_ReadRange_Generated',
-        username: 'username',
-        password: 'password'
+        endpoint: "https://host.wadus.com/mail/bar.nsf/api/calendar/events/646503F7F545D629C12580FB0030DC5E_0-Lotus_ReadRange_Generated",
+        username: "username",
+        password: "password"
       )
 
-      instances = response_data['instances']
+      instances = response_data["instances"]
 
       assert_equal 9, instances.size
-      assert_equal '20170303T110000Z', instances[0]['recurrenceId']
-      assert_equal '20170407T113000Z', instances[1]['recurrenceId']
-      assert_equal '20171201T110000Z', instances[8]['recurrenceId']
+      assert_equal "20170303T110000Z", instances[0]["recurrenceId"]
+      assert_equal "20170407T113000Z", instances[1]["recurrenceId"]
+      assert_equal "20171201T110000Z", instances[8]["recurrenceId"]
     end
   end
 
   def test_get_person_events_with_invalid_credentials
     assert_raises ::IbmNotes::InvalidCredentials do
-      VCR.use_cassette('ibm_notes/calendar_events_invalid_credentials', decode_compressed_response: true) do
+      VCR.use_cassette("ibm_notes/calendar_events_invalid_credentials", decode_compressed_response: true) do
         IbmNotes::Api.get_person_events(
-          endpoint: 'https://host.wadus.com/endpoint',
-          username: 'INVALID',
-          password: 'INVALID'
+          endpoint: "https://host.wadus.com/endpoint",
+          username: "INVALID",
+          password: "INVALID"
         )
       end
     end
   end
 
   def test_get_person_events_with_no_events
-    VCR.use_cassette('ibm_notes/calendar_events_no_events', decode_compressed_response: true) do
+    VCR.use_cassette("ibm_notes/calendar_events_no_events", decode_compressed_response: true) do
       IbmNotes::Api.get_person_events(
-        endpoint: 'https://host.wadus.com/endpoint?since=2013-07-01T00:00:00Z&before=2013-07-31T00:00:00Z',
-        username: 'username',
-        password: 'password'
+        endpoint: "https://host.wadus.com/endpoint?since=2013-07-01T00:00:00Z&before=2013-07-31T00:00:00Z",
+        username: "username",
+        password: "password"
       )
     end
   end
 
   def test_get_person_events_json_parser_error
     assert_raises JSON::ParserError do
-      VCR.use_cassette('ibm_notes/calendar_events_json_parser_error', decode_compressed_response: true) do
+      VCR.use_cassette("ibm_notes/calendar_events_json_parser_error", decode_compressed_response: true) do
         IbmNotes::Api.get_person_events(
-          endpoint: 'https://host.wadus.com/endpoint',
-          username: 'username',
-          password: 'password'
+          endpoint: "https://host.wadus.com/endpoint",
+          username: "username",
+          password: "password"
         )
       end
     end
   end
-
 end

--- a/test/lib/ibm_notes/person_event_test.rb
+++ b/test/lib/ibm_notes/person_event_test.rb
@@ -1,7 +1,8 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 class IbmNotes::PersonEventTest < ActiveSupport::TestCase
-
   def setup
     super
     persisted_ibm_notes_event_gobierto_event.save!
@@ -18,19 +19,18 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
 
   def response_data(params = {})
     {
-      'id'       => params[:id] || 'Ibm Notes event ID',
-      'summary'  => params[:summary] || 'Ibm Notes event title',
-      'location' => params.has_key?(:location) ? params[:location] : 'Ibm Notes event location',
-      'start'    => params[:start] || { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-      'end'      => params[:end] || { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true }
+      "id"       => params[:id] || "Ibm Notes event ID",
+      "summary"  => params[:summary] || "Ibm Notes event title",
+      "location" => params.has_key?(:location) ? params[:location] : "Ibm Notes event location",
+      "start"    => params[:start] || { "date" => "2017-04-11", "time" => "10:00:00", "utc" => true },
+      "end"      => params[:end] || { "date" => "2017-04-11", "time" => "11:00:00", "utc" => true }
     }
   end
 
-
   def persisted_ibm_notes_event_response_data
     @persisted_ibm_notes_event_response_data ||= response_data(
-      id: 'Ibm Notes persisted event ID',
-      summary: 'Ibm Notes persisted event title'
+      id: "Ibm Notes persisted event ID",
+      summary: "Ibm Notes persisted event title"
     )
   end
 
@@ -40,8 +40,8 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
 
   def persisted_ibm_notes_event_gobierto_event
     @persisted_ibm_notes_event_gobierto_event ||= GobiertoCalendars::Event.new(
-      id: 'Ibm Notes persisted event ID',
-      title: 'Ibm Notes persisted event title',
+      id: "Ibm Notes persisted event ID",
+      title: "Ibm Notes persisted event title",
       starts_at: utc_time("2017-04-11 10:00:00"),
       ends_at:   utc_time("2017-04-11 11:00:00"),
       collection: person.events_collection,
@@ -51,8 +51,8 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
 
   def new_ibm_notes_event_response_data
     @new_ibm_notes_event_response_data ||= response_data(
-      id: 'Ibm Notes new event ID',
-      summary: 'Ibm Notes new event title'
+      id: "Ibm Notes new event ID",
+      summary: "Ibm Notes new event title"
     )
   end
 
@@ -61,11 +61,11 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
   end
 
   def test_initialize
-    assert_equal 'Ibm Notes persisted event ID', persisted_ibm_notes_event.id
-    assert_equal 'Ibm Notes persisted event title', persisted_ibm_notes_event.title
+    assert_equal "Ibm Notes persisted event ID", persisted_ibm_notes_event.id
+    assert_equal "Ibm Notes persisted event title", persisted_ibm_notes_event.title
     assert_equal person, persisted_ibm_notes_event.person
-    assert_equal utc_time('2017-04-11 10:00:00'), persisted_ibm_notes_event.starts_at
-    assert_equal utc_time('2017-04-11 11:00:00'), persisted_ibm_notes_event.ends_at
+    assert_equal utc_time("2017-04-11 10:00:00"), persisted_ibm_notes_event.starts_at
+    assert_equal utc_time("2017-04-11 11:00:00"), persisted_ibm_notes_event.ends_at
   end
 
   def test_initialize_event_location
@@ -73,13 +73,12 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
 
     assert_nil ibm_notes_event.location
 
-    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: ''))
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: ""))
 
     assert_nil ibm_notes_event.location
 
-    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: 'valid location name'))
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: "valid location name"))
 
-    assert_equal 'valid location name', ibm_notes_event.location
+    assert_equal "valid location name", ibm_notes_event.location
   end
-
 end

--- a/test/lib/secret_attribute_test.rb
+++ b/test/lib/secret_attribute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SecretAttributeTest < Minitest::Test

--- a/test/mailers/gobierto_admin/admin_mailer_test.rb
+++ b/test/mailers/gobierto_admin/admin_mailer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/mailers/gobierto_people/person_mailer_test.rb
+++ b/test/mailers/gobierto_people/person_mailer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople
@@ -15,12 +17,10 @@ module GobiertoPeople
     end
 
     def test_new_message
-      email = PersonMailer.new_message({
-        person_id: person.id,
-        reply_to: 'foo@example.com',
-        name: 'Sender',
-        body: "This is my message"
-      }).deliver_now
+      email = PersonMailer.new_message(person_id: person.id,
+                                       reply_to: "foo@example.com",
+                                       name: "Sender",
+                                       body: "This is my message").deliver_now
 
       refute ActionMailer::Base.deliveries.empty?
 

--- a/test/mailers/user/notification_mailer_test.rb
+++ b/test/mailers/user/notification_mailer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NotificationMailerTest < ActionMailer::TestCase

--- a/test/mailers/user/user_mailer_test.rb
+++ b/test/mailers/user/user_mailer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::UserMailerTest < ActionMailer::TestCase

--- a/test/misc/i18n_test.rb
+++ b/test/misc/i18n_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "i18n/tasks"
 
@@ -30,7 +32,7 @@ module Misc
     def test_normalized
       assert_empty non_normalized_paths, "The following files need to be normalized:\n" \
         "#{non_normalized_paths.map { |path| "  #{path}" }.join("\n")}\n" \
-        'Please run `i18n-tasks normalize` to fix'
+        "Please run `i18n-tasks normalize` to fix"
     end
   end
 end

--- a/test/models/census_item_test.rb
+++ b/test/models/census_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CensusItemTest < ActiveSupport::TestCase

--- a/test/models/gobierto_admin/admin_test.rb
+++ b/test/models/gobierto_admin/admin_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/authentication/authenticable_test"
 require "support/concerns/authentication/confirmable_test"
@@ -93,7 +95,7 @@ module GobiertoAdmin
       refute admin.managing_user?
     end
 
-    def module_allowed?(module_namespace)
+    def module_allowed?(_module_namespace)
       refute admin.module_allowed?("GobiertoCms")
       assert admin.module_allowed?("GobiertoBudgetConsultations")
     end

--- a/test/models/gobierto_admin/census_import_test.rb
+++ b/test/models/gobierto_admin/census_import_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/models/gobierto_admin/permission_test.rb
+++ b/test/models/gobierto_admin/permission_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/models/gobierto_attachments/attachment_test.rb
+++ b/test/models/gobierto_attachments/attachment_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAttachments
   class AttachmentTest < ActiveSupport::TestCase
-
     def setup
       super
       Pathname.any_instance.stubs(:close).returns(nil)
@@ -30,29 +31,29 @@ module GobiertoAttachments
 
     def uploaded_pdf_file
       @uploaded_pdf_file ||= ActionDispatch::Http::UploadedFile.new(
-        filename: 'pdf-attachment.pdf',
-        tempfile: file_fixture('gobierto_attachments/attachment/pdf-attachment.pdf')
+        filename: "pdf-attachment.pdf",
+        tempfile: file_fixture("gobierto_attachments/attachment/pdf-attachment.pdf")
       )
     end
 
     def uploaded_new_pdf_file
       @uploaded_new_pdf_file ||= ActionDispatch::Http::UploadedFile.new(
-        filename: 'new-pdf-attachment.pdf',
-        tempfile: file_fixture('gobierto_attachments/attachment/new-pdf-attachment.pdf')
+        filename: "new-pdf-attachment.pdf",
+        tempfile: file_fixture("gobierto_attachments/attachment/new-pdf-attachment.pdf")
       )
     end
 
     def uploaded_xlsx_file
       @uploaded_xlsx_file ||= ActionDispatch::Http::UploadedFile.new(
-        filename: 'xlsx-attachment.xlsx',
-        tempfile: file_fixture('gobierto_attachments/attachment/xlsx-attachment.xlsx')
+        filename: "xlsx-attachment.xlsx",
+        tempfile: file_fixture("gobierto_attachments/attachment/xlsx-attachment.xlsx")
       )
     end
 
     def uploaded_txt_pdf_file
       @uploaded_txt_pdf_file ||= ActionDispatch::Http::UploadedFile.new(
-        filename: 'txt-pdf-attachment.txt.pdf',
-        tempfile: file_fixture('gobierto_attachments/attachment/txt-pdf-attachment.txt.pdf')
+        filename: "txt-pdf-attachment.txt.pdf",
+        tempfile: file_fixture("gobierto_attachments/attachment/txt-pdf-attachment.txt.pdf")
       )
     end
 
@@ -65,23 +66,23 @@ module GobiertoAttachments
     end
 
     def test_create_attachment
-      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns('http://host.com/attachments/new-pdf-attachment.pdf')
+      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/new-pdf-attachment.pdf")
 
       new_attachment = Attachment.create!(
         site: site,
-        name: 'New attachment name',
-        description: 'New attachment description',
+        name: "New attachment name",
+        description: "New attachment description",
         file: uploaded_new_pdf_file
       )
 
       assert new_attachment.valid?
 
-      assert_equal 'New attachment name',                                new_attachment.name
-      assert_equal 'New attachment description',                         new_attachment.description
-      assert_equal 'new-pdf-attachment.pdf',                             new_attachment.file_name
-      assert_equal file_digest(uploaded_new_pdf_file),                   new_attachment.file_digest
-      assert_equal 'http://host.com/attachments/new-pdf-attachment.pdf', new_attachment.url
-      assert_equal uploaded_new_pdf_file.size,                           new_attachment.file_size
+      assert_equal "New attachment name", new_attachment.name
+      assert_equal "New attachment description", new_attachment.description
+      assert_equal "new-pdf-attachment.pdf", new_attachment.file_name
+      assert_equal file_digest(uploaded_new_pdf_file), new_attachment.file_digest
+      assert_equal "http://host.com/attachments/new-pdf-attachment.pdf", new_attachment.url
+      assert_equal uploaded_new_pdf_file.size, new_attachment.file_size
 
       assert_equal 1, new_attachment.current_version
       assert_equal 1, new_attachment.versions.size
@@ -89,7 +90,7 @@ module GobiertoAttachments
 
     def test_create_attachment_with_duplicated_file
       assert_raises ActiveRecord::RecordInvalid do
-        Attachment.create!(site: site, name: 'pdf-attachment.pdf', file: uploaded_pdf_file)
+        Attachment.create!(site: site, name: "pdf-attachment.pdf", file: uploaded_pdf_file)
       end
     end
 
@@ -98,7 +99,7 @@ module GobiertoAttachments
 
       new_attachment = Attachment.create(
         site: site,
-        name: 'Attachment too big',
+        name: "Attachment too big",
         file: uploaded_new_pdf_file
       )
 
@@ -106,11 +107,11 @@ module GobiertoAttachments
     end
 
     def test_update_attachment
-      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns('http://host.com/attachments/new-pdf-attachment.pdf')
+      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/new-pdf-attachment.pdf")
 
       pdf_attachment.update_attributes!(
-        name: '(EDITED) PDF Attachment Name',
-        description: '(EDITED) Description of a PDF attachment',
+        name: "(EDITED) PDF Attachment Name",
+        description: "(EDITED) Description of a PDF attachment",
         file: uploaded_new_pdf_file
       )
 
@@ -119,23 +120,23 @@ module GobiertoAttachments
       assert_equal 2, pdf_attachment.current_version
       assert_equal 2, pdf_attachment.versions.size
 
-      assert_equal '(EDITED) PDF Attachment Name',                       pdf_attachment.name
-      assert_equal '(EDITED) Description of a PDF attachment',           pdf_attachment.description
-      assert_equal 'new-pdf-attachment.pdf',                             pdf_attachment.file_name
-      assert_equal file_digest(uploaded_new_pdf_file),                   pdf_attachment.file_digest
-      assert_equal 'http://host.com/attachments/new-pdf-attachment.pdf', pdf_attachment.url
-      assert_equal uploaded_new_pdf_file.size,                           pdf_attachment.file_size
+      assert_equal "(EDITED) PDF Attachment Name", pdf_attachment.name
+      assert_equal "(EDITED) Description of a PDF attachment", pdf_attachment.description
+      assert_equal "new-pdf-attachment.pdf", pdf_attachment.file_name
+      assert_equal file_digest(uploaded_new_pdf_file), pdf_attachment.file_digest
+      assert_equal "http://host.com/attachments/new-pdf-attachment.pdf", pdf_attachment.url
+      assert_equal uploaded_new_pdf_file.size, pdf_attachment.file_size
     end
 
     def test_update_attachment_file
-      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns('http://host.com/attachments/new-pdf-attachment.pdf')
+      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/new-pdf-attachment.pdf")
 
       pdf_attachment.update_attributes!(file: uploaded_new_pdf_file)
 
       assert_equal 2, pdf_attachment.current_version
       assert_equal 2, pdf_attachment.versions.size
 
-      assert_equal 'new-pdf-attachment.pdf', pdf_attachment.file_name
+      assert_equal "new-pdf-attachment.pdf", pdf_attachment.file_name
       assert_equal uploaded_new_pdf_file.size, pdf_attachment.file_size
     end
 
@@ -146,12 +147,12 @@ module GobiertoAttachments
     end
 
     def test_update_attachment_metadata
-      pdf_attachment.update_attributes!(name: '(SECOND EDIT) PDF Attachment Name')
+      pdf_attachment.update_attributes!(name: "(SECOND EDIT) PDF Attachment Name")
 
       assert_equal 1, pdf_attachment.current_version
       assert_equal 1, pdf_attachment.versions.size
 
-      assert_equal '(SECOND EDIT) PDF Attachment Name', pdf_attachment.name
+      assert_equal "(SECOND EDIT) PDF Attachment Name", pdf_attachment.name
     end
 
     def test_destroy_attachment
@@ -163,15 +164,14 @@ module GobiertoAttachments
 
       last_version = PaperTrail::Version.where(item_id: pdf_attachment.id).last
 
-      assert 'destroy', last_version.event
+      assert "destroy", last_version.event
     end
 
     def test_attachment_extension
-      assert_equal 'pdf',  pdf_attachment.extension
-      assert_equal 'xlsx', xlsx_attachment.extension
-      assert_equal '',     attachment.extension
-      assert_equal 'pdf',  txt_pdf_attachment.extension
+      assert_equal "pdf", pdf_attachment.extension
+      assert_equal "xlsx", xlsx_attachment.extension
+      assert_equal "", attachment.extension
+      assert_equal "pdf", txt_pdf_attachment.extension
     end
-
   end
 end

--- a/test/models/gobierto_budget_consultations/consultation_item_test.rb
+++ b/test/models/gobierto_budget_consultations/consultation_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/gobierto_common/sortable_test"
 

--- a/test/models/gobierto_budget_consultations/consultation_response_item_test.rb
+++ b/test/models/gobierto_budget_consultations/consultation_response_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations
@@ -42,10 +44,10 @@ module GobiertoBudgetConsultations
     def consultation_response_item_params
       @consultation_response_item_params ||= begin
         {
-          item_id: 26213347,
+          item_id: 26_213_347,
           item_title: "Pavimentación de vías públicas",
           item_budget_line_amount: "10.0",
-          item_response_options: {"0"=>"reduce", "1"=>"keep", "2"=>"increase"},
+          item_response_options: { "0" => "reduce", "1" => "keep", "2" => "increase" }
         }
       end
     end

--- a/test/models/gobierto_budget_consultations/consultation_response_test.rb
+++ b/test/models/gobierto_budget_consultations/consultation_response_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoBudgetConsultations

--- a/test/models/gobierto_budget_consultations/consultation_test.rb
+++ b/test/models/gobierto_budget_consultations/consultation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/user/subscribable_test"
 

--- a/test/models/gobierto_budgets/budget_line_test.rb
+++ b/test/models/gobierto_budgets/budget_line_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoBudgets
   class BudgetLineTest < ActiveSupport::TestCase
-
     def setup
       super
       budget_line.stubs(:population).returns(666)
@@ -15,10 +16,10 @@ module GobiertoBudgets
     def budget_line
       @budget_line ||= BudgetLine.new(
         site: site,
-        index: 'index_forecast',
+        index: "index_forecast",
         area_name: EconomicArea.area_name,
         kind: BudgetLine::EXPENSE,
-        code: '1',
+        code: "1",
         year: 2015,
         amount: 123.45
       )
@@ -28,34 +29,34 @@ module GobiertoBudgets
       {
         index: SearchEngineConfiguration::BudgetLine.index_forecast,
         type: EconomicArea.area_name,
-        id: '28079/2015/1/G'
+        id: "28079/2015/1/G"
       }
     end
 
     def test_get_level
-      assert_equal 1, BudgetLine.get_level('0')
-      assert_equal 1, BudgetLine.get_level('1')
-      assert_equal 3, BudgetLine.get_level('123')
-      assert_equal 4, BudgetLine.get_level('123-00')
+      assert_equal 1, BudgetLine.get_level("0")
+      assert_equal 1, BudgetLine.get_level("1")
+      assert_equal 3, BudgetLine.get_level("123")
+      assert_equal 4, BudgetLine.get_level("123-00")
     end
 
     def test_get_parent_code
-      assert_nil BudgetLine.get_parent_code('0')
-      assert_nil BudgetLine.get_parent_code('1')
-      assert_equal '12',  BudgetLine.get_parent_code('123')
-      assert_equal '123', BudgetLine.get_parent_code('123-00')
+      assert_nil BudgetLine.get_parent_code("0")
+      assert_nil BudgetLine.get_parent_code("1")
+      assert_equal "12", BudgetLine.get_parent_code("123")
+      assert_equal "123", BudgetLine.get_parent_code("123-00")
     end
 
     def test_save
-      client = mock()
+      client = mock
 
       client.expects(:index)
             .with(has_entries(budget_line_arguments_for_indexing))
-            .returns( { '_shards' => { 'failed' => 0 } } )
+            .returns("_shards" => { "failed" => 0 })
 
       SearchEngine.stubs(client: client)
 
-      algolia_index = mock()
+      algolia_index = mock
 
       algolia_index.expects(:add_object).with(budget_line.algolia_as_json)
 
@@ -65,15 +66,15 @@ module GobiertoBudgets
     end
 
     def test_save_fail
-      client = mock()
+      client = mock
 
       client.expects(:index)
             .with(has_entries(budget_line_arguments_for_indexing))
-            .returns( { '_shards' => { 'failed' => 1 } } )
+            .returns("_shards" => { "failed" => 1 })
 
       SearchEngine.stubs(client: client)
 
-      algolia_index = mock()
+      algolia_index = mock
 
       algolia_index.expects(:add_object).with(budget_line.algolia_as_json).never
 
@@ -83,17 +84,17 @@ module GobiertoBudgets
     end
 
     def test_destroy
-      algolia_index = mock()
+      algolia_index = mock
 
       algolia_index.expects(:delete_object).with(budget_line.algolia_id)
 
       BudgetLine.stubs(algolia_index: algolia_index)
 
-      client = mock()
+      client = mock
 
       client.expects(:delete)
             .with(has_entries(budget_line_arguments_for_indexing))
-            .returns( { '_shards' => { 'failed' => 0 } } )
+            .returns("_shards" => { "failed" => 0 })
 
       SearchEngine.stubs(client: client)
 
@@ -101,11 +102,10 @@ module GobiertoBudgets
     end
 
     def test_algolia_as_json
-
       expected_hash = {
-        objectID: 'index_forecast/economic/28079/2015/1/G',
-        index: 'index_forecast',
-        type: 'economic',
+        objectID: "index_forecast/economic/28079/2015/1/G",
+        index: "index_forecast",
+        type: "economic",
         site_id: site.id,
         ine_code: budget_line.ine_code,
         year: budget_line.year,
@@ -113,16 +113,15 @@ module GobiertoBudgets
         kind: budget_line.kind,
         resource_path: budget_line.resource_path,
         class_name: budget_line.class.name,
-        'name_es'        => 'Gastos de personal (custom, translated)',
-        'description_es' => 'Los gastos de personal son... (custom, translated)',
-        'name_en'        => 'Personal expenses (custom, translated)',
-        'description_en' => 'Personal expenses are... (custom, translated)',
-        'name_ca'        => 'Gastos de personal (custom, translated)',
-        'description_ca' => 'Los gastos de personal son... (custom, translated)'
+        "name_es"        => "Gastos de personal (custom, translated)",
+        "description_es" => "Los gastos de personal son... (custom, translated)",
+        "name_en"        => "Personal expenses (custom, translated)",
+        "description_en" => "Personal expenses are... (custom, translated)",
+        "name_ca"        => "Gastos de personal (custom, translated)",
+        "description_ca" => "Los gastos de personal son... (custom, translated)"
       }
 
       assert_equal expected_hash, budget_line.algolia_as_json
     end
-
   end
 end

--- a/test/models/gobierto_budgets/economic_area_test.rb
+++ b/test/models/gobierto_budgets/economic_area_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/gobierto_budgets/describable_test"
 
@@ -7,7 +9,7 @@ class GobiertoBudgets::EconomicAreaTest < ActiveSupport::TestCase
   def test_all_items
     items = GobiertoBudgets::EconomicArea.all_items
     assert_kind_of Hash, items
-    assert_includes items.keys, 'G'
-    assert_includes items.keys, 'I'
+    assert_includes items.keys, "G"
+    assert_includes items.keys, "I"
   end
 end

--- a/test/models/gobierto_budgets/functional_area_test.rb
+++ b/test/models/gobierto_budgets/functional_area_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/gobierto_budgets/describable_test"
 
@@ -7,7 +9,7 @@ class GobiertoBudgets::FunctionalAreaTest < ActiveSupport::TestCase
   def test_all_items
     items = GobiertoBudgets::FunctionalArea.all_items
     assert_kind_of Hash, items
-    assert_includes items.keys, 'G'
-    assert_not_includes items.keys, 'I'
+    assert_includes items.keys, "G"
+    assert_not_includes items.keys, "I"
   end
 end

--- a/test/models/gobierto_calendars/event_attendee_test.rb
+++ b/test/models/gobierto_calendars/event_attendee_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoCalendars

--- a/test/models/gobierto_calendars/event_location_test.rb
+++ b/test/models/gobierto_calendars/event_location_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoCalendars

--- a/test/models/gobierto_calendars/event_test.rb
+++ b/test/models/gobierto_calendars/event_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/user/subscribable_test"
 require "support/concerns/gobierto_common/sluggable_test"
@@ -22,7 +24,7 @@ module GobiertoCalendars
 
     def new_event
       subject_class.create!(
-        title: 'Person Event Title',
+        title: "Person Event Title",
         starts_at: Time.zone.now,
         ends_at: Time.zone.now + 1.hour,
         site: sites(:madrid),

--- a/test/models/gobierto_calendars/sluggable_test.rb
+++ b/test/models/gobierto_calendars/sluggable_test.rb
@@ -1,19 +1,20 @@
-require 'test_helper'
-require 'support/event_helpers'
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/event_helpers"
 
 module GobiertoCalendars
   class SluggableTest < ActiveSupport::TestCase
     include ::EventHelpers
 
     def test_assign_slug_with_date
-      event_1 = create_event(title: '_* (Title)-',  starts_at: '2017-01-02 18:00:00')
-      event_2 = create_event(title: '_* (Title)--', starts_at: '2017-01-02 20:00:00')
-      event_3 = create_event(title: '_* (Title)_2', starts_at: '2017-01-02')
+      event_1 = create_event(title: "_* (Title)-", starts_at: "2017-01-02 18:00:00")
+      event_2 = create_event(title: "_* (Title)--", starts_at: "2017-01-02 20:00:00")
+      event_3 = create_event(title: "_* (Title)_2", starts_at: "2017-01-02")
 
-      assert_equal '2017-01-02-title',     event_1.slug
-      assert_equal '2017-01-02-title-2',   event_2.slug
-      assert_equal '2017-01-02-title-2-2', event_3.slug
+      assert_equal "2017-01-02-title", event_1.slug
+      assert_equal "2017-01-02-title-2", event_2.slug
+      assert_equal "2017-01-02-title-2-2", event_3.slug
     end
-
   end
 end

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/gobierto_attachments/attachable_test"
 
 module GobiertoCms
   class PageTest < ActiveSupport::TestCase
-
     include GobiertoAttachments::AttachableTest
 
     def page

--- a/test/models/gobierto_common/collection_item_test.rb
+++ b/test/models/gobierto_common/collection_item_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoCommon
   class CollectionItemTest < ActiveSupport::TestCase

--- a/test/models/gobierto_common/collection_test.rb
+++ b/test/models/gobierto_common/collection_test.rb
@@ -1,5 +1,7 @@
-require 'test_helper'
-require 'support/concerns/gobierto_attachments/attachable_test'
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/concerns/gobierto_attachments/attachable_test"
 
 module GobiertoCommon
   class CollectionTest < ActiveSupport::TestCase

--- a/test/models/gobierto_common/content_block_field_test.rb
+++ b/test/models/gobierto_common/content_block_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoCommon

--- a/test/models/gobierto_common/content_block_record_test.rb
+++ b/test/models/gobierto_common/content_block_record_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoCommon

--- a/test/models/gobierto_common/content_block_test.rb
+++ b/test/models/gobierto_common/content_block_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoCommon

--- a/test/models/gobierto_common/custom_user_field_record_test.rb
+++ b/test/models/gobierto_common/custom_user_field_record_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoCommon::CustomUserFieldRecordTest < ActiveSupport::TestCase
@@ -20,51 +22,51 @@ class GobiertoCommon::CustomUserFieldRecordTest < ActiveSupport::TestCase
   def test_value_assignment
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_single_option
-    subject.value = 'foo'
-    assert_equal 'foo', subject.payload[custom_user_field_single_option.name]
+    subject.value = "foo"
+    assert_equal "foo", subject.payload[custom_user_field_single_option.name]
   end
 
   def test_raw_value
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_single_option
-    subject.value = 'randomstring1'
-    assert_equal 'randomstring1', subject.raw_value
+    subject.value = "randomstring1"
+    assert_equal "randomstring1", subject.raw_value
 
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_string
-    subject.value = 'randomstring1'
-    assert_equal 'randomstring1', subject.raw_value
+    subject.value = "randomstring1"
+    assert_equal "randomstring1", subject.raw_value
 
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_paragraph
-    subject.value = 'randomstring1'
-    assert_equal 'randomstring1', subject.raw_value
+    subject.value = "randomstring1"
+    assert_equal "randomstring1", subject.raw_value
 
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_multiple_options
-    subject.value = ['randomstring1', 'random2']
-    assert_equal ['randomstring1', 'random2'], subject.raw_value
+    subject.value = %w(randomstring1 random2)
+    assert_equal %w(randomstring1 random2), subject.raw_value
   end
 
   def test_values
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_single_option
-    subject.value = 'randomstring1'
-    assert_equal 'Center', subject.value
+    subject.value = "randomstring1"
+    assert_equal "Center", subject.value
 
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_string
-    subject.value = 'randomstring1'
-    assert_equal 'randomstring1', subject.value
+    subject.value = "randomstring1"
+    assert_equal "randomstring1", subject.value
 
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_paragraph
-    subject.value = 'randomstring1'
-    assert_equal 'randomstring1', subject.value
+    subject.value = "randomstring1"
+    assert_equal "randomstring1", subject.value
 
     subject = GobiertoCommon::CustomUserFieldRecord.new
     subject.custom_user_field = custom_user_field_multiple_options
-    subject.value = ['randomstring1']
-    assert_equal ['Sports'], subject.value
+    subject.value = ["randomstring1"]
+    assert_equal ["Sports"], subject.value
   end
 end

--- a/test/models/gobierto_common/custom_user_field_test.rb
+++ b/test/models/gobierto_common/custom_user_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoCommon::CustomUserFieldTest < ActiveSupport::TestCase
@@ -6,7 +8,7 @@ class GobiertoCommon::CustomUserFieldTest < ActiveSupport::TestCase
   end
 
   def test_localized_title
-    subject.title = { 'en' => 'title en', 'es' => 'title es' }
-    assert_equal 'title en', subject.localized_title
+    subject.title = { "en" => "title en", "es" => "title es" }
+    assert_equal "title en", subject.localized_title
   end
 end

--- a/test/models/gobierto_module_settings_test.rb
+++ b/test/models/gobierto_module_settings_test.rb
@@ -1,18 +1,19 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoModuleSettingsTest < ActiveSupport::TestCase
-
   def gobierto_people_settings
     @gobierto_people_settings ||= gobierto_module_settings(:gobierto_people_settings_madrid)
   end
 
   def test_dynamic_setters
     module_settings = GobiertoModuleSettings.new
-    module_settings.first_setting = 'foo'
-    module_settings.second_setting = 'bar'
+    module_settings.first_setting = "foo"
+    module_settings.second_setting = "bar"
 
-    assert_equal 'foo', module_settings.settings['first_setting']
-    assert_equal 'bar', module_settings.settings['second_setting']
+    assert_equal "foo", module_settings.settings["first_setting"]
+    assert_equal "bar", module_settings.settings["second_setting"]
   end
 
   def test_update

--- a/test/models/gobierto_participation/area_test.rb
+++ b/test/models/gobierto_participation/area_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoParticipation

--- a/test/models/gobierto_participation/process_stage_test.rb
+++ b/test/models/gobierto_participation/process_stage_test.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoParticipation
   class ProcessStageTest < ActiveSupport::TestCase
-
     def process
       @process ||= gobierto_participation_processes(:gender_violence_process)
     end
@@ -14,9 +15,9 @@ module GobiertoParticipation
     def stages
       {
         information: process.stages.find_by!(stage_type: ProcessStage.stage_types[:information]),
-           meetings: process.stages.find_by!(stage_type: ProcessStage.stage_types[:meetings]),
-              ideas: process.stages.find_by!(stage_type: ProcessStage.stage_types[:ideas]),
-            results: process.stages.find_by!(stage_type: ProcessStage.stage_types[:results])
+        meetings: process.stages.find_by!(stage_type: ProcessStage.stage_types[:meetings]),
+        ideas: process.stages.find_by!(stage_type: ProcessStage.stage_types[:ideas]),
+        results: process.stages.find_by!(stage_type: ProcessStage.stage_types[:results])
       }
     end
 
@@ -47,6 +48,5 @@ module GobiertoParticipation
       assert stages[:ideas].current?
       refute stages[:results].current?
     end
-
   end
 end

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -1,19 +1,20 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoCms
   class ProcessTest < ActiveSupport::TestCase
-
     def process
       @process ||= gobierto_participation_processes(:gender_violence_process)
     end
     alias collectionable_object process
 
     def process_news
-      [ gobierto_cms_pages(:notice_1), gobierto_cms_pages(:notice_2) ]
+      [gobierto_cms_pages(:notice_1), gobierto_cms_pages(:notice_2)]
     end
 
     def process_events
-      [ gobierto_calendars_events(:reading_club), gobierto_calendars_events(:swimming_lessons) ]
+      [gobierto_calendars_events(:reading_club), gobierto_calendars_events(:swimming_lessons)]
     end
 
     def test_valid
@@ -27,6 +28,5 @@ module GobiertoCms
     def test_process_events
       assert array_match process_events, process.events
     end
-
   end
 end

--- a/test/models/gobierto_people/person_ibm_notes_calendar_configuration_test.rb
+++ b/test/models/gobierto_people/person_ibm_notes_calendar_configuration_test.rb
@@ -1,8 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoPeople
   class PersonIbmNotesCalendarConfigurationTest < ActiveSupport::TestCase
-
     def person
       gobierto_people_people(:nelson)
     end
@@ -10,15 +11,14 @@ module GobiertoPeople
     def test_endpoint
       configuration = PersonIbmNotesCalendarConfiguration.create(person: person)
 
-      assert_equal Hash.new, configuration.data
+      assert_equal({}, configuration.data)
 
-      configuration.endpoint = 'http://calendar/nelson'
+      configuration.endpoint = "http://calendar/nelson"
       configuration.save
 
       configuration = PersonIbmNotesCalendarConfiguration.find_by(person: person)
 
-      assert_equal 'http://calendar/nelson', configuration.endpoint
+      assert_equal "http://calendar/nelson", configuration.endpoint
     end
-
   end
 end

--- a/test/models/gobierto_people/person_message_test.rb
+++ b/test/models/gobierto_people/person_message_test.rb
@@ -1,14 +1,15 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoPeople
   class PersonMessageTest < ActiveSupport::TestCase
-
     def person
       @person ||= gobierto_people_people(:richard)
     end
 
     def subject
-      @subject ||= GobiertoPeople::PersonMessage.new name: 'Sender', email: 'foo@example.com', person: person, body: 'This is my message'
+      @subject ||= GobiertoPeople::PersonMessage.new name: "Sender", email: "foo@example.com", person: person, body: "This is my message"
     end
 
     def test_valid

--- a/test/models/gobierto_people/person_post_test.rb
+++ b/test/models/gobierto_people/person_post_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/user/subscribable_test"
 require "support/concerns/gobierto_common/sluggable_test"
@@ -14,7 +16,7 @@ module GobiertoPeople
 
     def new_person_post
       ::GobiertoPeople::PersonPost.create!(
-        title: 'Person Post Title',
+        title: "Person Post Title",
         person: gobierto_people_people(:richard),
         site: sites(:madrid)
       )

--- a/test/models/gobierto_people/person_statement_test.rb
+++ b/test/models/gobierto_people/person_statement_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/user/subscribable_test"
 require "support/concerns/gobierto_common/sluggable_test"
@@ -14,7 +16,7 @@ module GobiertoPeople
 
     def new_person_statement
       GobiertoPeople::PersonStatement.create!(
-        title: 'Person Statement Title',
+        title: "Person Statement Title",
         published_on: Time.zone.now,
         person: gobierto_people_people(:richard),
         site: sites(:madrid)

--- a/test/models/gobierto_people/person_test.rb
+++ b/test/models/gobierto_people/person_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/user/subscribable_test"
 require "support/concerns/gobierto_common/sluggable_test"
@@ -13,7 +15,7 @@ module GobiertoPeople
     alias subscribable person
 
     def new_person
-      ::GobiertoPeople::Person.create!(name: 'Person Name', site: sites(:madrid))
+      ::GobiertoPeople::Person.create!(name: "Person Name", site: sites(:madrid))
     end
     alias create_sluggable new_person
 
@@ -22,7 +24,7 @@ module GobiertoPeople
     end
 
     def test_collection_is_created
-      person = ::GobiertoPeople::Person.create!(name: 'New Person Name', site: sites(:madrid))
+      person = ::GobiertoPeople::Person.create!(name: "New Person Name", site: sites(:madrid))
       assert person.events_collection.present?
     end
   end

--- a/test/models/gobierto_people/political_group_test.rb
+++ b/test/models/gobierto_people/political_group_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/gobierto_common/sluggable_test"
 
@@ -12,7 +14,7 @@ module GobiertoPeople
 
     def new_political_group
       ::GobiertoPeople::PoliticalGroup.create!(
-        name: 'Political Group Name',
+        name: "Political Group Name",
         site: sites(:madrid)
       )
     end

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class IssueTest < ActiveSupport::TestCase
@@ -13,7 +15,7 @@ class IssueTest < ActiveSupport::TestCase
     assert_nil Issue.find_by_slug! nil
     assert_nil Issue.find_by_slug! ""
     assert_raises(ActiveRecord::RecordNotFound) do
-      Issue.find_by_slug!('foo')
+      Issue.find_by_slug!("foo")
     end
 
     assert_equal issue, Issue.find_by_slug!(issue.slug_es)

--- a/test/models/site_configuration_test.rb
+++ b/test/models/site_configuration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SiteConfigurationTest < ActiveSupport::TestCase
@@ -84,13 +86,13 @@ class SiteConfigurationTest < ActiveSupport::TestCase
   def site_configuration_params
     @site_configuration_params ||= begin
       {
-        "modules"           => ["Wadus", "GobiertoDevelopment"], # Note that the "Wadus" module is not standard
+        "modules"           => %w(Wadus GobiertoDevelopment), # Note that the "Wadus" module is not standard
         "logo"              => "gobierto_development.png",
-        "links_markup"      => %Q{<a href="http://madrid.es">Ayuntamiento de Madrid</a>},
+        "links_markup"      => %(<a href="http://madrid.es">Ayuntamiento de Madrid</a>),
         "demo"              => true,
         "wadus"             => "wadus", # Note that this is not a whitelisted property
         "default_locale"    => "ca",
-        "available_locales" => ["ca", "es"],
+        "available_locales" => %w(ca es),
         "site_id"           => site.id,
         "privacy_page_id"   => page.id
       }

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SiteTest < ActiveSupport::TestCase
@@ -51,8 +53,8 @@ class SiteTest < ActiveSupport::TestCase
 
   def test_find_by_allowed_domain
     assert_equal site, Site.find_by_allowed_domain(site.domain)
-    refute Site.find_by_allowed_domain('presupuestos.' + ENV.fetch("HOST"))
-    refute Site.find_by_allowed_domain('foo')
+    refute Site.find_by_allowed_domain("presupuestos." + ENV.fetch("HOST"))
+    refute Site.find_by_allowed_domain("foo")
   end
 
   def test_seeder_called_after_create
@@ -61,9 +63,9 @@ class SiteTest < ActiveSupport::TestCase
                     location_type: INE::Places::Place, external_id: INE::Places::Place.find_by_slug("albacete").id
 
     site.configuration_data = {
-      "links_markup" => %Q{<a href="http://madrid.es">Ayuntamiento de Madrid</a>},
+      "links_markup" => %(<a href="http://madrid.es">Ayuntamiento de Madrid</a>),
       "logo" => "http://www.madrid.es/assets/images/logo-madrid.png",
-      "modules" => ["GobiertoBudgets", "GobiertoBudgetConsultations", "GobiertoPeople"],
+      "modules" => %w(GobiertoBudgets GobiertoBudgetConsultations GobiertoPeople),
       "locale" => "en",
       "google_analytics_id" => "UA-000000-01"
     }
@@ -72,12 +74,11 @@ class SiteTest < ActiveSupport::TestCase
     assert module_site_seeder_spy.has_been_called?
     assert_equal ["GobiertoBudgets", site], module_seeder_spy.calls.first.args
     assert_equal ["gobierto_populate", "GobiertoBudgets", site], module_site_seeder_spy.calls.first.args
-
   end
 
   def test_seeder_called_after_modules_updated
     configuration_data = site.configuration_data
-    configuration_data['modules'].push "GobiertoIndicators"
+    configuration_data["modules"].push "GobiertoIndicators"
     site.configuration_data = configuration_data
     site.save!
     assert module_seeder_spy.has_been_called?

--- a/test/models/user/notification_test.rb
+++ b/test/models/user/notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NotificationTest < ActiveSupport::TestCase

--- a/test/models/user/subscription_test.rb
+++ b/test/models/user/subscription_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::SubscriptionTest < ActiveSupport::TestCase

--- a/test/models/user/verification/census_verification_test.rb
+++ b/test/models/user/verification/census_verification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::Verification::CensusVerificationTest < ActiveSupport::TestCase

--- a/test/models/user/verification_test.rb
+++ b/test/models/user/verification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::VerificationTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/concerns/authentication/authenticable_test"
 require "support/concerns/authentication/confirmable_test"

--- a/test/policies/gobierto_admin/admin_policy_test.rb
+++ b/test/policies/gobierto_admin/admin_policy_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module GobiertoAdmin
   class AdminPolicyTest < ActiveSupport::TestCase

--- a/test/policies/gobierto_admin/gobierto_common/content_block_policy_test.rb
+++ b/test/policies/gobierto_admin/gobierto_common/content_block_policy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/policies/gobierto_admin/layout_policy_test.rb
+++ b/test/policies/gobierto_admin/layout_policy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/policies/gobierto_admin/site_policy_test.rb
+++ b/test/policies/gobierto_admin/site_policy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/presenters/gobierto_admin/gobierto_calendars/person_events_presenter_test.rb
+++ b/test/presenters/gobierto_admin/gobierto_calendars/person_events_presenter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/pub_sub/subscribers/admin_activity_test.rb
+++ b/test/pub_sub/subscribers/admin_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::AdminActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::AdminActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::AdminActivity.new('admins')
+    @subject ||= Subscribers::AdminActivity.new("admins")
   end
 
   def admin
@@ -26,10 +28,10 @@ class Subscribers::AdminActivityTest < ActiveSupport::TestCase
   end
 
   def test_invitation_created_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.invitation_created Event.new(name: "admins/admins.invitation_created", payload: {
-        author: admin, ip: IP
-      })
+                                             author: admin, ip: IP
+                                           })
     end
 
     activity = Activity.last
@@ -42,10 +44,10 @@ class Subscribers::AdminActivityTest < ActiveSupport::TestCase
   end
 
   def test_invitation_accepted_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.invitation_accepted Event.new(name: "admins/admins.invitation_accepted", payload: {
-        subject: admin, author: admin, ip: IP
-      })
+                                              subject: admin, author: admin, ip: IP
+                                            })
     end
 
     activity = Activity.last
@@ -58,10 +60,10 @@ class Subscribers::AdminActivityTest < ActiveSupport::TestCase
   end
 
   def test_admin_created_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.admin_created Event.new(name: "admins/admins.admin_created", payload: {
-        subject: admin_subject, author: admin, ip: IP
-      })
+                                        subject: admin_subject, author: admin, ip: IP
+                                      })
     end
 
     activity = Activity.last
@@ -74,20 +76,20 @@ class Subscribers::AdminActivityTest < ActiveSupport::TestCase
   end
 
   def test_admin_updated_event_handling_no_changes
-    assert_no_difference 'Activity.count' do
+    assert_no_difference "Activity.count" do
       subject.admin_updated Event.new(name: "admins/admins.admin_updated", payload: {
-        subject: admin_subject, author: admin, ip: IP,
-        changes: []
-      })
+                                        subject: admin_subject, author: admin, ip: IP,
+                                        changes: []
+                                      })
     end
   end
 
   def test_admin_updated_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.admin_updated Event.new(name: "admins/admins.admin_updated", payload: {
-        subject: admin_subject, author: admin, ip: IP,
-        changes: ["name" => "Foo"]
-      })
+                                        subject: admin_subject, author: admin, ip: IP,
+                                        changes: ["name" => "Foo"]
+                                      })
     end
 
     activity = Activity.last
@@ -100,11 +102,11 @@ class Subscribers::AdminActivityTest < ActiveSupport::TestCase
   end
 
   def test_admin_updated_event_handling_for_authorization_level_updated
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.admin_updated Event.new(name: "admins/admins.admin_authorization_level_updated", payload: {
-        subject: admin_subject, author: admin, ip: IP,
-        changes: {"authorization_level"=>"manager"}
-      })
+                                        subject: admin_subject, author: admin, ip: IP,
+                                        changes: { "authorization_level" => "manager" }
+                                      })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/census_activity_test.rb
+++ b/test/pub_sub/subscribers/census_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::CensusActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::CensusActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::CensusActivity.new('users')
+    @subject ||= Subscribers::CensusActivity.new("users")
   end
 
   def census_import
@@ -26,10 +28,10 @@ class Subscribers::CensusActivityTest < ActiveSupport::TestCase
   end
 
   def test_census_imported_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.census_imported Event.new(name: "census/census_imported", payload: {
-        author: admin, ip: IP, subject: census_import,
-      })
+                                          author: admin, ip: IP, subject: census_import
+                                        })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/gobierto_attachments_attachment_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_attachments_attachment_activity_test.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoAttachmentsAttachmentActivityTest < ActiveSupport::TestCase
   class Event < OpenStruct; end
 
-  IP = '1.2.3.4'
+  IP = "1.2.3.4"
 
   def site
     @site ||= sites(:madrid)
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoAttachmentsAttachmentActivity.new('activities')
+    @subject ||= Subscribers::GobiertoAttachmentsAttachmentActivity.new("activities")
   end
 
   def attachment
@@ -22,12 +24,12 @@ class Subscribers::GobiertoAttachmentsAttachmentActivityTest < ActiveSupport::Te
   end
 
   def ip_address
-    @ip_address ||= IPAddr.new('1.2.3.4')
+    @ip_address ||= IPAddr.new("1.2.3.4")
   end
 
   def test_attachment_created_event_handling
-    assert_difference 'Activity.count' do
-      subject.attachment_created Event.new(name: 'activities/gobierto_attachments_attachments.attachment_created',
+    assert_difference "Activity.count" do
+      subject.attachment_created Event.new(name: "activities/gobierto_attachments_attachments.attachment_created",
                                            payload: { subject: attachment, author: admin, ip: IP, site_id: site.id })
     end
 
@@ -35,14 +37,14 @@ class Subscribers::GobiertoAttachmentsAttachmentActivityTest < ActiveSupport::Te
     assert_equal attachment, activity.subject
     assert_equal admin, activity.author
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'gobierto_attachments.attachment_created', activity.action
+    assert_equal "gobierto_attachments.attachment_created", activity.action
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
   end
 
   def test_attachment_updated_event_handling
-    assert_difference 'Activity.count' do
-      subject.attachment_updated Event.new(name: 'activities/gobierto_attachments_attachments.attachment_updated',
+    assert_difference "Activity.count" do
+      subject.attachment_updated Event.new(name: "activities/gobierto_attachments_attachments.attachment_updated",
                                            payload: { subject: attachment, author: admin, ip: IP, site_id: site.id })
     end
 
@@ -50,7 +52,7 @@ class Subscribers::GobiertoAttachmentsAttachmentActivityTest < ActiveSupport::Te
     assert_equal attachment, activity.subject
     assert_equal admin, activity.author
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'gobierto_attachments.attachment_updated', activity.action
+    assert_equal "gobierto_attachments.attachment_updated", activity.action
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
   end

--- a/test/pub_sub/subscribers/gobierto_budget_consultations_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_budget_consultations_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoBudgetConsultationsTest < ActiveSupport::TestCase
@@ -14,31 +16,31 @@ class Subscribers::GobiertoBudgetConsultationsTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoBudgetConsultationsActivity.new('trackable')
+    @subject ||= Subscribers::GobiertoBudgetConsultationsActivity.new("trackable")
   end
 
   def test_event_updated_for_non_gobierto_budget_consultations_event
-    assert_no_difference 'Activity.count' do
+    assert_no_difference "Activity.count" do
       subject.updated Event.new(name: "foo", payload: {
-        gid: users(:dennis).to_gid, admin_id: admin.id,  site_id: site.id
-      })
+                                  gid: users(:dennis).to_gid, admin_id: admin.id, site_id: site.id
+                                })
     end
   end
 
   def test_event_updated_for_gobierto_budget_consultation_consultation
     activity_subject = gobierto_budget_consultations_consultations(:madrid_open)
 
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.updated Event.new(name: "trackable", payload: {
-        gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
-      })
+                                  gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
+                                })
     end
 
     activity = Activity.last
     assert_equal activity_subject, activity.subject
     assert_equal admin, activity.author
     assert_equal "gobierto_budget_consultations.consultation.updated", activity.action
-    assert_nil   activity.recipient
+    assert_nil activity.recipient
     refute activity.admin_activity
     assert_equal site.id, activity.site_id
   end
@@ -46,17 +48,17 @@ class Subscribers::GobiertoBudgetConsultationsTest < ActiveSupport::TestCase
   def test_event_visibility_level_changed_for_gobierto_budget_consultations_consultation
     activity_subject = gobierto_budget_consultations_consultations(:madrid_open)
 
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.visibility_level_changed Event.new(name: "trackable", payload: {
-        gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
-      })
+                                                   gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
+                                                 })
     end
 
     activity = Activity.last
     assert_equal activity_subject, activity.subject
     assert_equal admin, activity.author
     assert_equal "gobierto_budget_consultations.consultation.published", activity.action
-    assert_nil   activity.recipient
+    assert_nil activity.recipient
     refute activity.admin_activity
     assert_equal site.id, activity.site_id
   end

--- a/test/pub_sub/subscribers/gobierto_budget_consultations_consultation_response_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_budget_consultations_consultation_response_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoBudgetConsultationsConsultationResponseActivityTest < ActiveSupport::TestCase
@@ -18,7 +20,7 @@ class Subscribers::GobiertoBudgetConsultationsConsultationResponseActivityTest <
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoBudgetConsultationsConsultationResponseActivity.new('activities/gobierto_budget_consultations_consultation_response')
+    @subject ||= Subscribers::GobiertoBudgetConsultationsConsultationResponseActivity.new("activities/gobierto_budget_consultations_consultation_response")
   end
 
   def activity_subject
@@ -26,10 +28,10 @@ class Subscribers::GobiertoBudgetConsultationsConsultationResponseActivityTest <
   end
 
   def test_event_created
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.consultation_response_created Event.new(name: "consultation_response_created", payload: {
-        author: admin,  site_id: site.id, subject: activity_subject, recipient: consultation, ip: IP
-      })
+                                                        author: admin, site_id: site.id, subject: activity_subject, recipient: consultation, ip: IP
+                                                      })
     end
 
     activity = Activity.last
@@ -39,14 +41,13 @@ class Subscribers::GobiertoBudgetConsultationsConsultationResponseActivityTest <
     assert_equal consultation, activity.recipient
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
-
   end
 
   def test_event_deleted
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.consultation_response_deleted Event.new(name: "consultation_response_deleted", payload: {
-        author: admin, site_id: site.id, subject: activity_subject, recipient: consultation, ip: IP
-      })
+                                                        author: admin, site_id: site.id, subject: activity_subject, recipient: consultation, ip: IP
+                                                      })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/gobierto_budgets_budget_line_test.rb
+++ b/test/pub_sub/subscribers/gobierto_budgets_budget_line_test.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoBudgetsBudgetLineActivityTest < ActiveSupport::TestCase
   class Event < OpenStruct; end
 
-  LOCALHOST = '127.0.0.1'
+  LOCALHOST = "127.0.0.1"
 
   def site
     @site ||= sites(:madrid)
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoBudgetsBudgetLineActivity.new('activities')
+    @subject ||= Subscribers::GobiertoBudgetsBudgetLineActivity.new("activities")
   end
 
   def ip_address
@@ -19,18 +21,17 @@ class Subscribers::GobiertoBudgetsBudgetLineActivityTest < ActiveSupport::TestCa
 
   def create_event(index, area)
     Event.new(name: "gobierto_budgets.budgets_#{index}_#{area.area_name}_updated",
-      payload: {
-        subject: site,
-        ip: LOCALHOST,
-        site_id: site.id
-      }
-    )
+              payload: {
+                subject: site,
+                ip: LOCALHOST,
+                site_id: site.id
+              })
   end
 
   def test_budgets_forecast_economic_updated_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.budgets_forecast_economic_updated(
-        create_event('forecast', GobiertoBudgets::EconomicArea)
+        create_event("forecast", GobiertoBudgets::EconomicArea)
       )
     end
 
@@ -38,74 +39,73 @@ class Subscribers::GobiertoBudgetsBudgetLineActivityTest < ActiveSupport::TestCa
 
     assert_equal site, activity.subject
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'gobierto_budgets.budgets_forecast_economic_updated', activity.action
+    assert_equal "gobierto_budgets.budgets_forecast_economic_updated", activity.action
     assert_equal site.id, activity.site_id
     refute activity.admin_activity
   end
 
   def test_budgets_forecast_functional_updated_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.budgets_forecast_functional_updated(
-        create_event('forecast', GobiertoBudgets::FunctionalArea)
+        create_event("forecast", GobiertoBudgets::FunctionalArea)
       )
     end
 
     activity = Activity.last
 
     assert_equal site, activity.subject
-    assert_equal 'gobierto_budgets.budgets_forecast_functional_updated', activity.action
+    assert_equal "gobierto_budgets.budgets_forecast_functional_updated", activity.action
   end
 
   def test_budgets_forecast_custom_updated_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.budgets_forecast_custom_updated(
-        create_event('forecast', GobiertoBudgets::CustomArea)
+        create_event("forecast", GobiertoBudgets::CustomArea)
       )
     end
 
     activity = Activity.last
 
     assert_equal site, activity.subject
-    assert_equal 'gobierto_budgets.budgets_forecast_custom_updated', activity.action
+    assert_equal "gobierto_budgets.budgets_forecast_custom_updated", activity.action
   end
 
   def test_budgets_execution_economic_updated_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.budgets_execution_economic_updated(
-        create_event('execution', GobiertoBudgets::EconomicArea)
+        create_event("execution", GobiertoBudgets::EconomicArea)
       )
     end
 
     activity = Activity.last
 
     assert_equal site, activity.subject
-    assert_equal 'gobierto_budgets.budgets_execution_economic_updated', activity.action
+    assert_equal "gobierto_budgets.budgets_execution_economic_updated", activity.action
   end
 
   def test_budgets_execution_functional_updated_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.budgets_execution_functional_updated(
-        create_event('execution', GobiertoBudgets::FunctionalArea)
+        create_event("execution", GobiertoBudgets::FunctionalArea)
       )
     end
 
     activity = Activity.last
 
     assert_equal site, activity.subject
-    assert_equal 'gobierto_budgets.budgets_execution_functional_updated', activity.action
+    assert_equal "gobierto_budgets.budgets_execution_functional_updated", activity.action
   end
 
   def test_budgets_execution_custom_updated_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.budgets_execution_custom_updated(
-        create_event('execution', GobiertoBudgets::CustomArea)
+        create_event("execution", GobiertoBudgets::CustomArea)
       )
     end
 
     activity = Activity.last
 
     assert_equal site, activity.subject
-    assert_equal 'gobierto_budgets.budgets_execution_custom_updated', activity.action
+    assert_equal "gobierto_budgets.budgets_execution_custom_updated", activity.action
   end
-
 end

--- a/test/pub_sub/subscribers/gobierto_calendars_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_calendars_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoCalendarsActivityTest < ActiveSupport::TestCase
@@ -14,16 +16,16 @@ class Subscribers::GobiertoCalendarsActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoCalendarsActivity.new('trackable')
+    @subject ||= Subscribers::GobiertoCalendarsActivity.new("trackable")
   end
 
   def test_event_updated_for_gobierto_calendars_event
     activity_subject = gobierto_calendars_events(:richard_published)
 
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.updated Event.new(name: "trackable", payload: {
-        gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
-      })
+                                  gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
+                                })
     end
 
     activity = Activity.last
@@ -38,10 +40,10 @@ class Subscribers::GobiertoCalendarsActivityTest < ActiveSupport::TestCase
   def test_event_visibility_level_changed_for_gobierto_calendars_event
     activity_subject = gobierto_calendars_events(:richard_published)
 
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.visibility_level_changed Event.new(name: "trackable", payload: {
-        gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
-      })
+                                                   gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
+                                                 })
     end
 
     activity = Activity.last
@@ -56,10 +58,10 @@ class Subscribers::GobiertoCalendarsActivityTest < ActiveSupport::TestCase
   def test_event_state_changed_for_gobierto_calendars_event
     activity_subject = gobierto_calendars_events(:richard_published)
 
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.visibility_level_changed Event.new(name: "trackable", payload: {
-        gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
-      })
+                                                   gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
+                                                 })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/gobierto_cms_page_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_cms_page_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoCmsPageActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::GobiertoCmsPageActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoCmsPageActivity.new('activities')
+    @subject ||= Subscribers::GobiertoCmsPageActivity.new("activities")
   end
 
   def page
@@ -26,10 +28,10 @@ class Subscribers::GobiertoCmsPageActivityTest < ActiveSupport::TestCase
   end
 
   def test_page_created_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.page_created Event.new(name: "activities/gobierto_cms_pages.page_created", payload: {
-        subject: page, author: admin, ip: IP, site_id: site.id
-      })
+                                       subject: page, author: admin, ip: IP, site_id: site.id
+                                     })
     end
 
     activity = Activity.last
@@ -42,10 +44,10 @@ class Subscribers::GobiertoCmsPageActivityTest < ActiveSupport::TestCase
   end
 
   def test_page_updated_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.page_updated Event.new(name: "activities/gobierto_cms_pages.page_updated", payload: {
-        subject: page, author: admin, ip: IP, site_id: site.id
-      })
+                                       subject: page, author: admin, ip: IP, site_id: site.id
+                                     })
     end
 
     activity = Activity.last
@@ -58,10 +60,10 @@ class Subscribers::GobiertoCmsPageActivityTest < ActiveSupport::TestCase
   end
 
   def test_page_deleted_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.page_deleted Event.new(name: "activities/gobierto_cms_pages.page_deleted", payload: {
-        subject: page, author: admin, ip: IP, site_id: site.id
-      })
+                                       subject: page, author: admin, ip: IP, site_id: site.id
+                                     })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/gobierto_common_collection_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_common_collection_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoCommonCollectionActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::GobiertoCommonCollectionActivityTest < ActiveSupport::TestCas
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoCommonCollectionActivity.new('activities')
+    @subject ||= Subscribers::GobiertoCommonCollectionActivity.new("activities")
   end
 
   def collection
@@ -26,10 +28,10 @@ class Subscribers::GobiertoCommonCollectionActivityTest < ActiveSupport::TestCas
   end
 
   def test_collection_created_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.collection_created Event.new(name: "activities/gobierto_common_collections.collection_created", payload: {
-        subject: collection, author: admin, ip: IP, site_id: site.id
-      })
+                                             subject: collection, author: admin, ip: IP, site_id: site.id
+                                           })
     end
 
     activity = Activity.last
@@ -42,10 +44,10 @@ class Subscribers::GobiertoCommonCollectionActivityTest < ActiveSupport::TestCas
   end
 
   def test_collection_updated_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.collection_updated Event.new(name: "activities/gobierto_common_collections.collection_updated", payload: {
-        subject: collection, author: admin, ip: IP, site_id: site.id
-      })
+                                             subject: collection, author: admin, ip: IP, site_id: site.id
+                                           })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/gobierto_participation_process_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_participation_process_activity_test.rb
@@ -1,16 +1,18 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 class Subscribers::GobiertoParticipationProcessActivityTest < ActiveSupport::TestCase
   class Event < OpenStruct; end
 
-  IP = '1.2.3.4'
+  IP = "1.2.3.4"
 
   def site
     @site ||= sites(:madrid)
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoParticipationProcessActivity.new('activities')
+    @subject ||= Subscribers::GobiertoParticipationProcessActivity.new("activities")
   end
 
   def process
@@ -22,37 +24,37 @@ class Subscribers::GobiertoParticipationProcessActivityTest < ActiveSupport::Tes
   end
 
   def ip_address
-    @ip_address ||= IPAddr.new('1.2.3.4')
+    @ip_address ||= IPAddr.new("1.2.3.4")
   end
 
   def test_process_created_event_handling
-    assert_difference 'Activity.count' do
-      subject.process_created Event.new(name: 'activities/gobierto_participation_processes.process_created', payload: {
-        subject: process, author: admin, ip: IP, site_id: site.id
-      })
+    assert_difference "Activity.count" do
+      subject.process_created Event.new(name: "activities/gobierto_participation_processes.process_created", payload: {
+                                          subject: process, author: admin, ip: IP, site_id: site.id
+                                        })
     end
 
     activity = Activity.last
     assert_equal process, activity.subject
     assert_equal admin, activity.author
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'gobierto_participation.process_created', activity.action
+    assert_equal "gobierto_participation.process_created", activity.action
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
   end
 
   def test_process_updated_event_handling
-    assert_difference 'Activity.count' do
-      subject.process_updated Event.new(name: 'activities/gobierto_participation_processes.process_updated', payload: {
-        subject: process, author: admin, ip: IP, site_id: site.id
-      })
+    assert_difference "Activity.count" do
+      subject.process_updated Event.new(name: "activities/gobierto_participation_processes.process_updated", payload: {
+                                          subject: process, author: admin, ip: IP, site_id: site.id
+                                        })
     end
 
     activity = Activity.last
     assert_equal process, activity.subject
     assert_equal admin, activity.author
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'gobierto_participation.process_updated', activity.action
+    assert_equal "gobierto_participation.process_updated", activity.action
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
   end

--- a/test/pub_sub/subscribers/gobierto_people_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_people_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::GobiertoPeopleActivityTest < ActiveSupport::TestCase
@@ -14,24 +16,24 @@ class Subscribers::GobiertoPeopleActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::GobiertoPeopleActivity.new('trackable')
+    @subject ||= Subscribers::GobiertoPeopleActivity.new("trackable")
   end
 
   def test_event_updated_for_non_gobierto_people_event
-    assert_no_difference 'Activity.count' do
+    assert_no_difference "Activity.count" do
       subject.updated Event.new(name: "foo", payload: {
-        gid: users(:dennis).to_gid, admin_id: admin.id,  site_id: site.id
-      })
+                                  gid: users(:dennis).to_gid, admin_id: admin.id, site_id: site.id
+                                })
     end
   end
 
   def test_event_updated_for_gobierto_people_person
     activity_subject = gobierto_people_people(:richard)
 
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.updated Event.new(name: "trackable", payload: {
-        gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
-      })
+                                  gid: activity_subject.to_gid, admin_id: admin.id, site_id: site.id
+                                })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/issue_activity_test.rb
+++ b/test/pub_sub/subscribers/issue_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::IssueActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::IssueActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::IssueActivity.new('activities')
+    @subject ||= Subscribers::IssueActivity.new("activities")
   end
 
   def issue
@@ -22,12 +24,12 @@ class Subscribers::IssueActivityTest < ActiveSupport::TestCase
   end
 
   def ip_address
-    @ip_address ||= IPAddr.new('1.2.3.4')
+    @ip_address ||= IPAddr.new("1.2.3.4")
   end
 
   def test_issue_created_event_handling
-    assert_difference 'Activity.count' do
-      subject.issue_created Event.new(name: 'activities/issues.issue_created',
+    assert_difference "Activity.count" do
+      subject.issue_created Event.new(name: "activities/issues.issue_created",
                                       payload: { subject: issue,
                                                  author: admin,
                                                  ip: IP,
@@ -38,14 +40,14 @@ class Subscribers::IssueActivityTest < ActiveSupport::TestCase
     assert_equal issue, activity.subject
     assert_equal admin, activity.author
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'issues.issue_created', activity.action
+    assert_equal "issues.issue_created", activity.action
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
   end
 
   def test_issue_updated_event_handling
-    assert_difference 'Activity.count' do
-      subject.issue_updated Event.new(name: 'activities/issues.issue_updated',
+    assert_difference "Activity.count" do
+      subject.issue_updated Event.new(name: "activities/issues.issue_updated",
                                       payload: { subject: issue,
                                                  author: admin,
                                                  ip: IP,
@@ -56,7 +58,7 @@ class Subscribers::IssueActivityTest < ActiveSupport::TestCase
     assert_equal issue, activity.subject
     assert_equal admin, activity.author
     assert_equal ip_address, activity.subject_ip
-    assert_equal 'issues.issue_updated', activity.action
+    assert_equal "issues.issue_updated", activity.action
     assert activity.admin_activity
     assert_equal site.id, activity.site_id
   end

--- a/test/pub_sub/subscribers/site_activity_test.rb
+++ b/test/pub_sub/subscribers/site_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::SiteActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::SiteActivity.new('activities')
+    @subject ||= Subscribers::SiteActivity.new("activities")
   end
 
   def admin
@@ -39,10 +41,10 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_created_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.site_created Event.new(name: "activities/sites.site_created", payload: {
-        subject: site, author: admin, ip: IP
-      })
+                                       subject: site, author: admin, ip: IP
+                                     })
     end
 
     activity = Activity.last
@@ -55,20 +57,20 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_updated_event_handling_for_empty_changes
-    refute_difference 'Activity.count' do
+    refute_difference "Activity.count" do
       subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
-        subject: site, author: admin, ip: IP,
-        changes: {}
-      })
+                                       subject: site, author: admin, ip: IP,
+                                       changes: {}
+                                     })
     end
   end
 
   def test_site_updated_event_handling_for_site_updated_activity
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
-        subject: site, author: admin, ip: IP,
-        changes: {"name"=>["Ayuntamiento de Madrid", "Ayuntamiento de los Madriles"]}
-      })
+                                       subject: site, author: admin, ip: IP,
+                                       changes: { "name" => ["Ayuntamiento de Madrid", "Ayuntamiento de los Madriles"] }
+                                     })
     end
 
     activity = Activity.last
@@ -81,11 +83,11 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_updated_event_handling_for_site_visibility_updated_activity
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
-        subject: site, author: admin, ip: IP,
-        changes: {"visibility_level"=>["active", "draft"]}
-      })
+                                       subject: site, author: admin, ip: IP,
+                                       changes: { "visibility_level" => %w(active draft) }
+                                     })
     end
 
     activity = Activity.last
@@ -98,11 +100,11 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_updated_event_handling_for_site_modules_updated_activity
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
-        subject: site, author: admin, ip: IP,
-        changes: configuration_data_modules_updated
-      })
+                                       subject: site, author: admin, ip: IP,
+                                       changes: configuration_data_modules_updated
+                                     })
     end
 
     activity = Activity.last
@@ -115,15 +117,15 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_updated_event_handling_for_multiple_changes
-    assert_difference 'Activity.count', 3 do
+    assert_difference "Activity.count", 3 do
       subject.site_updated Event.new(name: "activities/sites.site_updated", payload: {
-        subject: site, author: admin, ip: IP,
-        changes: {
-          "visibility_level"=>["active", "draft"],
-          "name"=>["Ayuntamiento de Madrid", "Ayuntamiento de los Madriles"],
-          "configuration_data" => configuration_data_modules_updated["configuration_data"]
-        }
-      })
+                                       subject: site, author: admin, ip: IP,
+                                       changes: {
+                                         "visibility_level" => %w(active draft),
+                                         "name" => ["Ayuntamiento de Madrid", "Ayuntamiento de los Madriles"],
+                                         "configuration_data" => configuration_data_modules_updated["configuration_data"]
+                                       }
+                                     })
     end
 
     last_activities_action = Activity.all[1..-1].pluck(:action)
@@ -133,12 +135,12 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
   end
 
   def test_site_deleted_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       site.destroy
 
       subject.site_deleted Event.new(name: "activities/sites.site_destroyed", payload: {
-        subject: site, author: admin, ip: IP
-      })
+                                       subject: site, author: admin, ip: IP
+                                     })
     end
 
     activity = Activity.last

--- a/test/pub_sub/subscribers/user_activity_test.rb
+++ b/test/pub_sub/subscribers/user_activity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Subscribers::UserActivityTest < ActiveSupport::TestCase
@@ -10,7 +12,7 @@ class Subscribers::UserActivityTest < ActiveSupport::TestCase
   end
 
   def subject
-    @subject ||= Subscribers::UserActivity.new('users')
+    @subject ||= Subscribers::UserActivity.new("users")
   end
 
   def user
@@ -26,11 +28,11 @@ class Subscribers::UserActivityTest < ActiveSupport::TestCase
   end
 
   def test_user_updated_event_handling
-    assert_difference 'Activity.count' do
+    assert_difference "Activity.count" do
       subject.user_updated Event.new(name: "users/user_updated", payload: {
-        author: admin, ip: IP, subject: user,
-        changes: { name: 'Foo' }
-      })
+                                       author: admin, ip: IP, subject: user,
+                                       changes: { name: "Foo" }
+                                     })
     end
 
     activity = Activity.last

--- a/test/repositories/census_repository_test.rb
+++ b/test/repositories/census_repository_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CensusRepositoryTest < ActiveSupport::TestCase
@@ -48,7 +50,6 @@ class CensusRepositoryTest < ActiveSupport::TestCase
   end
 
   def test_parse_document_number
-
     document_numbers = ["12345678A", " 1234 5678 a ", "ñ1?23 45*6¿78--a"]
 
     document_numbers.each do |document_number|
@@ -65,7 +66,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
   def test_exists?
     refute census_repository.exists?
 
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "00000000A",
       date_of_birth: census_item.date_of_birth
@@ -75,7 +76,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
   end
 
   def test_exists_with_no_letter?
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "12345678",
       date_of_birth: Date.parse("1998-01-01")
@@ -83,7 +84,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
 
     assert existing_census_repository.exists?
 
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "12345678A",
       date_of_birth: Date.parse("1998-01-01")
@@ -93,7 +94,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
   end
 
   def test_exists_with_special_letters
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "x5104959v",
       date_of_birth: Date.parse("1998-01-01")
@@ -101,7 +102,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
 
     assert existing_census_repository.exists?
 
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "x05104959v",
       date_of_birth: Date.parse("1998-01-01")
@@ -109,7 +110,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
 
     assert existing_census_repository.exists?
 
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "05104959v",
       date_of_birth: Date.parse("1998-01-01")
@@ -117,7 +118,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
 
     assert existing_census_repository.exists?
 
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "x05104959",
       date_of_birth: Date.parse("1998-01-01")
@@ -125,7 +126,7 @@ class CensusRepositoryTest < ActiveSupport::TestCase
 
     assert existing_census_repository.exists?
 
-    existing_census_repository =  CensusRepository.new(
+    existing_census_repository = CensusRepository.new(
       site_id: census_item.site_id,
       document_number: "X5104959",
       date_of_birth: Date.parse("1998-01-01")

--- a/test/services/gobierto_admin/admin_invitation_builder_test.rb
+++ b/test/services/gobierto_admin/admin_invitation_builder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module GobiertoAdmin

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/file_uploader_helpers"
 

--- a/test/services/gobierto_admin/gobierto_budget_consultations/budget_line_collection_builder_test.rb
+++ b/test/services/gobierto_admin/gobierto_budget_consultations/budget_line_collection_builder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "support/populate_data_helpers"
 

--- a/test/services/gobierto_budget_consultations/csv_exporter_test.rb
+++ b/test/services/gobierto_budget_consultations/csv_exporter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoBudgetConsultations::CsvExporterTest < ActiveSupport::TestCase
@@ -12,12 +14,12 @@ class GobiertoBudgetConsultations::CsvExporterTest < ActiveSupport::TestCase
 
   def test_export
     csv = @subject.export(consultation)
-    assert_equal csv, <<-CSV
-id,age,gender,location,question,answer
-692345489,35,male,,Pavimentación de vías públicas,-5
-692345489,35,male,,Inversión en Instalaciones Deportivas,5
-112679343,,,,Pavimentación de vías públicas,5
-112679343,,,,Inversión en Instalaciones Deportivas,5
+    assert_equal csv, <<~CSV
+      id,age,gender,location,question,answer
+      692345489,35,male,,Pavimentación de vías públicas,-5
+      692345489,35,male,,Inversión en Instalaciones Deportivas,5
+      112679343,,,,Pavimentación de vías públicas,5
+      112679343,,,,Inversión en Instalaciones Deportivas,5
 CSV
   end
 end

--- a/test/services/gobierto_common/active_notifier/daily_test.rb
+++ b/test/services/gobierto_common/active_notifier/daily_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoCommon::ActiveNotifier::DailyTest < ActiveSupport::TestCase

--- a/test/services/gobierto_common/gobierto_seeder/module_seeder_test.rb
+++ b/test/services/gobierto_common/gobierto_seeder/module_seeder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoCommon::GobiertoSeeder::ModuleSeederTest < ActiveSupport::TestCase

--- a/test/services/gobierto_common/gobierto_seeder/module_site_seeder_test.rb
+++ b/test/services/gobierto_common/gobierto_seeder/module_site_seeder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class GobiertoCommon::GobiertoSeeder::ModuleSiteSeederTest < ActiveSupport::TestCase

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -1,10 +1,11 @@
-require 'test_helper'
-require 'support/calendar_integration_helpers'
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/calendar_integration_helpers"
 
 module GobiertoPeople
   module GoogleCalendar
     class CalendarIntegrationTest < ActiveSupport::TestCase
-
       include ::CalendarIntegrationHelpers
 
       def richard
@@ -16,89 +17,89 @@ module GobiertoPeople
       end
 
       def google_calendar_id
-        'richard@google-calendar.com'
+        "richard@google-calendar.com"
       end
 
       def setup
         super
 
         ## Mocks
-        date1 = mock()
+        date1 = mock
         date1.stubs(date_time: Time.now)
-        date2 = mock()
+        date2 = mock
         date2.stubs(date_time: 1.hour.from_now)
 
         # Private event, ignored
-        event1 = mock()
-        event1.stubs(visibility: 'private')
+        event1 = mock
+        event1.stubs(visibility: "private")
 
-        creator_event2 = mock()
+        creator_event2 = mock
         creator_event2.stubs(email: google_calendar_id)
 
-        creator_event3 = mock()
+        creator_event3 = mock
         creator_event3.stubs(email: google_calendar_id)
 
-        attendee1 = mock()
+        attendee1 = mock
         attendee1.stubs(self?: true, display_name: richard.name, email: google_calendar_id)
 
-        attendee2 = mock()
-        attendee2.stubs(self?: false, display_name: 'Wadus person', email: nil)
+        attendee2 = mock
+        attendee2.stubs(self?: false, display_name: "Wadus person", email: nil)
 
         # Single event, organized by richard, with two attendees, from calendar that is not selected
-        event7 = mock()
-        event7.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: 'event7',
-                     summary: 'Event 7', start: date1, end: date2, attendees: [attendee1, attendee2])
+        event7 = mock
+        event7.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: "event7",
+                     summary: "Event 7", start: date1, end: date2, attendees: [attendee1, attendee2])
 
         # Single event, organized by richard, with two attendees
-        event2 = mock()
-        event2.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: 'event2',
-                     summary: 'Event 2', start: date1, end: date2, attendees: [attendee1, attendee2])
+        event2 = mock
+        event2.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: "event2",
+                     summary: "Event 2", start: date1, end: date2, attendees: [attendee1, attendee2])
 
         # Single event, organized by other, Richard is invited
-        event3 = mock()
-        event3.stubs(visibility: nil, location: 'Patio de mi casa 1, 28005, Madrid', creator: creator_event3, recurrence: nil, id: 'event3',
-                     summary: 'Event 3', start: date1, end: date2, attendees: [attendee1, attendee2])
+        event3 = mock
+        event3.stubs(visibility: nil, location: "Patio de mi casa 1, 28005, Madrid", creator: creator_event3, recurrence: nil, id: "event3",
+                     summary: "Event 3", start: date1, end: date2, attendees: [attendee1, attendee2])
 
         # Recurring event
-        event4 = mock()
-        event4.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: ["WEEK=1"], id: 'event4',
-                     summary: 'Event 4', start: date1, end: date2, attendees: [attendee1, attendee2])
+        event4 = mock
+        event4.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: ["WEEK=1"], id: "event4",
+                     summary: "Event 4", start: date1, end: date2, attendees: [attendee1, attendee2])
 
         # Instance 1 of recurring event event4
-        event5 = mock()
-        event5.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: 'event4_instance_1',
-                     summary: 'Event 5', start: date1, end: date2, attendees: [attendee1, attendee2])
+        event5 = mock
+        event5.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_1",
+                     summary: "Event 5", start: date1, end: date2, attendees: [attendee1, attendee2])
 
         # Instance 2 of recurring event event4
-        event6 = mock()
-        event6.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: 'event4_instance_2',
-                     summary: 'Event 6', start: date1, end: date2, attendees: [attendee1, attendee2])
+        event6 = mock
+        event6.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_2",
+                     summary: "Event 6", start: date1, end: date2, attendees: [attendee1, attendee2])
 
-        calendar1 = mock()
+        calendar1 = mock
         calendar1.stubs(id: google_calendar_id, primary?: true)
 
-        calendar2 = mock()
+        calendar2 = mock
         calendar2.stubs(id: 2, primary?: false)
 
-        calendar3 = mock()
+        calendar3 = mock
         calendar3.stubs(id: 3, primary?: false)
 
-        calendar_1_items_response = mock()
+        calendar_1_items_response = mock
         calendar_1_items_response.stubs(:items).returns([event1, event2])
 
-        calendar_2_items_response = mock()
+        calendar_2_items_response = mock
         calendar_2_items_response.stubs(:items).returns([event3, event4])
 
-        calendar_3_items_response = mock()
+        calendar_3_items_response = mock
         calendar_3_items_response.stubs(:items).returns([event7])
 
-        event_4_instances_response = mock()
+        event_4_instances_response = mock
         event_4_instances_response.stubs(:items).returns([event5, event6])
 
-        calendar_items_response = mock()
+        calendar_items_response = mock
         calendar_items_response.stubs(:items).returns([calendar1, calendar2, calendar3])
 
-        client_options = mock()
+        client_options = mock
         client_options.stubs(:application_name=).returns(true)
 
         ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_calendar_lists).returns(calendar_items_response)
@@ -111,67 +112,67 @@ module GobiertoPeople
 
         ## Configure site and person
         activate_google_calendar_calendar_integration(sites(:madrid))
-        configure_google_calendar_integration(richard, { calendars: [calendar1.id, calendar2.id] })
+        configure_google_calendar_integration(richard, calendars: [calendar1.id, calendar2.id])
       end
 
       def test_sync_events
         Publishers::Trackable.expects(:broadcast_event).times(3)
 
-        assert_difference 'GobiertoCalendars::Event.count', 4 do
+        assert_difference "GobiertoCalendars::Event.count", 4 do
           CalendarIntegration.sync_person_events(richard)
         end
 
         # Event 2 checks
-        event = richard.events.find_by external_id: 'event2'
-        assert_equal 'Event 2', event.title
+        event = richard.events.find_by external_id: "event2"
+        assert_equal "Event 2", event.title
         assert_empty event.locations
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
         assert_nil event.attendees.second.person
-        assert_equal 'Wadus person', event.attendees.second.name
+        assert_equal "Wadus person", event.attendees.second.name
 
         # Event 3 checks
-        event = site.events.find_by external_id: 'event3'
-        assert_equal 'Event 3', event.title
-        assert_equal 'Patio de mi casa 1, 28005, Madrid', event.locations.first.name
+        event = site.events.find_by external_id: "event3"
+        assert_equal "Event 3", event.title
+        assert_equal "Patio de mi casa 1, 28005, Madrid", event.locations.first.name
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
-        assert_equal 'Wadus person', event.attendees.second.name
+        assert_equal "Wadus person", event.attendees.second.name
 
         # Event 5 checks
-        event = site.events.find_by external_id: 'event4_instance_1'
-        assert_equal 'Event 5', event.title
+        event = site.events.find_by external_id: "event4_instance_1"
+        assert_equal "Event 5", event.title
         assert_empty event.locations
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
-        assert_equal 'Wadus person', event.attendees.second.name
+        assert_equal "Wadus person", event.attendees.second.name
 
         # Event 6 checks
-        event = site.events.find_by external_id: 'event4_instance_2'
-        assert_equal 'Event 6', event.title
+        event = site.events.find_by external_id: "event4_instance_2"
+        assert_equal "Event 6", event.title
         assert_empty event.locations
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
-        assert_equal 'Wadus person', event.attendees.second.name
+        assert_equal "Wadus person", event.attendees.second.name
       end
 
       def test_sync_events_updates_event_attributes
         CalendarIntegration.sync_person_events(richard)
 
-        event = richard.events.find_by external_id: 'event2'
-        event.title = 'Event 2 updated'
+        event = richard.events.find_by external_id: "event2"
+        event.title = "Event 2 updated"
         event.save
 
         CalendarIntegration.sync_person_events(richard)
 
         event.reload
-        assert_equal 'Event 2', event.title
+        assert_equal "Event 2", event.title
       end
 
       def test_sync_events_removes_deleted_event_attributes
         CalendarIntegration.sync_person_events(richard)
 
-        event = richard.events.find_by external_id: 'event2'
+        event = richard.events.find_by external_id: "event2"
         GobiertoCalendars::EventLocation.create!(event: event, name: "I'll be deleted")
 
         CalendarIntegration.sync_person_events(richard)
@@ -183,7 +184,7 @@ module GobiertoPeople
       def test_sync_attendees
         CalendarIntegration.sync_person_events(richard)
 
-        event = richard.events.find_by external_id: 'event2'
+        event = richard.events.find_by external_id: "event2"
         event.attendees.second.delete
 
         CalendarIntegration.sync_person_events(richard)

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -1,10 +1,11 @@
-require 'test_helper'
-require 'support/calendar_integration_helpers'
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/calendar_integration_helpers"
 
 module GobiertoPeople
   module IbmNotes
     class CalendarIntegrationTest < ActiveSupport::TestCase
-
       include ::CalendarIntegrationHelpers
 
       def richard
@@ -25,49 +26,47 @@ module GobiertoPeople
       end
 
       def rst_to_utc(date)
-        ActiveSupport::TimeZone['Madrid'].parse(date).utc
+        ActiveSupport::TimeZone["Madrid"].parse(date).utc
       end
 
       def setup
         super
         activate_ibm_notes_calendar_integration(sites(:madrid))
-        set_ibm_notes_calendar_endpoint(richard, 'https://host.wadus.com/mail/foo.nsf/api/calendar/events')
+        set_ibm_notes_calendar_endpoint(richard, "https://host.wadus.com/mail/foo.nsf/api/calendar/events")
       end
 
       def create_ibm_notes_event(params = {})
-        ::IbmNotes::PersonEvent.new(richard, {
-          'id'       => params[:id] || 'Ibm Notes event ID',
-          'summary'  => params[:summary] || 'Ibm Notes event summary',
-          'location' => params.has_key?(:location) ? params[:location] : 'Ibm Notes event location',
-          'start'    => { 'date' => '2017-04-11', 'time' => '10:00:00', 'utc' => true },
-          'end'      => { 'date' => '2017-04-11', 'time' => '11:00:00', 'utc' => true }
-        })
+        ::IbmNotes::PersonEvent.new(richard, "id" => params[:id] || "Ibm Notes event ID",
+                                             "summary"  => params[:summary] || "Ibm Notes event summary",
+                                             "location" => params.has_key?(:location) ? params[:location] : "Ibm Notes event location",
+                                             "start"    => { "date" => "2017-04-11", "time" => "10:00:00", "utc" => true },
+                                             "end"      => { "date" => "2017-04-11", "time" => "11:00:00", "utc" => true })
       end
 
       def new_ibm_notes_event
         @new_ibm_notes_event ||= create_ibm_notes_event(
-          id: 'Ibm Notes new event ID',
-          summary: 'Ibm Notes new event summary',
-          location: 'Ibm Notes new event location',
+          id: "Ibm Notes new event ID",
+          summary: "Ibm Notes new event summary",
+          location: "Ibm Notes new event location"
         )
       end
 
       def outdated_ibm_notes_event
         @outdated_ibm_notes_event ||= create_ibm_notes_event(
-          id: 'Ibm Notes outdated event ID',
-          summary: 'Ibm Notes outdated event title - THIS HAS CHANGED',
-          location: 'Ibm Notes outdated event location - THIS HAS CHANGED'
+          id: "Ibm Notes outdated event ID",
+          summary: "Ibm Notes outdated event title - THIS HAS CHANGED",
+          location: "Ibm Notes outdated event location - THIS HAS CHANGED"
         )
       end
 
       def ibm_notes_event_gobierto_event
         @ibm_notes_event_gobierto_event ||= GobiertoCalendars::Event.new(
           site: site,
-          external_id: 'Ibm Notes event ID',
-          title: 'Ibm Notes event title',
+          external_id: "Ibm Notes event ID",
+          title: "Ibm Notes event title",
           starts_at: utc_time("2017-04-11 10:00:00"),
           ends_at:   utc_time("2017-04-11 11:00:00"),
-          state: GobiertoCalendars::Event.states['published'],
+          state: GobiertoCalendars::Event.states["published"],
           collection: richard.events_collection
         )
       end
@@ -75,21 +74,21 @@ module GobiertoPeople
       def outdated_ibm_notes_event_gobierto_event
         @outdated_ibm_notes_event_gobierto_event ||= GobiertoCalendars::Event.new(
           site: site,
-          external_id: 'Ibm Notes outdated event ID',
-          title: 'Ibm Notes outdated event title',
+          external_id: "Ibm Notes outdated event ID",
+          title: "Ibm Notes outdated event title",
           starts_at: utc_time("2017-04-11 10:00:00"),
           ends_at:   utc_time("2017-04-11 11:00:00"),
-          state: GobiertoCalendars::Event.states['published'],
+          state: GobiertoCalendars::Event.states["published"],
           collection: richard.events_collection
         )
       end
 
       def test_sync_events_v9
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
-        non_recurrent_events       = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
+        non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
         recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$")
 
         assert_equal 2, non_recurrent_events.count
@@ -106,24 +105,24 @@ module GobiertoPeople
       end
 
       def test_sync_events_updates_event_attributes
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
         # Change arbitrary data, and check it gets  updated accordingly after the
         # next synchronization
 
-        non_recurrent_event = richard.events.find_by(external_id: 'BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated')
-        non_recurrent_event.title = 'Old non recurrent event title'
+        non_recurrent_event = richard.events.find_by(external_id: "BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated")
+        non_recurrent_event.title = "Old non recurrent event title"
         non_recurrent_event.starts_at = utc_time("2017-05-05 10:00:00")
         non_recurrent_event.save!
 
-        recurrent_event_instance = richard.events.find_by(external_id: 'D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z')
-        recurrent_event_instance.title = 'Old recurrent event instance title'
-        recurrent_event_instance.locations.first.update_attributes!(name: 'Old location')
+        recurrent_event_instance = richard.events.find_by(external_id: "D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z")
+        recurrent_event_instance.title = "Old recurrent event instance title"
+        recurrent_event_instance.locations.first.update_attributes!(name: "Old location")
         recurrent_event_instance.save!
 
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -133,23 +132,23 @@ module GobiertoPeople
         assert_equal "Buscar alcaldessa al seu despatx i Sortida cap a l'acte Gran Via Corts Catalanes, 400", non_recurrent_event.title
         assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_event.starts_at
 
-        assert_equal 'CAEM', recurrent_event_instance.title
-        assert_equal 'Sala de juntes 1a. planta Ajuntament', recurrent_event_instance.locations.first.name
+        assert_equal "CAEM", recurrent_event_instance.title
+        assert_equal "Sala de juntes 1a. planta Ajuntament", recurrent_event_instance.locations.first.name
         assert_equal 1, recurrent_event_instance.locations.size
       end
 
       def test_sync_events_removes_deleted_event_attributes
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
         # Add new data to events, and check it is removed after sync
-        event = richard.events.find_by(external_id: 'BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated')
+        event = richard.events.find_by(external_id: "BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated")
         GobiertoCalendars::EventLocation.create!(event: event, name: "I'll be deleted")
 
         assert 1, event.locations.size
 
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -160,33 +159,33 @@ module GobiertoPeople
       # Se piden eventos en el intervalo [1,3], 1 y 3 son recurrentes y son el mismo, el 2 es uno no recurrente
       # De las 9 instancias del evento recurrente, la que tiene recurrenceId=20170407T113000Z (la segunda) da 404
       def test_sync_events_v8
-        VCR.use_cassette('ibm_notes/person_events_collection_v8', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
-        non_recurrent_events       = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
+        non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
         recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$").order(:external_id)
 
         assert_equal 1, non_recurrent_events.count
         assert_equal 8, recurrent_events_instances.count
 
         assert_equal "rom", non_recurrent_events.first.title
-        assert_equal 'CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated', non_recurrent_events.first.external_id
-        assert_equal rst_to_utc('2017-05-05 16:00:00'), non_recurrent_events.first.starts_at
+        assert_equal "CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated", non_recurrent_events.first.external_id
+        assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
 
         assert_equal "Coordinació Política Igualtat + dinar", recurrent_events_instances.first.title
-        assert_equal 'EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170303T110000Z', recurrent_events_instances.first.external_id
-        assert_equal rst_to_utc('2017-03-03 12:00:00'), recurrent_events_instances.first.starts_at
+        assert_equal "EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170303T110000Z", recurrent_events_instances.first.external_id
+        assert_equal rst_to_utc("2017-03-03 12:00:00"), recurrent_events_instances.first.starts_at
 
         assert_equal "Coordinació Política Igualtat + dinar", recurrent_events_instances.second.title
-        assert_equal 'EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170505T100000Z', recurrent_events_instances.second.external_id
-        assert_equal rst_to_utc('2017-05-05 12:00:00'), recurrent_events_instances.second.starts_at
+        assert_equal "EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170505T100000Z", recurrent_events_instances.second.external_id
+        assert_equal rst_to_utc("2017-05-05 12:00:00"), recurrent_events_instances.second.starts_at
       end
 
       # Only v8 will return past events instances, but use v9 cassette for simplicity
       def test_sync_events_marks_unreceived_upcoming_events_as_pending
-        Timecop.freeze(Time.zone.parse('2017-05-03')) do
-          VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        Timecop.freeze(Time.zone.parse("2017-05-03")) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
             # Returns 3 events, all of them upcoming
             CalendarIntegration.sync_person_events(richard)
           end
@@ -197,8 +196,8 @@ module GobiertoPeople
           assert richard_synchronized_events.all?(&:active?)
         end
 
-        Timecop.freeze(Time.zone.parse('2017-05-05 01:00:00')) do
-          VCR.use_cassette('ibm_notes/person_events_collection_v9_mark_as_pending', decode_compressed_response: true) do
+        Timecop.freeze(Time.zone.parse("2017-05-05 01:00:00")) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9_mark_as_pending", decode_compressed_response: true) do
             # Returns first event from the previous set, which is now past
             CalendarIntegration.sync_person_events(richard)
           end
@@ -214,7 +213,6 @@ module GobiertoPeople
       end
 
       def test_sync_event_creates_new_event_with_location
-
         refute GobiertoCalendars::Event.exists?(external_id: new_ibm_notes_event.id)
 
         created_event_external_id = CalendarIntegration.sync_event(new_ibm_notes_event)
@@ -227,7 +225,7 @@ module GobiertoPeople
         assert_equal new_ibm_notes_event.title, gobierto_event.title
         assert_equal richard, gobierto_event.collection.container
 
-        assert_equal 'Ibm Notes new event location', gobierto_event.locations.first.name
+        assert_equal "Ibm Notes new event location", gobierto_event.locations.first.name
       end
 
       def test_sync_event_updates_existing_event
@@ -236,13 +234,13 @@ module GobiertoPeople
         updated_gobierto_event = GobiertoCalendars::Event.find_by(external_id: outdated_ibm_notes_event.id)
 
         assert updated_gobierto_event.published?
-        assert_equal 'Ibm Notes outdated event title - THIS HAS CHANGED', updated_gobierto_event.title
+        assert_equal "Ibm Notes outdated event title - THIS HAS CHANGED", updated_gobierto_event.title
       end
 
       def test_sync_event_doesnt_create_duplicated_events
         CalendarIntegration.sync_event(outdated_ibm_notes_event)
 
-        assert_no_difference 'GobiertoCalendars::Event.count' do
+        assert_no_difference "GobiertoCalendars::Event.count" do
           CalendarIntegration.sync_event(outdated_ibm_notes_event)
         end
       end
@@ -259,19 +257,19 @@ module GobiertoPeople
         gobierto_event.reload
         assert gobierto_event.locations.empty?
 
-        ibm_notes_event.location = 'Location name added afterwards'
+        ibm_notes_event.location = "Location name added afterwards"
 
         CalendarIntegration.sync_event(ibm_notes_event)
         gobierto_event.reload
 
-        assert_equal 'Location name added afterwards', gobierto_event.locations.first.name
+        assert_equal "Location name added afterwards", gobierto_event.locations.first.name
 
-        ibm_notes_event.location = 'Location name updated afterwards'
+        ibm_notes_event.location = "Location name updated afterwards"
 
         CalendarIntegration.sync_event(ibm_notes_event)
         gobierto_event.reload
 
-        assert_equal 'Location name updated afterwards', gobierto_event.locations.first.name
+        assert_equal "Location name updated afterwards", gobierto_event.locations.first.name
 
         ibm_notes_event.location = nil
 
@@ -283,17 +281,17 @@ module GobiertoPeople
 
       def test_sync_attendees
         # Cassette contains one confirmed attendee and two requested participants.
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 
-        event = richard.events.find_by(external_id: 'D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z')
+        event = richard.events.find_by(external_id: "D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z")
         attendees = event.attendees
 
         assert_equal 4, attendees.size
 
-        assert_equal 'Josep M. Farreras', attendees.first.name
-        assert_equal 'Horatio Nelson', attendees.second.person.name
+        assert_equal "Josep M. Farreras", attendees.first.name
+        assert_equal "Horatio Nelson", attendees.second.person.name
         assert_equal nelson, attendees.second.person
         assert_equal richard, attendees.fourth.person
 
@@ -301,7 +299,7 @@ module GobiertoPeople
 
         event.attendees.second.delete
 
-        VCR.use_cassette('ibm_notes/person_events_collection_v9', decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
           CalendarIntegration.sync_person_events(richard)
         end
 

--- a/test/services/user/notification_digest_agent_test.rb
+++ b/test/services/user/notification_digest_agent_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NotificationDigestAgentTest < ActiveSupport::TestCase

--- a/test/services/user/notification_digest_test.rb
+++ b/test/services/user/notification_digest_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::NotificationDigestTest < ActiveSupport::TestCase

--- a/test/services/user/subscription/finder_test.rb
+++ b/test/services/user/subscription/finder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::Subscription::FinderTest < ActiveSupport::TestCase
@@ -42,7 +44,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::Person", person.id],
       ["GobiertoPeople::Person", nil],
       ["GobiertoPeople", nil],
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
@@ -57,7 +59,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::PersonEvent", nil],
       ["GobiertoPeople::Person", person.id],
       ["GobiertoPeople::Person", nil],
-      ["GobiertoPeople", nil],
+      ["GobiertoPeople", nil]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
@@ -78,7 +80,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::PersonEvent", person_event.id],
       ["GobiertoPeople::PersonEvent", nil],
       ["GobiertoPeople::Person", person.id],
-      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople::Person", nil]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
@@ -99,7 +101,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
     [
       ["GobiertoPeople::PersonEvent", person_event.id],
       ["GobiertoPeople::PersonEvent", nil],
-      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", person.id]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
@@ -120,7 +122,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
 
     [
       ["GobiertoPeople::PersonEvent", person_event.id],
-      ["GobiertoPeople::PersonEvent", nil],
+      ["GobiertoPeople::PersonEvent", nil]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
@@ -141,7 +143,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
     User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::PersonEvent", subscribable_id: person_event.id
 
     [
-      ["GobiertoPeople::PersonEvent", person_event.id],
+      ["GobiertoPeople::PersonEvent", person_event.id]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
@@ -168,7 +170,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::Person", person.id],
       ["GobiertoPeople::Person", nil],
       ["GobiertoPeople", nil],
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       assert_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -182,13 +184,13 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::PersonEvent", nil],
       ["GobiertoPeople::Person", person.id],
       ["GobiertoPeople::Person", nil],
-      ["GobiertoPeople", nil],
+      ["GobiertoPeople", nil]
     ].each do |subscribable_type, subscribable_id|
       assert_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
 
     [
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       refute_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -201,14 +203,14 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::PersonEvent", person_event.id],
       ["GobiertoPeople::PersonEvent", nil],
       ["GobiertoPeople::Person", person.id],
-      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople::Person", nil]
     ].each do |subscribable_type, subscribable_id|
       assert_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
 
     [
       ["GobiertoPeople", nil],
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       refute_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -220,7 +222,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
     [
       ["GobiertoPeople::PersonEvent", person_event.id],
       ["GobiertoPeople::PersonEvent", nil],
-      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", person.id]
     ].each do |subscribable_type, subscribable_id|
       assert_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -228,7 +230,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
     [
       ["GobiertoPeople::Person", nil],
       ["GobiertoPeople", nil],
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       refute_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -239,7 +241,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
 
     [
       ["GobiertoPeople::PersonEvent", person_event.id],
-      ["GobiertoPeople::PersonEvent", nil],
+      ["GobiertoPeople::PersonEvent", nil]
     ].each do |subscribable_type, subscribable_id|
       assert_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -248,7 +250,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::Person", person.id],
       ["GobiertoPeople::Person", nil],
       ["GobiertoPeople", nil],
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       refute_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -258,7 +260,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
     User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::PersonEvent", subscribable_id: person_event.id
 
     [
-      ["GobiertoPeople::PersonEvent", person_event.id],
+      ["GobiertoPeople::PersonEvent", person_event.id]
     ].each do |subscribable_type, subscribable_id|
       assert_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end
@@ -268,7 +270,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::Person", person.id],
       ["GobiertoPeople::Person", nil],
       ["GobiertoPeople", nil],
-      ["Site", site.id],
+      ["Site", site.id]
     ].each do |subscribable_type, subscribable_id|
       refute_includes subject.subscriptions_for(subscribable_type, subscribable_id, site.id), user.id
     end

--- a/test/services/user/subscription/notification_builder_test.rb
+++ b/test/services/user/subscription/notification_builder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
@@ -18,14 +20,14 @@ class User::Subscription::NotificationBuilderTest < ActiveSupport::TestCase
   end
 
   def published_event
-    OpenStruct.new name: 'trackable.visibility_level_changed', payload: {
+    OpenStruct.new name: "trackable.visibility_level_changed", payload: {
       site_id: site.id,
       gid: subscribable.to_gid
     }
   end
 
   def updated_event
-    OpenStruct.new name: 'trackable.updated', payload: {
+    OpenStruct.new name: "trackable.updated", payload: {
       site_id: site.id,
       gid: subscribable.to_gid
     }

--- a/test/services/user/verification_service_test.rb
+++ b/test/services/user/verification_service_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class User::VerificationServiceTest < ActiveSupport::TestCase

--- a/test/support/calendar_integration_helpers.rb
+++ b/test/support/calendar_integration_helpers.rb
@@ -1,18 +1,19 @@
+# frozen_string_literal: true
+
 module CalendarIntegrationHelpers
-
   def activate_ibm_notes_calendar_integration(site)
-    gp_module_settings = site.module_settings.find_by(module_name: 'GobiertoPeople')
+    gp_module_settings = site.module_settings.find_by(module_name: "GobiertoPeople")
 
-    gp_module_settings.calendar_integration = 'ibm_notes'
-    gp_module_settings.ibm_notes_usr = 'username'
-    gp_module_settings.ibm_notes_pwd = 'password'
+    gp_module_settings.calendar_integration = "ibm_notes"
+    gp_module_settings.ibm_notes_usr = "username"
+    gp_module_settings.ibm_notes_pwd = "password"
 
     gp_module_settings.save!
   end
 
   def activate_google_calendar_calendar_integration(site)
-    gp_module_settings = site.module_settings.find_by(module_name: 'GobiertoPeople')
-    gp_module_settings.calendar_integration = 'google_calendar'
+    gp_module_settings = site.module_settings.find_by(module_name: "GobiertoPeople")
+    gp_module_settings.calendar_integration = "google_calendar"
     gp_module_settings.save!
   end
 
@@ -27,5 +28,4 @@ module CalendarIntegrationHelpers
     calendar_conf.data = options
     calendar_conf.save!
   end
-
 end

--- a/test/support/common_helpers.rb
+++ b/test/support/common_helpers.rb
@@ -1,7 +1,7 @@
-module CommonHelpers
+# frozen_string_literal: true
 
+module CommonHelpers
   def array_match(expected, actual)
     expected.sort == actual.sort
   end
-
 end

--- a/test/support/concerns/authentication/authenticable_test.rb
+++ b/test/support/concerns/authentication/authenticable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authentication::AuthenticableTest
   def test_password_authentication
     assert user.authenticate("gobierto")

--- a/test/support/concerns/authentication/confirmable_test.rb
+++ b/test/support/concerns/authentication/confirmable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authentication::ConfirmableTest
   def test_confirmed_scope
     subject = user.class.confirmed

--- a/test/support/concerns/authentication/invitable_test.rb
+++ b/test/support/concerns/authentication/invitable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authentication::InvitableTest
   def test_invitations_scope
     subject = user.class.invitation

--- a/test/support/concerns/authentication/recoverable_test.rb
+++ b/test/support/concerns/authentication/recoverable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authentication::RecoverableTest
   def test_recoverable_scope
     subject = recoverable_user.class.recoverable

--- a/test/support/concerns/gobierto_attachments/attachable_test.rb
+++ b/test/support/concerns/gobierto_attachments/attachable_test.rb
@@ -1,5 +1,6 @@
-module GobiertoAttachments::AttachableTest
+# frozen_string_literal: true
 
+module GobiertoAttachments::AttachableTest
   def pdf_attachment
     @pdf_attachment ||= gobierto_attachments_attachments(:pdf_attachment)
   end
@@ -9,7 +10,7 @@ module GobiertoAttachments::AttachableTest
   end
 
   def attachables
-    [ attachable_without_attachment, attachable_with_attachment ]
+    [attachable_without_attachment, attachable_with_attachment]
   end
 
   def test_link_attachment
@@ -18,8 +19,8 @@ module GobiertoAttachments::AttachableTest
     assert_equal 1, attachable_without_attachment.attachments.size
     assert_equal 2, attachable_with_attachment.attachments.size
 
-    assert_equal 'http://host.com/attachments/pdf-attachment.pdf', attachable_without_attachment.attachments.first.url
-    assert_equal 'http://host.com/attachments/xslsx-attachment.xlsx', attachable_with_attachment.attachments.first.url
+    assert_equal "http://host.com/attachments/pdf-attachment.pdf", attachable_without_attachment.attachments.first.url
+    assert_equal "http://host.com/attachments/xslsx-attachment.xlsx", attachable_with_attachment.attachments.first.url
   end
 
   def test_unlink_attachment
@@ -43,5 +44,4 @@ module GobiertoAttachments::AttachableTest
     assert_equal [pdf_attachment], attachable_without_attachment.attachments
     assert_equal [xlsx_attachment, pdf_attachment], attachable_with_attachment.attachments.order(:name)
   end
-
 end

--- a/test/support/concerns/gobierto_budgets/describable_test.rb
+++ b/test/support/concerns/gobierto_budgets/describable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoBudgets::DescribableTest
   class GobiertoBudgets::Klass
     include Describable

--- a/test/support/concerns/gobierto_common/sluggable_test.rb
+++ b/test/support/concerns/gobierto_common/sluggable_test.rb
@@ -1,5 +1,6 @@
-module GobiertoCommon::SluggableTestModule
+# frozen_string_literal: true
 
+module GobiertoCommon::SluggableTestModule
   def test_assings_slug_on_creation
     sluggable_1 = create_sluggable
     sluggable_2 = create_sluggable
@@ -9,5 +10,4 @@ module GobiertoCommon::SluggableTestModule
     assert (sluggable_2.slug =~ /-2$/) > 0
     assert_not_equal sluggable_1.slug, sluggable_2.slug
   end
-
 end

--- a/test/support/concerns/gobierto_common/sortable_test.rb
+++ b/test/support/concerns/gobierto_common/sortable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCommon::SortableTest
   def test_update_positions
     positions_from_params = { "0" => { "id" => sortable_object.id, "position" => 1 } }

--- a/test/support/concerns/session/trackable_test.rb
+++ b/test/support/concerns/session/trackable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Session::TrackableTest
   def test_update_session_data
     remote_ip = IPAddr.new("0.0.0.0")

--- a/test/support/concerns/user/subscribable_test.rb
+++ b/test/support/concerns/user/subscribable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module User::SubscribableTest
   class User::SubscribableClass
     include Subscribable
@@ -26,7 +28,7 @@ module User::SubscribableTest
 
   def test_to_path
     subscribable_identifier = subscribable.respond_to?(:slug) ? subscribable.slug : subscribable.to_param
-    
+
     assert_not_nil subscribable.to_path
     assert_includes subscribable.to_path, subscribable_identifier
   end
@@ -37,6 +39,6 @@ module User::SubscribableTest
     assert_not_nil subscribable.to_url
     assert_includes subscribable.to_url, subscribable_identifier
     assert_includes subscribable.to_url, ENV["HOST"]
-    assert_includes subscribable.to_url(host: 'site.gobierto.dev'), 'site.gobierto.dev'
+    assert_includes subscribable.to_url(host: "site.gobierto.dev"), "site.gobierto.dev"
   end
 end

--- a/test/support/concerns/user/subscriber_test.rb
+++ b/test/support/concerns/user/subscriber_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module User::SubscriberTest
   def user_subscription
     @user_subscription ||= gobierto_budget_consultations_consultations(:madrid_open)

--- a/test/support/event_helpers.rb
+++ b/test/support/event_helpers.rb
@@ -1,5 +1,6 @@
-module EventHelpers
+# frozen_string_literal: true
 
+module EventHelpers
   def create_event(options = {})
     person = options[:person] || gobierto_people_people(:richard)
     collection = person.events_collection
@@ -19,5 +20,4 @@ module EventHelpers
 
     event
   end
-
 end

--- a/test/support/extensions/gobierto_common/trackable_test.rb
+++ b/test/support/extensions/gobierto_common/trackable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCommon::TrackableTest
   def setup
     super
@@ -19,9 +21,7 @@ module GobiertoCommon::TrackableTest
   def test_trackable_notify?
     if trackable.trackable.respond_to?(:active?)
       trackable.trackable.stub(:active?, true) do
-        if trackable.trackable.admin_id.present?
-          assert trackable.notify?
-        end
+        assert trackable.notify? if trackable.trackable.admin_id.present?
       end
 
       trackable.trackable.stub(:active?, false) do

--- a/test/support/file_uploader_helpers.rb
+++ b/test/support/file_uploader_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FileUploaderHelpers
   def with_stubbed_s3_file_upload
     FileUploader::S3.stub_any_instance(:call, public_url) do

--- a/test/support/gobierto_site_constraint_helpers.rb
+++ b/test/support/gobierto_site_constraint_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GobiertoSiteConstraint
   def matches?(_)
     true

--- a/test/support/integration/authentication_helpers.rb
+++ b/test/support/integration/authentication_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Integration
   module AuthenticationHelpers
     def with_signed_in_admin(admin)
@@ -28,7 +30,7 @@ module Integration
 
     def sign_out_admin
       within("header") do
-        if (javascript_driver?)
+        if javascript_driver?
           with_hidden_elements do
             find("#admin-sign-out").trigger("click")
           end
@@ -53,7 +55,7 @@ module Integration
     def sign_out_user
       within("header .user_links") do
         if Capybara.current_driver == Capybara.javascript_driver
-          find_link("Sign out", visible: false).trigger('click')
+          find_link("Sign out", visible: false).trigger("click")
         else
           find_link("Sign out", visible: false).click
         end

--- a/test/support/integration/dynamic_content_helpers.rb
+++ b/test/support/integration/dynamic_content_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Integration
   module DynamicContentHelpers
     def content_blocks

--- a/test/support/integration/matcher_helpers.rb
+++ b/test/support/integration/matcher_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Integration
   module MatcherHelpers
     def has_message?(text)

--- a/test/support/integration/page_helpers.rb
+++ b/test/support/integration/page_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Integration
   module PageHelpers
     def scroll_to_top

--- a/test/support/integration/request_authentication_helpers.rb
+++ b/test/support/integration/request_authentication_helpers.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Integration
   module RequestAuthenticationHelpers
-    DEFAULT_ADMIN_PASSWORD = "gobierto".freeze
-    DEFAULT_USER_PASSWORD  = "gobierto".freeze
+    DEFAULT_ADMIN_PASSWORD = "gobierto"
+    DEFAULT_USER_PASSWORD = "gobierto"
 
     def with_signed_in_admin(admin)
       sign_in_admin(admin)

--- a/test/support/integration/site_session_helpers.rb
+++ b/test/support/integration/site_session_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Integration
   module SiteSessionHelpers
     def with_selected_site(site)

--- a/test/support/message_delivery_helpers.rb
+++ b/test/support/message_delivery_helpers.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class ActionMailer::MessageDelivery
-  def deliver_later(options = {})
+  def deliver_later(_options = {})
     deliver_now
   end
 end

--- a/test/support/populate_data_helpers.rb
+++ b/test/support/populate_data_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PopulateDataHelpers
   def with_stubbed_budget_line_collection
     GobiertoAdmin::GobiertoBudgetConsultations::BudgetLineCollectionBuilder.stub_any_instance(:call, [populate_data_budget_line_summary]) do

--- a/test/support/session_helpers.rb
+++ b/test/support/session_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SessionHelpers
   def with_current_admin(admin)
     GobiertoAdmin::BaseController.stub_any_instance(:current_admin, admin) do
@@ -12,7 +14,6 @@ module SessionHelpers
   end
 
   def login_admin_for_api(admin)
-    post admin_sessions_url, params: { session: { email: admin.email, password: 'gobierto' } }
+    post admin_sessions_url, params: { session: { email: admin.email, password: "gobierto" } }
   end
-
 end

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SiteSessionHelpers
   def with_current_site(site)
     GobiertoSiteConstraint.stub_any_instance(:matches?, true) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] = "test"
 ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"] = "1"
 ENV["HOST"] = "www.example.com"
@@ -59,7 +61,7 @@ WebMock.disable_net_connect!(
 )
 
 VCR.configure do |c|
-  c.cassette_library_dir = 'test/vcr_cassettes'
+  c.cassette_library_dir = "test/vcr_cassettes"
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true
 end


### PR DESCRIPTION
Improvemnete

### What does this PR do?

This PR adds a new Rubocop configuration and applies this to these folders:

- config/
- db/
- lib/
- test/ 

From now on we should try to run Rubocop in our regular process. This snippet helps to run it just for the changes in the current topic branch:

```
rubocop `git diff --name-only master..HEAD`
```

Ideally we'll be able to have soon all the files with frozen strings enabled, and to gain a bit of performance for free.

