### PR TITLE
Keep collection attribute when there are form errors

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -9,8 +9,8 @@ module GobiertoAdmin
       end
 
       def new
-        @page_form = PageForm.new(site_id: current_site.id)
         @collection = find_collection(params[:collection_id])
+        @page_form = PageForm.new(site_id: current_site.id, collection_id: @collection.id)
         @page_visibility_levels = get_page_visibility_levels
       end
 
@@ -19,24 +19,24 @@ module GobiertoAdmin
         @collection = @page.collection
         @page_visibility_levels = get_page_visibility_levels
         @page_form = PageForm.new(
-          @page.attributes.except(*ignored_page_attributes)
+          @page.attributes.except(*ignored_page_attributes).merge(collection_id: @collection.id)
         )
       end
 
       def create
-        @page_form = PageForm.new(page_params.merge(site_id: current_site.id))
+        @collection = find_collection(params[:page][:collection_id])
+        @page_form = PageForm.new(page_params.merge(site_id: current_site.id, collection_id: @collection.id))
 
         if @page_form.save
           track_create_activity
-          ::GobiertoCommon::Collection.find(params[:page][:collection_id]).append(@page_form.page)
+          @collection.append(@page_form.page)
 
           redirect_to(
-            edit_admin_cms_page_path(@page_form.page.id, collection_id: params[:page][:collection_id]),
+            edit_admin_cms_page_path(@page_form.page.id, collection_id: @collection.id),
             notice: t(".success_html", link: gobierto_cms_page_preview_url(@page_form.page, host: current_site.domain))
           )
         else
           @page_visibility_levels = get_page_visibility_levels
-          @collection = ::GobiertoCommon::Collection.find(params[:page][:collection_id])
           render :edit
         end
       end

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -16,7 +16,7 @@ module GobiertoAdmin
 
       delegate :persisted?, to: :page
 
-      validates :site, :visibility_level, presence: true
+      validates :site, :visibility_level, :collection_id, presence: true
 
       def save
         save_page if valid?

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -1,7 +1,7 @@
 <%= render "gobierto_admin/shared/validation_errors", resource: @page_form %>
 
 <%= form_for(@page_form, as: :page, url: @page_form.persisted? ? admin_cms_page_path(@page_form) : :admin_cms_pages, data: { "globalized-form-container" => true }) do |f| %>
-  <%= f.hidden_field :collection_id, value: params[:collection_id] %>
+  <%= f.hidden_field :collection_id %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
       <div class="globalized_fields">

--- a/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
@@ -11,6 +11,7 @@ module GobiertoAdmin
           title_translations: { I18n.locale => page.title },
           body_translations: { I18n.locale => page.body },
           slug: "page-form-slug",
+          collection_id: collection.id,
           visibility_level: page.visibility_level
         )
       end
@@ -31,6 +32,10 @@ module GobiertoAdmin
 
       def site
         @site ||= sites(:santander)
+      end
+
+      def collection
+        @collection ||= gobierto_common_collections(:gender_violence_process_news)
       end
 
       def test_save_with_valid_attributes

--- a/test/integration/gobierto_admin/gobierto_participation/processes/process_pages_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/process_pages_test.rb
@@ -62,6 +62,10 @@ module GobiertoAdmin
 
               fill_in "page_title_translations_en", with: "News Title"
               find("#page_body_translations_en", visible: false).set("The content of the page")
+              click_button "Create"
+
+              assert has_alert?("URL can't be blank")
+
               fill_in "page_slug", with: "new-page"
               click_button "Create"
 


### PR DESCRIPTION
Connects to #908

### What does this PR do?

This PR fixes page creation after a validation error.

### How should this be manually tested?

Firstly, from the selected process in admin:
`./admin/participation/processes/XXXXXX/contribution_containers
`
you have to create a contribution container

And then, you have to create with this script contribution examples:

```
cc = GobiertoParticipation::ContributionContainer.first

(0..150).each do |i|
  c = GobiertoParticipation::Contribution.new(contribution_container: cc )
  c.title = "Title " + i.to_s
  c.description = "Description " + i.to_s
  c.user = User.first
  c.site = Site.last
  c.save
end
```

1. Try to vote an idea. We have to decide that messages to show when one is without login or an idea has already voted.
2. Try to change the pagination with bullets or arrows.
3. Test the filters

We have to decide:

- If an idea is not voted, is necessary to show the votes bar?
- What do we do when an idea is already voted?
- Can we undo votes or reports?
- How do we show that a vote or idea has been reported?
