### PR TITLE
91 - Integrate links to external pages of trips and gifts

### DIFF
--- a/app/decorators/gobierto_people/person_decorator.rb
+++ b/app/decorators/gobierto_people/person_decorator.rb
@@ -32,6 +32,14 @@ module GobiertoPeople
       person_contact_method_for("LinkedIn", "service_url")
     end
 
+    def trips_url
+      person_custom_link_for('Viajes')
+    end
+
+    def gifts_url
+      person_custom_link_for('Obsequios')
+    end
+
     def content_blocks_for_bio(site_id)
       object.content_blocks(site_id).where.not(internal_id:  GobiertoCommon::DynamicContent::CONTACT_BLOCK_ID)
     end
@@ -42,6 +50,22 @@ module GobiertoPeople
       person_contact_methods.detect do |contact_method|
         contact_method["service_name"] == service_name
       end.try(:[], attribute_name)
+    end
+
+    def person_custom_link_for(service_name)
+      content_block = object.content_blocks.find_by(internal_id: GobiertoCommon::DynamicContent::CUSTOM_LINKS_BLOCK_ID)
+      payloads = content_block.records.pluck(:payload)
+      service_payload = payloads.detect { |payload| payload['service_name'] == service_name }
+      
+      if service_payload && valid_url?(service_payload['service_url'])
+        service_payload['service_url']
+      else
+        nil
+      end
+    end
+
+    def valid_url?(url)
+      /http.*\..*/.match(url)
     end
 
     protected

--- a/app/models/concerns/gobierto_common/dynamic_content.rb
+++ b/app/models/concerns/gobierto_common/dynamic_content.rb
@@ -3,6 +3,7 @@ module GobiertoCommon
     extend ActiveSupport::Concern
 
     CONTACT_BLOCK_ID = "gobierto_people_contact_block"
+    CUSTOM_LINKS_BLOCK_ID = "gobierto_people_custom_links"
 
     included do
       has_many :content_block_records, as: :content_context, dependent: :destroy, class_name: "GobiertoCommon::ContentBlockRecord"

--- a/app/views/gobierto_people/people/_navigation.html.erb
+++ b/app/views/gobierto_people/people/_navigation.html.erb
@@ -16,6 +16,12 @@
       <% if statements_submodule_active? %>
         <li><h3><%= link_to t(".statements"), gobierto_people_person_statements_path(@person.slug), class: class_if("active", controller_name == "person_statements")  %></h3></li>
       <% end %>
+      <% if @person.trips_url %>
+        <li><h3><%= link_to t(".trips"), @person.trips_url %></h3></li>
+      <% end %>
+      <% if @person.gifts_url %>
+        <li><h3><%= link_to t(".gifts"), @person.gifts_url  %></h3></li>
+      <% end %>
     </ul>
 
   </div>

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -49,7 +49,9 @@ ca:
         bio: Biografia i CV
         blog: Blog
         exports: Descarrega les dades en format reutilitzable
+        gifts: Obsequis i regals
         statements: Béns i activitats
+        trips: Viatges
       people_filter:
         organigram: Organigrama de %{name}
         political_groups: Grups polítics de %{name}

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -48,7 +48,9 @@ en:
         bio: Biography and CV
         blog: Blog
         exports: Download data in a reusable format
+        gifts: Gifts
         statements: Goods and Activities
+        trips: Trips
       people_filter:
         organigram: "%{name} organigram"
         political_groups: "%{name} political groups"

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -49,7 +49,9 @@ es:
         bio: Biografía y CV
         blog: Blog
         exports: Descarga los datos en formato reutilizable
+        gifts: Obsequios y regalos
         statements: Bienes y Actividades
+        trips: Viajes
       people_filter:
         organigram: Organigrama de %{name}
         political_groups: Grupos políticos de %{name}

--- a/db/seeds/modules/gobierto_people/seeds.rb
+++ b/db/seeds/modules/gobierto_people/seeds.rb
@@ -2,6 +2,7 @@
 
 module GobiertoSeeds
   class Recipe
+
     def self.run(site)
       # Config keys
       settings = GobiertoModuleSettings.find_by site: site, module_name: "GobiertoPeople"
@@ -57,6 +58,32 @@ module GobiertoSeeds
                                                   label: { "ca" => "Notes", "es" => "Notas" })
       end
 
+      ## Custom links block
+      custom_links_block = GobiertoCommon::ContentBlock.find_by(site_id: site.id, internal_id: GobiertoCommon::DynamicContent::CUSTOM_LINKS_BLOCK_ID)
+      if custom_links_block.nil?
+        custom_links_block = GobiertoCommon::ContentBlock.create!(internal_id: GobiertoCommon::DynamicContent::CUSTOM_LINKS_BLOCK_ID,
+                                                             site: site,
+                                                             content_model_name: "GobiertoPeople::Person",
+                                                             title: { "ca" => "Links personalitzats", "es" => "Links personalizados", "en" => "Custom links" })
+      end
+
+      ## Custom links fields
+      custom_links_block_field = GobiertoCommon::ContentBlockField.find_by content_block: custom_links_block, name: "service_name"
+      if custom_links_block_field.nil?
+        GobiertoCommon::ContentBlockField.create!(content_block: custom_links_block,
+                                                  name: "service_name",
+                                                  field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
+                                                  label: { "ca" => "Servei", "es" => "Servicio", "en" => "Service" })
+      end
+
+      custom_links_block_field = GobiertoCommon::ContentBlockField.find_by content_block: custom_links_block, name: "service_url"
+      if custom_links_block_field.nil?
+        GobiertoCommon::ContentBlockField.create!(content_block: custom_links_block,
+                                                  name: "service_url",
+                                                  field_type: ::GobiertoCommon::ContentBlockField.field_types["text"],
+                                                  label: { "ca" => "URL", "es" => "URL", "en" => "URL" })
+      end
+
       ## Seed loader
       seeds_filenames = Dir.glob(File.join(File.dirname(__FILE__), "*_seeds.yml"))
 
@@ -81,6 +108,8 @@ module GobiertoSeeds
           end
         end
       end
+
     end
+
   end
 end

--- a/test/fixtures/gobierto_common/content_block_records.yml
+++ b/test/fixtures/gobierto_common/content_block_records.yml
@@ -8,6 +8,16 @@ contact_method_twitter_alternative:
   content_block: contact_methods
   payload: <%= { "service_name" => "Twitter", "service_handle" => "@tamara", "service_url" => "https://twitter.com/tamara", "service_notes" => "Tamara's Twitter account" }.to_json %>
 
+custom_link_trips:
+  content_context: richard (GobiertoPeople::Person)
+  content_block: custom_links
+  payload: <%= { "service_name" => "Viajes", "service_url" => "https://viajes.com/richard" }.to_json %>
+
+custom_link_gifts:
+  content_context: richard (GobiertoPeople::Person)
+  content_block: custom_links
+  payload: <%= { "service_name" => "Obsequios", "service_url" => "https://obsequios.com/richard" }.to_json %>
+
 accomplishment_nobel_prize:
   content_context: richard (GobiertoPeople::Person)
   content_block: accomplishments

--- a/test/fixtures/gobierto_common/content_blocks.yml
+++ b/test/fixtures/gobierto_common/content_blocks.yml
@@ -4,6 +4,12 @@ contact_methods:
   title: <%= { "en" => "Contact methods", "es" => "Formas de contacto" }.to_json %>
   internal_id: <%= GobiertoCommon::DynamicContent::CONTACT_BLOCK_ID %>
 
+custom_links:
+  site: madrid
+  content_model_name: GobiertoPeople::Person
+  title: <%= { "en" => "Custom links", "es" => "Links personalizados" }.to_json %>
+  internal_id: <%= GobiertoCommon::DynamicContent::CUSTOM_LINKS_BLOCK_ID %>
+
 accomplishments:
   site: madrid
   content_model_name: GobiertoPeople::Person

--- a/test/integration/gobierto_admin/gobierto_common/content_block_record_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_block_record_test.rb
@@ -106,7 +106,8 @@ module GobiertoAdmin
 
                   # Remove attachment for third record
                   edit_links[2].trigger(:click)
-                  find("#person_content_block_records_attributes_3_remove_attachment", visible: false).trigger(:click)
+                  # WARNING: it's third record inside accomplishments, but fifth record in total
+                  find("#person_content_block_records_attributes_5_remove_attachment", visible: false).trigger(:click)
                 end
 
                 FileUploader::S3.any_instance.stubs(:call).returns("http://www.madrid.es/assets/documents/document-1.pdf", "http://www.madrid.es/assets/documents/document-2.pdf")

--- a/test/integration/gobierto_people/people/custom_links_navigation_test.rb
+++ b/test/integration/gobierto_people/people/custom_links_navigation_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module GobiertoPeople
+  module People
+    class CustomLinksNavigationTest < ActionDispatch::IntegrationTest
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def richard
+        @richard ||= gobierto_people_people(:richard)
+      end
+
+      def tamara
+        @tamara ||= gobierto_people_people(:tamara)
+      end
+
+      def test_custom_links_navigation
+        with_current_site(site) do
+          visit gobierto_people_person_path(richard.slug)
+
+          within '.people-navigation' do
+            assert has_link?('Trips')
+            assert has_link?('Gifts')
+          end
+
+          visit gobierto_people_person_path(tamara.slug)
+          
+          within '.people-navigation' do
+            refute has_link?('Trips')
+            refute has_link?('Gifts')
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Connects to [#91](https://github.com/PopulateTools/issues/issues/91)

### What does this PR do?

Implements the possibility to link external resources for the *Trips* and *Gifts* GobiertoPeople sections. A *custom links* `BlockRecord` with two fields was created: one for `service_name` and other for `service_url`.

### Setup for staging and production

1. Run the seeder for the site:

  ```ruby
  GobiertoCommon::GobiertoSeeder::ModuleSeeder.seed("GobiertoPeople", some_site)
  ```

2. Edit the person from the admin menu, adding two records to the *custom links* block:

  ![image](https://user-images.githubusercontent.com/9287468/31125498-c71fc1c8-a848-11e7-9a38-736e976c7082.png)

3. so it ends having two keys: `Viajes` and `Obsequios`:

  ![image](https://user-images.githubusercontent.com/9287468/31125563-f64c30a8-a848-11e7-8b1e-2b34a6a99b0a.png)

4. Now when you view the person in the frontend links to *gifts* and *trips* should be available:

 ![image](https://user-images.githubusercontent.com/9287468/31125639-3fc3e294-a849-11e7-9ff3-6e7012314a7d.png)


### Does this PR changes any configuration file?

No