### PR TITLE
New task to check existing indexes and create the new ones

### DIFF
--- a/lib/tasks/gobierto_core/search.rake
+++ b/lib/tasks/gobierto_core/search.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :gobierto_core do
+  namespace :search do
+    desc "Check indexes and create missing ones"
+    task migrate_indexes: :environment do
+      algolia_models = ActiveRecord::Base.descendants.select{ |model| model.respond_to?(:reindex) }
+      algolia_models.each do |model|
+        begin
+          model.index.search "test"
+        rescue Algolia::AlgoliaProtocolError
+          puts "- Creating index for #{model.name}"
+          model.reindex
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to [#94](https://github.com/PopulateTools/issues/issues/94)

### What does this PR do?

This PR adds a new task to be executed during the deploy. This task checks the searchable models in Algolia and checks if the index exists. If it doesn't, the script will create it.
