### PR TITLE
Fix google calendar url with the new base host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ RACK_ENV=development
 RAILS_ENV=development
 TLD_LENGTH=2
 HOST=gobierto.dev
+BASE_HOST=gobierto.dev
 PORT=3000
 RAILS_MAX_THREADS=5
 

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/person_calendar_configuration/edit.html.erb
@@ -10,7 +10,7 @@
         <% if @google_calendar_configuration.nil? %>
           <div class="form_item input_text">
             <p><%= t('.share_link') %></p>
-            <p><input type="text" name="google_calendar_invitation_url" value="<%= new_gobierto_people_google_calendar_authorization_url(token: @person.google_calendar_token) %>"/></p>
+            <p><input type="text" name="google_calendar_invitation_url" value="<%= new_gobierto_people_google_calendar_authorization_url(token: @person.google_calendar_token, host: ENV['BASE_HOST']) %>"/></p>
           </div>
         <% else %>
           <p><%= t('.calendar_configured') %>:</p>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -13,6 +13,7 @@ RACK_ENV=development
 RAILS_ENV=development
 TLD_LENGTH=2
 HOST=gobierto.dev
+BASE_HOST=gobierto.dev
 PORT=3000
 RAILS_MAX_THREADS=5
 
@@ -62,6 +63,7 @@ MAILER_SMTP_PASSWORD=
 - `RACK_ENV` and `RAILS_ENV`: Rack and Rails environment
 - `TLD_LENGTH`: TLD length setting for the session storage. See `config/initializers/session_store.rb`
 - `HOST` and `PORT`: application host and port
+- `BASE_HOST`: the application main host. It might be different from host, for example: hosted.gobierto.es vs gobierto.es
 - `RAILS_MAX_THREADS`: Puma setting
 - `TEST_LOG_LEVEL`: logger level in test environment. Set it to `fatal` to don't log anything.
 - `INTEGRATION_INSPECTOR` and `INTEGRATION_DEBUG`: Poltergeist settings to enable the inspector and the debugger. See https://github.com/teampoltergeist/poltergeist#remote-debugging-experimental


### PR DESCRIPTION
Connects to https://github.com/PopulateTools/issues/issues/92

### What does this PR do?

This PR fixes the Google connection URL in the installations where the host of the application is not `ENV['HOST']`. That's why we have introduced the concept of `ENV['BASE_HOST']`, which is where the application runs.
