### PR TITLE
98 - Sort people on welcome controller

### DIFF
--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -5,7 +5,7 @@ module GobiertoPeople
     before_action :check_active_submodules
 
     def index
-      @people = current_site.people.active.politician.government.last(10)
+      @people = current_site.people.active.politician.government.sorted.last(10)
       @posts  = current_site.person_posts.active.sorted.last(10)
       @political_groups = get_political_groups
       @home_text = load_home_text


### PR DESCRIPTION
Connects to [#98](https://github.com/PopulateTools/issues/issues/98)

### What does this PR do?

Fixes people order on `GobiertoPeople::WelcomeController`
