### PR TITLE
968 - Fix and document through tests Process open scope

### DIFF
--- a/app/controllers/gobierto_participation/processes_controller.rb
+++ b/app/controllers/gobierto_participation/processes_controller.rb
@@ -7,8 +7,8 @@ module GobiertoParticipation
     helper_method :current_process, :process_stage_path
 
     def index
-      @processes = current_site.processes.process.open.active
-      @groups = current_site.processes.group_process.open.active
+      @processes = current_site.processes.process.active
+      @groups = current_site.processes.group_process.active
     end
 
     def show

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -85,11 +85,9 @@ module GobiertoParticipation
     end
 
     def open?
-      if starts.present? && ends.present?
-        Time.zone.now.between?(starts, ends)
-      else
-        false
-      end
+      return false if starts.present? && starts > Time.zone.now
+      return false if ends.present? && ends < Time.zone.now
+      return true
     end
 
     private

--- a/test/fixtures/gobierto_participation/processes.yml
+++ b/test/fixtures/gobierto_participation/processes.yml
@@ -1,3 +1,5 @@
+# Groups
+
 green_city_group:
   site: madrid
   title_translations: <%= { 'en' => 'Green city', 'es' => 'Ciudad verde' }.to_json %>
@@ -15,6 +17,30 @@ cultural_city_group:
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels["draft"] %>
   issue: culture
+
+public_debates_group_future:
+  site: madrid
+  title_translations: <%= { 'en' => 'Public Debates', 'es' => 'Debates Públicos' }.to_json %>
+  body_translations: <%= { 'en' => 'Take part in these interesting debates', 'es' => 'Participa en estos interesantes debates' }.to_json %>
+  slug: public-debates
+  process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
+  visibility_level: <%= Site.visibility_levels['active'] %>
+  starts: <%= 1.week.from_now %>
+  ends:
+  scope: center
+
+dance_studio_group_ended:
+  site: madrid
+  title_translations: <%= { 'en' => 'Dance Studio', 'es' => 'Taller de danza' }.to_json %>
+  body_translations: <%= { 'en' => '', 'es' => '' }.to_json %>
+  slug: dance-studio
+  process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
+  visibility_level: <%= Site.visibility_levels['active'] %>
+  starts:
+  ends: <%= 1.week.ago %>
+  scope: center
+
+# Processes
 
 sport_city_process:
   site: madrid

--- a/test/integration/gobierto_participation/processes/process_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_index_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 module GobiertoParticipation
   class ProcessIndexTest < ActionDispatch::IntegrationTest
+
     def setup
       super
       @path = gobierto_participation_processes_path
@@ -13,12 +14,24 @@ module GobiertoParticipation
       @site ||= sites(:madrid)
     end
 
-    def processes
-      @processes ||= site.processes.process.open.active
+    def open_and_active_process
+      @open_and_active_process ||= gobierto_participation_processes(:sport_city_process)
     end
 
-    def groups
-      @groups ||= site.processes.group_process.open.active
+    def open_and_active_group
+      @open_and_active_group ||= gobierto_participation_processes(:green_city_group)
+    end
+
+    def draft_group
+      @draft_group ||= gobierto_participation_processes(:cultural_city_group)
+    end
+
+    def future_closed_group
+      @future_closed_group ||= gobierto_participation_processes(:public_debates_group_future)
+    end
+
+    def past_closed_group
+      @past_closed_group ||= gobierto_participation_processes(:dance_studio_group_ended)
     end
 
     def test_breadcrumb_items
@@ -66,14 +79,13 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        processes.each do |process|
-          assert has_link?(process.title)
-        end
-
-        groups.each do |group|
-          assert has_link?(group.title)
-        end
+        assert has_link?(open_and_active_process.title)
+        assert has_link?(open_and_active_group.title)
+        refute has_link?(draft_group.title)
+        assert has_link?(future_closed_group.title)
+        assert has_link?(past_closed_group.title)
       end
     end
+
   end
 end

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -61,5 +61,28 @@ module GobiertoCms
       assert_nil process_with_only_current_stage.next_stage
     end
 
+    def test_open?
+      # false when 'ends' date exceeded
+
+      process.update_attributes!(starts: nil, ends: 1.week.ago)
+      refute process.open?
+
+      # false when 'starts' date exceeded
+
+      process.update_attributes!(starts: 1.week.from_now, ends: nil)
+      refute process.open?
+
+      # true in any other case
+
+      process.update_attributes!(starts: nil, ends: nil)
+      assert process.open?
+
+      process.update_attributes!(starts: nil, ends: 1.week.from_now)
+      assert process.open?
+
+      process.update_attributes!(starts: 1.week.ago, ends: nil)
+      assert process.open?
+    end
+
   end
 end


### PR DESCRIPTION
Connects to #968 

### What does this PR do?

The *drafts* issue was already solved, but I solved a couple of issues related to the `Process#open?` method:

* `ProcessesController` no longer applies the `.open` scope. We want future and past processes/groups to be displayed in the front.
* I modified the `open?` method so:
  1. A process is considered closed if its `ends` date has already passed.
  2. A process is considered closes if its `starts` date is future.
  3. A process is considered open in any other case.
* I updated the `processes#index` integration so the circumstances when a process is displayed in the front are more explicit.

### Does this PR changes any configuration file?

No
