### PR TITLE
Create Section and SectionItem models

### DIFF
--- a/app/models/gobierto_cms/section.rb
+++ b/app/models/gobierto_cms/section.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_cms"
+
+module GobiertoCms
+  class Section < ApplicationRecord
+    include GobiertoCommon::Sluggable
+
+    belongs_to :site
+    has_many :section_items, dependent: :destroy, class_name: "GobiertoCms::SectionItem"
+
+    translates :title
+
+    validates :site, :title, presence: true
+    validates :slug, uniqueness: { scope: :site }
+
+    def attributes_for_slug
+      [title]
+    end
+  end
+end

--- a/app/models/gobierto_cms/section_item.rb
+++ b/app/models/gobierto_cms/section_item.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_cms"
+
+module GobiertoCms
+  class SectionItem < ApplicationRecord
+    belongs_to :item, polymorphic: true
+    belongs_to :section
+    belongs_to :parent, class_name: "GobiertoCms::SectionItem", foreign_key: "parent_id"
+    has_many :child_section_items, class_name: "GobiertoCms::SectionItem", foreign_key: "parent_id"
+
+    validates :item_id, :item_type, :position, :parent_id, :section_id, :level, presence: true
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -38,6 +38,7 @@ class Site < ApplicationRecord
 
   # Gobierto CMS integration
   has_many :pages, dependent: :destroy, class_name: "GobiertoCms::Page"
+  has_many :sections, dependent: :destroy, class_name: "GobiertoCms::Section"
 
   # Gobierto Attachments integration
   has_many :attachments, dependent: :destroy, class_name: "GobiertoAttachments::Attachment"

--- a/db/migrate/20171019074630_create_gobierto_cms_section_models.rb
+++ b/db/migrate/20171019074630_create_gobierto_cms_section_models.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateGobiertoCmsSectionModels < ActiveRecord::Migration[5.1]
+  def change
+    create_table :gcms_sections do |t|
+      t.jsonb :title_translations
+      t.string :slug, null: false, default: ""
+      t.references :site
+
+      t.timestamps
+    end
+
+    create_table :gcms_section_items do |t|
+      t.belongs_to :item, polymorphic: true
+      t.integer :position, null: false, default: 0
+      t.integer :parent_id, null: false
+      t.references :section
+      t.integer :level, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 20171019074630) do
     t.integer "site_id"
     t.index ["admin_id", "site_id"], name: "index_admin_admin_sites_on_admin_id_and_site_id"
     t.index ["admin_id"], name: "index_admin_admin_sites_on_admin_id"
-    t.index ["site_id", "admin_id"], name: "index_admin_admin_sites_on_site_id_and_admin_id", unique: true
     t.index ["site_id"], name: "index_admin_admin_sites_on_site_id"
   end
 
@@ -84,7 +83,6 @@ ActiveRecord::Schema.define(version: 20171019074630) do
     t.string "namespace", default: "", null: false
     t.string "resource_name", default: "", null: false
     t.string "action_name", default: "", null: false
-    t.bigint "resource_id"
     t.index ["admin_id", "namespace", "resource_name", "action_name"], name: "index_admin_permissions_on_admin_id_and_fields"
     t.index ["admin_id"], name: "index_admin_permissions_on_admin_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171012153920) do
+ActiveRecord::Schema.define(version: 20171019074630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20171012153920) do
     t.integer "site_id"
     t.index ["admin_id", "site_id"], name: "index_admin_admin_sites_on_admin_id_and_site_id"
     t.index ["admin_id"], name: "index_admin_admin_sites_on_admin_id"
+    t.index ["site_id", "admin_id"], name: "index_admin_admin_sites_on_site_id_and_admin_id", unique: true
     t.index ["site_id"], name: "index_admin_admin_sites_on_site_id"
   end
 
@@ -83,6 +84,7 @@ ActiveRecord::Schema.define(version: 20171012153920) do
     t.string "namespace", default: "", null: false
     t.string "resource_name", default: "", null: false
     t.string "action_name", default: "", null: false
+    t.bigint "resource_id"
     t.index ["admin_id", "namespace", "resource_name", "action_name"], name: "index_admin_permissions_on_admin_id_and_fields"
     t.index ["admin_id"], name: "index_admin_permissions_on_admin_id"
   end
@@ -278,6 +280,28 @@ ActiveRecord::Schema.define(version: 20171012153920) do
     t.index ["body_translations"], name: "index_gcms_pages_on_body_translations", using: :gin
     t.index ["site_id"], name: "index_gcms_pages_on_site_id"
     t.index ["title_translations"], name: "index_gcms_pages_on_title_translations", using: :gin
+  end
+
+  create_table "gcms_section_items", force: :cascade do |t|
+    t.string "item_type"
+    t.bigint "item_id"
+    t.integer "position", default: 0, null: false
+    t.integer "parent_id", null: false
+    t.bigint "section_id"
+    t.integer "level", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_type", "item_id"], name: "index_gcms_section_items_on_item_type_and_item_id"
+    t.index ["section_id"], name: "index_gcms_section_items_on_section_id"
+  end
+
+  create_table "gcms_sections", force: :cascade do |t|
+    t.jsonb "title_translations"
+    t.string "slug", default: "", null: false
+    t.bigint "site_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id"], name: "index_gcms_sections_on_site_id"
   end
 
   create_table "gobierto_calendars_event_attendees", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,8 @@ fixtures_to_load = [
   "gobierto_calendars/event_locations",
   "gobierto_calendars/event_attendees",
   "gobierto_cms/pages",
+  "gobierto_cms/sections",
+  "gobierto_cms/section_items",
   "gobierto_attachments/attachments",
   "gobierto_attachments/attachings",
   "versions",

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -58,3 +58,11 @@ about_site:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_news
+
+about_participation:
+  title_translations: <%= {'en' => 'About participation' }.to_json %>
+  body_translations: <%= {'en' => 'Sobre participación' }.to_json %>
+  slug: 'about-participation'
+  visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
+  site: madrid
+  collection: site_news

--- a/test/fixtures/gobierto_cms/section_items.yml
+++ b/test/fixtures/gobierto_cms/section_items.yml
@@ -1,0 +1,6 @@
+participation_items:
+  item: about_participation (GobiertoCms::Page)
+  position: 0
+  parent_id: nil
+  section: participation (GobiertoCms::Section)
+  level: 0

--- a/test/fixtures/gobierto_cms/sections.yml
+++ b/test/fixtures/gobierto_cms/sections.yml
@@ -1,0 +1,4 @@
+participation:
+  title_translations: <%= { 'en' => 'Participation', 'es' => 'Participación' }.to_json %>
+  slug: 'participacion'
+  site: madrid

--- a/test/models/gobierto_cms/section_item_test.rb
+++ b/test/models/gobierto_cms/section_item_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SectionItemTest < ActiveSupport::TestCase
+  def section_item
+    @section_item ||= gobierto_cms_section_items(:participation_items)
+  end
+
+  def test_valid
+    assert section_item.valid?
+  end
+end

--- a/test/models/gobierto_cms/section_test.rb
+++ b/test/models/gobierto_cms/section_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SectionTest < ActiveSupport::TestCase
+  def section
+    @section ||= gobierto_cms_sections(:participation)
+  end
+
+  def test_valid
+    assert section.valid?
+  end
+end


### PR DESCRIPTION
Connects to #1013 

### What does this PR do?

Create two new models in GobiertoCMS module:
- Section: a section is a container of section items. Belongs to a site, and when destroyed, all its section items should be destroyed. Attributes:
- localized title
- site_id (references to Site)
- slug

SectionItem: a section item belongs to a Section. Attributes:

- item_id
- item_type
- position
- parent_id (references to SectionItem)
- section_id (references to the Section)
- level (it can be useful to render the tree)

### How should this be manually tested?
From console show the section and section item
