### PR TITLE
Section admin

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCms
+    class SectionsController < BaseController
+      def index
+        @sections = current_site.sections
+
+        @section_form = SectionForm.new(site_id: current_site.id)
+      end
+
+      def show
+        @section = find_section
+        @pages = ::GobiertoCms::Page.pages_in_collections(current_site)
+      end
+
+      def new
+        @section_form = SectionForm.new
+
+        render(:new_modal, layout: false) && return if request.xhr?
+      end
+
+      def edit
+        @section = find_section
+        @section_form = SectionForm.new(
+          @section.attributes.except(*ignored_section_attributes)
+        )
+
+        render(:edit_modal, layout: false) && return if request.xhr?
+      end
+
+      def create
+        @section_form = SectionForm.new(section_params.merge(site_id: current_site.id))
+
+        if @section_form.save
+          # track_create_activity
+
+          redirect_to(
+            admin_cms_section_path(@section_form.section),
+            notice: t(".success_html", link: "gobierto_participation_section_url(@section_form.section.slug, host: current_site.domain)")
+          )
+        else
+          render(:new_modal, layout: false) && return if request.xhr?
+          render :new
+        end
+      end
+
+      def update
+        @section = find_section
+        @section_form = SectionForm.new(
+          section_params.merge(id: params[:id])
+        )
+
+        if @section_form.save
+          # track_update_activity
+
+          redirect_to(
+            admin_cms_section_path(@section_form.section),
+            notice: t(".success_html", link: "gobierto_participation_section_url(@section_form.section.slug, host: current_site.domain)")
+          )
+        else
+          render(:edit_modal, layout: false) && return if request.xhr?
+          render :edit
+        end
+      end
+
+      private
+
+      def track_create_activity
+        Publishers::SectionActivity.broadcast_event("section_created", default_activity_params.merge(subject: @section_form.section))
+      end
+
+      def track_update_activity
+        Publishers::SectionActivity.broadcast_event("section_updated", default_activity_params.merge(subject: @section))
+      end
+
+      def default_activity_params
+        { ip: remote_ip, author: current_admin, site_id: current_site.id }
+      end
+
+      def section_params
+        params.require(:section).permit(
+          :slug,
+          title_translations: [*I18n.available_locales]
+        )
+      end
+
+      def ignored_section_attributes
+        %w(created_at updated_at)
+      end
+
+      def find_section
+        current_site.sections.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
@@ -33,7 +33,7 @@ module GobiertoAdmin
         @section_form = SectionForm.new(section_params.merge(site_id: current_site.id))
 
         if @section_form.save
-          # track_create_activity
+          track_create_activity
 
           redirect_to(
             admin_cms_section_path(@section_form.section),
@@ -52,7 +52,7 @@ module GobiertoAdmin
         )
 
         if @section_form.save
-          # track_update_activity
+          track_update_activity
 
           redirect_to(
             admin_cms_section_path(@section_form.section),
@@ -67,11 +67,11 @@ module GobiertoAdmin
       private
 
       def track_create_activity
-        Publishers::SectionActivity.broadcast_event("section_created", default_activity_params.merge(subject: @section_form.section))
+        Publishers::GobiertoCmsSectionActivity.broadcast_event("section_created", default_activity_params.merge(subject: @section_form.section))
       end
 
       def track_update_activity
-        Publishers::SectionActivity.broadcast_event("section_updated", default_activity_params.merge(subject: @section))
+        Publishers::GobiertoCmsSectionActivity.broadcast_event("section_updated", default_activity_params.merge(subject: @section))
       end
 
       def default_activity_params

--- a/app/forms/gobierto_admin/gobierto_cms/section_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/section_form.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCms
+    class SectionForm
+      include ActiveModel::Model
+
+      attr_accessor(
+        :id,
+        :site_id,
+        :title_translations,
+        :slug
+      )
+
+      delegate :persisted?, to: :section
+
+      validates :site, presence: true
+
+      def save
+        save_section if valid?
+      end
+
+      def section
+        @section ||= section_class.find_by(id: id).presence || build_section
+      end
+
+      def site_id
+        @site_id ||= section.site_id
+      end
+
+      def site
+        @site ||= Site.find_by(id: site_id)
+      end
+
+      private
+
+      def build_section
+        section_class.new
+      end
+
+      def section_class
+        ::GobiertoCms::Section
+      end
+
+      def save_section
+        @section = section.tap do |section_attributes|
+          section_attributes.site_id = site_id
+          section_attributes.title_translations = title_translations
+          section_attributes.slug = slug
+        end
+
+        if @section.valid?
+          @section.save
+        else
+          promote_errors(@section.errors)
+
+          false
+        end
+      end
+
+      protected
+
+      def promote_errors(errors_hash)
+        errors_hash.each do |attribute, message|
+          errors.add(attribute, message)
+        end
+      end
+    end
+  end
+end

--- a/app/models/gobierto_cms/section.rb
+++ b/app/models/gobierto_cms/section.rb
@@ -4,6 +4,7 @@ require_dependency "gobierto_cms"
 
 module GobiertoCms
   class Section < ApplicationRecord
+    include GobiertoCommon::Sortable
     include GobiertoCommon::Sluggable
 
     belongs_to :site

--- a/app/publishers/gobierto_cms_section_activity.rb
+++ b/app/publishers/gobierto_cms_section_activity.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Publishers
+  class GobiertoCmsSectionActivity
+    include Publisher
+    self.pub_sub_namespace = 'activities/gobierto_cms_sections'
+  end
+end

--- a/app/subscribers/gobierto_cms_section_activity.rb
+++ b/app/subscribers/gobierto_cms_section_activity.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class GobiertoCmsSectionActivity < ::Subscribers::Base
+
+    def section_created(event)
+      create_activity_from_event(event, 'gobierto_cms.section_created')
+    end
+
+    def section_updated(event)
+      create_activity_from_event(event, 'gobierto_cms.section_updated')
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      Activity.create! subject: event.payload[:subject],
+                       author: event.payload[:author],
+                       subject_ip: event.payload[:ip],
+                       action: action,
+                       site_id: event.payload[:site_id],
+                       admin_activity: true
+    end
+  end
+
+end

--- a/app/views/gobierto_admin/gobierto_cms/sections/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/_form.html.erb
@@ -1,0 +1,28 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @section_form %>
+
+<%= form_for(
+  @section_form, as: :section,
+  url: @section_form.persisted? ? admin_cms_section_path(@section_form) : admin_cms_sections_path(@section), data: { "globalized-form-container" => true}) do |f| %>
+
+  <div class="globalized_fields">
+    <%= render "gobierto_admin/shared/form_locale_switchers" %>
+
+    <% current_site.configuration.available_locales.each do |locale| %>
+      <div class="form_item input_text" data-locale="<%= locale %>">
+        <%= label_tag "section[title_translations][#{locale}]", f.object.class.human_attribute_name(:title) %>
+        <%= text_field_tag "section[title_translations][#{locale}]", f.object.title_translations && f.object.title_translations[locale], placeholder: t(".placeholders.title", locale: locale.to_sym) %>
+      </div>
+    <% end %>
+
+      <div class="form_item input_text">
+        <%= f.label :slug %>
+        <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
+      </div>
+
+  </div>
+
+  <div class="actions right">
+    <%= f.submit %>
+  </div>
+
+<% end %>

--- a/app/views/gobierto_admin/gobierto_cms/sections/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_cms/sections/edit_modal.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/edit_modal.html.erb
@@ -1,0 +1,6 @@
+<div class="modal">
+
+  <h2><%= t(".title") %></h2>
+  <%= render "form" %>
+
+</div>

--- a/app/views/gobierto_admin/gobierto_cms/sections/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/index.html.erb
@@ -1,0 +1,47 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= t(".title") %>
+</div>
+
+<h1><%= title t(".title") %></h1>
+
+<div class="admin_tools right">
+  <%= link_to t(".new"), new_admin_cms_section_path, class: 'button open_remote_modal' %>
+</div>
+
+<table>
+  <tr>
+    <th class="icon_col"></th>
+    <th><%= t('.header.title') %></th>
+    <th><%= t('.header.pages') %></th>
+    <th></th>
+  </tr>
+
+  <tbody>
+    <% @sections.each do |section| %>
+      <tr>
+        <td>
+          <%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_cms_section_path(section), title: t('views.edit') %>
+        </td>
+        <td>
+          <%= link_to section.title, admin_cms_section_path(section) %>
+        </td>
+        <td>
+          <%= section.section_items.size %>
+        </td>
+        <td>
+          <%= link_to "gobierto_participation_section_path(section.slug ,host: current_site.domain)", target: "_blank", class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view") %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<% content_for :javascript_hook do %>
+  <%= javascript_tag do %>
+    window.GobiertoAdmin.sections_controller.index();
+  <% end %>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_cms/sections/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/new.html.erb
@@ -1,0 +1,1 @@
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_cms/sections/new_modal.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/new_modal.html.erb
@@ -1,0 +1,6 @@
+<div class="modal">
+
+  <h2><%= t(".title") %></h2>
+  <%= render "form" %>
+
+</div>

--- a/app/views/gobierto_admin/gobierto_cms/sections/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/show.html.erb
@@ -31,7 +31,6 @@
           <h2>
             <%= link_to edit_admin_cms_page_path(page, collection_id: page.collection), class: "tipsit", title: t('.page_help') do %>
               <%= page.title %>
-              <% byebug %>
               <span class="secondary"><%= page.collection.title %></span>
             <% end %>
           </h2>

--- a/app/views/gobierto_admin/gobierto_cms/sections/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/show.html.erb
@@ -1,0 +1,43 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t(".sections"), admin_cms_sections_path %>
+  <%= link_to @section.title, admin_cms_section_path(@section) %>
+</div>
+
+<h1><%= @section.title %></h1>
+
+<div class="admin_tools right">
+  <%= link_to '<i class="fa fa-cog"></i> Configuración'.html_safe, edit_admin_cms_section_path(@section), class: 'open_remote_modal' %>
+</div>
+
+<div class="pure-g">
+
+  <div class="pure-u-1 pure-u-md-1-2 p_h_r_2">
+    TREE
+  </div>
+
+  <div class="pure-u-1 pure-u-md-1-2">
+
+    <div class="form_item input_text">
+      <label for="name"><%= t('.select_page') %></label>
+      <input type="text" id="name" placeholder="<%= t('.placeholders.search') %>">
+    </div>
+
+    <h3><%= t('.last_edited_pages') %></h3>
+
+    <div class="activity_feed section_editor">
+      <% @pages.each do |page| %>
+        <div class="activity_item">
+          <h2>
+            <%= link_to edit_admin_cms_page_path(page, collection_id: page.collection), class: "tipsit", title: t('.page_help') do %>
+              <%= page.title %>
+              <% byebug %>
+              <span class="secondary"><%= page.collection.title %></span>
+            <% end %>
+          </h2>
+          <div class="date"><%= time_ago_in_words(page.created_at) %></div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -136,6 +136,12 @@
             </li>
             <% end %>
 
+            <% if show_module_link?("GobiertoCms") %>
+            <li>
+              <%= link_to t(".sections"), admin_cms_sections_path %>
+            </li>
+            <% end %>
+
             <li class="sep"></li>
 
             <li>

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -17,6 +17,7 @@ Subscribers::GobiertoBudgetsBudgetLineActivity.attach_to("activities/gobierto_bu
 Subscribers::GobiertoCommonCollectionActivity.attach_to("activities/gobierto_common_collections")
 Subscribers::IssueActivity.attach_to("activities/issues")
 Subscribers::ScopeActivity.attach_to("activities/scopes")
+Subscribers::GobiertoCmsSectionActivity.attach_to("activities/gobierto_cms_sections")
 Subscribers::GobiertoParticipationProcessActivity.attach_to("activities/gobierto_participation_processes")
 Subscribers::GobiertoParticipationPollActivity.attach_to("activities/gobierto_participation_polls")
 Subscribers::GobiertoParticipationContributionContainerActivity.attach_to("activities/gobierto_participation_contribution_containers")

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/sections/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/sections/ca.yml
@@ -1,0 +1,11 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_cms:
+      sections:
+        create:
+          success_html: La secció ha estat creada correctament. <a href="%{link}">Veure
+            la secció</a>.
+        update:
+          success_html: La secció ha estat actualitzada correctament. <a href="%{link}">Veure
+            la secció</a>.

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/sections/en.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/sections/en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  gobierto_admin:
+    gobierto_cms:
+      sections:
+        create:
+          success_html: Section created successfully. <a href="%{link}">View the section</a>.
+        update:
+          success_html: Section updated successfully. <a href="%{link}">View the section</a>.

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/sections/es.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/sections/es.yml
@@ -1,0 +1,11 @@
+---
+es:
+  gobierto_admin:
+    gobierto_cms:
+      sections:
+        create:
+          success_html: La sección ha sido creada correctamente. <a href="%{link}">Ver
+            la sección</a>.
+        update:
+          success_html: La sección ha sido actualizada correctamente. <a href="%{link}">Ver
+            la sección</a>.

--- a/config/locales/gobierto_admin/gobierto_cms/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/models/ca.yml
@@ -6,5 +6,9 @@ ca:
         body: Contingut
         slug: URL
         title: Títol
+      gobierto_admin/gobierto_cms/section_form:
+        slug: URL
+        title: Títol
     models:
       gobierto_admin/gobierto_cms/page_form: Pàgina
+      gobierto_admin/gobierto_cms/section_form: Secció

--- a/config/locales/gobierto_admin/gobierto_cms/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/models/en.yml
@@ -6,5 +6,9 @@ en:
         body: Body
         slug: URL
         title: Title
+      gobierto_admin/gobierto_cms/section_form:
+        slug: URL
+        title: Title
     models:
       gobierto_admin/gobierto_cms/page_form: Page
+      gobierto_admin/gobierto_cms/section_form: Section

--- a/config/locales/gobierto_admin/gobierto_cms/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/models/es.yml
@@ -6,5 +6,9 @@ es:
         body: Contenido
         slug: URL
         title: Título
+      gobierto_admin/gobierto_cms/section_form:
+        slug: URL
+        title: Título
     models:
       gobierto_admin/gobierto_cms/page_form: Página
+      gobierto_admin/gobierto_cms/section_form: Sección

--- a/config/locales/gobierto_admin/gobierto_cms/views/sections/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/views/sections/ca.yml
@@ -1,0 +1,28 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_cms:
+      sections:
+        edit_modal:
+          title: Editar secció
+        form:
+          placeholders:
+            slug: sobre-aquesta-seccio
+            title: Títol de la secció
+        index:
+          header:
+            pages: Pàgines
+            title: Secció
+          new: Nova
+          title: Seccions
+          view: Veure secció
+        new_modal:
+          title: Nova secció
+        show:
+          last_edited_pages: Últimes pàgines editades
+          page_help: Arrossega i deixa anar a la part esquerra per col·locar aquesta
+            pàgina al menú
+          placeholders:
+            search: Escriu el títol de la pàgina per buscar
+          sections: Seccions
+          select_page: Selecciona pàgina per incloure en la secció

--- a/config/locales/gobierto_admin/gobierto_cms/views/sections/en.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/views/sections/en.yml
@@ -1,0 +1,27 @@
+---
+en:
+  gobierto_admin:
+    gobierto_cms:
+      sections:
+        edit_modal:
+          title: Edit section
+        form:
+          placeholders:
+            slug: about-this-section
+            title: Section title
+        index:
+          header:
+            pages: Sections
+            title: Section
+          new: New
+          title: Sections
+          view: View section
+        new_modal:
+          title: New section
+        show:
+          last_edited_pages: Last edited pages
+          page_help: Drag and drop on the left side to place this page in the menu
+          placeholders:
+            search: Enter the title of the page to search
+          sections: Sections
+          select_page: Select page to include in the section

--- a/config/locales/gobierto_admin/gobierto_cms/views/sections/es.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/views/sections/es.yml
@@ -1,0 +1,28 @@
+---
+es:
+  gobierto_admin:
+    gobierto_cms:
+      sections:
+        edit_modal:
+          title: Editar sección
+        form:
+          placeholders:
+            slug: acerca-de-esta-seccion
+            title: Título de la sección
+        index:
+          header:
+            pages: Páginas
+            title: Sección
+          new: Nueva
+          title: Secciones
+          view: Ver sección
+        new_modal:
+          title: Nueva sección
+        show:
+          last_edited_pages: Últimas páginas editadas
+          page_help: Arrastra y suelta en la parte izquierda para colocar esta página
+            en el menú
+          placeholders:
+            search: Escribe el título de la página para buscar
+          sections: Secciones
+          select_page: Selecciona página para incluir en la sección

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -21,6 +21,7 @@ ca:
         participation: Participació
         people: Alts càrrecs i Agendes
         scopes: Àmbits
+        sections: Seccions
         site_network: Xarxa
         users: Usuaris
         view_site: Veure site

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -21,6 +21,7 @@ en:
         participation: Participation
         people: Officers and Agendas
         scopes: Scopes
+        sections: Sections
         site_network: Network
         users: Users
         view_site: View site

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -21,6 +21,7 @@ es:
         participation: Participación
         people: Altos cargos y Agendas
         scopes: Ámbitos
+        sections: Secciones
         site_network: Red
         users: Usuarios
         view_site: Ver site

--- a/config/locales/gobierto_cms/views/ca.yml
+++ b/config/locales/gobierto_cms/views/ca.yml
@@ -6,6 +6,8 @@ ca:
       gobierto_cms_page_deleted: "%{subject_name}"
       gobierto_cms_page_published: "%{subject_name}"
       gobierto_cms_page_updated: "%{subject_name}"
+      gobierto_cms_section_created: Secció creat
+      gobierto_cms_section_updated: Secció actualitzada
     pages:
       index:
         filter: Filtrar per tema

--- a/config/locales/gobierto_cms/views/en.yml
+++ b/config/locales/gobierto_cms/views/en.yml
@@ -6,6 +6,8 @@ en:
       gobierto_cms_page_deleted: "%{subject_name}"
       gobierto_cms_page_published: "%{subject_name}"
       gobierto_cms_page_updated: "%{subject_name}"
+      gobierto_cms_section_created: Section created
+      gobierto_cms_section_updated: Section updated
     pages:
       index:
         filter: Filter by theme

--- a/config/locales/gobierto_cms/views/es.yml
+++ b/config/locales/gobierto_cms/views/es.yml
@@ -6,6 +6,8 @@ es:
       gobierto_cms_page_deleted: "%{subject_name}"
       gobierto_cms_page_published: "%{subject_name}"
       gobierto_cms_page_updated: "%{subject_name}"
+      gobierto_cms_section_created: Sección creada
+      gobierto_cms_section_updated: Sección actualizada
     pages:
       index:
         filter: Filtrar por tema

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
 
     namespace :gobierto_cms, as: :cms, path: :cms do
       resources :pages, only: [:index, :new, :edit, :create, :update]
+      resources :sections, only: [:index, :new, :edit, :create, :update, :show]
     end
 
     namespace :gobierto_attachments, as: :attachments, path: :attachments do

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -41,7 +41,7 @@ notice_1:
   slug: 'notice-1'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
-  collection: gender_violence_process_news (GobiertoCommon::Collection)
+  collection: gender_violence_process_news
 
 notice_2:
   title_translations: <%= {'en' => 'Notice 2 title' }.to_json %>
@@ -49,7 +49,7 @@ notice_2:
   slug: 'notice-2'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
-  collection: gender_violence_process_news (GobiertoCommon::Collection)
+  collection: gender_violence_process_news
 
 about_site:
   title_translations: <%= {'en' => 'About site' }.to_json %>

--- a/test/fixtures/gobierto_cms/section_items.yml
+++ b/test/fixtures/gobierto_cms/section_items.yml
@@ -2,5 +2,5 @@ participation_items:
   item: about_participation (GobiertoCms::Page)
   position: 0
   parent_id: nil
-  section: participation (GobiertoCms::Section)
+  section: participation
   level: 0

--- a/test/forms/gobierto_admin/gobierto_cms/section_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_cms/section_form_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCms
+    class SectionFormTest < ActiveSupport::TestCase
+      def valid_section_form
+        @valid_section_form ||= SectionForm.new(
+          site_id: site.id,
+          title_translations: { I18n.locale => section.title },
+          slug: "section-form-slug"
+        )
+      end
+
+      def invalid_section_form
+        @invalid_section_form ||= SectionForm.new(
+          site_id: nil,
+          title_translations: nil,
+          slug: nil
+        )
+      end
+
+      def section
+        @section ||= gobierto_cms_sections(:participation)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def test_save_with_valid_attributes
+        assert valid_section_form.save
+      end
+
+      def test_error_messages_with_invalid_attributes
+        invalid_section_form.save
+
+        assert_equal 1, invalid_section_form.errors.messages[:site].size
+      end
+    end
+  end
+end

--- a/test/pub_sub/subscribers/gobierto_cms_section_activity_test.rb
+++ b/test/pub_sub/subscribers/gobierto_cms_section_activity_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Subscribers::GobiertoCmsSectionActivityTest < ActiveSupport::TestCase
+  class Event < OpenStruct; end
+
+  IP = "1.2.3.4"
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def subject
+    @subject ||= Subscribers::GobiertoCmsSectionActivity.new("activities")
+  end
+
+  def section
+    @section ||= gobierto_cms_sections(:participation)
+  end
+
+  def admin
+    @admin ||= gobierto_admin_admins(:tony)
+  end
+
+  def ip_address
+    @ip_address ||= IPAddr.new("1.2.3.4")
+  end
+
+  def test_section_created_event_handling
+    assert_difference "Activity.count" do
+      subject.section_created Event.new(name: "activities/gobierto_cms_sectiones.section_created", payload: {
+                                        subject: section, author: admin, ip: IP, site_id: site.id
+                                        })
+    end
+
+    activity = Activity.last
+    assert_equal section, activity.subject
+    assert_equal admin, activity.author
+    assert_equal ip_address, activity.subject_ip
+    assert_equal "gobierto_cms.section_created", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_section_updated_event_handling
+    assert_difference "Activity.count" do
+      subject.section_updated Event.new(name: "activities/gobierto_cms_sectiones.section_updated", payload: {
+                                        subject: section, author: admin, ip: IP, site_id: site.id
+                                        })
+    end
+
+    activity = Activity.last
+    assert_equal section, activity.subject
+    assert_equal admin, activity.author
+    assert_equal ip_address, activity.subject_ip
+    assert_equal "gobierto_cms.section_updated", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+end


### PR DESCRIPTION
Connects to #926 

### What does this PR do?

- List current site sections
- Count the number of items in the section
- The link to view the section will be broken for the moment
- Open the form in a modal
- Add localized fields fo the title/name of the section
- Add a slug field (it's missing in the mockup)
- Create the section should redirecto an emtpy show page (it wil be http://gobierto.dev/sandbox/admin_cms_sections_section)
- Track admin activity

### How should this be manually tested?
Access the admin section

### Does this PR changes any console tasks?
#### Add collection to pages without Collection
```
Site.all.each do |site|
  collection = GobiertoCommon::Collection.where(container: site).first

  unless collection.present?
    collection =  GobiertoCommon::Collection.create!(title_translations: { "ca": "Lloc", "en": "Site", "es": "Sitio" }, item_type: "GobiertoCms::Page", container: site, site: site)
  end

  pages_without_collection = GobiertoCms::Page.where(collection_id: nil)

  pages_without_collection.each do |page|
    collection.append(page)
    page.collection = collection
    page.save
  end
end
```
