### PR TITLE
Fix permissions

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
@@ -12,6 +12,7 @@ module GobiertoAdmin
 
       def index
         @people = current_site.people.sorted
+        @can_create_person = site_people_policy.create?
         @manage_all_people = site_people_policy.manage_all_people_in_site?
       end
 
@@ -124,7 +125,7 @@ module GobiertoAdmin
       end
 
       def create_person_allowed!
-        if !PersonPolicy.new(current_admin: current_admin).create?
+        if !PersonPolicy.new(current_admin: current_admin, current_site: current_site).create?
           redirect_to(admin_people_people_path, alert: t('gobierto_admin.admin_unauthorized')) and return false
         end
       end

--- a/app/forms/gobierto_admin/admin_form.rb
+++ b/app/forms/gobierto_admin/admin_form.rb
@@ -77,7 +77,7 @@ module GobiertoAdmin
     end
 
     def set_permitted_sites(attributes)
-      if attributes[:authorization_level] != 'regular'
+      if authorization_level != 'regular'
         @permitted_sites = []
         @sites = []
       elsif attributes[:permitted_sites].present?
@@ -93,7 +93,7 @@ module GobiertoAdmin
     end
 
     def set_permitted_modules(attributes)
-      if attributes[:authorization_level] != 'regular'
+      if authorization_level != 'regular'
         @permitted_modules = []
       elsif attributes[:permitted_modules].present?
         @permitted_modules = attributes[:permitted_modules].select{ |m| m.present? }.compact
@@ -105,19 +105,19 @@ module GobiertoAdmin
     end
 
     def set_all_people_permitted(attributes)
-      if attributes[:authorization_level] != 'regular'
+      if authorization_level != 'regular'
         @all_people_permitted = false
       elsif attributes[:all_people_permitted].present?
         @all_people_permitted = (attributes[:all_people_permitted] == '1' || attributes[:all_people_permitted] == true)
       elsif admin.persisted?
         @all_people_permitted = admin.people_permissions.exists?(action_name: 'manage_all')
-      elsif admin
-        @all_people_permitted = true
+      else
+        @all_people_permitted = false
       end
     end
 
     def set_permitted_people(attributes)
-      if attributes[:authorization_level] != 'regular' || @all_people_permitted
+      if authorization_level != 'regular' || @all_people_permitted
         @permitted_people = []
       elsif attributes[:permitted_people].present?
         @permitted_people = attributes[:permitted_people].select{ |m| m.present? }.map{|id| id.to_i }.compact

--- a/app/forms/gobierto_admin/admin_form.rb
+++ b/app/forms/gobierto_admin/admin_form.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
       :last_sign_in_ip
     )
 
-    attr_reader :permissions, :permitted_sites, :permitted_modules, :permitted_people, :sites
+    attr_reader :permissions, :permitted_sites, :permitted_modules, :permitted_people, :all_people_permitted, :sites
 
     delegate :persisted?, to: :admin
 
@@ -38,6 +38,7 @@ module GobiertoAdmin
 
       set_permitted_sites(parsed_attributes)
       set_permitted_modules(parsed_attributes)
+      set_all_people_permitted(parsed_attributes)
       set_permitted_people(parsed_attributes)
     end
 
@@ -103,11 +104,21 @@ module GobiertoAdmin
       end
     end
 
-    def set_permitted_people(attributes)
+    def set_all_people_permitted(attributes)
       if attributes[:authorization_level] != 'regular'
+        @all_people_permitted = false
+      elsif attributes[:all_people_permitted].present?
+        @all_people_permitted = (attributes[:all_people_permitted] == '1' || attributes[:all_people_permitted] == true)
+      elsif admin.persisted?
+        @all_people_permitted = admin.people_permissions.exists?(action_name: 'manage_all')
+      elsif admin
+        @all_people_permitted = true
+      end
+    end
+
+    def set_permitted_people(attributes)
+      if attributes[:authorization_level] != 'regular' || @all_people_permitted
         @permitted_people = []
-      elsif attributes[:all_people_permitted] && attributes[:all_people_permitted] == 'on'
-        @permitted_people = ::GobiertoPeople::Person.where(site: sites).active.pluck(:id)
       elsif attributes[:permitted_people].present?
         @permitted_people = attributes[:permitted_people].select{ |m| m.present? }.map{|id| id.to_i }.compact
       elsif @admin
@@ -120,6 +131,7 @@ module GobiertoAdmin
     def build_permissions
       @permissions = admin.permissions
       build_modules_permissions
+      build_all_people_permissions
       build_people_permissions
       @permissions
     end
@@ -143,6 +155,21 @@ module GobiertoAdmin
       end
     end
 
+    def build_all_people_permissions
+      revoked_permissions_ids = []
+      existing_manage_all_people_permissions_ids = admin.people_permissions.where(action_name: 'manage_all').pluck(:id)
+
+      if permitted_people.any? || !@all_people_permitted ||  !permitted_modules_names.include?('gobierto_people')
+        revoked_permissions_ids.concat(existing_manage_all_people_permissions_ids)
+      elsif @all_people_permitted && existing_manage_all_people_permissions_ids.empty?
+        @permissions << build_all_people_permission
+      end
+
+      @permissions.each do |p|
+        p.mark_for_destruction if revoked_permissions_ids.include?(p.id)
+      end
+    end
+
     def build_people_permissions
       existing_people_permissions    = admin.permissions.where(namespace: 'gobierto_people', resource_name: 'person', action_name: 'manage')
       revoked_people_permissions_ids = existing_people_permissions.where.not(resource_id: permitted_people).pluck(:id)
@@ -161,7 +188,7 @@ module GobiertoAdmin
       # if site permissions where revoked, revoke site people permissions
       revoked_people_permissions_ids = []
       @permissions.each do |permission|
-        if permission.resource_name == 'person'
+        if permission.person_record_permission?
           person_site = ::GobiertoPeople::Person.find_by(id: permission.resource_id).site
           if !permitted_sites.include?(person_site.id)
             revoked_people_permissions_ids << permission.id
@@ -205,6 +232,15 @@ module GobiertoAdmin
         resource_name: 'person',
         resource_id: person.id,
         action_name: 'manage'
+      )
+    end
+
+    def build_all_people_permission
+      ::GobiertoAdmin::Permission.new(
+        admin: admin,
+        namespace: 'gobierto_people',
+        resource_name: 'person',
+        action_name: 'manage_all'
       )
     end
 

--- a/app/models/gobierto_admin/permission.rb
+++ b/app/models/gobierto_admin/permission.rb
@@ -13,6 +13,14 @@ module GobiertoAdmin
     validates :action_name, presence: true
     validates :namespace, uniqueness: { scope: [:admin_id, :resource_name, :resource_id, :action_name] }
 
+    def for_person?
+      (namespace == 'gobierto_people') && (resource_name == 'person')
+    end
+
+    def person_record_permission?
+      for_person? && resource_id.present? && (action_name == 'manage')
+    end
+
     def self.by_namespace(namespace)
       where(namespace: namespace)
     end

--- a/app/views/gobierto_admin/admins/_form.html.erb
+++ b/app/views/gobierto_admin/admins/_form.html.erb
@@ -87,18 +87,19 @@
                   <div class="option_suboptions" id="people_permissions" style="<%= module_active ? '' : 'display: none;' %>">
 
                     <div class="option" style="<%= permitted_sites.any? ? '' : 'display: none;' %>">
-                      <input type="checkbox" name="admin[all_people_permitted]" id="admin_all_people_permitted"/>
-                      <label for="admin_all_people_permitted">
-                        <span></span><b><%= 'Todas' %></b>
-                      </label>
+                      <%= f.check_box :all_people_permitted %>
+                      <%= f.label :all_people_permitted do %>
+                        <span></span><b><%= t('.all') %></b>
+                      <% end %>
                     </div>
 
                     <%= f.collection_check_boxes(:permitted_people, Array(@people), :id, :name) do |person_b| %>
                       <% person_site_id = person_b.object.site_id %>
                       <% person_site_permitted = permitted_sites.include?(person_site_id) %>
+                      <% person_policy = ::GobiertoAdmin::GobiertoPeople::PersonPolicy.new(current_admin: @admin, person: person_b.object) %>
 
                       <div class="option" data-class="site_person" data-site-id="<%= person_site_id %>" style="<%= person_site_permitted ? '' : 'display: none;' %>">
-                        <%= person_b.check_box(checked: @admin && ::GobiertoAdmin::GobiertoPeople::PersonPolicy.new(current_admin: @admin, person: person_b.object).manage?) %>
+                        <%= person_b.check_box(checked: @admin && person_policy.manage? && !person_policy.manage_all_people_in_site?) %>
                         <%= person_b.label do %>
                           <span></span><%= person_b.object.name %>
                         <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/index.html.erb
@@ -10,7 +10,9 @@
     <i class="fa fa-cog"></i>
     <%= t(".configuration") %>
   <% end %>
-  <%= link_to t(".new"), new_admin_people_person_path, class: "button" %>
+  <% if @can_create_person %>
+    <%= link_to t(".new"), new_admin_people_person_path, class: "button" %>
+  <% end %>
 </div>
 
 <table class="people-list">

--- a/config/locales/gobierto_admin/views/admins/ca.yml
+++ b/config/locales/gobierto_admin/views/admins/ca.yml
@@ -6,6 +6,7 @@ ca:
         title: Editar Administrador
       form:
         activity_block: Log d'actividad
+        all: Totes
         authorization_level:
           disabled: Deshabilitat
           manager: Manager

--- a/config/locales/gobierto_admin/views/admins/en.yml
+++ b/config/locales/gobierto_admin/views/admins/en.yml
@@ -6,6 +6,7 @@ en:
         title: Edit Admin
       form:
         activity_block: Activity log
+        all: All
         authorization_level:
           disabled: Disabled
           manager: Manager

--- a/config/locales/gobierto_admin/views/admins/es.yml
+++ b/config/locales/gobierto_admin/views/admins/es.yml
@@ -6,6 +6,7 @@ es:
         title: Editar Administrador
       form:
         activity_block: Log de actividad
+        all: Todas
         authorization_level:
           disabled: Deshabilitado
           manager: Manager

--- a/db/data/20171030134143_update_god_admins_authorization_level.rb
+++ b/db/data/20171030134143_update_god_admins_authorization_level.rb
@@ -1,0 +1,10 @@
+class UpdateGodAdminsAuthorizationLevel < ActiveRecord::Migration[5.1]
+
+  def up
+    GobiertoAdmin::Admin.where(god: true).each { |admin| admin.manager! }
+  end
+
+  def down
+  end
+
+end

--- a/test/fixtures/gobierto_admin/permissions.yml
+++ b/test/fixtures/gobierto_admin/permissions.yml
@@ -29,23 +29,3 @@ tony_tamara:
   resource_name: person
   resource_id: <%= ActiveRecord::FixtureSet.identify(:tamara) %>
   action_name: manage
-
-nick_gobierto_people:
-  admin: nick
-  resource_name: gobierto_people
-  namespace: site_module
-  action_name: manage
-
-nick_richard:
-  admin: nick
-  namespace: gobierto_people
-  resource_name: person
-  resource_id: <%= ActiveRecord::FixtureSet.identify(:richard) %>
-  action_name: manage
-
-nick_tamara:
-  admin: nick
-  namespace: gobierto_people
-  resource_name: person
-  resource_id: <%= ActiveRecord::FixtureSet.identify(:tamara) %>
-  action_name: manage

--- a/test/forms/gobierto_admin/admin_form_test.rb
+++ b/test/forms/gobierto_admin/admin_form_test.rb
@@ -257,12 +257,15 @@ module GobiertoAdmin
         permitted_modules: ['GobiertoPeople'],
         permitted_sites: [ madrid.id ],
         permitted_people: [],
-        all_people_permitted: 'on'
+        all_people_permitted: '1'
       ))
 
       assert admin_form.save
 
-      assert_equal madrid.people.active.size, madrid_and_santander_admin.people_permissions.size
+      people_permissions = madrid_and_santander_admin.people_permissions
+
+      assert_equal 1, people_permissions.size
+      assert_equal 'manage_all', people_permissions.first.action_name
     end
 
     def test_grant_person_permissions_without_site_permissions
@@ -304,15 +307,13 @@ module GobiertoAdmin
       assert_equal 1, madrid_and_santander_admin.people_permissions.size
     end
 
-    # Using the syntax .where("x NOT IN (?)", collection) may have unintended behavior
-    # for empty collections.
-    # Use this test to make sure .where.not(attribute: collection) syntax is used
     def test_revoke_all_people_permissions
       admin_form = AdminForm.new(admin_params.merge(
         id: madrid_and_santander_admin.id,
         permitted_modules: ['GobiertoPeople'],
         permitted_sites: [ madrid.id, santander.id ],
-        permitted_people: []
+        permitted_people: [],
+        all_people_permitted: '0'
       ))
 
       assert admin_form.save

--- a/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/people_index_test.rb
@@ -5,13 +5,20 @@ require "test_helper"
 module GobiertoAdmin
   module GobiertoPeople
     class PeopleIndexTest < ActionDispatch::IntegrationTest
+
+      include PermissionHelpers
+
       def setup
         super
         @path = admin_people_people_path
       end
 
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
+      def manager_admin
+        @manager_admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def regular_admin
+        @regular_admin ||= gobierto_admin_admins(:tony)
       end
 
       def site
@@ -22,10 +29,24 @@ module GobiertoAdmin
         @people ||= site.people
       end
 
+      def manageable_person
+        @manageable_person ||= gobierto_people_people(:richard)
+      end
+
+      def unmanageable_published_person
+        @unmanageable_person ||= gobierto_people_people(:nelson)
+      end
+
+      def unmanageable_draft_person
+        @unmanageable_draft_person ||= gobierto_people_people(:juana)
+      end
+
       def test_people_index
-        with_signed_in_admin(admin) do
+        with_signed_in_admin(manager_admin) do
           with_current_site(site) do
             visit @path
+
+            assert has_link? 'New person'
 
             within "table.people-list tbody" do
               assert has_selector?("tr", count: people.size)
@@ -46,6 +67,65 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_people_index_without_manage_all_permissions
+        with_signed_in_admin(regular_admin) do
+          with_current_site(site) do
+            visit @path
+
+            refute has_link? 'New person'
+
+            within "#person-item-#{manageable_person.id}" do
+              assert has_link? manageable_person.name
+              assert has_link? 'View person'
+              assert_equal 1, first('td').all('a').size
+            end
+
+            within "#person-item-#{unmanageable_published_person.id}" do
+              refute has_link? unmanageable_published_person.name
+              assert has_link? 'View person'
+              assert first('td').all('a').empty?
+            end
+
+            within "#person-item-#{unmanageable_draft_person.id}" do
+              refute has_link? unmanageable_draft_person.name
+              refute has_link? 'View person'
+              assert first('td').all('a').empty?
+            end
+          end
+        end
+      end
+
+      def test_people_index_regular_admin_with_manage_all_permissions
+        setup_specific_permissions(regular_admin, site: site, module: 'gobierto_people', all_people: true)
+
+        with_signed_in_admin(regular_admin) do
+          with_current_site(site) do
+            visit @path
+
+            assert has_link? 'New person'
+
+            within "#person-item-#{manageable_person.id}" do
+              assert has_link? manageable_person.name
+              assert has_link? 'View person'
+              assert_equal 1, first('td').all('a').size
+            end
+
+            within "#person-item-#{unmanageable_published_person.id}" do
+              assert has_link? unmanageable_published_person.name
+              assert has_link? 'View person'
+              assert_equal 1, first('td').all('a').size
+            end
+
+            within "#person-item-#{unmanageable_draft_person.id}" do
+              assert has_link? unmanageable_draft_person.name
+              assert has_link? 'View person'
+              assert_equal 1, first('td').all('a').size
+            end
+          end
+        end
+      end
+
     end
   end
 end

--- a/test/support/permission_helpers.rb
+++ b/test/support/permission_helpers.rb
@@ -35,6 +35,14 @@ module PermissionHelpers
       )
     end
 
+    if options[:all_people]
+      admin_permissions << admin.permissions.build(
+        namespace: 'gobierto_people',
+        resource_name: 'person',
+        action_name: 'manage_all'
+      )
+    end
+
     admin.sites = admin_sites
     admin.permissions = admin_permissions
     admin.save


### PR DESCRIPTION
Connects to [#118](https://github.com/PopulateTools/issues/issues/118)

### What does this PR do?

* Updates the permission system so only god, manager or regular admins with the `All people` options selected can create new people.
* Fixes a bug preventing god admins to edit/create people.
* This PR contains a **data migration** to update all god managers so they become of type `manager`.

### How should this be manually tested?

* Both god and manager admins should be able to edit all people and create new ones.
* Regular admins with permissions over specific people should be able to edit those and can't create new ones.
* Regular admins with permissions over "All people" should be able to edit everyone and create new people.
* Checking the option "All people" and selecting individual people should be exclusive options. When one is checked, the other is unchecked.

### Does this PR changes any configuration file?

No
