### PR TITLE
Import Google Calendar events description

### DIFF
--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -98,6 +98,7 @@ module GobiertoPeople
           site_id: person.site_id,
           external_id: event.id,
           title: event.summary,
+          description: event.description,
           starts_at: event.start.date_time || DateTime.parse(event.start.date),
           ends_at: event.end.date_time || DateTime.parse(event.end.date),
           state: GobiertoCalendars::Event.states[:published],

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -48,32 +48,32 @@ module GobiertoPeople
         # Single event, organized by richard, with two attendees, from calendar that is not selected
         event7 = mock
         event7.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: "event7",
-                     summary: "Event 7", start: date1, end: date2, attendees: [attendee1, attendee2])
+                     summary: "Event 7", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
         # Single event, organized by richard, with two attendees
         event2 = mock
         event2.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: "event2",
-                     summary: "Event 2", start: date1, end: date2, attendees: [attendee1, attendee2])
+                     summary: "Event 2", start: date1, end: date2, attendees: [attendee1, attendee2], description: "Event 2 description")
 
         # Single event, organized by other, Richard is invited
         event3 = mock
         event3.stubs(visibility: nil, location: "Patio de mi casa 1, 28005, Madrid", creator: creator_event3, recurrence: nil, id: "event3",
-                     summary: "Event 3", start: date1, end: date2, attendees: [attendee1, attendee2])
+                     summary: "Event 3", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
         # Recurring event
         event4 = mock
         event4.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: ["WEEK=1"], id: "event4",
-                     summary: "Event 4", start: date1, end: date2, attendees: [attendee1, attendee2])
+                     summary: "Event 4", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
         # Instance 1 of recurring event event4
         event5 = mock
         event5.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_1",
-                     summary: "Event 5", start: date1, end: date2, attendees: [attendee1, attendee2])
+                     summary: "Event 5", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
         # Instance 2 of recurring event event4
         event6 = mock
         event6.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_2",
-                     summary: "Event 6", start: date1, end: date2, attendees: [attendee1, attendee2])
+                     summary: "Event 6", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
         calendar1 = mock
         calendar1.stubs(id: google_calendar_id, primary?: true)
@@ -130,6 +130,7 @@ module GobiertoPeople
         assert_equal richard, event.attendees.first.person
         assert_nil event.attendees.second.person
         assert_equal "Wadus person", event.attendees.second.name
+        assert_equal "Event 2 description", event.description
 
         # Event 3 checks
         event = site.events.find_by external_id: "event3"


### PR DESCRIPTION
Bugfix

### What does this PR do?

This PR amends Google Calendar integration to import events description.

### How should this be manually tested?

Tested in staging

![screen shot 2017-10-31 at 19 09 14](https://user-images.githubusercontent.com/17616/32240942-01f86638-be6f-11e7-9e94-bd3234c94084.png)

