### PR TITLE
Sandbox leftover when listing issues in Participation Home

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -41,6 +41,21 @@ class Issue < ApplicationRecord
     GobiertoCms::Page.pages_in_collections_and_container(self.site, self).sorted.active
   end
 
+  def number_contributions
+    contributions.size
+  end
+
+  def number_contributing_neighbours
+    contributions.pluck(:user_id).uniq.size
+  end
+
+  def contributions
+    GobiertoParticipation::Contribution.joins(contribution_container: :process)
+                                       .where("gpart_processes.visibility_level = 1 AND
+                                               gpart_contribution_containers.visibility_level = 1 AND
+                                               gpart_processes.issue_id = ?", id)
+  end
+
   private
 
   def uniqueness_of_name

--- a/app/views/gobierto_participation/issues/_theme_teaser.html.erb
+++ b/app/views/gobierto_participation/issues/_theme_teaser.html.erb
@@ -8,8 +8,8 @@
 
       <% if meta %>
         <div class="meta right">
-          <div class="ib"><i class="fa fa-comment"></i> 30</div>
-          <div class="ib"><i class="fa fa-users"></i> 50</div>
+          <div class="ib"><i class="fa fa-comment"></i><%= issue.number_contributions %></div>
+          <div class="ib"><i class="fa fa-users"></i><%= issue.number_contributing_neighbours %></div>
         </div>
       <% end %>
   <% end %>


### PR DESCRIPTION
Connects to #1048 

### What does this PR do?

Displays for each theme the number of neighbours who have contributions and the number of contributions.

### How should this be manually tested?

In /participacion If you have the participation module activated and issues created.


