### PR TITLE
Define order for current_site.issues has_many with the scope sorted

### DIFF
--- a/app/controllers/gobierto_admin/issues_controller.rb
+++ b/app/controllers/gobierto_admin/issues_controller.rb
@@ -5,8 +5,7 @@ module GobiertoAdmin
     helper_method :issue_preview_url
 
     def index
-      @issues = current_site.issues
-
+      @issues = current_site.issues.sorted
       @issue_form = IssueForm.new(site_id: current_site.id)
     end
 

--- a/app/controllers/gobierto_admin/issues_controller.rb
+++ b/app/controllers/gobierto_admin/issues_controller.rb
@@ -5,7 +5,7 @@ module GobiertoAdmin
     helper_method :issue_preview_url
 
     def index
-      @issues = current_site.issues.sorted
+      @issues = current_site.issues
 
       @issue_form = IssueForm.new(site_id: current_site.id)
     end

--- a/app/controllers/gobierto_participation/activities_controller.rb
+++ b/app/controllers/gobierto_participation/activities_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoParticipation
   class ActivitiesController < BaseController
     def index
-      @issues = current_site.issues.alphabetically_sorted
+      @issues = current_site.issues
 
       @issue = find_issue if params[:issue_id]
 

--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class EventsController < GobiertoParticipation::ApplicationController
     def index
       @issue = find_issue if params[:issue_id]
-      @issues = current_site.issues.alphabetically_sorted
+      @issues = current_site.issues
 
       container_events
       set_events

--- a/app/controllers/gobierto_participation/issues_controller.rb
+++ b/app/controllers/gobierto_participation/issues_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoParticipation
   class IssuesController < GobiertoParticipation::ApplicationController
     def index
-      @issues = current_site.issues.alphabetically_sorted
+      @issues = current_site.issues
     end
 
     def show

--- a/app/controllers/gobierto_participation/processes/activities_controller.rb
+++ b/app/controllers/gobierto_participation/processes/activities_controller.rb
@@ -6,7 +6,7 @@ module GobiertoParticipation
       include ::PreviewTokenHelper
 
       def index
-        @issues = current_site.issues.alphabetically_sorted
+        @issues = current_site.issues
 
         @issue = find_issue if params[:issue_id]
 

--- a/app/controllers/gobierto_participation/processes/events_controller.rb
+++ b/app/controllers/gobierto_participation/processes/events_controller.rb
@@ -12,7 +12,7 @@ module GobiertoParticipation
       end
 
       def index
-        @issues = current_site.issues.alphabetically_sorted
+        @issues = current_site.issues
 
         @issue = find_issue if params[:issue_id]
 

--- a/app/controllers/gobierto_participation/welcome_controller.rb
+++ b/app/controllers/gobierto_participation/welcome_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class WelcomeController < GobiertoParticipation::ApplicationController
     def index
       @processes = current_site.processes.process.active
-      @issues = current_site.issues.alphabetically_sorted
+      @issues = current_site.issues
       @events = find_participation_events
       @news = find_participation_news
       @activities = find_participation_activities

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -47,7 +47,7 @@ class Site < ApplicationRecord
   has_many :module_settings, dependent: :destroy, class_name: "GobiertoModuleSettings"
 
   # Gobierto Participation integration
-  has_many :issues, dependent: :destroy, class_name: "Issue"
+  has_many :issues, -> { sorted }, dependent: :destroy, class_name: "Issue"
   has_many :processes, dependent: :destroy, class_name: "GobiertoParticipation::Process"
   has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"
   has_many :contributions, dependent: :destroy, class_name: "GobiertoParticipation::Contribution"

--- a/test/integration/gobierto_admin/create_issue_test.rb
+++ b/test/integration/gobierto_admin/create_issue_test.rb
@@ -63,7 +63,7 @@ module GobiertoAdmin
             assert has_field?("issue_name_translations_es", with: "Mi tema")
             assert has_field?("issue_description_translations_es", with: "Descripción de mi tema")
 
-            issue = site.issues.last
+            issue = site.issues.first
             activity = Activity.last
             assert_equal issue, activity.subject
             assert_equal admin, activity.author


### PR DESCRIPTION
Connects to #1047

### What does this PR do?

Correct that it always shows ordered issues in the site. The solution has been simple, in the relationship of issues with site is added the scope of ordering, so it is only in one place of the site

### How should this be manually tested?

In the participation module, in participation home, in the list of issues, in the filters for news or events, etc.
