### PR TITLE
Report slow tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :test do
   gem "timecop"
   gem "vcr"
   gem "webmock"
+  gem "minitest-test_profile"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,12 @@ GEM
     connection_pool (2.2.1)
     cookies_eu (1.6.3)
       js_cookie_rails
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.2)
@@ -269,12 +275,16 @@ GEM
     minitest-retry (0.1.9)
       minitest (>= 5.0)
     minitest-stub_any_instance (1.0.1)
+    minitest-test_profile (0.2.1)
+      coveralls
+      minitest
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (2.9.4)
+    netrc (0.11.0)
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
@@ -339,6 +349,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.1)
     rollbar (2.15.5)
       multi_json
@@ -392,6 +406,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     spy (0.4.5)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     therubyracer (0.12.3)
@@ -402,6 +418,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.7)
     timecop (0.9.1)
+    tins (1.15.0)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
@@ -471,6 +488,7 @@ DEPENDENCIES
   minitest-reporters
   minitest-retry
   minitest-stub_any_instance
+  minitest-test_profile
   mocha
   paper_trail
   pg (~> 0.19)
@@ -498,4 +516,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,12 +48,15 @@ require "capybara/email"
 require "minitest/retry"
 require "vcr"
 require "mocha/mini_test"
+require "minitest/test_profile"
 
 I18n.locale = I18n.default_locale = :en
 Time.zone = "Madrid"
 
 Minitest::Retry.use! if ENV["RETRY_FAILING_TEST"]
-Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
+# Incompatible with test profile
+# Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
+Minitest::TestProfile.use!
 
 WebMock.disable_net_connect!(
   allow_localhost: true,


### PR DESCRIPTION
### What does this PR do?

This PR updates the Minitest output to use a new profile that shows a report at the end of the execution with the list of 10 top slowest test
