### PR TITLE
Execution graph: control list categories

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/execution.js
+++ b/app/assets/javascripts/gobierto_budgets/execution.js
@@ -53,16 +53,15 @@ $( document ).on('turbolinks:load', function() {
 
   if($('body.budgets_execution_index').length) {
 
-    if(window.location.hash === "")
-      window.location.hash = "#functional,economic"
-
     var validValues = ['economic', 'functional', 'custom'];
-    var list = window.location.hash.slice(1).split(',');
-    var expensesKind = list[0];
-    var incomeKind = list[1];
+    if(window.location.hash === "") {
+      var expensesKind = $('.expenses_switcher').data('toggle');
+      var incomeKind = $('.income_switcher').data('toggle');
+      window.location.hash = "#" + expensesKind + "," + incomeKind;
+    }
+
     if(validValues.indexOf(expensesKind) === -1) expensesKind = validValues[0];
     if(validValues.indexOf(incomeKind) === -1) incomeKind = validValues[0];
-
 
     $('.execution_vs_budget_table tr:nth-of-type(n+6)').hide()
 

--- a/app/controllers/gobierto_budgets/budgets_execution_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_execution_controller.rb
@@ -12,14 +12,14 @@ class GobiertoBudgets::BudgetsExecutionController < GobiertoBudgets::Application
     @top_possitive_difference_expending_economic, @top_negative_difference_expending_economic = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, type: 'economic')
     @top_possitive_difference_expending_functional, @top_negative_difference_expending_functional = GobiertoBudgets::BudgetLine.top_differences(ine_code: @place.id, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, type: 'functional')
 
-    @any_economic_income_budget_lines    = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::INCOME,  area: GobiertoBudgets::EconomicArea,   index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed)
-    @any_economic_expense_budget_lines   = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::EconomicArea,   index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed)
-    @any_functional_expense_budget_lines = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::FunctionalArea, index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed)
-    @any_custom_income_budget_lines      = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::INCOME,  area: GobiertoBudgets::CustomArea,     index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed)
-    @any_custom_expense_budget_lines     = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::CustomArea,     index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed)
+    @any_economic_income_budget_lines    = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::INCOME,  area: GobiertoBudgets::EconomicArea,   index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, year: @year)
+    @any_economic_expense_budget_lines   = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::EconomicArea,   index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, year: @year)
+    @any_functional_expense_budget_lines = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::FunctionalArea, index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, year: @year)
+    @any_custom_income_budget_lines      = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::INCOME,  area: GobiertoBudgets::CustomArea,     index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, year: @year)
+    @any_custom_expense_budget_lines     = GobiertoBudgets::BudgetLine.any_data?(site: current_site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::CustomArea,     index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, year: @year)
 
-    @several_expenses_filters = [@any_economic_expense_budget_lines, @any_functional_expense_budget_lines, @any_custom_expense_budget_lines].select{ |e| e }.size > 1
-    @several_income_filters   = [@any_economic_income_budget_lines, @any_custom_income_budget_lines].select{ |e| e }.size > 1
+    @several_expenses_filters = [@any_economic_expense_budget_lines, @any_functional_expense_budget_lines, @any_custom_expense_budget_lines].any?{ |e| e == true }
+    @several_income_filters   = [@any_economic_income_budget_lines, @any_custom_income_budget_lines].any?{ |e| e == true }
 
     @budgets_data_updated_at   = current_site.budgets_data_updated_at('execution')
     @budgets_execution_summary = GobiertoBudgets::SiteStats.new(site: current_site, year: @year).budgets_execution_summary

--- a/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
@@ -410,21 +410,16 @@ module GobiertoBudgets
 
         indexes.each do |index|
           areas.each do |area|
-            break if any_data
-            begin
-              response = SearchEngine.client.search(
-                index: index,
-                type: area.area_name,
-                body: query
-              )
-              any_data ||= response['hits']['hits'].any?
-            rescue
-              nil
-            end
+            response = SearchEngine.client.search(
+              index: index,
+              type: area.area_name,
+              body: query
+            )
+            return true if response['hits']['hits'].any?
           end
         end
 
-        any_data
+        return false
       end
 
     end


### PR DESCRIPTION
Improvement

### What does this PR do?

This PR makes execution graph categories dynamic to the data available for the site. This way, if a site doesn't have data in one category, the button won't show and the default option will be the first with data.

Test it in http://esplugues.gobify.net/presupuestos/ejecucion/2017