### PR TITLE
GA tag in the admin shouldn’t include site tag

### DIFF
--- a/app/views/gobierto_admin/layouts/_analytics_footer_site.html.erb
+++ b/app/views/gobierto_admin/layouts/_analytics_footer_site.html.erb
@@ -1,0 +1,6 @@
+<% if APP_CONFIG["site"]["google_analytics_key"].present? %>
+  <script type="text/javascript">
+    ga('create', '<%= APP_CONFIG["site"]["google_analytics_key"] %>', 'auto', {'name': 'globalgobierto'});
+    gaCall('send', 'pageview');
+  </script>
+<% end %>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -190,7 +190,7 @@
   </div>
 
   <% if Rails.env.production? %>
-    <%= render 'layouts/analytics_footer_site' %>
+    <%= render "gobierto_admin/layouts/analytics_footer_site" %>
   <% end %>
 
   <%= javascript_tag data: { "turbolinks-eval" => false } do %>


### PR DESCRIPTION
Connects to #1116

### What does this PR do?

This PR removes site GA tag from the admin section

### How should this be manually tested?

It can't, because it's only displayed in production. You'll need to trust me 🥇 