### PR TITLE
GobiertoCMS should be enabled by default

### DIFF
--- a/app/controllers/gobierto_cms/application_controller.rb
+++ b/app/controllers/gobierto_cms/application_controller.rb
@@ -3,7 +3,5 @@ module GobiertoCms
     include User::SessionHelper
 
     layout "gobierto_cms/layouts/application"
-
-    before_action { module_enabled!(current_site, "GobiertoCms") }
   end
 end

--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -21,7 +21,6 @@ module GobiertoAdmin
     has_many :gobierto_budgets_permissions, class_name: 'Permission::GobiertoBudgets'
     has_many :gobierto_budget_consultations_permissions, class_name: 'Permission::GobiertoBudgetConsultations'
     has_many :gobierto_people_permissions, class_name: 'Permission::GobiertoPeople'
-    has_many :gobierto_cms_permissions, class_name: 'Permission::GobiertoCms'
     has_many :gobierto_indicators_permissions, class_name: 'Permission::GobiertoIndicators'
     has_many :gobierto_participation_permissions, class_name: 'Permission::GobiertoParticipation'
     has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"

--- a/config/application.yml
+++ b/config/application.yml
@@ -21,9 +21,6 @@ default: &default
       name: Gobierto Indicators
       namespace: GobiertoIndicators
     -
-      name: Gobierto CMS
-      namespace: GobiertoCms
-    -
       name: Gobierto Participation
       namespace: GobiertoParticipation
   site_modules_with_root_path:


### PR DESCRIPTION
Closes #1053

### What does this PR do?

Avoids the CMS module to be enabled or disabled, it's enabled by default

### How should this be manually tested?

- CMS option shouldn't be present in the admin

### Does this PR changes any configuration file?

Requires removing the CMS in the application.yml file