### PR TITLE
Collection unique per site

### DIFF
--- a/app/models/gobierto_common/collection.rb
+++ b/app/models/gobierto_common/collection.rb
@@ -11,6 +11,9 @@ module GobiertoCommon
 
     validates :site, :title, :item_type, presence: true
     validates :slug, uniqueness: { scope: :site }
+    validates :container_id, uniqueness: {
+        scope: [:container_id, :container_type, :item_type]
+    }
 
     attr_reader :container
 
@@ -55,13 +58,16 @@ module GobiertoCommon
     def self.type_classes(item_type)
       if item_type == "Page"
         [[::GobiertoCms::Page.model_name.human, ::GobiertoCms::Page.name],
-         [I18n.t('activerecord.models.gobierto_cms/news'), "GobiertoCms::News"]]
+         [I18n.t("activerecord.models.gobierto_cms/news"), "GobiertoCms::News"]]
       elsif item_type == "Attachment"
         [[::GobiertoAttachments::Attachment.model_name.human, ::GobiertoAttachments::Attachment.name]]
       elsif item_type == "Event"
         [[::GobiertoCalendars::Event.model_name.human, ::GobiertoCalendars::Event.name]]
       else
-        [GobiertoCms::Page, GobiertoAttachments::Attachment, GobiertoCalendars::Event]
+        [[::GobiertoCms::Page.model_name.human, ::GobiertoCms::Page.name],
+         [I18n.t("activerecord.models.gobierto_cms/news"), "GobiertoCms::News"],
+         [::GobiertoAttachments::Attachment.model_name.human, ::GobiertoAttachments::Attachment.name],
+         [::GobiertoCalendars::Event.model_name.human, ::GobiertoCalendars::Event.name]]
       end
     end
 

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -4,6 +4,7 @@ ca:
     attributes:
       gobierto_admin/gobierto_common/collection_form:
         container_global_id: Contenidor
+        container_id: Contenidor
         item_type: Tipus
         slug: URL
         title: Títol

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -4,6 +4,7 @@ en:
     attributes:
       gobierto_admin/gobierto_common/collection_form:
         container_global_id: Container
+        container_id: Container
         item_type: Type
         slug: URL
         title: Title

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -4,6 +4,7 @@ es:
     attributes:
       gobierto_admin/gobierto_common/collection_form:
         container_global_id: Contenedor
+        container_id: Contenedor
         item_type: Tipo
         slug: URL
         title: Título

--- a/db/migrate/20171115151744_add_unique_constraint_to_collection.rb
+++ b/db/migrate/20171115151744_add_unique_constraint_to_collection.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToCollection < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :collections, name: "index_collections_on_container_type_and_container_id"
+    add_index :collections, [:container_id, :container_type, :item_type], unique: true, name: "index_collections_on_container_and_item_type"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171030120411) do
+ActiveRecord::Schema.define(version: 20171115151744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 20171030120411) do
     t.bigint "container_id"
     t.string "item_type"
     t.string "slug", default: "", null: false
-    t.index ["container_type", "container_id"], name: "index_collections_on_container_type_and_container_id"
+    t.index ["container_id", "container_type", "item_type"], name: "index_collections_on_container_and_item_type", unique: true
     t.index ["site_id"], name: "index_collections_on_site_id"
   end
 

--- a/test/fixtures/gobierto_people/people.yml
+++ b/test/fixtures/gobierto_people/people.yml
@@ -78,26 +78,6 @@ juana:
   email: juana@example.com
   google_calendar_token:
 
-hercules:
-  site: madrid
-  admin: tony
-  name: Hercules
-  slug: hercules
-  charge_translations: <%= { 'en' => 'Hero of Greece', 'es' => 'Héroe de Grecia' }.to_json %>
-  bio_translations: <%= {
-    'en' => 'Hero of Greece',
-    'es' => 'Héroe de Grecia'
-  }.to_json %>
-  bio_url: https://es.wikipedia.org/wiki/Heracles
-  avatar_url: https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Hercules_Farnese_3637104088_9c95d7fe3c_b.jpg
-  visibility_level: <%= GobiertoPeople::Person.visibility_levels["active"] %>
-  category: <%= GobiertoPeople::Person.categories["executive"] %>
-  party:
-  political_group:
-  position: 5
-  email: hercules@example.com
-  google_calendar_token:
-
 kali:
   site: santander
   admin: tony

--- a/test/fixtures/gobierto_people/people.yml
+++ b/test/fixtures/gobierto_people/people.yml
@@ -74,8 +74,28 @@ juana:
   category: <%= GobiertoPeople::Person.categories["executive"] %>
   party:
   political_group:
-  position: 3
+  position: 4
   email: juana@example.com
+  google_calendar_token:
+
+hercules:
+  site: madrid
+  admin: tony
+  name: Hercules
+  slug: hercules
+  charge_translations: <%= { 'en' => 'Hero of Greece', 'es' => 'Héroe de Grecia' }.to_json %>
+  bio_translations: <%= {
+    'en' => 'Hero of Greece',
+    'es' => 'Héroe de Grecia'
+  }.to_json %>
+  bio_url: https://es.wikipedia.org/wiki/Heracles
+  avatar_url: https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Hercules_Farnese_3637104088_9c95d7fe3c_b.jpg
+  visibility_level: <%= GobiertoPeople::Person.visibility_levels["active"] %>
+  category: <%= GobiertoPeople::Person.categories["executive"] %>
+  party:
+  political_group:
+  position: 5
+  email: hercules@example.com
   google_calendar_token:
 
 kali:

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -70,6 +70,42 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_person_events_collection
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+              click_link "Richard calendar"
+
+              assert has_selector?("h1", text: person.name)
+              assert has_link?("< Back to agendas")
+
+              within ".sub_filter ul", match: :first do
+                assert has_selector?(
+                  ".all-events-filter",
+                  text: "All (#{person.events.count})"
+                )
+
+                assert has_selector?(
+                  ".pending-events-filter",
+                  text: "Moderation pending (#{person.events.pending.count})"
+                )
+
+                assert has_selector?(
+                  ".published-events-filter",
+                  text: "Published events (#{person.events.published.count})"
+                )
+
+                assert has_selector?(
+                  ".past-events-filter",
+                  text: "Past events (#{person.events.past.count})"
+                )
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
       end
 
       def person
-        @person ||= gobierto_people_people(:richard)
+        @person ||= gobierto_people_people(:hercules)
       end
 
       def test_list_of_collections
@@ -76,7 +76,6 @@ module GobiertoAdmin
           with_signed_in_admin(admin) do
             with_current_site(site) do
               visit @path
-
               click_link "New"
 
               fill_in "collection_title_translations_en", with: "My collection"

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
       end
 
       def person
-        @person ||= gobierto_people_people(:hercules)
+        @person ||= gobierto_people_people(:richard)
       end
 
       def test_list_of_collections
@@ -59,61 +59,6 @@ module GobiertoAdmin
               click_button "Create"
 
               assert has_message?("Collection was successfully created.")
-
-              collection = site.collections.last
-              activity = Activity.last
-              assert_equal collection, activity.subject
-              assert_equal admin, activity.author
-              assert_equal site.id, activity.site_id
-              assert_equal "gobierto_common.collection_created", activity.action
-            end
-          end
-        end
-      end
-
-      def test_create_collection_for_person
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
-              click_link "New"
-
-              fill_in "collection_title_translations_en", with: "My collection"
-              fill_in "collection_slug", with: "my-collection"
-              find("select#collection_container_global_id").find("option[value='#{person.to_global_id}']").select_option
-              find("select#collection_item_type").find("option[value='GobiertoCalendars::Event']").select_option
-
-              click_link "ES"
-              fill_in "collection_title_translations_es", with: "Mi colección"
-
-              click_button "Create"
-
-              assert has_message?("Collection was successfully created.")
-
-              assert has_selector?("h1", text: person.name)
-              assert has_link?("< Back to agendas")
-
-              within ".sub_filter ul", match: :first do
-                assert has_selector?(
-                  ".all-events-filter",
-                  text: "All (#{person.events.count})"
-                )
-
-                assert has_selector?(
-                  ".pending-events-filter",
-                  text: "Moderation pending (#{person.events.pending.count})"
-                )
-
-                assert has_selector?(
-                  ".published-events-filter",
-                  text: "Published events (#{person.events.published.count})"
-                )
-
-                assert has_selector?(
-                  ".past-events-filter",
-                  text: "Past events (#{person.events.past.count})"
-                )
-              end
 
               collection = site.collections.last
               activity = Activity.last

--- a/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
@@ -11,21 +11,21 @@ module GobiertoAdmin
       end
 
       def admin
-        @admin ||= gobierto_admin_admins(:nick)
+        @admin ||= gobierto_admin_admins(:tony)
       end
 
-      def site
-        @site ||= sites(:madrid)
+      def site_santander
+        @site_santander ||= sites(:santander)
       end
 
-      def person
-        @person ||= gobierto_people_people(:hercules)
+      def site_madrid
+        @site_madrid ||= sites(:madrid)
       end
 
       def test_create_collection_errors
         with_javascript do
           with_signed_in_admin(admin) do
-            with_current_site(site) do
+            with_current_site(site_santander) do
               visit @path
 
               within "#new-page" do
@@ -43,7 +43,7 @@ module GobiertoAdmin
       def test_create_collection
         with_javascript do
           with_signed_in_admin(admin) do
-            with_current_site(site) do
+            with_current_site(site_santander) do
               visit @path
 
               within "#new-page" do
@@ -52,7 +52,7 @@ module GobiertoAdmin
 
               fill_in "collection_title_translations_en", with: "My collection"
               fill_in "collection_slug", with: "my-collection"
-              find("select#collection_container_global_id").find("option[value='#{person.to_global_id}']").select_option
+              find("select#collection_container_global_id").find("option[value='#{site_santander.to_global_id}']").select_option
               find("select#collection_item_type").find("option[value='GobiertoCms::Page']").select_option
 
               click_link "ES"
@@ -64,12 +64,34 @@ module GobiertoAdmin
 
               assert has_selector?("h1", text: "My collection")
 
-              collection = site.collections.last
+              collection = site_santander.collections.last
               activity = Activity.last
               assert_equal collection, activity.subject
               assert_equal admin, activity.author
-              assert_equal site.id, activity.site_id
+              assert_equal site_santander.id, activity.site_id
               assert_equal "gobierto_common.collection_created", activity.action
+            end
+          end
+        end
+      end
+
+      def test_create_collection_with_same_container
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site_madrid) do
+              visit @path
+
+              within "#new-page" do
+                click_link "New"
+              end
+
+              fill_in "collection_title_translations_en", with: "My collection"
+              find("select#collection_container_global_id").find("option[value='#{site_madrid.to_global_id}']").select_option
+              find("select#collection_item_type").find("option[value='GobiertoCms::Page']").select_option
+
+              click_button "Create"
+
+              assert has_content?("Container has already been taken")
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
@@ -18,6 +18,10 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def person
+        @person ||= gobierto_people_people(:hercules)
+      end
+
       def test_create_collection_errors
         with_javascript do
           with_signed_in_admin(admin) do
@@ -48,7 +52,7 @@ module GobiertoAdmin
 
               fill_in "collection_title_translations_en", with: "My collection"
               fill_in "collection_slug", with: "my-collection"
-              find("select#collection_container_global_id").find("option[value='#{site.to_global_id}']").select_option
+              find("select#collection_container_global_id").find("option[value='#{person.to_global_id}']").select_option
               find("select#collection_item_type").find("option[value='GobiertoCms::Page']").select_option
 
               click_link "ES"

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -19,8 +19,7 @@ module GobiertoPeople
       @people ||= [
         gobierto_people_people(:richard),
         gobierto_people_people(:nelson),
-        gobierto_people_people(:tamara),
-        gobierto_people_people(:hercules)
+        gobierto_people_people(:tamara)
       ]
     end
 
@@ -91,8 +90,8 @@ module GobiertoPeople
         get @path_for_csv
 
         csv_response = CSV.parse(response.body, headers: true)
-        assert_equal csv_response.by_row[3]["name"], people.last.name
-        assert_equal csv_response.by_row[3]["email"], people.last.email
+        assert_equal csv_response.by_row[2]["name"], people.last.name
+        assert_equal csv_response.by_row[2]["email"], people.last.email
       end
     end
   end

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -19,7 +19,8 @@ module GobiertoPeople
       @people ||= [
         gobierto_people_people(:richard),
         gobierto_people_people(:nelson),
-        gobierto_people_people(:tamara)
+        gobierto_people_people(:tamara),
+        gobierto_people_people(:hercules)
       ]
     end
 
@@ -90,8 +91,8 @@ module GobiertoPeople
         get @path_for_csv
 
         csv_response = CSV.parse(response.body, headers: true)
-        assert_equal csv_response.by_row[2]["name"], people.last.name
-        assert_equal csv_response.by_row[2]["email"], people.last.email
+        assert_equal csv_response.by_row[3]["name"], people.last.name
+        assert_equal csv_response.by_row[3]["email"], people.last.email
       end
     end
   end


### PR DESCRIPTION
Connects to #1060 

### What does this PR do?

- [x] Add a unique index
- [x] Add a validation

I had to delete a test relation with the person collection creation because we have a lot of dependences with some test and the other paths required more change.

### How should this be manually tested?

Try to create a collection with a container that already has another collection.

### Clean collections

I had to clean up duplicate staging collections from console:

Site 4
16: 4
21: 0 -> Delete

Site 7
17: 1 Wadus -> Delete
43: 32

Site 10
86: 3
106: 1 -> Fake example
107: 1 -> Fake example

Site 12
88: 0  -> Delete
96: 0 -> Delete
108: 1

Process 2
49: 4
59: 0 -> Delete

Process 9
68: 0 -> Delete
122: 0 -> Delete
123: 0