### PR TITLE
1147 - Import all accessible Google Calendar events

### DIFF
--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -50,10 +50,10 @@ module GobiertoPeople
         end
       end
 
-      def sync_calendar_events( calendar)
+      def sync_calendar_events(calendar)
         response = service.list_events(calendar.id, always_include_email: true, time_min: Time.now.iso8601)
         response.items.each do |event|
-          next if is_private?(event) || (!is_creator?(event) && !is_attendee?(event))
+          next if is_private?(event)
 
           if is_recurring?(event)
             service.list_event_instances(calendar.id, event.id).items.each_with_index do |event, i|
@@ -67,14 +67,6 @@ module GobiertoPeople
 
       def is_private?(event)
         %w( private confidential ).include?(event.visibility)
-      end
-
-      def is_creator?(event)
-        event.creator.email == configuration.google_calendar_id
-      end
-
-      def is_attendee?(event)
-        Array(event.attendees).any?{ |a| a.email == configuration.google_calendar_id }
       end
 
       def is_recurring?(event)
@@ -97,6 +89,7 @@ module GobiertoPeople
         person_event_params = {
           site_id: person.site_id,
           external_id: event.id,
+          person_id: person.id,
           title: event.summary,
           description: event.description,
           starts_at: event.start.date_time || DateTime.parse(event.start.date),
@@ -105,11 +98,6 @@ module GobiertoPeople
           attendees: event_attendees(event),
           notify: i.nil? || i == 0
         }
-        if is_creator?(event)
-          person_event_params.merge!(person_id: person.id)
-        else
-          person_event_params.merge!(person_id: 0)
-        end
 
         if event.location.present?
           person_event_params.merge!(locations_attributes: {"0" => {name: event.location} })

--- a/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
@@ -65,6 +65,9 @@
             <%= l(event.starts_at, format: :short) %>
           </td>
           <td>
+            <% if event.first_location %>
+              <%= event.first_location.name %>
+            <% end %>
           </td>
           <td>
             <% if event.pending? %>

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -55,7 +55,7 @@ module GobiertoPeople
         event2.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: "event2",
                      summary: "Event 2", start: date1, end: date2, attendees: [attendee1, attendee2], description: "Event 2 description")
 
-        # Single event, organized by other, Richard is invited
+        # Single event, organized by other, calendar shared with Richard
         event3 = mock
         event3.stubs(visibility: nil, location: "Patio de mi casa 1, 28005, Madrid", creator: creator_event3, recurrence: nil, id: "event3",
                      summary: "Event 3", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
@@ -125,6 +125,7 @@ module GobiertoPeople
         # Event 2 checks
         event = richard.events.find_by external_id: "event2"
         assert_equal "Event 2", event.title
+        assert_equal richard, event.collection.container
         assert_empty event.locations
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
@@ -135,6 +136,7 @@ module GobiertoPeople
         # Event 3 checks
         event = site.events.find_by external_id: "event3"
         assert_equal "Event 3", event.title
+        assert_equal richard, event.collection.container
         assert_equal "Patio de mi casa 1, 28005, Madrid", event.locations.first.name
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
@@ -143,6 +145,7 @@ module GobiertoPeople
         # Event 5 checks
         event = site.events.find_by external_id: "event4_instance_1"
         assert_equal "Event 5", event.title
+        assert_equal richard, event.collection.container
         assert_empty event.locations
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person
@@ -151,6 +154,7 @@ module GobiertoPeople
         # Event 6 checks
         event = site.events.find_by external_id: "event4_instance_2"
         assert_equal "Event 6", event.title
+        assert_equal richard, event.collection.container
         assert_empty event.locations
         assert_equal 2, event.attendees.size
         assert_equal richard, event.attendees.first.person


### PR DESCRIPTION
Connects to #1147 

### What does this PR do?

* Modifies the Google Calendar integration service so it behaves like the following:
  * If an event is accessible through the API, a new `Event` instance will be created and the collection will be set to the corresponding person calendar, doesn't matter if the original event was created by another person and it's a shared calendar.
  * Following PRs will apply this approach also to IBM Notes and Microsoft Exchange
* First event loation is now displayed in admin person events index. Code was missing.

### How should this be manually tested?

* In the person calendar configuration, make the OAuth with an account that has a calendar shared with it. Give access to this calendar and check its events are being imported.

### Does this PR changes any configuration file?

No
