### PR TITLE
Show an icon according to filetype

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,4 +43,19 @@ module ApplicationHelper
     !params[:controller].include?('user/')
   end
 
+  def filetype_icon(attachment)
+    extension = if attachment.class == String
+                  attachment.split(".").last
+                else
+                  attachment.extension
+                end
+
+    fontawesome_filetype = if ::GobiertoAttachments::Attachment.extension_fontawesome_matching.has_key?(extension.to_sym)
+                             "-" + ::GobiertoAttachments::Attachment.extension_fontawesome_matching[extension.to_sym]
+                           else
+                             ""
+                           end
+    html = "<i class='fa fa-file" + fontawesome_filetype + "-o'></i>"
+    html.html_safe
+  end
 end

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -56,6 +56,16 @@ module GobiertoAttachments
       MIME::Types.type_for(url).first.content_type
     end
 
+    def self.extension_fontawesome_matching
+      { "doc": "word", "docx": "word",
+        "xls": "excel", "xlsx": "excel",
+        "ppt": "powerpoint", "pptx": "powerpoint",
+        "zip": "zip", "gzip": "zip", "tar": "zip",
+        "pdf": "pdf",
+        "jpg": "image", "gif": "image", "bmp": "image", "jpeg": "image", "png": "image",
+        "avi": "video", "mp4": "video", "wmv": "video", "mpg": "video", "mov": "video" }
+    end
+
     def self.file_attachments_in_collections(site)
       ids = GobiertoCommon::CollectionItem.where(item_type: 'GobiertoAttachments::Attachment').map(&:item_id)
       where(id: ids, site: site)

--- a/app/views/gobierto_admin/gobierto_attachments/file_attachments/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_attachments/file_attachments/_form.html.erb
@@ -5,7 +5,7 @@
     <div class='pure-u-1 pure-u-md-16-24'>
       <div class='form_item file_field avatar_file_field'>
         <% if f.object.url.present? %>
-          <%= image_tag f.object.url, height: 150 %>
+          <%= filetype_icon(f.object.url) %>
         <% end %>
         <%= f.label :file, t('.file_constraints') %>
         <%= f.file_field :file %>

--- a/app/views/gobierto_admin/gobierto_attachments/file_attachments/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_attachments/file_attachments/index.html.erb
@@ -17,6 +17,7 @@
         <div class="activity_item">
           <h2>
             <%= link_to edit_admin_attachments_file_attachment_path(file_attachment.id, collection_id: file_attachment.collection) do %>
+              <%= filetype_icon(file_attachment) %>
               <%= file_attachment.name %>
             <% end %>
           </h2>

--- a/app/views/gobierto_admin/gobierto_common/collections/show/_file_attachments.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/collections/show/_file_attachments.html.erb
@@ -1,6 +1,7 @@
 <table class="pages-list">
   <tr>
     <th></th>
+    <th></th>
     <th><%= t('.file_name') %></th>
     <th><%= GobiertoCms::Page.human_attribute_name(:title) %></th>
     <th><%= t('.created_at') %></th>
@@ -11,6 +12,7 @@
     <% @file_attachments.each do |file_attachment| %>
       <tr id="file_attachment-item-<%= file_attachment.id %>">
         <td><%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_attachments_file_attachment_path(file_attachment.id, collection_id: @collection.id) %></td>
+        <td><%= filetype_icon(file_attachment) %></td>
         <td><%= file_attachment.file_name %></td>
         <td><%= link_to file_attachment.name, edit_admin_attachments_file_attachment_path(file_attachment.id, collection_id: @collection.id) %></td>
         <td><%= time_ago_in_words(file_attachment.created_at) %></td>

--- a/app/views/gobierto_cms/templates/_new.html.erb
+++ b/app/views/gobierto_cms/templates/_new.html.erb
@@ -13,6 +13,8 @@
                 <%= link_to attachment.name , attachment.url, target: '_blank' %>
                 <div class='soft'>
                   <small>
+                    <%= filetype_icon(attachment) %>
+                     ·
                     <%= attachment.extension.upcase %>
                      ·
                     <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %>

--- a/app/views/gobierto_cms/templates/_page.html.erb
+++ b/app/views/gobierto_cms/templates/_page.html.erb
@@ -46,7 +46,7 @@
                     <div class="icon"><%= filetype_icon(attachment) %></div>
                     <h4><%= attachment.name %></h4>
                     <div class="meta">
-                      <%= filetype_icon(attachment) %> · <%= attachment.extension.upcase %> · <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %> · <%= attachment.file_name %>
+                      <%= attachment.extension.upcase %> · <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %> · <%= attachment.file_name %>
                     </div>
                   <% end %>
                 </div>

--- a/app/views/gobierto_cms/templates/_page.html.erb
+++ b/app/views/gobierto_cms/templates/_page.html.erb
@@ -43,10 +43,10 @@
               <% @page.attachments.each do |attachment| %>
                 <div class="file">
                   <%= link_to attachment.url do %>
-                    <div class="icon"><i class="fa fa-file-pdf-o"></i></div>
+                    <div class="icon"><%= filetype_icon(attachment) %></div>
                     <h4><%= attachment.name %></h4>
                     <div class="meta">
-                      <%= attachment.extension.upcase %> · <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %> · <%= attachment.file_name %>
+                      <%= filetype_icon(attachment) %> · <%= attachment.extension.upcase %> · <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %> · <%= attachment.file_name %>
                     </div>
                   <% end %>
                 </div>

--- a/app/views/gobierto_participation/shared/attachments/_attachment.html.erb
+++ b/app/views/gobierto_participation/shared/attachments/_attachment.html.erb
@@ -8,6 +8,8 @@
 <div class='document'>
   <div class='soft'>
     <small>
+      <%= filetype_icon(attachment) %>
+       ·
       <%= attachment.extension.upcase %>
        ·
       <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %>

--- a/app/views/gobierto_participation/shared/attachments/_attachment_teaser.html.erb
+++ b/app/views/gobierto_participation/shared/attachments/_attachment_teaser.html.erb
@@ -1,7 +1,9 @@
 <div class='news_teaser'>
   <h3>
     <% if try(:current_process).present? %>
-      <%= link_to attachment.name, gobierto_participation_process_attachment_path(process_id: current_process.slug, id: attachment.slug) %>
+      <%= link_to gobierto_participation_process_attachment_path(process_id: current_process.slug, id: attachment.slug) do %>
+        <%= filetype_icon(attachment) %><%= attachment.name %>
+      <% end %>
     <% elsif current_module == "gobierto_participation" %>
       <%= link_to attachment.name, gobierto_participation_attachment_path(id: attachment.slug) %>
     <% end %>

--- a/app/views/gobierto_participation/shared/attachments/_attachment_teaser.html.erb
+++ b/app/views/gobierto_participation/shared/attachments/_attachment_teaser.html.erb
@@ -5,7 +5,9 @@
         <%= filetype_icon(attachment) %><%= attachment.name %>
       <% end %>
     <% elsif current_module == "gobierto_participation" %>
-      <%= link_to attachment.name, gobierto_participation_attachment_path(id: attachment.slug) %>
+      <%= link_to gobierto_participation_attachment_path(id: attachment.slug) do %>
+        <%= filetype_icon(attachment) %><%= attachment.name %>
+      <% end %>
     <% end %>
   </h3>
 

--- a/app/views/gobierto_participation/shared/pages/_page.html.erb
+++ b/app/views/gobierto_participation/shared/pages/_page.html.erb
@@ -10,6 +10,8 @@
             <%= link_to attachment.name , attachment.url, target: '_blank' %>
             <div class='soft'>
               <small>
+                <%= filetype_icon(attachment) %>
+                 ·
                 <%= attachment.extension.upcase %>
                  ·
                 <%= number_to_human_size(attachment.file_size, precision: 2, separator: ',') %>

--- a/app/views/gobierto_people/people/person_bio/show.html.erb
+++ b/app/views/gobierto_people/people/person_bio/show.html.erb
@@ -10,10 +10,9 @@
 <div class="separator"></div>
 
 <div class="section_header">
-
   <% if @person.bio_url.present? %>
     <div class="download_file f_right">
-      <i class="fa fa-file-pdf-o"></i>
+      <%= filetype_icon(@person.bio_url) %>
       <strong><%= link_to t(".download"), @person.bio_url, download: "" %></strong>
     </div>
   <% end %>

--- a/app/views/gobierto_people/people/person_statements/show.html.erb
+++ b/app/views/gobierto_people/people/person_statements/show.html.erb
@@ -14,7 +14,7 @@
 
   <% if @statement.attachment_url.present? %>
     <div class="download_file f_right">
-      <i class="fa fa-file-pdf-o"></i>
+      <%= filetype_icon(@statement.attachment_url) %>
       <%= link_to @statement.attachment_url, download: "", role:"button" do %>
         <%= t(".download", file_size: number_to_human_size(@statement.attachment_size || 0)) %>
       <% end %>


### PR DESCRIPTION
Connects to #1020 

### What does this PR do?

Add icon for files depending on type.

### How should this be manually tested?

Testing done on site with id 7 and 10

ADMIN:

- /admin/attachments/file_attachments
- /admin/participation/processes/process_id/file_attachments

FRONT:

- /s/participacion/pagina_slug
- /personas/person_slug/biografia
- /declaraciones/person_slug/person_statement_slug
- /participacion/p/process_slug/documentos
- /participacion/p/process_slug/documentos/document_slug
- /participacion/p/process_slug/noticias/new_slug

I have seen that the events have attachments but on the front are not visible ("Altos Cargos y Agendas" and "Participation". I checked the sandbox, but there's no views. Where do I add them?
We can leave this to the issue https://github.com/PopulateTools/issues/issues/149