### PR TITLE
Fix slug indexes and sync 2 days back for agendas

### DIFF
--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -51,7 +51,7 @@ module GobiertoPeople
       end
 
       def sync_calendar_events( calendar)
-        response = service.list_events(calendar.id, always_include_email: true, time_min: Time.now.iso8601)
+        response = service.list_events(calendar.id, always_include_email: true, time_min: 2.days.ago.iso8601)
         response.items.each do |event|
           next if is_private?(event) || (!is_creator?(event) && !is_attendee?(event))
 

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -122,7 +122,7 @@ module GobiertoPeople
 
       def self.request_params_for_events(person)
         {
-          endpoint: person_calendar_endpoint(person),
+          endpoint: person_calendar_endpoint(person).concat("?since=#{sync_range_start}"),
           username: plain_text_username(person),
           password: plain_text_password(person)
         }
@@ -154,6 +154,11 @@ module GobiertoPeople
         SecretAttribute.decrypt(person.site.gobierto_people_settings.ibm_notes_pwd)
       end
       private_class_method :plain_text_password
+
+      def self.sync_range_start
+        5.days.ago.iso8601.split('+')[0].concat('Z')
+      end
+      private_class_method :sync_range_start
 
     end
   end

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -5,7 +5,7 @@ module GobiertoPeople
       attr_reader :person, :site
 
       SYNC_RANGE = {
-        start_date: DateTime.now - 2.months,
+        start_date: DateTime.now - 2.days,
         end_date:   DateTime.now + 1.year
       }
 

--- a/db/data/20171120094614_fill_missing_attachment_slugs.rb
+++ b/db/data/20171120094614_fill_missing_attachment_slugs.rb
@@ -1,0 +1,24 @@
+class FillMissingAttachmentSlugs < ActiveRecord::Migration[5.1]
+
+  def up
+    attachmenents_with_blank_slug = GobiertoAttachments::Attachment.where(slug: '')
+
+    attachmenents_with_blank_slug.each do |attachment|
+      base_slug = attachment.attributes_for_slug.join('-').gsub('_', ' ').parameterize
+      new_slug  = base_slug
+
+      count = 2
+      while GobiertoAttachments::Attachment.exists?(site: attachment.site, slug: new_slug)
+        new_slug = "#{base_slug}-#{count}"
+        count += 1
+      end
+      puts "\t=> Updating attachment(name: #{attachment.name}, slug: #{attachment.slug}) with slug: #{new_slug}"
+      attachment.update_attributes!(slug: new_slug)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+end

--- a/db/migrate/20171120133657_scope_slug_indexes_on_site.rb
+++ b/db/migrate/20171120133657_scope_slug_indexes_on_site.rb
@@ -1,0 +1,57 @@
+class ScopeSlugIndexesOnSite < ActiveRecord::Migration[5.1]
+
+  def up
+    add_index :collections, [:site_id, :slug], unique: true
+    add_index :ga_attachments, [:site_id, :slug], unique: true
+    add_index :gcms_pages, [:site_id, :slug], unique: true
+    add_index :gcms_sections, [:site_id, :slug], unique: true
+
+    remove_index :gobierto_calendars_events, name: 'index_gobierto_calendars_events_on_slug'
+    add_index :gobierto_calendars_events, [:site_id, :slug], unique: true
+
+    remove_index :gp_people, name: 'index_gp_people_on_slug'
+    add_index :gp_people, [:site_id, :slug], unique: true
+
+    remove_index :gp_person_posts, name: 'index_gp_person_posts_on_slug'
+    add_index :gp_person_posts, [:site_id, :slug], unique: true
+
+    remove_index :gp_person_statements, name: 'index_gp_person_statements_on_slug'
+    add_index :gp_person_statements, [:site_id, :slug], unique: true
+
+    add_index :gpart_contribution_containers, [:site_id, :slug], unique: true
+    add_index :gpart_contributions, [:site_id, :slug], unique: true
+
+    remove_index :gpart_processes, name: 'index_gpart_processes_on_slug'
+    add_index :gpart_processes, [:site_id, :slug], unique: true
+
+    add_index :issues, [:site_id, :slug], unique: true
+  end
+
+  def down
+    remove_index :collections, name: 'index_collections_on_site_id_and_slug'
+    remove_index :ga_attachments, name: 'index_ga_attachments_on_site_id_and_slug'
+    remove_index :gcms_pages, name: 'index_gcms_pages_on_site_id_and_slug'
+    remove_index :gcms_sections, name: 'index_gcms_sections_on_site_id_and_slug'
+
+    remove_index :gobierto_calendars_events, name: 'index_gobierto_calendars_events_on_site_id_and_slug'
+    add_index :gobierto_calendars_events, :slug, unique: true
+
+    remove_index :gp_people, name: 'index_gp_people_on_site_id_and_slug'
+    add_index :gp_people, :slug, unique: true
+
+    remove_index :gp_person_posts, name: 'index_gp_person_posts_on_site_id_and_slug'
+    add_index :gp_person_posts, :slug, unique: true
+
+    remove_index :gp_person_statements, name: 'index_gp_person_statements_on_site_id_and_slug'
+    add_index :gp_person_statements, :slug, unique: true
+
+    remove_index :gpart_contribution_containers, name: 'index_gpart_contribution_containers_on_site_id_and_slug'
+    remove_index :gpart_contributions, name: 'index_gpart_contributions_on_site_id_and_slug'
+
+    remove_index :gpart_processes, name: 'index_gpart_processes_on_site_id_and_slug'
+    add_index :gpart_processes, :slug, unique: true
+
+    remove_index :issues, name: 'index_issues_on_site_id_and_slug'
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115151744) do
+ActiveRecord::Schema.define(version: 20171120133657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.string "item_type"
     t.string "slug", default: "", null: false
     t.index ["container_id", "container_type", "item_type"], name: "index_collections_on_container_and_item_type", unique: true
+    t.index ["site_id", "slug"], name: "index_collections_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_collections_on_site_id"
   end
 
@@ -209,6 +210,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.datetime "updated_at", null: false
     t.string "slug", default: "", null: false
     t.integer "collection_id"
+    t.index ["site_id", "slug"], name: "index_ga_attachments_on_site_id_and_slug", unique: true
   end
 
   create_table "gb_budget_line_feedbacks", force: :cascade do |t|
@@ -289,6 +291,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.string "slug", default: "", null: false
     t.integer "collection_id"
     t.index ["body_translations"], name: "index_gcms_pages_on_body_translations", using: :gin
+    t.index ["site_id", "slug"], name: "index_gcms_pages_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gcms_pages_on_site_id"
     t.index ["title_translations"], name: "index_gcms_pages_on_title_translations", using: :gin
   end
@@ -312,6 +315,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.bigint "site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["site_id", "slug"], name: "index_gcms_sections_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gcms_sections_on_site_id"
   end
 
@@ -351,7 +355,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.string "slug", null: false
     t.integer "collection_id"
     t.index ["description_translations"], name: "index_gobierto_calendars_events_on_description_translations", using: :gin
-    t.index ["slug"], name: "index_gobierto_calendars_events_on_slug", unique: true
+    t.index ["site_id", "slug"], name: "index_gobierto_calendars_events_on_site_id_and_slug", unique: true
     t.index ["title_translations"], name: "index_gobierto_calendars_events_on_title_translations", using: :gin
   end
 
@@ -393,8 +397,8 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.index ["google_calendar_token"], name: "index_gp_people_on_google_calendar_token", unique: true
     t.index ["party"], name: "index_gp_people_on_party"
     t.index ["political_group_id"], name: "index_gp_people_on_political_group_id"
+    t.index ["site_id", "slug"], name: "index_gp_people_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gp_people_on_site_id"
-    t.index ["slug"], name: "index_gp_people_on_slug", unique: true
   end
 
   create_table "gp_person_calendar_configurations", id: :serial, force: :cascade do |t|
@@ -414,7 +418,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.integer "site_id", null: false
     t.string "slug", null: false
     t.index ["person_id"], name: "index_gp_person_posts_on_person_id"
-    t.index ["slug"], name: "index_gp_person_posts_on_slug", unique: true
+    t.index ["site_id", "slug"], name: "index_gp_person_posts_on_site_id_and_slug", unique: true
     t.index ["tags"], name: "index_gp_person_posts_on_tags", using: :gin
   end
 
@@ -430,7 +434,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.integer "site_id", null: false
     t.string "slug", null: false
     t.index ["person_id"], name: "index_gp_person_statements_on_person_id"
-    t.index ["slug"], name: "index_gp_person_statements_on_slug", unique: true
+    t.index ["site_id", "slug"], name: "index_gp_person_statements_on_site_id_and_slug", unique: true
     t.index ["title_translations"], name: "index_gp_person_statements_on_title_translations", using: :gin
   end
 
@@ -500,6 +504,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.integer "visibility_user_level", default: 0, null: false
     t.index ["admin_id"], name: "index_gpart_contribution_containers_on_admin_id"
     t.index ["process_id"], name: "index_gpart_contribution_containers_on_process_id"
+    t.index ["site_id", "slug"], name: "index_gpart_contribution_containers_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gpart_contribution_containers_on_site_id"
   end
 
@@ -517,6 +522,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.string "slug", default: "", null: false
     t.index ["contribution_container_id"], name: "index_gpart_contributions_on_contribution_container_id"
     t.index ["description"], name: "index_gpart_contributions_on_description"
+    t.index ["site_id", "slug"], name: "index_gpart_contributions_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gpart_contributions_on_site_id"
     t.index ["title"], name: "index_gpart_contributions_on_title"
     t.index ["user_id"], name: "index_gpart_contributions_on_user_id"
@@ -609,8 +615,8 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.jsonb "information_text_translations"
     t.bigint "scope_id"
     t.index ["body_translations"], name: "index_gpart_processes_on_body_translations", using: :gin
+    t.index ["site_id", "slug"], name: "index_gpart_processes_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gpart_processes_on_site_id"
-    t.index ["slug"], name: "index_gpart_processes_on_slug", unique: true
     t.index ["title_translations"], name: "index_gpart_processes_on_title_translations", using: :gin
   end
 
@@ -641,6 +647,7 @@ ActiveRecord::Schema.define(version: 20171115151744) do
     t.string "slug", default: "", null: false
     t.index ["name_translations"], name: "index_issues_on_name_translations", using: :gin
     t.index ["position"], name: "index_issues_on_position"
+    t.index ["site_id", "slug"], name: "index_issues_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_issues_on_site_id"
   end
 

--- a/test/fixtures/gobierto_attachments/attachments.yml
+++ b/test/fixtures/gobierto_attachments/attachments.yml
@@ -7,6 +7,7 @@ pdf_attachment:
   description: Description of a PDF attachment
   current_version: 1
   site: madrid
+  slug: pdf-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
@@ -33,6 +34,7 @@ xlsx_attachment:
   description: Description of a XLSX attachment
   current_version: 2
   site: madrid
+  slug: xlsx-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
@@ -45,6 +47,7 @@ attachment:
   description: Description of attachment without extension
   current_version: 3
   site: madrid
+  slug: attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
@@ -57,6 +60,7 @@ txt_pdf_attachment:
   description: Description of attachment with two extensions in name
   current_version: 4
   site: madrid
+  slug: txt-pdf-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
@@ -69,5 +73,6 @@ santander_attachment:
   description: An attachment belonging to other site
   current_version: 1
   site: santander
+  slug: santander-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -84,7 +84,7 @@ module GobiertoPeople
       end
 
       def test_sync_events_v9
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -105,7 +105,7 @@ module GobiertoPeople
       end
 
       def test_sync_events_updates_event_attributes
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -122,7 +122,7 @@ module GobiertoPeople
         recurrent_event_instance.locations.first.update_attributes!(name: "Old location")
         recurrent_event_instance.save!
 
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -138,7 +138,7 @@ module GobiertoPeople
       end
 
       def test_sync_events_removes_deleted_event_attributes
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -148,7 +148,7 @@ module GobiertoPeople
 
         assert 1, event.locations.size
 
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -159,7 +159,7 @@ module GobiertoPeople
       # Se piden eventos en el intervalo [1,3], 1 y 3 son recurrentes y son el mismo, el 2 es uno no recurrente
       # De las 9 instancias del evento recurrente, la que tiene recurrenceId=20170407T113000Z (la segunda) da 404
       def test_sync_events_v8
-        VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -185,7 +185,7 @@ module GobiertoPeople
       # Only v8 will return past events instances, but use v9 cassette for simplicity
       def test_sync_events_marks_unreceived_upcoming_events_as_pending
         Timecop.freeze(Time.zone.parse("2017-05-03")) do
-          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             # Returns 3 events, all of them upcoming
             CalendarIntegration.sync_person_events(richard)
           end
@@ -197,7 +197,7 @@ module GobiertoPeople
         end
 
         Timecop.freeze(Time.zone.parse("2017-05-05 01:00:00")) do
-          VCR.use_cassette("ibm_notes/person_events_collection_v9_mark_as_pending", decode_compressed_response: true) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9_mark_as_pending", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             # Returns first event from the previous set, which is now past
             CalendarIntegration.sync_person_events(richard)
           end
@@ -281,7 +281,7 @@ module GobiertoPeople
 
       def test_sync_attendees
         # Cassette contains one confirmed attendee and two requested participants.
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 
@@ -299,7 +299,7 @@ module GobiertoPeople
 
         event.attendees.second.delete
 
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true) do
+        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
           CalendarIntegration.sync_person_events(richard)
         end
 


### PR DESCRIPTION
Connects to [#156 - Sync 2 days back](https://github.com/PopulateTools/issues/issues/156) and [#974 - Amend sluggable module](https://github.com/PopulateTools/gobierto/issues/974)

### What does this PR do?

* Syncs events since 2 days back for all agendas integrations
* Fixes many slug DB indexes so they are unique in the scope of the site (fixes Rollbar related to duplicated slug)

### How should this be manually tested?

Example: create an event in a synced calendar 1 day ago, manually run synchronization and check the event gets added/updated.

You can manually run a calendar synchronization doing something like this:

```ruby
site = Site.find_by(domain: "domain.gobify.net")
person = site.people.first
site.calendar_integration.sync_person_events(person)
```

### Important notes related to migrations

This has been tested locally with both DB data from staging and production, so it is expected to succeed without problems, but we should keep an eye on this.

There were many attachment records in staging with a blank slug. The migration scripts assigns slugs for this records.

### Does this PR changes any configuration file?

No
