### PR TITLE
Force turbolinks in navigation

### DIFF
--- a/app/views/gobierto_budgets/layouts/_navigation.html.erb
+++ b/app/views/gobierto_budgets/layouts/_navigation.html.erb
@@ -5,8 +5,8 @@
     <%= link_to t('gobierto_budgets.layouts.menu_subsections.elaboration'), gobierto_budgets_budgets_elaboration_path, data: { turbolinks: false }  %></li>
   <% end %>
   <%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), data: { turbolinks: false } %>
-  <%= link_to t('gobierto_budgets.layouts.menu_subsections.guide'), gobierto_budgets_budgets_guide_path %></li>
+  <%= link_to t('gobierto_budgets.layouts.menu_subsections.guide'), gobierto_budgets_budgets_guide_path, data: { turbolinks: false } %></li>
   <% if budgets_receipt_active? %>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.receipt'), gobierto_budgets_receipt_path, class: class_if('active', controller_name == 'receipts')  %>
+    <%= link_to t('gobierto_budgets.layouts.menu_subsections.receipt'), gobierto_budgets_receipt_path, class: class_if('active', controller_name == 'receipts'), data: { turbolinks: false }  %>
   <% end %>
 </div>

--- a/app/views/gobierto_participation/layouts/_navigation.html.erb
+++ b/app/views/gobierto_participation/layouts/_navigation.html.erb
@@ -1,9 +1,9 @@
 <div class="pure-u-1 pure-u-md-1-4 section">
-  <h2><%= link_to t("gobierto_participation.layouts.application.title"), gobierto_participation_root_path %></h2>
+  <h2><%= link_to t("gobierto_participation.layouts.application.title"), gobierto_participation_root_path, data: { turbolinks: false } %></h2>
 
   <%= link_to t('gobierto_participation.layouts.menu_subsections.about'), '#' %>
-  <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
-  <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
+  <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path, data: { turbolinks: false } %>
+  <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path, data: { turbolinks: false } %>
   <%= link_to t('gobierto_participation.layouts.menu_subsections.questions'), '#' %>
   <%= link_to t('gobierto_participation.layouts.menu_subsections.ideas'), '#' %>
 </div>

--- a/app/views/gobierto_people/layouts/_navigation.html.erb
+++ b/app/views/gobierto_people/layouts/_navigation.html.erb
@@ -1,12 +1,12 @@
 <div class="pure-u-1 pure-u-md-1-4 section">
 
   <% if welcome_submodule_active? %>
-    <h2><%= link_to t("gobierto_people.layouts.application.title"), gobierto_people_root_path  %></h2>
+    <h2><%= link_to t("gobierto_people.layouts.application.title"), gobierto_people_root_path, data: { turbolinks: false }  %></h2>
   <% end %>
 
   <% active_submodules.each do |submodule| %>
     <% if !welcome_submodule_active? %><h2><% end %>
-    <%= link_to submodule_title_for(submodule), submodule_path_for(submodule), class: class_if('active', controller_name == submodule_controller_for(submodule)) %>
+    <%= link_to submodule_title_for(submodule), submodule_path_for(submodule), class: class_if('active', controller_name == submodule_controller_for(submodule)), data: { turbolinks: false } %>
     <% if !welcome_submodule_active? %></h2><% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Bugfix

### What does this PR do?

This PR forces all the items from the menu to load the section without Turbolinks to avoid javascript issues.
