### PR TITLE
Sanitize slugs

### DIFF
--- a/app/models/concerns/gobierto_common/sluggable.rb
+++ b/app/models/concerns/gobierto_common/sluggable.rb
@@ -11,10 +11,13 @@ module GobiertoCommon
     private
 
     def set_slug
-      return if self.slug.present?
+      if slug.present?
+        self.slug = self.slug.tr("_", " ").parameterize
+        return
+      end
 
-      base_slug = attributes_for_slug.join('-').gsub('_', ' ').parameterize
-      new_slug  = base_slug
+      base_slug = attributes_for_slug.join("-").tr("_", " ").parameterize
+      new_slug = base_slug
 
       count = 2
       while self.class.exists?(site: site, slug: new_slug)


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/150

### What does this PR do?

When you add a slug with spaces in the creation of any object, it creates the slug correctly.

### How should this be manually tested?

Create an object that requires slug, for example, processes, pages