### PR TITLE
Force turbolinks editing a process

### DIFF
--- a/app/views/gobierto_admin/gobierto_participation/processes/poll_answers/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/poll_answers/index.html.erb
@@ -1,7 +1,7 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
-  <%= link_to current_process.title, edit_admin_participation_process_path(current_process) %>
+  <%= link_to current_process.title, edit_admin_participation_process_path(current_process), data: { turbolinks: false } %>
 </div>
 
 <h1><%= current_process.title %></h1>

--- a/app/views/gobierto_admin/gobierto_participation/processes/polls/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/polls/edit.html.erb
@@ -1,7 +1,7 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
-  <%= link_to current_process.title, edit_admin_participation_process_path(current_process) %>
+  <%= link_to current_process.title, edit_admin_participation_process_path(current_process), data: { turbolinks: false } %>
 </div>
 
 <h1>

--- a/app/views/gobierto_admin/gobierto_participation/processes/polls/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/polls/index.html.erb
@@ -1,7 +1,7 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
-  <%= link_to current_process.title, edit_admin_participation_process_path(current_process) %>
+  <%= link_to current_process.title, edit_admin_participation_process_path(current_process), data: { turbolinks: false } %>
 </div>
 
 <h1>

--- a/app/views/gobierto_admin/gobierto_participation/processes/polls/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/polls/new.html.erb
@@ -1,7 +1,7 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
-  <%= link_to current_process.title, edit_admin_participation_process_path(current_process) %> »
+  <%= link_to current_process.title, edit_admin_participation_process_path(current_process), data: { turbolinks: false } %> »
   <%= t('.title') %>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_participation/shared/_breadcrumb.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/shared/_breadcrumb.html.erb
@@ -2,7 +2,7 @@
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
   <% if process %>
-    <%= link_to process.title, edit_admin_participation_process_path(process) %> »
+    <%= link_to process.title, edit_admin_participation_process_path(process), data: { turbolinks: false } %> »
   <% end %>
   <%= last_breadcrumb_item %>
 </div>

--- a/app/views/gobierto_admin/gobierto_participation/shared/_navigation.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/shared/_navigation.html.erb
@@ -2,7 +2,7 @@
   <ul>
 
     <li class="<%= class_if('active', controller_name == 'processes') %>">
-      <%= link_to t('.stage'), edit_admin_participation_process_path(current_process) %>
+      <%= link_to t('.stage'), edit_admin_participation_process_path(current_process), data: { turbolinks: false } %>
     </li>
 
     <li class="<%= class_if("active", controller_name.include?('process_information')) %>">

--- a/app/views/gobierto_admin/gobierto_participation/welcome/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/welcome/index.html.erb
@@ -57,11 +57,11 @@
     <% @processes.each do |process| %>
       <tr class="odd">
         <td>
-          <%= link_to edit_admin_participation_process_path(process) do %>
+          <%= link_to edit_admin_participation_process_path(process), data: { turbolinks: false } do %>
             <i class="fa fa-edit"></i>
           <% end %>
         </td>
-        <td><%= link_to process.title, edit_admin_participation_process_path(process) %></td>
+        <td><%= link_to process.title, edit_admin_participation_process_path(process), data: { turbolinks: false } %></td>
         <td>
           <%= time_ago_in_words(process.last_activity_at) %>
           <% if process.last_activity %>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/151

### What does this PR do?

In all calls to edit_admin_participation_process_path I've added 

`
data: { turbolinks: false } 
`

We have to remember that every time we send a link to a page with datepicker you have to send:

`
data: { turbolinks: false } 
`

### How should this be manually tested?

Editing a process
