### PR TITLE
Restore past events link

### DIFF
--- a/app/assets/javascripts/gobierto_people/app/controllers/person_events_controller.js
+++ b/app/assets/javascripts/gobierto_people/app/controllers/person_events_controller.js
@@ -3,7 +3,9 @@ this.GobiertoPeople.PersonEventsController = (function() {
   function PersonEventsController() {}
 
   PersonEventsController.prototype.index = function(){
-    _initializeFullCalendar(_reorganizeHTML);
+    if ($('#calendar').length) {
+      _initializeFullCalendar(_reorganizeHTML);
+    }
   };
 
   function _initializeFullCalendar(nextStep) {

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -26,20 +26,26 @@
       <div class="pure-u-1 pure-u-md-1-2">
 
         <h3 class="filter-option <%= class_if("active", controller_name == "person_events") %>">
-          <%= link_to_unless_current t(".upcoming_events"), gobierto_people_person_events_path(@person.slug) %>
+          <% if request.path != gobierto_people_person_events_path(@person.slug) %>
+            <%= link_to t('.upcoming_events'), gobierto_people_person_events_path(@person.slug, list_view: true) %>
+          <% else %>
+            <%= t('.upcoming_events') %>
+          <% end %>
         </h3>
 
       </div>
 
-      <% pending do %>
-        <div class="pure-u-1 pure-u-md-1-2 right">
+      <div class="pure-u-1 pure-u-md-1-2 right">
 
-          <h3 class="filter-option <%= class_if("active", controller_name == "past_person_events") %>">
-            <%= link_to_unless_current t(".past_events"), gobierto_people_person_past_events_path(@person.slug) %>
-          </h3>
+        <h3 class="filter-option <%= class_if("active", controller_name == "past_person_events") %>">
+          <% if request.path != gobierto_people_person_past_events_path(@person.slug) %>
+            <%= link_to t(".past_events"), gobierto_people_person_past_events_path(@person.slug, list_view: true) %>
+          <% else %>
+            <%= t(".past_events") %>
+          <% end %>
+        </h3>
 
-        </div>
-      <% end %>
+      </div>
 
     </div>
 
@@ -56,8 +62,10 @@
 
 </div>
 
-<div id='calendar'>
-</div>
+<% if request.path == gobierto_people_person_events_path(@person.slug) %>
+  <div id='calendar'>
+  </div>
+<% end %>
 
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>
 

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -52,7 +52,7 @@ module GobiertoPeople
             within ".events-summary" do
               assert has_content?("Agenda")
               refute has_link?("View more")
-              # PENDING: assert has_link?("Past events")
+              assert has_link?("Past events")
 
               upcoming_events.each do |event|
                 assert has_selector?(".person_event-item", text: event.title)
@@ -79,13 +79,12 @@ module GobiertoPeople
               assert has_content?(future_event.title)
             end
 
-            # PENDING
-            # click_link "Past events"
+            click_link "Past events"
 
-            # within ".events-summary" do
-            #   assert has_content?(past_event.title)
-            #   refute has_content?(future_event.title)
-            # end
+            within ".events-summary" do
+              assert has_content?(past_event.title)
+              refute has_content?(future_event.title)
+            end
           end
         end
       end


### PR DESCRIPTION
Closes #1171 

### What does this PR do?

Restores the past events link in a person agenda, but hides the Fullcalendar tabs when done.