### PR TITLE
1083 admin contributor containers small fixes

### DIFF
--- a/app/assets/javascripts/gobierto_participation/app/controllers/contribution_containers_controller.js
+++ b/app/assets/javascripts/gobierto_participation/app/controllers/contribution_containers_controller.js
@@ -79,12 +79,16 @@ this.GobiertoParticipation.ContributionContainersController = (function() {
       createCards(nodes);
 
       var urlHash = window.location.hash;
-      if (urlHash && $(urlHash).length){
-        $.ajax({
-          type: "GET",
-          dataType: "script",
-          url: $(urlHash).attr("data-url")
-        });
+      if (urlHash.length) {
+
+        var selected_cards = data.filter(function(c) { return c.slug == urlHash.substr(1); });
+        if (selected_cards.length > 0) {
+          $.ajax({
+            type: "GET",
+            dataType: "script",
+            url: selected_cards[0].to_path
+          });
+        }
       }
 
     $('#next').click(function() {

--- a/app/assets/javascripts/gobierto_participation/app/controllers/contribution_containers_controller.js
+++ b/app/assets/javascripts/gobierto_participation/app/controllers/contribution_containers_controller.js
@@ -78,6 +78,15 @@ this.GobiertoParticipation.ContributionContainersController = (function() {
 
       createCards(nodes);
 
+      var urlHash = window.location.hash;
+      if (urlHash && $(urlHash).length){
+        $.ajax({
+          type: "GET",
+          dataType: "script",
+          url: $(urlHash).attr("data-url")
+        });
+      }
+
     $('#next').click(function() {
         page++;
         viewdata = data.slice((page-1)*cardnumber,page*cardnumber);
@@ -508,7 +517,8 @@ this.GobiertoParticipation.ContributionContainersController = (function() {
         .enter()
         .append('div')
         .attr('class', 'card')
-        .attr('data-url', function(d) { return d.name['to_path']; });
+        .attr('data-url', function(d) { return d.name['to_path']; })
+        .attr('id', function(d) { return d.name['slug']; });
 
       card
         .append('div')

--- a/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
@@ -11,6 +11,7 @@ module GobiertoAdmin
         def show
           @contribution_container = find_contribution_container
           @process = @contribution_container.process
+          @votes_headers = ::GobiertoParticipation::ContributionDecorator.headings
         end
 
         def new

--- a/app/decorators/gobierto_participation/contribution_decorator.rb
+++ b/app/decorators/gobierto_participation/contribution_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GobiertoParticipation
+  class ContributionDecorator < BaseDecorator
+    VOTES = { 2 => { short_form: '++',
+                     label: 'gobierto_participation.processes.contributions.contribution.enchants' },
+              1 => { short_form: '+',
+                     label: 'gobierto_participation.processes.contributions.contribution.like' },
+              0 => { short_form: '0',
+                     label: 'gobierto_participation.processes.contributions.contribution.indifferent' },
+             -1 => { short_form: '-',
+                     label: 'gobierto_participation.processes.contributions.contribution.not_like' } }
+
+    def initialize(contribution)
+      @object = contribution
+    end
+
+    def self.headings
+      return VOTES
+    end
+
+    def votes_distribution
+      @votes_distribution ||= votes.group(:vote_weight).count
+    end
+  end
+end

--- a/app/models/gobierto_participation/contribution.rb
+++ b/app/models/gobierto_participation/contribution.rb
@@ -149,7 +149,7 @@ module GobiertoParticipation
     end
 
     def self.javascript_json
-      all.to_json(only: [:title, :votes_count, :user_id], methods: [:to_path, :love_pct, :like_pct, :neutral_pct, :hate_pct, :created_at_ymd])
+      all.to_json(only: [:title, :votes_count, :user_id, :slug], methods: [:to_path, :love_pct, :like_pct, :neutral_pct, :hate_pct, :created_at_ymd])
     end
   end
 end

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
@@ -9,8 +9,14 @@
     <strong><%= @contribution_container.title  %></strong> » Aportaciones
   </div>
   <div class="pure-u-1-4 admin_tools right">
-    <%= link_to t('.config'), edit_admin_participation_process_contribution_container_path(@contribution_container.id, process_id: @contribution_container.process.id) %>
-    <%= link_to t('.new'), new_admin_participation_process_contribution_container_path, class: 'button' %>
+    <%= link_to edit_admin_participation_process_contribution_container_path(@contribution_container.id, process_id: @contribution_container.process.id) do %>
+      <i class="fa fa-cog"></i>
+      <%= t('.config') %>
+    <% end %>
+    <%= link_to gobierto_participation_process_contribution_container_url(@contribution_container.slug, process_id: @process.slug, host: current_site.domain), target: '_blank' do %>
+      <i class="fa fa-eye"></i>
+      <%= t('.see_container') %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
@@ -23,7 +23,9 @@
     <th><%= t('.votes') %></th>
     <th><%= t('.comments') %></th>
     <th><%= t('.marked') %></th>
-    <th><%= t('.status') %></th>
+    <% if false #TODO: Publicada/Moderada %>
+      <th><%= t('.status') %></th>
+    <% end %>
     <th></th>
   </tr>
 
@@ -35,15 +37,16 @@
       <td><%= contribution.votes_count %></td>
       <td><%= contribution.comments_count %></td>
       <td><!-- TODO: Marcada --></td>
-      <td>
-        <!-- TODO: Publicada/Moderada -->
-        <% if true %>
-          <i class="fa fa-lock"></i>
-          <%= t(".status_level.published") %>
-        <% else %>
-          <%= t(".status_level.moderate") %>
-        <% end %>
-      </td>
+      <% if false #TODO: Publicada/Moderada %>
+        <td>
+          <% if true %>
+            <i class="fa fa-lock"></i>
+            <%= t(".status_level.published") %>
+          <% else %>
+            <%= t(".status_level.moderate") %>
+          <% end %>
+        </td>
+      <% end %>
       <td>
         <%= link_to '#public_view', target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
@@ -20,7 +20,6 @@
     <!-- TODO: Edit <th></th> -->
     <th><%= t('.contribution') %></th>
     <th><%= t('.participants') %></th>
-    <th><%= t('.votes') %></th>
     <% @votes_headers.each do |weight, values| %>
       <th title="<%= t(values[:label]) %>"><%= values[:short_form] %></th>
     <% end %>
@@ -38,7 +37,6 @@
       <!-- TODO: Edit <td><%= link_to '<i class="fa fa-edit"></i>'.html_safe, '' %></td> -->
       <td><%= contribution.title %></td>
       <td><%= contribution.number_participants %></td>
-      <td><%= contribution.votes_count %></td>
       <% @votes_headers.each do |weight, values| %>
         <td><%= contribution.votes_distribution[weight] %></td>
       <% end %>

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
@@ -21,6 +21,9 @@
     <th><%= t('.contribution') %></th>
     <th><%= t('.participants') %></th>
     <th><%= t('.votes') %></th>
+    <% @votes_headers.each do |weight, values| %>
+      <th title="<%= t(values[:label]) %>"><%= values[:short_form] %></th>
+    <% end %>
     <th><%= t('.comments') %></th>
     <th><%= t('.marked') %></th>
     <% if false #TODO: Publicada/Moderada %>
@@ -30,11 +33,15 @@
   </tr>
 
   <% @contribution_container.contributions.each do |contribution| %>
+    <% contribution = GobiertoParticipation::ContributionDecorator.new(contribution) %>
     <tr>
       <!-- TODO: Edit <td><%= link_to '<i class="fa fa-edit"></i>'.html_safe, '' %></td> -->
       <td><%= contribution.title %></td>
       <td><%= contribution.number_participants %></td>
       <td><%= contribution.votes_count %></td>
+      <% @votes_headers.each do |weight, values| %>
+        <td><%= contribution.votes_distribution[weight] %></td>
+      <% end %>
       <td><%= contribution.comments_count %></td>
       <td><!-- TODO: Marcada --></td>
       <% if false #TODO: Publicada/Moderada %>

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
@@ -59,7 +59,7 @@
         </td>
       <% end %>
       <td>
-        <%= link_to '#public_view', target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_participation_process_contribution_container_url(@contribution_container.slug, process_id: @process.slug, host: current_site.domain, anchor: contribution.slug), target: "_blank", class: "view_item" do %>
           <i class="fa fa-eye"></i>
           <%= t(".see_contribution") %>
         <% end %>

--- a/config/locales/gobierto_admin/gobierto_participation/views/processes/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/processes/ca.yml
@@ -44,8 +44,8 @@ ca:
             config: Configuració
             contribution: Aportació
             marked: Marcada
-            new: Nova
             participants: Participants
+            see_container: Veure
             see_contribution: Veure aportació
             status: Estat
             status_level:

--- a/config/locales/gobierto_admin/gobierto_participation/views/processes/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/processes/ca.yml
@@ -51,7 +51,6 @@ ca:
             status_level:
               moderate: Moderada
               published: Publicada
-            votes: Valoracions
         process_file_attachments:
           index:
             configuration: Configuració

--- a/config/locales/gobierto_admin/gobierto_participation/views/processes/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/processes/en.yml
@@ -44,8 +44,8 @@ en:
             config: Config
             contribution: Contribution
             marked: Marked
-            new: New
             participants: Participants
+            see_container: See
             see_contribution: See contribution
             status: Status
             status_level:

--- a/config/locales/gobierto_admin/gobierto_participation/views/processes/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/processes/en.yml
@@ -51,7 +51,6 @@ en:
             status_level:
               moderate: Moderate
               published: Published
-            votes: Votes
         process_file_attachments:
           index:
             configuration: Configuration

--- a/config/locales/gobierto_admin/gobierto_participation/views/processes/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/processes/es.yml
@@ -51,7 +51,6 @@ es:
             status_level:
               moderate: Moderada
               published: Publicada
-            votes: Valoraciones
         process_file_attachments:
           index:
             configuration: Configuración

--- a/config/locales/gobierto_admin/gobierto_participation/views/processes/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/processes/es.yml
@@ -44,8 +44,8 @@ es:
             config: Configuración
             contribution: Aportación
             marked: Marcada
-            new: Nueva
             participants: Participantes
+            see_container: Ver
             see_contribution: Ver aportación
             status: Estado
             status_level:

--- a/test/integration/gobierto_participation/processes/process_contribution_containers_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contribution_containers_show_test.rb
@@ -23,6 +23,14 @@ module GobiertoParticipation
       )
     end
 
+    def contribution_path
+      @contribution_path ||= gobierto_participation_process_contribution_container_path(
+        process_id: process.slug,
+        id: contribution_container.slug,
+        anchor: contribution.slug
+      )
+    end
+
     def process
       @process ||= gobierto_participation_processes(:sport_city_process)
     end
@@ -53,6 +61,15 @@ module GobiertoParticipation
 
     def contribution_comments
       @contribution_comments ||= contribution.comments
+    end
+
+    def test_contribution_path
+      with_javascript do
+        with_current_site(site) do
+          visit contribution_path
+          assert has_content? "Carril bici para que los niños puedan llegar al parque desde cualquier punto de Barajas."
+        end
+      end
     end
 
     def test_all_contributions_show


### PR DESCRIPTION
Related with #1083

### What does this PR do?
- [x] Hides Column State
- [x] "Valoraciones": Let's show a column for each value (with title attribute so we show the full label): 
<img width="138" alt="screen shot 2017-11-23 at 15 44 37" src="https://user-images.githubusercontent.com/446459/33178132-4def5008-d065-11e7-9717-0fee20f6d57c.png">

- [x] Links "View item" correctly to the front: The link is the same link to the pool with a hash and the slug of the contribution.
- [x] Substitutes the "New" button (it doesn't make sense in this context) with "View" (and a link target blank to the front)
<img width="289" alt="screen shot 2017-11-23 at 15 44 48" src="https://user-images.githubusercontent.com/446459/33178181-861f0202-d065-11e7-8b78-67a30db31b48.png">

### How should this be manually tested?
Visit http://madrid.gobify.net/admin/participation/processes/27/contribution_containers/12


### Does this PR changes any configuration file?
No
