### PR TITLE
Don’t require authentication to get the list of municipalities

### DIFF
--- a/app/assets/javascripts/admin/app/controllers/sites_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/sites_controller.js
@@ -1,7 +1,7 @@
 this.GobiertoAdmin.SitesController = (function() {
   function SitesController() {}
 
-  function _handleSiteLocationAutocomplete(api_token) {
+  function _handleSiteLocationAutocomplete() {
     var locationFieldHandler = "#site_location_name";
     var municipalityFieldHandler = "#site_municipality_id";
     var autocompleteOptions = {
@@ -9,7 +9,6 @@ this.GobiertoAdmin.SitesController = (function() {
         var element = $(this)[0].element;
         $.ajax({
           url: element.data("autocompleteUrl"),
-          headers: { "authorization": "Bearer " + api_token },
           crossDomain: true,
           dataType: "json",
           method: "GET",
@@ -58,8 +57,8 @@ this.GobiertoAdmin.SitesController = (function() {
   }
 
 
-  SitesController.prototype.edit = function(api_token, site_modules_with_root_path) {
-    _handleSiteLocationAutocomplete(api_token);
+  SitesController.prototype.edit = function(site_modules_with_root_path) {
+    _handleSiteLocationAutocomplete();
     _homePage(site_modules_with_root_path);
   };
 

--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -196,7 +196,6 @@
 
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
-    window.GobiertoAdmin.sites_controller.edit("<%= current_site.configuration.populate_data_api_token %>",
-                                               "<%= APP_CONFIG["site_modules_with_root_path"] %>");
+    window.GobiertoAdmin.sites_controller.edit("<%= APP_CONFIG["site_modules_with_root_path"] %>");
   <% end %>
 <% end %>


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR removes the api key requirement to fetch the list of available municipalities from Populate Data.

### How should this be manually tested?

Try to create a new site without introducing the API key, and the autocomplete of municipalities should work.