### PR TITLE
Deal with events with nil datetime attributes

### DIFF
--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -65,6 +65,12 @@ module GobiertoPeople
         event4.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: ["WEEK=1"], id: "event4",
                      summary: "Event 4", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
+
+        # Event no start
+        event_no_start = mock
+        event_no_start.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event-no-start",
+                             summary: "Event no start", start: nil, end: nil, attendees: [], description: "")
+
         # Instance 1 of recurring event event4
         event5 = mock
         event5.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_1",
@@ -88,7 +94,7 @@ module GobiertoPeople
         calendar_1_items_response.stubs(:items).returns([event1, event2])
 
         calendar_2_items_response = mock
-        calendar_2_items_response.stubs(:items).returns([event3, event4])
+        calendar_2_items_response.stubs(:items).returns([event3, event4, event_no_start])
 
         calendar_3_items_response = mock
         calendar_3_items_response.stubs(:items).returns([event7])


### PR DESCRIPTION
Closes #1192

### What does this PR do?

This PR deals with events without start/end attribute:

1. avoids the exception
2. logs them in the logger for further investigation
