### PR TITLE
Liquid tag list children pages

### DIFF
--- a/app/assets/stylesheets/comp-content.scss
+++ b/app/assets/stylesheets/comp-content.scss
@@ -36,7 +36,7 @@
 }
 .content {
   .inner,
-  // article:not(.news_article) 
+  // article:not(.news_article)
   {
     max-width: 650px;
     margin: 0 auto;
@@ -82,9 +82,15 @@
     }
 
     h2 {
-      font-size: 1.875em;
+      font-size: $f4;
       padding-bottom: 0.5em;
       border-bottom: 1px solid #DEEFF1;
+    }
+    h3 {
+      font-size: $f5;
+    }
+    h4 {
+      font-size: $f6;
     }
 
     h3 {

--- a/app/assets/stylesheets/comp-text_content.scss
+++ b/app/assets/stylesheets/comp-text_content.scss
@@ -75,7 +75,9 @@ figure.png, figure.jpg, figure.gif {
     }
   }
   article {
-    padding-left: 6em;
+    @include min-screen(740) {
+      padding-left: 6em;
+    }
     .breadcrumb {
       margin-top: 0;
       padding-top: 0;
@@ -125,6 +127,45 @@ figure.png, figure.jpg, figure.gif {
         .meta {
           opacity: .65;
           font-size: $f7;
+        }
+      }
+    }
+  }
+}
+
+.page_children {
+  display: flex;
+  flex-wrap: wrap;
+  line-height: 1.2;
+  .page_child {
+    background: $color_1_soft;
+    border-radius: 6px;
+    margin: .5em;
+    font-size: $f5;
+    font-weight: 600;
+    box-sizing: border-box;
+    width: 40%;
+    flex: 2 1 auto;
+    a {
+      display: block;
+      padding: 1em;
+    }
+    a:hover {
+      background: darken($color_1_soft, 5%);
+    }
+    .page_children {
+      padding: 0 1em 1em 1em;
+      display: block;
+      .page_child {
+        font-weight: normal;
+        font-size: .85rem;
+        margin: 0;
+        display: inline;
+        background: none;
+        padding: 0;
+        margin: 0;
+        a {
+          padding: 0;
         }
       }
     }

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -75,7 +75,7 @@ module GobiertoAdmin
       def save_section_item(id, section, parent)
         parent = parent ? parent : 0
         parent_node = ::GobiertoCms::SectionItem.find_by(id: parent, section: section)
-        position = ::GobiertoCms::SectionItem.where(parent_id: parent, section: section).size
+        position = ::GobiertoCms::SectionItem.where(parent_id: parent, section: section).size - 1
         section_item = ::GobiertoCms::SectionItem.find_or_initialize_by(item_id: id,
                                                                         item_type: "GobiertoCms::Page")
         if section == "" && section_item.present?

--- a/app/views/gobierto_cms/templates/_new.html.erb
+++ b/app/views/gobierto_cms/templates/_new.html.erb
@@ -34,7 +34,7 @@
               <%= l(@page.updated_at, format: :long) %>
             </time>
           </div>
-          <%= raw @page.body %>
+          <%= raw render_liquid(@page.body) %>
           <div class='note'>
             <%= t('gobierto_participation.shared.published_at', date: l(@page.updated_at, format: :long), site: current_site.name) %>
           </div>

--- a/app/views/gobierto_cms/templates/_page.html.erb
+++ b/app/views/gobierto_cms/templates/_page.html.erb
@@ -35,7 +35,7 @@
 
           <h1><%= @page.title %></h1>
 
-          <%= raw @page.body %>
+          <%= raw render_liquid(@page.body) %>
 
           <% if @page.attachments && @page.attachments.any? %>
             <div class="page_attachments">

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -4,3 +4,4 @@ Liquid::Template.error_mode = :lax
 
 require "liquid/tags/page_url"
 require "liquid/tags/page_title"
+require "liquid/tags/list_children_pages"

--- a/lib/liquid/tags/list_children_pages.rb
+++ b/lib/liquid/tags/list_children_pages.rb
@@ -5,7 +5,11 @@ class ListChildrenPages < Liquid::Tag
     super
 
     @page_slug = params.split("|").first.strip
-    @level = params.split("|").last.split(":").last.strip.to_i
+    @level = if params.include?("level")
+               params.split("|").last.split(":").last.strip.to_i
+             else
+               1
+             end
   end
 
   def render(context)

--- a/lib/liquid/tags/list_children_pages.rb
+++ b/lib/liquid/tags/list_children_pages.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ListChildrenPages < Liquid::Tag
+  def initialize(tag_name, params, tokens)
+    super
+
+    @page_slug = params.split("|").first.strip
+    @level = params.split("|").last.split(":").last.strip.to_i
+  end
+
+  def render(context)
+    current_site = context.environments.first["current_site"]
+    page = current_site.pages.find_by_slug!(@page_slug)
+    section_item = ::GobiertoCms::SectionItem.where(item_id: page.id)
+
+    if section_item.any?
+      return children_pages(section_item.first.children, @level)
+    else
+      return ""
+    end
+  rescue ActiveRecord::RecordNotFound
+    return ""
+  end
+
+  def children_pages(nodes, level)
+    html = []
+    if nodes.any?
+      html << "<div class='page_children'>"
+      nodes.each do |node|
+        html << "<div class='page_child'>"
+        html << "<a href='" + node.item.to_url + "'>" + node.item.title + "</a>"
+        level -= 1
+        if node.children.any? && level != 0
+          html << children_pages(node.children, level)
+        end
+        html << "</div>"
+      end
+      html << "</div>"
+    end
+    html.join.html_safe
+  end
+end
+
+Liquid::Template.register_tag("list_children_pages", ListChildrenPages)


### PR DESCRIPTION
Closes #1182 

### What does this PR do?

- We will have the tag **list_children_pages** available
- Now you can put liquid tags in the body of the pages.
- Extra: I found "section error", Alvaro, yesterday mistake https://rollbar.com/Populate/gobierto/items/643/

### How should this be manually tested?

Add tag in the body of the pages

```
{% list_children_pages page-slug  | levels: 1 %}

{% list_children_pages page-slug %}

```

My test:

[http://participacion.gobify.net/s/participacion/ayuda-global-del-sitio](http://participacion.gobify.net/s/participacion/ayuda-global-del-sitio)

### Output Example

```
<div class="page_children">
  <div class="page_child">
    <a href="http://madrid.gobierto.dev/s/participacion/sobre">Sobre Nosotros</a>
    <div class="page_children">
      <div class="page_child">
        <a href="http://madrid.gobierto.dev/s/participacion/segundo-nivel">Segundo nivel</a>
        <div class="page_children">
          <div class="page_child">
            <a href="http://madrid.gobierto.dev/s/participacion/tercer-nivel">Tercer nivel</a>
          </div>
        </div>
      </div>
    </div>
  </div>
</div>
```
