### PR TITLE
Fix levels parameter for list_children_pages

### DIFF
--- a/app/helpers/gobierto_cms/page_helper.rb
+++ b/app/helpers/gobierto_cms/page_helper.rb
@@ -1,17 +1,20 @@
+# frozen_string_literal: true
+
 module GobiertoCms
   module PageHelper
     def section_tag(nodes, viewables)
-      html = ""
+      html = []
       html << "<ul>"
       nodes.each do |node|
-        html << "<li>" + link_to(node.item.title, node.item.to_url(section: true, host: current_site.domain))
+        html << "<li>" + link_to(node.item.title, node.item.to_url(section: true,
+                                                                   host: current_site.domain))
         if node.children.any? && !(viewables & node.children).empty?
           html << section_tag(node.children, viewables)
         end
         html << "</li>"
       end
       html << "</ul>"
-      html.html_safe
+      html.join.html_safe
     end
   end
 end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -89,6 +89,21 @@ module GobiertoCms
       to_url
     end
 
+    def to_path(options = {})
+      if collection
+        if collection.container_type == "GobiertoParticipation::Process"
+          url_helpers.gobierto_participation_process_page_path({ id: slug, process_id: collection.container.slug }.merge(options))
+        elsif collection.container_type == "GobiertoParticipation"
+          url_helpers.gobierto_participation_page_path({ id: slug }.merge(options))
+        elsif section.present? || options[:section]
+          options.delete(:section)
+          url_helpers.gobierto_cms_section_item_path({ id: slug, slug_section: section.slug }.merge(options))
+        else
+          url_helpers.gobierto_cms_page_path({ id: slug }.merge(options))
+        end
+      end
+    end
+
     def to_url(options = {})
       host = site.domain
       if collection

--- a/lib/liquid/tags/list_children_pages.rb
+++ b/lib/liquid/tags/list_children_pages.rb
@@ -28,18 +28,19 @@ class ListChildrenPages < Liquid::Tag
 
   def children_pages(nodes, level)
     html = []
-    if nodes.any?
-      html << "<div class='page_children'>"
-      nodes.each do |node|
-        html << "<div class='page_child'>"
-        html << "<a href='" + node.item.to_url + "'>" + node.item.title + "</a>"
-        level -= 1
-        if node.children.any? && level != 0
-          html << children_pages(node.children, level)
+    if level.positive?
+      if nodes.any?
+        html << "<div class='page_children'>"
+        nodes.each do |node|
+          html << "<div class='page_child'>"
+          html << "<a href='" + node.item.to_path + "'>" + node.item.title + "</a>"
+          if node.children.any? && level.positive?
+            html << children_pages(node.children, level - 1)
+          end
+          html << "</div>"
         end
         html << "</div>"
       end
-      html << "</div>"
     end
     html.join.html_safe
   end


### PR DESCRIPTION
Closes #1203 

### What does this PR do?

Review list_children_pages tag, wasn't working properly.

My test:

[http://participacion.gobify.net/s/participacion/ayuda-global-del-sitio](http://participacion.gobify.net/s/participacion/ayuda-global-del-sitio)

The order of the children is fixed in https://github.com/PopulateTools/gobierto/pull/1207


### How should this be manually tested?

{% list_children_pages page_slug %} (by default 1 level)
{% list_children_pages page_slug | levels: 0 %}
{% list_children_pages page_slug | levels: 1 %}
{% list_children_pages page_slug | levels: 2 %}
...
