### PR TITLE
Limit recurring events time window

### DIFF
--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -151,7 +151,7 @@ module GobiertoPeople
 
     def recurring_event_in_window
       if recurring?
-        errors.add(:starts_at) if starts_at > 3.months.from_now
+        errors.add(:starts_at) if starts_at > 3.months.from_now || starts_at < 1.year.ago
       end
     end
 

--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -14,12 +14,14 @@ module GobiertoPeople
       :state,
       :notify,
       :locations,
-      :attendees
+      :attendees,
+      :recurring
     )
 
     delegate :persisted?, to: :person_event
 
     validates :external_id, :title, :starts_at, :ends_at, :site, :collection, presence: true
+    validate :recurring_event_in_window
 
     trackable_on :person_event
 
@@ -31,6 +33,10 @@ module GobiertoPeople
 
     def site
       @site ||= Site.find_by(id: site_id)
+    end
+
+    def recurring?
+      @recurring ||= false
     end
 
     def person_event
@@ -141,6 +147,12 @@ module GobiertoPeople
 
     def person_class
       ::GobiertoPeople::Person
+    end
+
+    def recurring_event_in_window
+      if recurring?
+        errors.add(:starts_at) if starts_at > 3.months.from_now
+      end
     end
 
     def save_person_event

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -96,7 +96,8 @@ module GobiertoPeople
           ends_at: parse_date(event.end),
           state: GobiertoCalendars::Event.states[:published],
           attendees: event_attendees(event),
-          notify: i.nil? || i == 0
+          notify: i.nil? || i == 0,
+          recurring: i.present?
         }
 
         if event.location.present?

--- a/test/forms/gobierto_people/person_event_form_test.rb
+++ b/test/forms/gobierto_people/person_event_form_test.rb
@@ -19,6 +19,22 @@ module GobiertoPeople
       )
     end
 
+    def invalid_recurring_event_form
+      @valid_event_form ||= PersonEventForm.new(
+        external_id: "123",
+        site_id: site.id,
+        person_id: person.id,
+        title: event.title,
+        description: event.description,
+        starts_at: 4.months.from_now,
+        ends_at: 4.months.from_now,
+        state: event.state,
+        locations: [],
+        attendees: [],
+        recurring: true
+      )
+    end
+
     def invalid_event_form
       @invalid_event_form ||= PersonEventForm.new(
         external_id: nil,
@@ -58,6 +74,12 @@ module GobiertoPeople
       assert_equal 1, invalid_event_form.errors.messages[:external_id].size
       assert_equal 1, invalid_event_form.errors.messages[:title].size
       assert_equal 1, invalid_event_form.errors.messages[:ends_at].size
+    end
+
+    def test_error_messages_with_invalid_recurring_event
+      invalid_recurring_event_form.save
+
+      assert_equal 1, invalid_recurring_event_form.errors.messages[:starts_at].size
     end
   end
 end

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -28,6 +28,8 @@ module GobiertoPeople
         date1.stubs(date_time: Time.now)
         date2 = mock
         date2.stubs(date_time: 1.hour.from_now)
+        invalid_date = mock
+        invalid_date.stubs(date_time: Time.now + 4.months)
 
         # Private event, ignored
         event1 = mock
@@ -81,6 +83,11 @@ module GobiertoPeople
         event6.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_2",
                      summary: "Event 6", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
+        # Instance 3 of recurring event event4
+        event8 = mock
+        event8.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_3",
+                     summary: "Event 8", start: invalid_date, end: invalid_date, attendees: [], description: "")
+
         calendar1 = mock
         calendar1.stubs(id: google_calendar_id, primary?: true)
 
@@ -100,7 +107,7 @@ module GobiertoPeople
         calendar_3_items_response.stubs(:items).returns([event7])
 
         event_4_instances_response = mock
-        event_4_instances_response.stubs(:items).returns([event5, event6])
+        event_4_instances_response.stubs(:items).returns([event5, event6, event8])
 
         calendar_items_response = mock
         calendar_items_response.stubs(:items).returns([calendar1, calendar2, calendar3])


### PR DESCRIPTION
Closes #1196

### What does this PR do?

This PR limits recurring events window to

- 3 months in advance
- 1 year before the current date

### How should this be manually tested?

1. Sync a Google Calendar account with recurring events
2. Check the above conditions are accomplished