### PR TITLE
Limit the size of the body attribute indexed in the search engine

### DIFF
--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -15,10 +15,11 @@ module GobiertoCms
     include GobiertoCommon::Sluggable
     include GobiertoCommon::Collectionable
     include GobiertoCommon::Sectionable
+    include ActionView::Helpers::SanitizeHelper
 
     algoliasearch_gobierto do
-      attribute :site_id, :updated_at, :title_en, :title_es, :title_ca, :body_en, :body_es, :body_ca, :collection_id
-      searchableAttributes %w(title_en title_es title_ca body_en body_es body_ca)
+      attribute :site_id, :updated_at, :title_en, :title_es, :title_ca, :searchable_body, :collection_id
+      searchableAttributes %w(title_en title_es title_ca searchable_body)
       attributesForFaceting [:site_id]
       add_attribute :resource_path, :class_name
     end
@@ -120,6 +121,13 @@ module GobiertoCms
       if collection
         collection.append(self)
       end
+    end
+
+    def searchable_body
+      return "" if body_translations.nil?
+      body = body_translations.values.join(" ").tr("\n\r", " ").gsub(/\s+/, " ")
+      body = strip_tags(body)
+      body[0..9300]
     end
   end
 end

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -1,6 +1,6 @@
 consultation_faq:
   title_translations: <%= { 'en' => 'Consultation page FAQ', 'es' => 'FAQ consultas' }.to_json %>
-  body_translations: <%= { 'en' => 'This is the body of the page', 'es' => 'Cuerpo página consultas' }.to_json %>
+  body_translations: <%= { 'en' => 'This is the <strong>body</strong> of the page', 'es' => 'Cuerpo <strong>página</strong> consultas' }.to_json %>
   slug: 'consultation-faq'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -20,5 +20,16 @@ module GobiertoCms
     def test_valid
       assert page.valid?
     end
+
+    def test_searchable_body
+      assert page.searchable_body.include?("This is the body of the page")
+      assert page.searchable_body.include?("Cuerpo página consultas")
+    end
+
+    def test_searchable_body_on_empty_page
+      new_page = GobiertoCms::Page.new
+      assert_equal "", new_page.searchable_body
+      assert_equal "", new_page.searchable_body
+    end
   end
 end


### PR DESCRIPTION
Closes #1117

### What does this PR do?

This PR deals with an issue indexing big pages in Algolia. This is what is done:

- cleans HTML of the pages
- merges all the translations in a single attribute
- limits the length of the page

This is the simplest solution for the moment. In a further iteration we should probably split the page in subitems, but it's not an obvious solution with the current Algolia Rails gem.

### How should this be manually tested?

Index in staging a very loooong page. 