### PR TITLE
Increase attachments max file size

### DIFF
--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -13,7 +13,7 @@ module GobiertoAttachments
     include GobiertoCommon::Sluggable
     include GobiertoCommon::Collectionable
 
-    MAX_FILE_SIZE_IN_MBYTES = 10
+    MAX_FILE_SIZE_IN_MBYTES = 50
     MAX_FILE_SIZE_IN_BYTES  = MAX_FILE_SIZE_IN_MBYTES.megabytes
 
     default_scope { order(id: :desc) }


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR increases the maximum file size of attachments to 50Mb
