### PR TITLE
1135 calendar updates button

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -40,7 +40,10 @@ module GobiertoAdmin
           calendar_integration.sync_person_events(@calendar_configuration_form.collection_container)
           publish_calendar_sync_activity(@calendar_configuration_form)
         end
-        redirect_to edit_admin_calendars_configuration_path(@collection)
+        redirect_to(
+          edit_admin_calendars_configuration_path(@collection),
+          notice: t('.success')
+        )
       end
 
       private

--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -57,10 +57,7 @@ module GobiertoAdmin
                        current_site.activities.where(action: 'admin_gobierto_calendars.calendars_synchronized', subject: collection_container)
                          .order(created_at: :asc)
                          .last.try(:created_at)
-                     else
-                       nil
                      end
-
       end
 
       def load_collection

--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -33,6 +33,14 @@ module GobiertoAdmin
         end
       end
 
+      def sync_calendars
+        @calendar_configuration_form = CalendarConfigurationForm.new(current_site: current_site, collection_id: @collection.id)
+        if (calendar_integration = @calendar_configuration_form.calendar_integration_class).present?
+          calendar_integration.sync_person_events(@calendar_configuration_form.collection_container)
+        end
+        redirect_to edit_admin_calendars_configuration_path(@collection)
+      end
+
       private
 
       def load_collection

--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -13,6 +13,7 @@ module GobiertoAdmin
         load_calendar_integrations
         @google_calendar_configuration = find_google_calendar_configuration
         load_calendars
+        set_last_sync
 
         render 'gobierto_admin/gobierto_calendars/calendar_configuration/edit'
       end
@@ -46,6 +47,17 @@ module GobiertoAdmin
 
       def publish_calendar_sync_activity(calendar_configuration_form)
         Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: remote_ip, author: current_admin, subject: calendar_configuration_form.collection_container, site_id: current_site.id })
+      end
+
+      def set_last_sync
+        @last_sync = if collection_container = @calendar_configuration_form.try(:collection_container)
+                       current_site.activities.where(action: 'admin_gobierto_calendars.calendars_synchronized', subject: collection_container)
+                         .order(created_at: :asc)
+                         .last.try(:created_at)
+                     else
+                       nil
+                     end
+
       end
 
       def load_collection

--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -37,11 +37,16 @@ module GobiertoAdmin
         @calendar_configuration_form = CalendarConfigurationForm.new(current_site: current_site, collection_id: @collection.id)
         if (calendar_integration = @calendar_configuration_form.calendar_integration_class).present?
           calendar_integration.sync_person_events(@calendar_configuration_form.collection_container)
+          publish_calendar_sync_activity(@calendar_configuration_form)
         end
         redirect_to edit_admin_calendars_configuration_path(@collection)
       end
 
       private
+
+      def publish_calendar_sync_activity(calendar_configuration_form)
+        Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: remote_ip, author: current_admin, subject: calendar_configuration_form.collection_container, site_id: current_site.id })
+      end
 
       def load_collection
         @collection = current_site.collections.find(params[:id])

--- a/app/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form.rb
+++ b/app/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form.rb
@@ -9,6 +9,7 @@ module GobiertoAdmin
       attr_accessor(
         :current_site,
         :calendar_integration,
+        :calendar_integration_class,
         :collection_id,
         :ibm_notes_usr,
         :ibm_notes_pwd,
@@ -120,6 +121,10 @@ module GobiertoAdmin
           conf = base_calendar_configuration_class.find_by(collection_id: collection_id)
           conf ? conf.integration_name : nil
         end
+      end
+
+      def calendar_integration_class
+        @calendar_integration_class ||= collection ? collection.calendar_integration : nil
       end
 
       def collection_container

--- a/app/publishers/admin_gobierto_calendars_activity.rb
+++ b/app/publishers/admin_gobierto_calendars_activity.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Publishers
+  class AdminGobiertoCalendarsActivity
+    include Publisher
+
+    self.pub_sub_namespace = 'activities/admin_gobierto_calendars'
+  end
+end

--- a/app/services/gobierto_people/remote_calendars.rb
+++ b/app/services/gobierto_people/remote_calendars.rb
@@ -13,6 +13,7 @@ module GobiertoPeople
         log_agenda_synchronization(collection, container, site)
 
         calendar_integration.sync_person_events(container)
+        Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: '127.0.0.1',  subject: container, site_id: site.id })
       end
     end
 

--- a/app/subscribers/admin_gobierto_calendars_activity.rb
+++ b/app/subscribers/admin_gobierto_calendars_activity.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class AdminGobiertoCalendarsActivity < ::Subscribers::Base
+    def calendars_synchronized(event)
+      create_activity_from_event(event, 'admin_gobierto_calendars.calendars_synchronized')
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      Activity.create! subject: event.payload[:subject],
+                       author: event.payload[:author],
+                       subject_ip: event.payload[:ip],
+                       action: action,
+                       site_id: event.payload[:site_id],
+                       admin_activity: true
+    end
+  end
+end
+
+

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -8,7 +8,7 @@
       <%= t('.last_sync') %>: <%= time_ago_in_words @last_sync %> -
     <% end %>
 
-    <%= link_to sync_calendars_admin_calendars_configuration_path(@calendar_configuration_form.collection_id), method: :put, data: { confirm: "Are you sure?" } do %>
+    <%= link_to sync_calendars_admin_calendars_configuration_path(@calendar_configuration_form.collection_id), method: :put, data: { confirm: t(".confirm_sync") } do %>
       <i class="fa fa-refresh"></i>
       <%= t('.sync') %>
     <% end %>

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -4,6 +4,10 @@
 
 <% if @calendar_configuration_form.calendar_integration.present? %>
   <div class="admin_tools">
+    <% if @last_sync.present? %>
+      <%= t('.last_sync') %>: <%= time_ago_in_words @last_sync %> -
+    <% end %>
+
     <%= link_to sync_calendars_admin_calendars_configuration_path(@calendar_configuration_form.collection_id), method: :put, data: { confirm: "Are you sure?" } do %>
       <i class="fa fa-refresh"></i>
       <%= t('.sync') %>

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -2,6 +2,15 @@
 
 <%= render "gobierto_admin/gobierto_calendars/calendar_configuration/#{@calendar_configuration_form.collection_container_identifier}_navigation", collection_container:  @calendar_configuration_form.collection_container %>
 
+<% if @calendar_configuration_form.calendar_integration.present? %>
+  <div class="admin_tools">
+    <%= link_to sync_calendars_admin_calendars_configuration_path(@calendar_configuration_form.collection_id), method: :put, data: { confirm: "Are you sure?" } do %>
+      <i class="fa fa-refresh"></i>
+      <%= t('.sync') %>
+    <% end %>
+  </div>
+<% end %>
+
 <%= form_for @calendar_configuration_form, as: :calendar_configuration, url: admin_calendars_configuration_path,  method: :patch do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -25,6 +25,7 @@ Subscribers::GobiertoParticipationPollActivity.attach_to("activities/gobierto_pa
 Subscribers::GobiertoParticipationContributionContainerActivity.attach_to("activities/gobierto_participation_contribution_containers")
 Subscribers::UserActivity.attach_to("activities/users")
 Subscribers::SiteActivity.attach_to("activities/sites")
+Subscribers::AdminGobiertoCalendarsActivity.attach_to("activities/admin_gobierto_calendars")
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|

--- a/config/locales/gobierto_admin/gobierto_calendars/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/controllers/ca.yml
@@ -3,6 +3,8 @@ ca:
   gobierto_admin:
     gobierto_calendars:
       calendar_configuration:
+        sync_calendars:
+          success: Sincronització realitzada
         update:
           success: Preferències actualitzades correctament
       events:

--- a/config/locales/gobierto_admin/gobierto_calendars/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/controllers/en.yml
@@ -3,6 +3,8 @@ en:
   gobierto_admin:
     gobierto_calendars:
       calendar_configuration:
+        sync_calendars:
+          success: Synchronization done
         update:
           success: Settings updated successfully
       events:

--- a/config/locales/gobierto_admin/gobierto_calendars/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/controllers/es.yml
@@ -3,6 +3,8 @@ es:
   gobierto_admin:
     gobierto_calendars:
       calendar_configuration:
+        sync_calendars:
+          success: Sincronización realizada
         update:
           success: Preferencias actualizadas correctamente
       events:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -5,6 +5,7 @@ ca:
       calendar_configuration:
         edit:
           calendar_integration: Integració de calendari
+          confirm_sync: Estàs segur?
           google_calendar: Google Calendar
           ibm_notes: IBM Notes
           labels:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -20,6 +20,7 @@ ca:
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. perico85
           remove_configuration: Eliminar configuració
+          sync: Sincronitzar ara
         gobierto_people_person_navigation:
           calendar_configuration: Configuració del calendari
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -14,6 +14,7 @@ ca:
             microsoft_exchange_pwd: Contrasenya
             microsoft_exchange_url: URL del calendari
             microsoft_exchange_usr: Compte de Microsoft Exchange
+          last_sync: Darrera sincronització
           microsoft_exchange: Microsoft Exchange
           placeholders:
             ibm_notes_url: ex. https://example.com/mail/abc.nsf/api/calendar/events

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -5,6 +5,7 @@ en:
       calendar_configuration:
         edit:
           calendar_integration: Calendar integration
+          confirm_sync: Are you sure?
           google_calendar: Google Calendar
           ibm_notes: IBM Notes
           labels:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -14,6 +14,7 @@ en:
             microsoft_exchange_pwd: Password
             microsoft_exchange_url: Calendar URL
             microsoft_exchange_usr: Microsoft Exchange account
+          last_sync: Last sync
           microsoft_exchange: Microsoft Exchange
           placeholders:
             ibm_notes_url: ex. https://example.com/mail/abc.nsf/api/calendar/events

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -20,6 +20,7 @@ en:
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. someone85
           remove_configuration: Remove calendar configuration
+          sync: Sync now
         gobierto_people_person_navigation:
           calendar_configuration: Calendar configuration
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -5,6 +5,7 @@ es:
       calendar_configuration:
         edit:
           calendar_integration: Integración de calendario
+          confirm_sync: "¿Estás seguro?"
           google_calendar: Google Calendar
           ibm_notes: IBM Notes
           labels:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -20,6 +20,7 @@ es:
             microsoft_exchange_url: ej. https://ejemplo.com/ews/exchange.asmx
             username: ej. perico85
           remove_configuration: Eliminar configuración de calendario
+          sync: Sincronizar ahora
         gobierto_people_person_navigation:
           calendar_configuration: Configuración de calendario
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -14,6 +14,7 @@ es:
             microsoft_exchange_pwd: Contraseña
             microsoft_exchange_url: URL del calendario
             microsoft_exchange_usr: Cuenta de Microsoft Exchange
+          last_sync: Última sincronización
           microsoft_exchange: Microsoft Exchange
           placeholders:
             ibm_notes_url: ej. https://ejemplo.com/mail/abc.nsf/api/calendar/events

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -1,5 +1,8 @@
 ---
 ca:
+  admin_gobierto_calendars:
+    events:
+      admin_gobierto_calendars_calendars_synchronized: Calendaris sincronitzats
   admins:
     events:
       admins_admin_authorization_level_updated: Nivel autorització admin actualitzat

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  admin_gobierto_calendars:
+    events:
+      admin_gobierto_calendars_calendars_synchronized: Synchronized calendars
   admins:
     events:
       admins_admin_authorization_level_updated: Admin authorization level updated

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -1,5 +1,8 @@
 ---
 es:
+  admin_gobierto_calendars:
+    events:
+      admin_gobierto_calendars_calendars_synchronized: Calendarios sincronizados
   admins:
     events:
       admins_admin_authorization_level_updated: Nivel autorización admin actualizado

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,7 +138,11 @@ Rails.application.routes.draw do
     namespace :gobierto_calendars, as: :calendars do
       resources :events
       resources :collections, only: [:index]
-      resources :calendar_configurations, only: [:edit, :update], controller: "calendar_configuration", as: :configurations, path: :configurations
+      resources :calendar_configurations, only: [:edit, :update], controller: "calendar_configuration", as: :configurations, path: :configurations do
+        member do
+          put 'sync_calendars'
+        end
+      end
     end
   end
 

--- a/test/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form_test.rb
@@ -136,6 +136,11 @@ module GobiertoAdmin
         assert_nil form.dummy_microsoft_exchange_pwd
       end
 
+      def test_calendar_integration_class_get_data_from_collection
+        calendar_configuration_form = CalendarConfigurationForm.new(ibm_notes_calendar_configuration_attributes)
+        assert_equal ::GobiertoPeople::IbmNotes::CalendarIntegration, calendar_configuration_form.calendar_integration_class
+      end
+
     end
   end
 end


### PR DESCRIPTION
Related with #1135

### What does this PR do?
Adds a link on admin edition view of calendar configurations to sync the calendar if some integration is defined. Also a new activity is created when a calendar is synchronized. If there are previous calendar update activities the date of last sync is shown next to the link.

### How should this be manually tested?

Visit http://madrid.gobify.net/admin/gobierto_calendars/configurations/29/edit

### Does this PR changes any configuration file?

- Only `config/initializers/subscribers.rb` to include activities related with calendars
