### PR TITLE
Sanitize separation characters properly

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
@@ -642,8 +642,8 @@ var VisLineasJ = Class.extend({
   },
 
   _normalize: (function() {
-    var from = "ÃÀÁÄÂÈÉËÊÌÍÏÎÒÓÖÔÙÚÜÛãàáäâèéëêìíïîòóöôùúüûÑñÇç ",
-        to   = "AAAAAEEEEIIIIOOOOUUUUaaaaaeeeeiiiioooouuuunncc_",
+    var from = "ÃÀÁÄÂÈÉËÊÌÍÏÎÒÓÖÔÙÚÜÛãàáäâèéëêìíïîòóöôùúüûÑñÇç ',.",
+        to   = "AAAAAEEEEIIIIOOOOUUUUaaaaaeeeeiiiioooouuuunncc_---",
         mapping = {};
 
     for(var i = 0, j = from.length; i < j; i++ )


### PR DESCRIPTION
Closes #1253

### What does this PR do?

This PR fixes how municipality names are normalized to obtain a CSS class and fixes names like "Hospitalet de Llobregat, L'"

### How should this be manually tested?

Add that municipality to a comparison and check the colors work.
