### PR TITLE
Comparison show place name

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_lineas_tabla.js
@@ -318,7 +318,10 @@ var VisLineasJ = Class.extend({
           .attr('d', function(d) { return this.line(d.values.filter(function(v) { return v.value != null; })); }.bind(this))
           .style('stroke', function(d) { return this.colorScale(d.name); }.bind(this))
           .style('stroke-width', function(d, i) {
-            return i == 3 ? this.heavyLine : this.lightLine;
+            if(this.series == 'means')
+              return i == 3 ? this.heavyLine : this.lightLine;
+            else
+              return this.lightLine;
           }.bind(this))
 
 

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -276,7 +276,7 @@ module GobiertoBudgets
               "values": mean_national
             },
             {
-              name: @code ? @category_name : @place.name,
+              name: @place.name,
               "values": place_values
             }
           ]


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR shows the place name instead of the category name in the comparison graph.

It also removes the highlighted line when the comparison graphs doesn't show the means.