### PR TITLE
Fix timeout and bug in Microsoft Exchange calendar integration

### DIFF
--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -24,7 +24,7 @@ module GobiertoPeople
 
         mark_unreceived_events_as_drafts(calendar_items)
 
-        calendar_items.each do |item|
+        Array(calendar_items).each do |item|
           sync_event(item)
         end
       rescue ::Errno::EADDRNOTAVAIL, ::SocketError, ::ArgumentError, ::Addressable::URI::InvalidURIError
@@ -100,7 +100,7 @@ module GobiertoPeople
       end
 
       def mark_unreceived_events_as_drafts(calendar_items)
-        if calendar_items.any?
+        if calendar_items && calendar_items.any?
           received_external_ids = calendar_items.map(&:id)
           person.events
                 .where(starts_at: SYNC_RANGE[:start_date]..SYNC_RANGE[:end_date])

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -29,6 +29,8 @@ module GobiertoPeople
         end
       rescue ::Errno::EADDRNOTAVAIL, ::SocketError, ::ArgumentError, ::Addressable::URI::InvalidURIError
         Rails.logger.info "#{log_preffix} Invalid endpoint address for #{person.name} (id: #{person.id}): #{Exchanger.config.endpoint}"
+      rescue ::HTTPClient::ConnectTimeoutError
+        Rails.logger.info "#{log_preffix} Timeout error for #{person.name} (id: #{person.id}): #{Exchanger.config.endpoint}"
       end
 
       private

--- a/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
+++ b/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
@@ -75,6 +75,20 @@ module GobiertoPeople
         }
       end
 
+      def test_sync_returns_nil
+        target_folder = mock
+        target_folder.stubs(:expanded_items).returns(nil)
+        target_folder.stubs(:display_name).returns(CalendarIntegration::TARGET_CALENDAR_NAME)
+
+        root_folder = mock
+        root_folder.stubs(:folders).returns([target_folder])
+        Exchanger::Folder.stubs(:find).returns(root_folder)
+
+        assert_difference 'GobiertoCalendars::Event.count', 0 do
+          CalendarIntegration.sync_person_events(richard)
+        end
+      end
+
       def test_sync_events
         event_1 = event_attributes
         event_2 = {


### PR DESCRIPTION
Bugfix

### What does this PR do?

This PR closes two bugs in Exchange integration:

- deals with timeouts
- detects when the service returns a nil
