### PR TITLE
1265 verification filter

### DIFF
--- a/app/controllers/concerns/user/verification_helper.rb
+++ b/app/controllers/concerns/user/verification_helper.rb
@@ -3,6 +3,12 @@ module User::VerificationHelper
 
   private
 
+  def check_visibility_level(resource, user)
+    unless resource.visibility_level_allowed_for?(user)
+      raise_visibility_forbidden(resource, user)
+    end
+  end
+
   def verify_user_in!(site)
     raise_user_not_verified(site) unless user_verified_in?(site)
   end
@@ -22,6 +28,15 @@ module User::VerificationHelper
       request.referrer || user_root_path,
       alert: t('user.census_verifications.messages.already_verified')
     )
+  end
+
+  def raise_visibility_forbidden(resource, user)
+    case resource.visibility_user_level
+    when 'verified'
+      raise_user_not_verified(resource.site)
+    when 'registered'
+      raise_user_not_signed_in
+    end
   end
 
   def raise_user_not_verified(site)

--- a/app/controllers/gobierto_admin/gobierto_participation/processes/polls_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/polls_controller.rb
@@ -64,6 +64,7 @@ module GobiertoAdmin
             :starts_at,
             :ends_at,
             :visibility_level,
+            :visibility_user_level,
             title_translations: [*I18n.available_locales],
             description_translations: [*I18n.available_locales],
             questions_attributes: [

--- a/app/controllers/gobierto_participation/comments_controller.rb
+++ b/app/controllers/gobierto_participation/comments_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class CommentsController < GobiertoParticipation::ApplicationController
     include User::VerificationHelper
 
-    before_action(only: [:create]) { verify_user_in!(current_site) if current_contribution_container.visibility_user_level == "verified" }
+    before_action(only: [:new, :create, :destroy]) { check_visibility_level(current_contribution_container, current_user) }
 
 
     def index

--- a/app/controllers/gobierto_participation/flags_controller.rb
+++ b/app/controllers/gobierto_participation/flags_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class FlagsController < GobiertoParticipation::ApplicationController
     include User::VerificationHelper
 
-    before_action(only: [:new, :create, :destroy]) { verify_user_in!(current_site) if current_contribution_container.visibility_user_level == "verified" }
+    before_action(only: [:new, :create, :destroy]) { check_visibility_level(current_contribution_container, current_user) }
 
     def new
       @flaggable = find_flaggable

--- a/app/controllers/gobierto_participation/processes/contributions_controller.rb
+++ b/app/controllers/gobierto_participation/processes/contributions_controller.rb
@@ -5,7 +5,7 @@ module GobiertoParticipation
     class ContributionsController < BaseController
       include User::VerificationHelper
 
-      before_action(only: [:new, :create]) { verify_user_in!(current_site) if find_contribution_container.visibility_user_level == "verified" }
+      before_action(only: [:new, :create]) { check_visibility_level(find_contribution_container, current_user) }
 
       def new
         @contribution_container = find_contribution_container

--- a/app/controllers/gobierto_participation/processes/poll_answers_controller.rb
+++ b/app/controllers/gobierto_participation/processes/poll_answers_controller.rb
@@ -6,7 +6,7 @@ module GobiertoParticipation
       include User::VerificationHelper
 
       before_action :authenticate_user!
-      before_action { verify_user_in!(current_site) if current_poll.visibility_user_level == "verified" }
+      before_action { check_visibility_level(current_poll, current_user) }
       before_action { check_active_stage(current_process, ProcessStage.stage_types[:polls]) }
       before_action(only: [:new]) { current_poll.answerable_by?(current_user) }
 

--- a/app/controllers/gobierto_participation/votes_controller.rb
+++ b/app/controllers/gobierto_participation/votes_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class VotesController < GobiertoParticipation::ApplicationController
     include User::VerificationHelper
 
-    before_action(only: [:new, :create, :destroy]) { verify_user_in!(current_site) if current_contribution_container.visibility_user_level == "verified" }
+    before_action(only: [:new, :create, :destroy]) { check_visibility_level(current_contribution_container, current_user) }
 
     def new
       @votable = find_votable

--- a/app/models/concerns/gobierto_common/has_visibility_user_levels.rb
+++ b/app/models/concerns/gobierto_common/has_visibility_user_levels.rb
@@ -1,0 +1,23 @@
+module GobiertoCommon
+  module HasVisibilityUserLevels
+    extend ActiveSupport::Concern
+
+    included do
+      enum visibility_user_level: { registered: 0, verified: 1 }
+      validates :visibility_user_level, presence: true
+    end
+
+    def visibility_level_allowed_for?(user)
+      return false if user.blank?
+
+      if registered?
+        user.try :confirmed?
+      elsif verified?
+        user.try(:verified_in_site?, site)
+      else
+        user.try(:verified_in_site_with_level?, site, visibility_user_level)
+      end
+    end
+
+  end
+end

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -21,7 +21,7 @@ module GobiertoBudgets
 
     def total_budget_per_inhabitant(year = nil)
       year ||= @year
-      BudgetTotal.budgeted_for(@place.id, year, BudgetLine::EXPENSE) / (population(year) || population(year-1) || population(year-2)).to_f
+      BudgetTotal.budgeted_for(@place.id, year, BudgetLine::EXPENSE).to_f / (population(year) || population(year-1) || population(year-2)).to_f
     end
 
     def total_income_budget(year = nil)
@@ -36,7 +36,7 @@ module GobiertoBudgets
 
     def total_income_budget_per_inhabitant(year = nil)
       year ||= @year
-      BudgetTotal.budgeted_for(@place.id, year, BudgetLine::INCOME) / (population(year) || population(year-1) || population(year-2)).to_f
+      BudgetTotal.budgeted_for(@place.id, year, BudgetLine::INCOME).to_f / (population(year) || population(year-1) || population(year-2)).to_f
     end
 
     def total_budget(year = nil)

--- a/app/models/gobierto_participation/contribution_container.rb
+++ b/app/models/gobierto_participation/contribution_container.rb
@@ -6,6 +6,7 @@ module GobiertoParticipation
   class ContributionContainer < ApplicationRecord
     include User::Subscribable
     include GobiertoCommon::Sluggable
+    include GobiertoCommon::HasVisibilityUserLevels
 
     translates :title, :description
 
@@ -15,12 +16,11 @@ module GobiertoParticipation
     has_many :contributions
 
     enum visibility_level: { draft: 0, active: 1 }
-    enum visibility_user_level: { registered: 0, verified: 1 }
     enum contribution_type: { idea: 0, question: 1, proposal: 2 }
 
     scope :open, -> { where("starts <= ? AND ends >= ?", Time.zone.now, Time.zone.now) }
 
-    validates :site, :process, :title, :description, :admin, :visibility_user_level, presence: true
+    validates :site, :process, :title, :description, :admin, presence: true
 
     def parameterize
       { slug: slug }

--- a/app/models/gobierto_participation/poll.rb
+++ b/app/models/gobierto_participation/poll.rb
@@ -9,6 +9,7 @@ module GobiertoParticipation
     include PollResultsHelpers
 
     belongs_to :process
+    delegate :site, to: :process, allow_nil: true
     has_many :questions, -> { order(order: :asc) }, class_name: "GobiertoParticipation::PollQuestion", dependent: :destroy, autosave: true
     has_many :answers, class_name: "GobiertoParticipation::PollAnswer", autosave: true
 

--- a/app/models/gobierto_participation/poll.rb
+++ b/app/models/gobierto_participation/poll.rb
@@ -5,6 +5,7 @@ require_dependency "gobierto_participation"
 module GobiertoParticipation
   class Poll < ApplicationRecord
     class PollHasAnswers < StandardError; end
+    include GobiertoCommon::HasVisibilityUserLevels
 
     include PollResultsHelpers
 
@@ -14,7 +15,6 @@ module GobiertoParticipation
     has_many :answers, class_name: "GobiertoParticipation::PollAnswer", autosave: true
 
     enum visibility_level: { draft: 0, published: 1 }
-    enum visibility_user_level: { registered: 0, verified: 1 }
 
     scope :open, -> { where("starts_at <= ? AND ends_at >= ?", Time.zone.now, Time.zone.now) }
     scope :answerable, -> { published.open }

--- a/test/controllers/gobierto_admin/gobierto_budget_consultations/consultations/consultation_reports_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_budget_consultations/consultations/consultation_reports_controller_test.rb
@@ -14,6 +14,10 @@ module GobiertoAdmin
           @admin ||= gobierto_admin_admins(:natasha)
         end
 
+        def site
+          @site ||= sites(:madrid)
+        end
+
         def setup
           super
           sign_in_admin(admin)
@@ -27,9 +31,11 @@ module GobiertoAdmin
         end
 
         def test_show
-          get admin_budget_consultation_consultation_reports_url(consultation), params: { format: :csv }
-          assert_response :success
-          assert exporter_spy.has_been_called?
+          with_current_site(site) do
+            get admin_budget_consultation_consultation_reports_url(consultation), params: { format: :csv }
+            assert_response :success
+            assert exporter_spy.has_been_called?
+          end
         end
       end
     end

--- a/test/fixtures/gobierto_participation/contribution_containers.yml
+++ b/test/fixtures/gobierto_participation/contribution_containers.yml
@@ -10,3 +10,15 @@ children_contributions:
   ends: <%= 30.days.from_now %>
   slug: children-contributions
   visibility_user_level: <%= GobiertoParticipation::ContributionContainer.visibility_user_levels['registered'] %>
+neighbors_contributions:
+  site: madrid
+  admin: tony
+  process: sport_city_process
+  title_translations: <%= { 'en' => 'What sport facilities can be created for the neighbors?', 'es' => '¿Qué instalaciones deportivas pueden ser instaladas para los vecinos?' }.to_json %>
+  description_translations: <%= { 'en' => 'Ideas sport facilities.', 'es' => 'Ideas para instalaciones deportivas.' }.to_json %>
+  visibility_level: <%= GobiertoParticipation::ContributionContainer.visibility_levels[:active] %>
+  contribution_type: <%= GobiertoParticipation::ContributionContainer.contribution_types[:idea] %>
+  starts: <%= 1.month.ago %>
+  ends: <%= 1.month.from_now %>
+  slug: sport-facilities-contributions
+  visibility_user_level: <%= GobiertoParticipation::ContributionContainer.visibility_user_levels['verified'] %>

--- a/test/fixtures/gobierto_participation/poll_answer_templates.yml
+++ b/test/fixtures/gobierto_participation/poll_answer_templates.yml
@@ -88,3 +88,15 @@ noise_problems_multiple_choice_answer_template_fancy_headphones:
   question: noise_problems_multiple_choice
   text: Uso los cascos insonorizados que están de moda en la ofi
   order: 2
+
+## neighbor_opinion_poll answers
+
+neighbor_opinion_poll_single_choice_yes:
+  question: neighbor_opinion_poll_single_choice
+  text: 'Yes'
+  order: 0
+
+neighbor_opinion_poll_single_choice_no:
+  question: neighbor_opinion_poll_single_choice
+  text: 'No'
+  order: 1

--- a/test/fixtures/gobierto_participation/poll_questions.yml
+++ b/test/fixtures/gobierto_participation/poll_questions.yml
@@ -95,3 +95,14 @@ noise_problems_open:
   }.to_json %>
   answer_type: <%= GobiertoParticipation::PollQuestion.answer_types[:open] %>
   order: 2
+
+## neighbor_opinion_poll
+
+neighbor_opinion_poll_single_choice:
+  poll: neighbor_opinion_poll
+  title_translations: <%= {
+    'en' => 'Do you mind if the carnival parade takes place next to your house?',
+    'es' => '¿Te importa si la cabalgata del carnaval transcurre cerca de tu casa?'
+  }.to_json %>
+  answer_type: <%= GobiertoParticipation::PollQuestion.answer_types[:single_choice] %>
+  order: 0

--- a/test/fixtures/gobierto_participation/polls.yml
+++ b/test/fixtures/gobierto_participation/polls.yml
@@ -72,3 +72,18 @@ noise_problems_past:
   ends_at: <%= 1.months.ago %>
   visibility_level: <%= GobiertoParticipation::Poll.visibility_levels['published'] %>
   visibility_user_level: <%= GobiertoParticipation::Poll.visibility_user_levels['registered'] %>
+
+neighbor_opinion_poll:
+  process: commission_for_carnival_festivities
+  title_translations: <%= {
+    'en' => 'What do the residents of the neighborhood think?',
+    'es' => '¿Qué opinan los vecinos del barrio?'
+  }.to_json %>
+  description_translations: <%= {
+    'en' => 'Poll only for neighbors',
+    'es' => 'Encuesta dirigida exclusivamente a los vecinos'
+  }.to_json %>
+  starts_at: <%= 1.month.ago %>
+  ends_at: <%= 1.month.from_now %>
+  visibility_level: <%= GobiertoParticipation::Poll.visibility_levels['published'] %>
+  visibility_user_level: <%= GobiertoParticipation::Poll.visibility_user_levels['verified'] %>

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -54,7 +54,7 @@ huesca:
     "modules" => ["GobiertoBudgets"],
     "default_locale" => "en",
     "available_locales" => ["en", "es"],
-    "home_page" => "GobiertoBudgets",
+    "home_page" => "GobiertoCms",
     "google_analytics_id" => "UA-000000-03" }.to_yaml.inspect %>
   location_name: Santander
   municipality_id: <%= INE::Places::Place.find_by_slug("huesca").id %>

--- a/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
@@ -12,7 +12,7 @@ module GobiertoParticipation
         end
 
         def registered_level_user
-          @registrered_level_user ||= users(:susan)
+          @registered_level_user ||= users(:susan)
         end
 
         def verified_level_user

--- a/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module GobiertoParticipation
+  module Processes
+    module Polls
+      class PermissionLevelsTest < ActionDispatch::IntegrationTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def registered_level_user
+          @registrered_level_user ||= users(:susan)
+        end
+
+        def verified_level_user
+          @verified_level_user ||= users(:peter)
+        end
+
+        def process
+          @process ||= gobierto_participation_processes(:commission_for_carnival_festivities)
+        end
+
+        def process_polls_path
+          @process_polls_path ||= gobierto_participation_process_polls_path(
+            process_id: process.slug
+          )
+        end
+
+        def registered_level_poll
+          @registered_level_poll ||= gobierto_participation_polls(:ordinance_of_terraces_published)
+        end
+
+        def verified_level_poll
+          @verified_level_poll ||= gobierto_participation_polls(:neighbor_opinion_poll)
+        end
+
+        def process_polls
+          @process_polls ||= process.polls
+        end
+
+        def assert_both_levels_appear_in_index
+          with_current_site(site) do
+            visit process_polls_path
+            assert has_content? 'General aspects of the ordinance'
+            assert has_content? 'What do the residents of the neighborhood think?'
+          end
+        end
+
+        def test_polls_not_registered_index
+          sign_out_user
+          assert_both_levels_appear_in_index
+        end
+
+        def test_polls_registered_index
+          with_signed_in_user(registered_level_user) do
+            assert_both_levels_appear_in_index
+          end
+        end
+
+        def test_polls_verified_index
+          with_signed_in_user(verified_level_user) do
+            assert_both_levels_appear_in_index
+          end
+        end
+
+        def test_polls_not_registered_tries_to_answer
+          with_current_site(site) do
+            visit process_polls_path
+            within "#poll_#{ registered_level_poll.id }" do
+              click_link 'Participate in this poll'
+            end
+            refute has_content? 'Do you think that the ordinance should be modified?'
+
+            visit process_polls_path
+            within "#poll_#{ verified_level_poll.id }" do
+              click_link 'Participate in this poll'
+            end
+            refute has_content? 'Do you mind if the carnival parade takes place next to your house?'
+          end
+        end
+
+        def test_polls_registered_level_tries_to_answer
+          with_signed_in_user(registered_level_user) do
+            with_current_site(site) do
+              visit process_polls_path
+              within "#poll_#{ registered_level_poll.id }" do
+                click_link 'Participate in this poll'
+              end
+              assert has_content? 'Do you think that the ordinance should be modified?'
+
+              visit process_polls_path
+              within "#poll_#{ verified_level_poll.id }" do
+                click_link 'Participate in this poll'
+              end
+              refute has_content? 'Do you mind if the carnival parade takes place next to your house?'
+            end
+          end
+        end
+
+        def test_polls_verified_tries_to_answer
+          with_signed_in_user(verified_level_user) do
+            with_current_site(site) do
+              visit process_polls_path
+              within "#poll_#{ registered_level_poll.id }" do
+                click_link 'Participate in this poll'
+              end
+              assert has_content? 'Do you think that the ordinance should be modified?'
+
+              visit process_polls_path
+              within "#poll_#{ verified_level_poll.id }" do
+                click_link 'Participate in this poll'
+              end
+              assert has_content? 'Do you mind if the carnival parade takes place next to your house?'
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -35,10 +35,10 @@ module GobiertoParticipation
         end
 
         def with_js_session_of_user(user)
-          visit root_path
-          sign_out_user unless has_content? "Sign in"
-          with_current_site(site) do
-            with_javascript do
+          with_javascript do
+            with_current_site(site) do
+              visit root_path
+              sign_out_user unless has_content? "Sign in"
               with_signed_in_user(user) do
                 yield
               end

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoParticipation
+  module Processes
+    module ProcessContributions
+      class PermissionLevelsTest < ActionDispatch::IntegrationTest
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def registered_level_user
+          @registrered_level_user ||= users(:susan)
+        end
+
+        def verified_level_user
+          @verified_level_user ||= users(:peter)
+        end
+
+        def registered_level_contribution_container
+          @registered_level_contribution_container ||= gobierto_participation_contribution_containers(:children_contributions)
+        end
+
+        def verified_level_contribution_container
+          @verified_level_contribution_container ||= gobierto_participation_contribution_containers(:neighbors_contributions)
+        end
+
+        def container_path(container)
+          gobierto_participation_process_contribution_container_path(container.process.slug, container.slug)
+        end
+
+        def new_participation_path(container)
+          new_gobierto_participation_process_contribution_container_contribution_path(container.process.slug, container.slug)
+        end
+
+        def with_js_session_of_user(user)
+          sign_out_user
+          with_current_site(site) do
+            with_javascript do
+              with_signed_in_user(user) do
+                yield
+              end
+            end
+          end
+        end
+
+        def test_not_registered_user_contributions
+          sign_out_user
+          with_current_site(site) do
+            visit container_path registered_level_contribution_container
+            refute has_link? 'Have an idea!', href: new_participation_path(registered_level_contribution_container)
+
+            visit container_path verified_level_contribution_container
+            refute has_link? 'Have an idea!', href: new_participation_path(verified_level_contribution_container)
+          end
+        end
+
+        def test_registered_level_user_contributions_registered_level
+          with_js_session_of_user(registered_level_user) do
+            visit container_path registered_level_contribution_container
+            assert has_link? 'Have an idea!', href: new_participation_path(registered_level_contribution_container)
+            page.find("a", text: "Have an idea!").trigger("click")
+            assert page.has_content? "WRITE YOUR IDEA CONCISE"
+          end
+        end
+
+        def test_registered_level_user_contributions_verified_level
+          with_js_session_of_user(registered_level_user) do
+            visit container_path verified_level_contribution_container
+            assert has_link? 'Have an idea!', href: new_participation_path(verified_level_contribution_container)
+            page.find("a", text: "Have an idea!").trigger("click")
+            refute page.has_content? "WRITE YOUR IDEA CONCISE"
+          end
+        end
+
+        def test_verified_level_user_contributions_registered_level
+          with_js_session_of_user(verified_level_user) do
+            visit container_path registered_level_contribution_container
+            assert has_link? 'Have an idea!', href: new_participation_path(registered_level_contribution_container)
+            page.find("a", text: "Have an idea!").trigger("click")
+            assert page.has_content? "WRITE YOUR IDEA CONCISE"
+          end
+        end
+
+        def test_verified_level_user_contributions_verified_level
+          with_js_session_of_user(verified_level_user) do
+            visit container_path verified_level_contribution_container
+            assert has_link? 'Have an idea!', href: new_participation_path(verified_level_contribution_container)
+            page.find("a", text: "Have an idea!").trigger("click")
+            assert page.has_content? "WRITE YOUR IDEA CONCISE"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -11,7 +11,7 @@ module GobiertoParticipation
         end
 
         def registered_level_user
-          @registrered_level_user ||= users(:susan)
+          @registered_level_user ||= users(:susan)
         end
 
         def verified_level_user

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -35,7 +35,8 @@ module GobiertoParticipation
         end
 
         def with_js_session_of_user(user)
-          sign_out_user
+          visit root_path
+          sign_out_user unless has_content? "Sign in"
           with_current_site(site) do
             with_javascript do
               with_signed_in_user(user) do

--- a/test/models/gobierto_participation/contribution_container_test.rb
+++ b/test/models/gobierto_participation/contribution_container_test.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require 'support/concerns/gobierto_common/has_visibility_user_levels_test'
 
 module GobiertoParticipation
   class ContributionContainerTest < ActiveSupport::TestCase
+    include ::GobiertoCommon::HasVisibilityUserLevelsTest
+
+    def setup
+      super
+      setup_visibility_user_levels_test(
+        registered_level_user: users(:susan),
+        verified_level_user: users(:peter),
+        registered_level_resource: gobierto_participation_contribution_containers(:children_contributions),
+        verified_level_resource: gobierto_participation_contribution_containers(:neighbors_contributions)
+      )
+    end
+
     def contribution_container
       @contribution_container ||= gobierto_participation_contribution_containers(:children_contributions)
     end

--- a/test/models/gobierto_participation/poll_test.rb
+++ b/test/models/gobierto_participation/poll_test.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require 'support/concerns/gobierto_common/has_visibility_user_levels_test'
 
 module GobiertoCms
   class ProcessTest < ActiveSupport::TestCase
+    include ::GobiertoCommon::HasVisibilityUserLevelsTest
+
+    def setup
+      super
+      setup_visibility_user_levels_test(
+        registered_level_user: users(:susan),
+        verified_level_user: users(:peter),
+        registered_level_resource: gobierto_participation_polls(:ordinance_of_terraces_published),
+        verified_level_resource: gobierto_participation_polls(:neighbor_opinion_poll)
+      )
+    end
+
     def published_poll
       @published_poll ||= gobierto_participation_polls(:ordinance_of_terraces_published)
     end

--- a/test/support/concerns/gobierto_common/has_visibility_user_levels_test.rb
+++ b/test/support/concerns/gobierto_common/has_visibility_user_levels_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module HasVisibilityUserLevelsTest
+
+    def setup_visibility_user_levels_test(opts = {}) #registered_level_user, verified_level_user, registered_level_resource, verified_level_resource)
+      @registered_level_user ||= opts[:registered_level_user]
+      @verified_level_user ||= opts[:verified_level_user]
+      @registered_level_resource ||= opts[:registered_level_resource]
+      @verified_level_resource ||= opts[:verified_level_resource]
+    end
+
+    def test_registered_level
+      refute @registered_level_resource.visibility_level_allowed_for? nil
+      assert @registered_level_resource.visibility_level_allowed_for? @registered_level_user
+      assert @registered_level_resource.visibility_level_allowed_for? @verified_level_user
+    end
+
+    def test_verified_level
+      refute @verified_level_resource.visibility_level_allowed_for? nil
+      refute @verified_level_resource.visibility_level_allowed_for? @registered_level_user
+      assert @verified_level_resource.visibility_level_allowed_for? @verified_level_user
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -138,6 +138,7 @@ class ActionDispatch::IntegrationTest
   def with_javascript
     Capybara.current_driver = Capybara.javascript_driver
     yield
+    Capybara.reset_session!
   ensure
     Capybara.current_driver = Capybara.default_driver
   end


### PR DESCRIPTION
Closes #1265

### What does this PR do?
Defines a model concern to manage a `visibility_user_level` enum defined for some tools of Gobierto Participation module. This concern provides a method to check if a user has permissions over a resource depending on visibility level. By default, there are only 2 levels:

* `registered`: The user must exist in database and confirmed.
* `verified`: The user must be verified in the site the resource belongs to.

More levels can be created for a resource by defining them in the `visibility_user_level` enum and defining in User model or decorator an instance method called `verified_in_level_with_site?` which accepts the `visibility_user_level` name and the site.

This concern is used with `GobiertoParticipation::Poll` and `GobiertoParticipation::ContributionContainer` in controllers to filter creation, edition or deletion of depending resources, as poll answers, contributions, or votes / comments on contributions. The filter is stored in `app/controllers/concerns/user/verification_helper.rb` and defines the raised error and redirection for visibility_user_level defined on the resource if the user does not pass the validation. In this way if some resource requires an specific validation the user will be redirected to the mechanism associated with de validation, instead of receive a generic error message.

### How should this be manually tested?

From admin part define a poll or contribution_container in the corresponding stage of a process on a site and change settings in the edition form, in the USERS select. Then visit the page not logged in, with a confirmed user but not verified in the site and with a confirmed and verified in the site

### Does this PR changes any configuration file?

No