### PR TITLE
Site configuration optional variables

### DIFF
--- a/app/controllers/gobierto_admin/sites_controller.rb
+++ b/app/controllers/gobierto_admin/sites_controller.rb
@@ -159,6 +159,7 @@ module GobiertoAdmin
         :default_locale,
         :privacy_page_id,
         :populate_data_api_token,
+        :raw_configuration_variables,
         :home_page,
         :home_page_item_id,
         site_modules: [],

--- a/app/controllers/gobierto_people/application_controller.rb
+++ b/app/controllers/gobierto_people/application_controller.rb
@@ -5,5 +5,24 @@ module GobiertoPeople
     layout "gobierto_people/layouts/application"
 
     before_action { module_enabled!(current_site, "GobiertoPeople") }
+
+    helper_method :gifts_service_url, :travels_service_url
+
+    private
+
+    def gifts_service_url
+      current_site_configuration_variables["gifts_service_url_#{I18n.locale}"] ||
+        current_site_configuration_variables["gifts_service_url"]
+    end
+
+    def travels_service_url
+      current_site_configuration_variables["travels_service_url_#{I18n.locale}"] ||
+        current_site_configuration_variables["travels_service_url"]
+    end
+
+    def current_site_configuration_variables
+      @current_site_configuration_variables ||= current_site.configuration.configuration_variables
+    end
+
   end
 end

--- a/app/controllers/gobierto_people/person_gifts_controller.rb
+++ b/app/controllers/gobierto_people/person_gifts_controller.rb
@@ -16,10 +16,5 @@ module GobiertoPeople
         redirect_to gobierto_people_root_path
       end
     end
-
-    def gifts_service_url
-      APP_CONFIG.dig("gobierto_people", "gifts_service_url_#{I18n.locale}") ||
-        APP_CONFIG.dig("gobierto_people", "gifts_service_url")
-    end
   end
 end

--- a/app/controllers/gobierto_people/person_travels_controller.rb
+++ b/app/controllers/gobierto_people/person_travels_controller.rb
@@ -16,10 +16,5 @@ module GobiertoPeople
         redirect_to gobierto_people_root_path
       end
     end
-
-    def travels_service_url
-      APP_CONFIG.dig("gobierto_people", "travels_service_url_#{I18n.locale}") ||
-        APP_CONFIG.dig("gobierto_people", "travels_service_url")
-    end
   end
 end

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -36,7 +36,8 @@ module GobiertoAdmin
       :privacy_page_id,
       :populate_data_api_token,
       :home_page,
-      :home_page_item_id
+      :home_page_item_id,
+      :raw_configuration_variables
     )
 
     attr_reader :logo_url
@@ -119,6 +120,10 @@ module GobiertoAdmin
       @populate_data_api_token ||= site.configuration.populate_data_api_token
     end
 
+    def raw_configuration_variables
+      @raw_configuration_variables ||= site.configuration.raw_configuration_variables
+    end
+
     def logo_url
       @logo_url ||= begin
         return site.configuration.logo unless logo_file.present?
@@ -167,6 +172,7 @@ module GobiertoAdmin
         site_attributes.configuration.available_locales = (available_locales.select{ |l| l.present? } + [default_locale]).uniq
         site_attributes.configuration.privacy_page_id = privacy_page_id
         site_attributes.configuration.populate_data_api_token = populate_data_api_token
+        site_attributes.configuration.raw_configuration_variables = raw_configuration_variables
       end
 
       if @site.valid?

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -15,7 +15,8 @@ class SiteConfiguration
     :privacy_page_id,
     :populate_data_api_token,
     :home_page,
-    :home_page_item_id
+    :home_page_item_id,
+    :raw_configuration_variables
   ].freeze
 
   DEFAULT_LOGO_PATH = "sites/logo-default.png".freeze
@@ -68,6 +69,16 @@ class SiteConfiguration
 
   def default_modules
     [ 'GobiertoCms', 'GobiertoCalendars', 'GobiertoAttachments' ]
+  end
+
+  def configuration_variables
+    if raw_configuration_variables.blank?
+      {}
+    else
+      YAML.load(raw_configuration_variables)
+    end
+  rescue Psych::SyntaxError
+    {}
   end
 
   # Define question mark instance methods for each property.

--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -92,6 +92,10 @@
           <%= f.text_field :populate_data_api_token, placeholder: t(".placeholders.populate_data_api_token") %>
         </div>
 
+        <div class="form_item textarea code">
+          <%= f.label :raw_configuration_variables %>
+          <%= f.text_area :raw_configuration_variables %>
+        </div>
       </div>
 
       <div class="form_block">

--- a/app/views/gobierto_people/welcome/index.html.erb
+++ b/app/views/gobierto_people/welcome/index.html.erb
@@ -78,24 +78,27 @@
           <% end %>
         </div>
 
-        <div class="box fully_linked">
-          <%= link_to gobierto_people_gifts_path, role: "button" do %>
-            <h2 class="linked_headline">
-              <i class="fa fa-gift"></i>
-              <%= t(".gifts") %>
-            </h2>
-          <% end %>
-        </div>
+        <% if gifts_service_url.present? %>
+          <div class="box fully_linked">
+            <%= link_to gobierto_people_gifts_path, role: "button" do %>
+              <h2 class="linked_headline">
+                <i class="fa fa-gift"></i>
+                <%= t(".gifts") %>
+              </h2>
+            <% end %>
+          </div>
+        <% end %>
 
-        <div class="box fully_linked">
-          <%= link_to gobierto_people_travels_path, role: "button" do %>
-            <h2 class="linked_headline">
-              <i class="fa fa-plane"></i>
-              <%= t(".travels") %>
-            </h2>
-          <% end %>
-        </div>
-
+        <% if travels_service_url.present? %>
+          <div class="box fully_linked">
+            <%= link_to gobierto_people_travels_path, role: "button" do %>
+              <h2 class="linked_headline">
+                <i class="fa fa-plane"></i>
+                <%= t(".travels") %>
+              </h2>
+            <% end %>
+          </div>
+        <% end %>
       </div>
 
     <% end %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -51,9 +51,6 @@ default: &default
     municipalities_suggestions_endpoint: <%= ENV["MUNICIPALITIES_SUGGESTIONS_ENDPOINT"] %>
   gobierto_budgets:
     data_note_url: https://presupuestos.gobierto.es/about#method
-  gobierto_people:
-    gifts_service_url: http://populate.tools/
-    travels_service_url: http://populate.tools/
   populate_data:
     endpoint: <%= ENV["POPULATE_DATA_ENDPOINT"] %>
   gobierto_indicators:

--- a/config/locales/gobierto_admin/models/ca.yml
+++ b/config/locales/gobierto_admin/models/ca.yml
@@ -43,6 +43,7 @@ ca:
         name: Nom de l'entitat
         populate_data_api_token: API token Populate Data
         privacy_page_id: Pàgina privacitat
+        raw_configuration_variables: Altres variables configuració
         title: Nom del site
       gobierto_admin/user_form:
         email: Email

--- a/config/locales/gobierto_admin/models/en.yml
+++ b/config/locales/gobierto_admin/models/en.yml
@@ -43,6 +43,7 @@ en:
         name: Entity ame
         populate_data_api_token: API token Populate Data
         privacy_page_id: Privacy page
+        raw_configuration_variables: Other configuration variables
         title: Site name
       gobierto_admin/user_form:
         email: Email

--- a/config/locales/gobierto_admin/models/es.yml
+++ b/config/locales/gobierto_admin/models/es.yml
@@ -43,6 +43,7 @@ es:
         name: Nombre de la entidad
         populate_data_api_token: API token Populate Data
         privacy_page_id: Página de privacidad
+        raw_configuration_variables: Otras variables de configuración
         title: Nombre del site
       gobierto_admin/user_form:
         email: Email

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -31,6 +31,10 @@ module GobiertoAdmin
           fill_in "site_links_markup", with: "Site Links markup"
           fill_in "site_google_analytics_id", with: "UA-000000-01"
           fill_in "site_populate_data_api_token", with: "APITOKEN"
+          fill_in "site_raw_configuration_variables", with: <<-YAML
+key1: value1
+key2: value2
+YAML
           select "GobiertoPeople", from: "site_home_page"
 
           within ".site-check-boxes" do

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -43,6 +43,10 @@ module GobiertoAdmin
           fill_in "site_links_markup", with: "Site Links markup"
           fill_in "site_google_analytics_id", with: "UA-000000-01"
           fill_in "site_populate_data_api_token", with: "APITOKEN"
+          fill_in "site_raw_configuration_variables", with: <<-YAML
+var1: value1
+var2: value2
+YAML
 
           attach_file "site_logo_file", "test/fixtures/files/sites/logo-madrid.png"
 
@@ -76,6 +80,7 @@ module GobiertoAdmin
           assert has_select?("Privacy page", selected: privacy_page.title)
           assert has_select?("site_home_page", selected: "GobiertoParticipation")
           assert has_field?("site_populate_data_api_token", with: "APITOKEN")
+          assert has_field?("site_raw_configuration_variables", with: "var1: value1\r\nvar2: value2\r\n")
 
           within ".site-module-check-boxes" do
             assert has_checked_field?("Gobierto Development")

--- a/test/models/site_configuration_test.rb
+++ b/test/models/site_configuration_test.rb
@@ -81,6 +81,10 @@ class SiteConfigurationTest < ActiveSupport::TestCase
     assert site_configuration.privacy_page?
   end
 
+  def test_configuration_variables
+    assert_equal "bar", site_configuration.configuration_variables["foo"]
+  end
+
   private
 
   def site_configuration_params
@@ -94,7 +98,10 @@ class SiteConfigurationTest < ActiveSupport::TestCase
         "default_locale"    => "ca",
         "available_locales" => %w(ca es),
         "site_id"           => site.id,
-        "privacy_page_id"   => page.id
+        "privacy_page_id"   => page.id,
+        "raw_configuration_variables" => <<-YAML
+foo: bar
+YAML
       }
     end
   end


### PR DESCRIPTION
Closes #1289

### What does this PR do?

This PR adds a new setting in Gobierto site configuration named other variables which allows the admin to define variables in key/value style:

![screen shot 2018-01-02 at 16 35 42](https://user-images.githubusercontent.com/17616/34489016-fe97c78e-efda-11e7-8770-c41ef7cf61b8.png)


### How should this be manually tested?

It can be tested with trips and gifts variables.