### PR TITLE
Add new condition not starts with

### DIFF
--- a/app/models/gobierto_calendars/filtering_rule.rb
+++ b/app/models/gobierto_calendars/filtering_rule.rb
@@ -9,7 +9,7 @@ module GobiertoCalendars
     validates :value, presence: true
 
     enum field: { title: 0, description: 1 }, _suffix: true
-    enum condition: { contains: 0, not_contains: 1, starts_with: 2, ends_with: 3 }, _suffix: true
+    enum condition: { contains: 0, not_contains: 1, starts_with: 2, ends_with: 3, not_starts_with: 4 }, _suffix: true
     enum action: { ignore: 0, import_as_draft: 1, import: 2 }, _suffix: true
 
     def apply(event_attributes)
@@ -25,6 +25,8 @@ module GobiertoCalendars
           event_value.starts_with?(value)
         when "ends_with"
           event_value.ends_with?(value)
+        when "not_starts_with"
+          !event_value.starts_with?(value)
       end
 
       fullfills ? action : false

--- a/config/locales/gobierto_calendars/models/ca.yml
+++ b/config/locales/gobierto_calendars/models/ca.yml
@@ -19,6 +19,7 @@ ca:
           contains: Conté
           ends_with: Termina per
           not_contains: No conté
+          not_starts_with: No comença per
           starts_with: Comença per
         field:
           description: Cos

--- a/config/locales/gobierto_calendars/models/en.yml
+++ b/config/locales/gobierto_calendars/models/en.yml
@@ -19,6 +19,7 @@ en:
           contains: Contains
           ends_with: Ends with
           not_contains: Not contains
+          not_starts_with: Not starts with
           starts_with: Starts with
         field:
           description: Description

--- a/config/locales/gobierto_calendars/models/es.yml
+++ b/config/locales/gobierto_calendars/models/es.yml
@@ -19,6 +19,7 @@ es:
           contains: Contiene
           ends_with: Termina por
           not_contains: No contiene
+          not_starts_with: No empieza por
           starts_with: Empieza por
         field:
           description: Cuerpo

--- a/test/models/gobierto_calendars/filtering_rule_test.rb
+++ b/test/models/gobierto_calendars/filtering_rule_test.rb
@@ -41,6 +41,10 @@ module GobiertoCalendars
       filtering_rule.condition = :ends_with
       assert_equal "ignore", filtering_rule.apply({title: "Foo Bar @"})
       assert_equal false, filtering_rule.apply({title: "Foo @ Bar"})
+
+      filtering_rule.condition = :not_starts_with
+      assert_equal false, filtering_rule.apply({title: "@ Foo Bar"})
+      assert_equal "ignore", filtering_rule.apply({title: "Foo @ Bar"})
     end
   end
 end


### PR DESCRIPTION
Closes #1258

### What does this PR do?

This PR adds the option "Not starts with" to the events filter class.

### How should this be manually tested?

1. Create a rule using this option
2. Check it works

Example in burjassot.gobify.net:

![screen shot 2018-01-03 at 09 51 09](https://user-images.githubusercontent.com/17616/34514050-a714154e-f06b-11e7-9cf6-47955573e053.png)

Only imports events starting with "Clase":

![screen shot 2018-01-03 at 09 51 36](https://user-images.githubusercontent.com/17616/34514069-ba6f0838-f06b-11e7-858f-9834bbe726eb.png)

