### PR TITLE
#190: Add asymmectric_encryptor dependency to id number verification

### DIFF
--- a/app/models/user/verification/id_number.rb
+++ b/app/models/user/verification/id_number.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'asymmetric_encryptor'
+
 class User::Verification::IdNumber < User::Verification
   before_save :encrypt_id_number
 


### PR DESCRIPTION
Related with #1267

### What does this PR do?
Adds a dependency to `User::Verification::IdNumber` with `AsymmetricEncryptor`. This avoids an 'uninitialized constant' error on production environment.