### PR TITLE
Fix show process without information stage

### DIFF
--- a/app/views/gobierto_participation/processes/show.html.erb
+++ b/app/views/gobierto_participation/processes/show.html.erb
@@ -63,7 +63,7 @@
 
         <% information_stage = current_process.stages.where(stage_type: 0).try(:first) %>
 
-        <% if information_stage.process_stage_page %>
+        <% if information_stage && information_stage.process_stage_page %>
           <%= link_to t('.more_information'), stage_url(information_stage), class: "button outline rounded" %>
         <% end %>
       </div>


### PR DESCRIPTION
### What does this PR do?

Enable visualization of processes without information phase

### How should this be manually tested?

Alvaro created a new site, with a new group and two phases configured from scratch, but it gives me 500
