### PR TITLE
Fix GobiertoParticipation Collection editions

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
@@ -39,12 +39,13 @@ module GobiertoAdmin
 
       def edit
         @containers = find_containers
-        @container_selected = @collection.container.to_global_id
+
+        @container_selected = @collection.container.is_a?(Module) ? @collection.container : @collection.container.to_global_id
         @types = type_names
         @type_selected = @collection.item_type
 
         @collection_form = CollectionForm.new(
-          @collection.attributes.except(*ignored_collection_attributes).merge(container_global_id: @collection.container.to_global_id)
+          @collection.attributes.except(*ignored_collection_attributes).merge(container_global_id: @container_selected)
         )
 
         render :edit_modal, layout: false and return if request.xhr?
@@ -61,7 +62,7 @@ module GobiertoAdmin
 
           redirect_to(
             admin_common_collection_path(@collection_form.collection),
-            notice: t('.success')
+            notice: t(".success")
           )
         else
           render :new_modal, layout: false and return if request.xhr?
@@ -82,7 +83,7 @@ module GobiertoAdmin
 
           redirect_to(
             admin_common_collection_path(@collection),
-            notice: t('.success')
+            notice: t(".success")
           )
         else
           render :edit_modal, layout: false and return if request.xhr?
@@ -93,11 +94,11 @@ module GobiertoAdmin
       private
 
       def track_create_activity
-        Publishers::GobiertoCommonCollectionActivity.broadcast_event('collection_created', default_activity_params.merge(subject: @collection_form.collection))
+        Publishers::GobiertoCommonCollectionActivity.broadcast_event("collection_created", default_activity_params.merge(subject: @collection_form.collection))
       end
 
       def track_update_activity
-        Publishers::GobiertoCommonCollectionActivity.broadcast_event('collection_updated', default_activity_params.merge(subject: @collection))
+        Publishers::GobiertoCommonCollectionActivity.broadcast_event("collection_updated", default_activity_params.merge(subject: @collection))
       end
 
       def default_activity_params
@@ -114,7 +115,7 @@ module GobiertoAdmin
       end
 
       def ignored_collection_attributes
-        %w[created_at updated_at container_type container_id]
+        %w(created_at updated_at container_type container_id)
       end
 
       def container_items
@@ -123,7 +124,7 @@ module GobiertoAdmin
 
       def find_containers
         @containers ||= container_items.map { |item| ["#{item.class.model_name.human}: #{item}", item.to_global_id] }
-        @containers.insert(1, ["GobiertoParticipation", nil])
+        @containers.insert(1, %w(GobiertoParticipation GobiertoParticipation))
       end
 
       def type_names
@@ -141,24 +142,24 @@ module GobiertoAdmin
 
       def redirect_to_custom_show
         case @collection.item_type
-        when 'GobiertoCms::News'
-            if @collection.container.is_a?(::GobiertoParticipation::Process)
-              redirect_to admin_participation_process_pages_path(@collection.container) and return false
-            end
-          when 'GobiertoCms::Page'
-            if @collection.container.is_a?(::GobiertoParticipation::Process)
-              redirect_to admin_participation_process_pages_path(@collection.container) and return false
-            end
-          when 'GobiertoAttachments::Attachment'
-            if @collection.container.is_a?(::GobiertoParticipation::Process)
-              redirect_to admin_participation_process_file_attachments_path(@collection.container) and return false
-            end
-          when 'GobiertoCalendars::Event'
-            if @collection.container.is_a?(::GobiertoPeople::Person)
-              redirect_to admin_people_person_events_path(@collection.container) and return false
-            elsif @collection.container.is_a?(::GobiertoParticipation::Process)
-              redirect_to admin_participation_process_events_path(@collection.container) and return false
-            end
+        when "GobiertoCms::News"
+          if @collection.container.is_a?(::GobiertoParticipation::Process)
+            redirect_to admin_participation_process_pages_path(@collection.container) and return false
+          end
+        when "GobiertoCms::Page"
+          if @collection.container.is_a?(::GobiertoParticipation::Process)
+            redirect_to admin_participation_process_pages_path(@collection.container) and return false
+          end
+        when "GobiertoAttachments::Attachment"
+          if @collection.container.is_a?(::GobiertoParticipation::Process)
+            redirect_to admin_participation_process_file_attachments_path(@collection.container) and return false
+          end
+        when "GobiertoCalendars::Event"
+          if @collection.container.is_a?(::GobiertoPeople::Person)
+            redirect_to admin_people_person_events_path(@collection.container) and return false
+          elsif @collection.container.is_a?(::GobiertoParticipation::Process)
+            redirect_to admin_participation_process_events_path(@collection.container) and return false
+          end
         end
       end
     end

--- a/app/forms/gobierto_admin/gobierto_common/collection_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/collection_form.rb
@@ -55,6 +55,7 @@ module GobiertoAdmin
             collection_attributes.container = container
           else
             collection_attributes.container_type = "GobiertoParticipation"
+            collection_attributes.container_id = nil
           end
           collection_attributes.item_type = item_type
         end

--- a/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
@@ -75,6 +75,41 @@ module GobiertoAdmin
         end
       end
 
+      def test_create_edit_participation_collection
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site_santander) do
+              visit @path
+
+              within "#new-page" do
+                click_link "New"
+              end
+
+              fill_in "collection_title_translations_en", with: "My collection in GobiertoParticipation"
+              fill_in "collection_slug", with: "my-collection-participation"
+              find("select#collection_container_global_id").find("option[value='GobiertoParticipation']").select_option
+              find("select#collection_item_type").find("option[value='GobiertoCms::News']").select_option
+
+              click_button "Create"
+
+              assert has_message?("Collection was successfully created.")
+
+              assert has_selector?("h1", text: "My collection in GobiertoParticipation")
+
+              click_on "Configuration"
+
+              within "form.edit_collection" do
+                fill_in "collection_title_translations_en", with: "My collection in GobiertoParticipation updated"
+
+                click_button "Update"
+              end
+
+              assert has_message?("Collection was successfully updated.")
+            end
+          end
+        end
+      end
+
       def test_create_collection_with_same_container
         with_javascript do
           with_signed_in_admin(admin) do


### PR DESCRIPTION
Closes [https://github.com/PopulateTools/issues/issues/208](https://github.com/PopulateTools/issues/issues/208)

### What does this PR do?

When you update a collection from context Site to context ParticipationModule was giving 500.

In addition, I have corrected the possibility of editing a collection of GovernmentParticipation container.

### How should this be manually tested?

From /admin/cms/pages editing collections