### PR TITLE
Participacion Admin / Breadcrumb for tool (contributions/polls)

### DIFF
--- a/app/views/gobierto_admin/gobierto_participation/processes/polls/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/polls/edit.html.erb
@@ -1,7 +1,8 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
-  <%= link_to current_process.title, edit_admin_participation_process_path(current_process), data: { turbolinks: false } %>
+  <%= link_to current_process.title, edit_admin_participation_process_path(current_process), data: { turbolinks: false } %> »
+  <%= link_to t('.polls'), admin_participation_process_polls_path(current_process), data: { turbolinks: false } %>
 </div>
 
 <h1>

--- a/app/views/gobierto_admin/gobierto_participation/processes/polls/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/polls/index.html.erb
@@ -10,8 +10,13 @@
 
 <%= render 'gobierto_admin/gobierto_participation/shared/navigation' %>
 
-<div class='admin_tools right'>
-  <%= link_to t('.new'), new_admin_participation_process_poll_path(current_process), class: 'button', data: { turbolinks: false } %>
+<div class="pure-g">
+  <div class="pure-u-3-4">
+    <strong><%= t('.polls') %></strong>
+  </div>
+  <div class="pure-u-1-4 admin_tools right">
+    <%= link_to t('.new'), new_admin_participation_process_poll_path(current_process), class: 'button', data: { turbolinks: false } %>
+  </div>
 </div>
 
 <table>

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/index.html.erb
@@ -1,11 +1,16 @@
-<%= render 'gobierto_admin/gobierto_participation/shared/breadcrumb', last_breadcrumb_item: t('gobierto_admin.gobierto_participation.processes.process_contribution_containers.index.title'), process: current_process %>
+<%= render 'gobierto_admin/gobierto_participation/shared/breadcrumb', last_breadcrumb_item: nil, process: current_process %>
 
 <h1><%= current_process.title %></h1>
 
 <%= render 'gobierto_admin/gobierto_participation/shared/navigation' %>
 
-<div class="admin_tools right">
-  <%= link_to t('.new'), new_admin_participation_process_contribution_container_path, class: 'button' %>
+<div class="pure-g">
+  <div class="pure-u-3-4">
+    <strong><%= t('.title') %></strong>
+  </div>
+  <div class="pure-u-1-4 admin_tools right">
+    <%= link_to t('.new'), new_admin_participation_process_contribution_container_path, class: 'button' %>
+  </div>
 </div>
 
 <table>

--- a/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/process_contribution_containers/show.html.erb
@@ -1,4 +1,7 @@
-<%= render 'gobierto_admin/gobierto_participation/shared/breadcrumb', last_breadcrumb_item: t('gobierto_admin.gobierto_participation.processes.process_contribution_containers.index.title'), process: current_process %>
+<%= render 'gobierto_admin/gobierto_participation/shared/breadcrumb',
+    last_breadcrumb_item: link_to(t('gobierto_admin.gobierto_participation.processes.process_contribution_containers.index.title'),
+                                  admin_participation_process_contribution_containers_path(current_process)),
+    process: current_process %>
 
 <h1><%= @process.title %></h1>
 
@@ -6,7 +9,11 @@
 
 <div class="pure-g">
   <div class="pure-u-3-4">
-    <strong><%= @contribution_container.title  %></strong> » Aportaciones
+    <strong>
+      <%= link_to(t('gobierto_admin.gobierto_participation.processes.process_contribution_containers.index.title'),
+                  admin_participation_process_contribution_containers_path(current_process)) %>
+    </strong>
+    » <%= @contribution_container.title  %>
   </div>
   <div class="pure-u-1-4 admin_tools right">
     <%= link_to edit_admin_participation_process_contribution_container_path(@contribution_container.id, process_id: @contribution_container.process.id) do %>
@@ -19,7 +26,6 @@
     <% end %>
   </div>
 </div>
-
 
 <table>
   <tr>

--- a/app/views/gobierto_admin/gobierto_participation/shared/_breadcrumb.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/shared/_breadcrumb.html.erb
@@ -2,7 +2,9 @@
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t('gobierto_admin.gobierto_participation.welcome.index.title'), admin_participation_path %> »
   <% if process %>
-    <%= link_to process.title, edit_admin_participation_process_path(process), data: { turbolinks: false } %> »
+    <%= link_to process.title, edit_admin_participation_process_path(process), data: { turbolinks: false } %>
   <% end %>
-  <%= last_breadcrumb_item %>
+  <% if last_breadcrumb_item %>
+     » <%= last_breadcrumb_item %>
+  <% end %>
 </div>

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/processes/polls/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/processes/polls/ca.yml
@@ -6,5 +6,9 @@ ca:
         polls:
           destroy:
             success: L'enquesta ha estat arxivada correctament
+          edit:
+            polls: Enquestes
+          index:
+            polls: Enquestes
           recover:
             success: L'enquesta ha estat recuperada correctament

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/processes/polls/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/processes/polls/en.yml
@@ -6,5 +6,9 @@ en:
         polls:
           destroy:
             success: Poll archived successfully
+          edit:
+            polls: Polls
+          index:
+            polls: Polls
           recover:
             success: Poll recovered successfully

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/processes/polls/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/processes/polls/es.yml
@@ -6,5 +6,9 @@ es:
         polls:
           destroy:
             success: La encuesta ha sido archivada correctamente
+          edit:
+            polls: Encuestas
+          index:
+            polls: Encuestas
           recover:
             success: La encuesta ha sido recuperada correctamente


### PR DESCRIPTION
Closes #1308 

### What does this PR do?

When seeing a contribution pool, the breadcrumb should be as in the sandbox:

http://newalcobendas.gobify.net/sandbox/admin_part_group_contributions

That is, here: http://newalcobendas.gobify.net/admin/participation/processes/31/contribution_containers/15 - we should:

- in the top breadcrumb, link the last item ("Aportaciones") to http://newalcobendas.gobify.net/admin/participation/processes/31/contribution_containers
- in the "inner breadcrumb" ("Ideas para mejorar la ciudad » Aportaciones") we should flip it to "Aportaciones » Ideas para mejorar la ciudad" and Aportaciones should be linked

### How should this be manually tested?

- http://newalcobendas.gobify.net/admin/participation/processes/31/contribution_containers
- http://newalcobendas.gobify.net/admin/participation/processes/31/contribution_containers/15

### Note

For polls, the phase view is the same as for contributions 
http://participacion.gobify.net/admin/participation/processes/30/polls

but I haven't added "inner breadcrumb" because the view of a poll in the back is the poll edition.

http://participacion.gobify.net/admin/participation/processes/30/polls/28/edit