### PR TITLE
Scope users in sites

### DIFF
--- a/app/controllers/concerns/gobierto_admin/site_session_helper.rb
+++ b/app/controllers/concerns/gobierto_admin/site_session_helper.rb
@@ -8,8 +8,8 @@ module GobiertoAdmin
       @current_site ||= begin
         if session[:admin_site_id] && (matched_site = Site.find_by(id: session[:admin_site_id]))
           SiteDecorator.new(matched_site)
-        else
-          SiteDecorator.new(managed_sites.first) if managed_sites.present?
+        elsif managed_sites.present?
+          SiteDecorator.new(managed_sites.include?(site_from_domain) ? site_from_domain : managed_sites.first)
         end
       end
     end
@@ -30,6 +30,14 @@ module GobiertoAdmin
       @managed_sites ||= begin
         current_admin.sites if admin_signed_in?
       end
+    end
+
+    def request_domain
+      (request.env["HTTP_HOST"] || request.env["SERVER_NAME"] || request.env["SERVER_ADDR"]).split(":").first
+    end
+
+    def site_from_domain
+      Site.find_by(domain: request_domain)
     end
   end
 end

--- a/app/controllers/concerns/user/session_helper.rb
+++ b/app/controllers/concerns/user/session_helper.rb
@@ -34,7 +34,7 @@ module User::SessionHelper
   end
 
   def find_current_user
-    User.confirmed.find_by(id: session[:user_id])
+    User.confirmed.find_by(id: session[:user_id], site: current_site)
   end
 
   def after_sign_in_path(referrer_url = nil)

--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -43,7 +43,6 @@ module GobiertoAdmin
       if request.host != current_site.domain
         if managed_sites && (site = managed_sites.find_by(domain: request.host))
           enter_site(site.id)
-          redirect_to admin_root_path
         end
       end
     end

--- a/app/controllers/gobierto_admin/sessions_controller.rb
+++ b/app/controllers/gobierto_admin/sessions_controller.rb
@@ -1,6 +1,7 @@
 module GobiertoAdmin
   class SessionsController < BaseController
     skip_before_action :authenticate_admin!, only: [:new, :create, :destroy]
+    skip_before_action :set_admin_site, only: [:new, :destroy]
     before_action :require_no_authentication, only: [:new, :create]
 
     layout "gobierto_admin/layouts/sessions"

--- a/app/controllers/gobierto_admin/users_controller.rb
+++ b/app/controllers/gobierto_admin/users_controller.rb
@@ -53,7 +53,7 @@ module GobiertoAdmin
       confirmation_token reset_password_token
       creation_ip last_sign_in_ip
       last_sign_in_at
-      source_site_id
+      site_id
       census_verified
       date_of_birth
       gender

--- a/app/controllers/gobierto_admin/users_controller.rb
+++ b/app/controllers/gobierto_admin/users_controller.rb
@@ -31,7 +31,7 @@ module GobiertoAdmin
     private
 
     def get_users_in_current_site
-      User.by_source_site(current_site)
+      User.by_site(current_site)
     end
 
     def find_user

--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -7,6 +7,7 @@ class User::ConfirmationsController < User::BaseController
     @user_confirmation_form = User::ConfirmationForm.new(
       confirmation_token: params[:confirmation_token],
       creation_ip: remote_ip,
+      site: current_site
     )
 
     @user_genders = get_user_genders
@@ -21,7 +22,8 @@ class User::ConfirmationsController < User::BaseController
         date_of_birth_year: user_confirmation_params["date_of_birth(1i)"],
         date_of_birth_month: user_confirmation_params["date_of_birth(2i)"],
         date_of_birth_day: user_confirmation_params["date_of_birth(3i)"],
-        creation_ip: remote_ip
+        creation_ip: remote_ip,
+        site: current_site
       )
     )
 

--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -8,7 +8,7 @@ class User::SessionsController < User::BaseController
   layout "user/layouts/sessions"
 
   def new
-    @user_session_form = User::SessionForm.new(referrer_url: @referrer_url)
+    @user_session_form = User::SessionForm.new(referrer_url: @referrer_url, site: @site)
     @user_registration_form = User::RegistrationForm.new(referrer_url: @referrer_url, referrer_entity: referrer_entity)
     @user_password_form = User::NewPasswordForm.new
 
@@ -53,7 +53,7 @@ class User::SessionsController < User::BaseController
   private
 
   def user_session_params
-    params.require(:user_session).permit(:email, :password, :referrer_url)
+    params.require(:user_session).permit(:email, :password, :referrer_url).merge(site: @site)
   end
 
   def referrer_entity

--- a/app/forms/gobierto_admin/user_form.rb
+++ b/app/forms/gobierto_admin/user_form.rb
@@ -73,7 +73,7 @@ module GobiertoAdmin
     end
 
     def deliver_confirmation_email
-      ::User::UserMailer.confirmation_instructions(user, user.source_site).deliver_later
+      ::User::UserMailer.confirmation_instructions(user, user.site).deliver_later
     end
   end
 end

--- a/app/forms/gobierto_admin/user_welcome_message_form.rb
+++ b/app/forms/gobierto_admin/user_welcome_message_form.rb
@@ -19,7 +19,7 @@ module GobiertoAdmin
     end
 
     def site
-      user.source_site
+      user.site
     end
 
     private

--- a/app/forms/user/confirmation_form.rb
+++ b/app/forms/user/confirmation_form.rb
@@ -40,7 +40,7 @@ class User::ConfirmationForm
   end
 
   def site
-    @site ||= user.source_site if user
+    @site ||= user.site if user
   end
 
   def date_of_birth
@@ -133,7 +133,7 @@ class User::ConfirmationForm
 
   def deliver_welcome_email
     if user
-      User::UserMailer.welcome(user, user.source_site).deliver_later
+      User::UserMailer.welcome(user, user.site).deliver_later
     end
   end
 

--- a/app/forms/user/confirmation_form.rb
+++ b/app/forms/user/confirmation_form.rb
@@ -13,6 +13,7 @@ class User::ConfirmationForm
     :date_of_birth,
     :gender,
     :creation_ip,
+    :site,
     :document_number
   )
   attr_reader :user
@@ -32,15 +33,11 @@ class User::ConfirmationForm
   end
 
   def user
-    @user ||= User.find_by_confirmation_token(confirmation_token)
+    @user ||= User.find_by(confirmation_token: confirmation_token, site: site)
   end
 
   def email
     @email ||= user.email
-  end
-
-  def site
-    @site ||= user.site if user
   end
 
   def date_of_birth

--- a/app/forms/user/confirmation_form.rb
+++ b/app/forms/user/confirmation_form.rb
@@ -22,6 +22,13 @@ class User::ConfirmationForm
   validates :password, presence: true, confirmation: true
   validate :user_verification
 
+  def initialize(options = {})
+    options = options.to_h.with_indifferent_access
+    ordered_options = options.slice(:site, :confirmation_token).merge!(options)
+
+    super(ordered_options)
+  end
+
   def require_user_verification?
     user.present? && user.referrer_entity == "GobiertoBudgetConsultations::Consultation"
   end

--- a/app/forms/user/registration_form.rb
+++ b/app/forms/user/registration_form.rb
@@ -27,7 +27,7 @@ class User::RegistrationForm
   def save_user
     @user = user.tap do |user_attributes|
       user_attributes.email = email
-      user_attributes.source_site = site
+      user_attributes.site = site
       user_attributes.creation_ip = creation_ip
       user_attributes.referrer_entity = referrer_entity
       user_attributes.referrer_url = referrer_url

--- a/app/forms/user/session_form.rb
+++ b/app/forms/user/session_form.rb
@@ -3,6 +3,7 @@ class User::SessionForm
 
   attr_accessor(
     :email,
+    :site,
     :password,
     :referrer_url
   )
@@ -16,6 +17,6 @@ class User::SessionForm
   end
 
   def user
-    @user ||= User.confirmed.find_by(email: email.downcase)
+    @user ||= User.confirmed.find_by(email: email.downcase, site: site)
   end
 end

--- a/app/forms/user/session_form.rb
+++ b/app/forms/user/session_form.rb
@@ -10,7 +10,7 @@ class User::SessionForm
 
   attr_reader :user
 
-  validates :email, :password, presence: true
+  validates :email, :password, :site, presence: true
 
   def save
     user.try(:authenticate, password) if valid?

--- a/app/forms/user/settings_form.rb
+++ b/app/forms/user/settings_form.rb
@@ -28,7 +28,7 @@ class User::SettingsForm
   end
 
   def site
-    @site ||= user.source_site
+    @site ||= user.site
   end
 
   def date_of_birth

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -20,6 +20,7 @@ class Site < ApplicationRecord
   # User integrations
   has_many :subscriptions, dependent: :destroy, class_name: "User::Subscription"
   has_many :notifications, dependent: :destroy, class_name: "User::Notification"
+  has_many :users, dependent: :nullify
 
   # GobiertoBudgets integration
   has_many :custom_budget_lines_categories, dependent: :destroy, class_name: "GobiertoBudgets::Category"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
 
   scope :census_verified, -> { where(census_verified: true) }
   scope :sorted, -> { order(created_at: :desc) }
-  scope :by_source_site, ->(source_site) { where(source_site: source_site) }
+  scope :by_site, ->(site) { where(site: site) }
 
   enum gender: { male: 0, female: 1 }
   enum notification_frequency: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   EMAIL_ADDRESS_REGEXP = /\A(.+)@(.+\..+)\z/
 
-  belongs_to :source_site, class_name: "Site"
+  belongs_to :site
 
   has_many :verifications, class_name: "User::Verification", dependent: :destroy
   has_many :census_verifications, class_name: "User::Verification::CensusVerification"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :custom_records
 
-  validates :email, uniqueness: true
+  validates :email, uniqueness: { scope: :site }
 
   scope :census_verified, -> { where(census_verified: true) }
   scope :sorted, -> { order(created_at: :desc) }

--- a/app/models/user/verification/census_verification.rb
+++ b/app/models/user/verification/census_verification.rb
@@ -32,7 +32,7 @@ class User::Verification::CensusVerification < User::Verification
   def verify!
     ActiveRecord::Base.transaction do
       update_columns(verified: will_verify?)
-      user.update_columns(source_site_id: site_id) if will_verify?
+      user.update_columns(site_id: site_id) if will_verify?
       user.update_columns(census_verified: will_verify?)
     end
   end

--- a/app/presenters/gobierto_admin/users/users_stats_presenter.rb
+++ b/app/presenters/gobierto_admin/users/users_stats_presenter.rb
@@ -27,7 +27,7 @@ module GobiertoAdmin
     private
 
     def users_scope
-      User.by_source_site(@site)
+      User.by_site(@site)
     end
   end
 end

--- a/app/views/gobierto_admin/users/_session_information.html.erb
+++ b/app/views/gobierto_admin/users/_session_information.html.erb
@@ -12,5 +12,5 @@
 
 <p>
   <strong>Sitio de origen</strong>:
-  <%= link_to user.source_site.name, user.source_site.domain %>
+  <%= link_to user.site.name, user.site.domain %>
 </p>

--- a/app/views/gobierto_admin/users/_session_information.html.erb
+++ b/app/views/gobierto_admin/users/_session_information.html.erb
@@ -1,16 +1,16 @@
 <p>
-  <strong>Último login</strong>:
+  <strong><%= t('.last_sign_in') %></strong>:
   <%= time_ago_in_words(user.last_sign_in_at) if user.last_sign_in_at %>
   <span class="soft ip"><%= user.last_sign_in_ip %></span>
 </p>
 
 <p>
-  <strong>Creado</strong>:
+  <strong><%= t('.created_at') %></strong>:
   <%= l(user.created_at, format: :short) if user.created_at %>
   <span class="soft ip"><%= user.creation_ip %></span>
 </p>
 
 <p>
-  <strong>Sitio de origen</strong>:
+  <strong><%= t('.site') %></strong>:
   <%= link_to user.site.name, user.site.domain %>
 </p>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,4 +4,5 @@
 
 Rails.application.config.session_store :cookie_store,
                                        key: "_gobierto_session",
+                                       domain: :all,
                                        tld_length: ENV.fetch("TLD_LENGTH") { "2" }.to_i

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,5 +4,4 @@
 
 Rails.application.config.session_store :cookie_store,
                                        key: "_gobierto_session",
-                                       domain: :all,
                                        tld_length: ENV.fetch("TLD_LENGTH") { "2" }.to_i

--- a/config/locales/gobierto_admin/views/users/ca.yml
+++ b/config/locales/gobierto_admin/views/users/ca.yml
@@ -32,3 +32,7 @@ ca:
           one: "%{count}% verificat"
           other: "%{count}% verificats"
         view_user: Veure usuari
+      session_information:
+        created_at: Creat
+        last_sign_in: Últim login
+        site: Site

--- a/config/locales/gobierto_admin/views/users/en.yml
+++ b/config/locales/gobierto_admin/views/users/en.yml
@@ -32,3 +32,7 @@ en:
           one: "%{count}% verified"
           other: "%{count}% verified"
         view_user: View User
+      session_information:
+        created_at: Created
+        last_sign_in: Last sign in
+        site: Site

--- a/config/locales/gobierto_admin/views/users/es.yml
+++ b/config/locales/gobierto_admin/views/users/es.yml
@@ -32,3 +32,7 @@ es:
           one: "%{count}% verificado"
           other: "%{count}% verificados"
         view_user: Ver Usuario
+      session_information:
+        created_at: Creado
+        last_sign_in: Último login
+        site: Sitio

--- a/config/locales/user/controllers/sessions/en.yml
+++ b/config/locales/user/controllers/sessions/en.yml
@@ -9,4 +9,4 @@ en:
         success: Signed out successfully
       user_already_authenticated: You are already signed in.
       user_not_authorized: You are not authorized.
-      user_not_signed_in: Regístrate o haz login si ya tienes cuenta para poder continuar.
+      user_not_signed_in: Register or sign in if you have an account to continue.

--- a/db/migrate/20180111105954_rename_users_source_site_column.rb
+++ b/db/migrate/20180111105954_rename_users_source_site_column.rb
@@ -1,0 +1,5 @@
+class RenameUsersSourceSiteColumn < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :users, :source_site_id, :site_id
+  end
+end

--- a/db/migrate/20180111122236_change_users_email_index.rb
+++ b/db/migrate/20180111122236_change_users_email_index.rb
@@ -1,0 +1,6 @@
+class ChangeUsersEmailIndex < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :email
+    add_index :users, [:email, :site_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -259,8 +259,8 @@ ActiveRecord::Schema.define(version: 20180115112209) do
     t.string "sharing_token"
     t.string "document_number_digest"
     t.jsonb "user_information"
-    t.index ["consultation_id", "document_number_digest"], name: "index_gbc_consultation_responses_on_document_number_digest", unique: true
     t.index ["consultation_id"], name: "index_gbc_consultation_responses_on_consultation_id"
+    t.index ["document_number_digest"], name: "index_gbc_consultation_responses_on_document_number_digest", unique: true
     t.index ["sharing_token"], name: "index_gbc_consultation_responses_on_sharing_token", unique: true
     t.index ["user_information"], name: "index_gbc_consultation_responses_on_user_information", using: :gin
   end
@@ -317,9 +317,9 @@ ActiveRecord::Schema.define(version: 20180115112209) do
     t.integer "state", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "external_id"
     t.jsonb "title_translations"
     t.jsonb "description_translations"
+    t.string "external_id"
     t.integer "site_id", null: false
     t.string "slug", null: false
     t.integer "collection_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -808,7 +808,7 @@ ActiveRecord::Schema.define(version: 20180115112209) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "source_site_id"
+    t.integer "site_id"
     t.boolean "census_verified", default: false, null: false
     t.integer "gender"
     t.integer "notification_frequency", default: 0, null: false
@@ -816,10 +816,10 @@ ActiveRecord::Schema.define(version: 20180115112209) do
     t.string "referrer_url"
     t.string "referrer_entity"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email", "site_id"], name: "index_users_on_email_and_site_id", unique: true
     t.index ["notification_frequency"], name: "index_users_on_notification_frequency"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["source_site_id"], name: "index_users_on_source_site_id"
+    t.index ["site_id"], name: "index_users_on_site_id"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/docs/user-namespace.md
+++ b/docs/user-namespace.md
@@ -8,17 +8,20 @@ URL: http://madrid.gobierto.test/user/login
 
 Available users:
 
-| Email                | Password | Notes                                                                                           |
-| ---                  | ---      | ---                                                                                             |
-| dennis@gobierto.dev  | gobierto | regular user, madrid.gobierto.test as source site, verified against census, password recoverable |
-| reed@gobierto.dev    | gobierto | regular user, unconfirmed, madrid.gobierto.test as source site, not verified against census      |
-| susan@gobierto.dev   | gobierto | regular user, santander.gobierto.test as source site, not verified against census                |
-| peter@gobierto.dev   | gobierto | regular user, madrid.gobierto.test as source site, not verified against census                   |
-| charles@gobierto.dev | gobierto | regular user, santander.gobierto.test as source site, not verified against census, not confirmed |
+| Email                | Password | Notes                                                                                     |
+| ---                  | ---      | ---                                                                                       |
+| dennis@gobierto.dev  | gobierto | regular user, madrid.gobierto.test as site, verified against census, password recoverable |
+| reed@gobierto.dev    | gobierto | regular user, unconfirmed, madrid.gobierto.test as site, not verified against census      |
+| susan@gobierto.dev   | gobierto | regular user, santander.gobierto.test as site, not verified against census                |
+| peter@gobierto.dev   | gobierto | regular user, madrid.gobierto.test as site, not verified against census                   |
+| charles@gobierto.dev | gobierto | regular user, santander.gobierto.test as site, not verified against census, not confirmed |
+| janet@gobierto.dev   | gobierto | regular user, madrid.gobierto.test as site, not verified against census, confirmed        |
 
 Available sites:
 
-| Domain                 | Title                        | Name                      | Notes                    | Modules                      |
-| ---                    | ---                          | ---                       | ---                      | ---                          |
-| madrid.gobierto.test   | Transparencia y Participción | Ayuntamiento de Madrid    | visibility level: active | Budgets, BudgetConsultations |
-| santander.gobierto.test| Transparencia Ciudadana      | Ayuntamiento de Santander | visibility level: draft  | Budgets                      |
+
+| Domain                  | Title                        | Name                      | Notes                    | Modules                                                                                          |
+| ---                     | ---                          | ---                       | ---                      | ---                                                                                              |
+| madrid.gobierto.test    | Transparencia y Participción | Ayuntamiento de Madrid    | visibility level: active | GobiertoBudgets, GobiertoBudgetConsultations, GobiertoPeople, GobiertoCms, GobiertoParticipation |
+| santander.gobierto.test | Transparencia Ciudadana      | Ayuntamiento de Santander | visibility level: draft  | GobiertoBudgets, GobiertoCms, GobiertoPeople                                                     |
+| huesca.gobierto.test    | Transparencia Ciudadana      | Ayuntamiento de Huesca    | visibility level: draft  | GobiertoBudgets                                                                                  |

--- a/test/controllers/user/confirmations_controller_test.rb
+++ b/test/controllers/user/confirmations_controller_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class User::ConfirmationsControllerTest < GobiertoControllerTest
+  def unconfirmed_user_in_site
+    @confirmed_user ||= users(:reed)
+  end
+
+  def unconfirmed_user_in_other_site
+    @unconfirmed_user_in_other_site ||= users(:charles)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def other_site
+    @other_site ||= sites(:santander)
+  end
+
+  def valid_session_params
+    {
+      email: confirmed_user.email,
+      password: "gobierto"
+    }
+  end
+
+  def test_unconfirmed_user_in_correct_site
+    with_current_site(site) do
+      get(new_user_confirmations_url(confirmation_token: unconfirmed_user_in_site.confirmation_token))
+      assert_response :success
+    end
+
+    with_current_site(other_site) do
+      get(new_user_confirmations_url(confirmation_token: unconfirmed_user_in_other_site.confirmation_token))
+      assert_response :success
+    end
+  end
+
+  def test_unconfirmed_user_in_wrong_site
+    with_current_site(other_site) do
+      get(new_user_confirmations_url(confirmation_token: unconfirmed_user_in_site.confirmation_token))
+      assert_redirected_to root_path
+      assert_equal "This URL doesn't seem to be valid",
+        flash[:alert]
+    end
+
+    with_current_site(site) do
+      get(new_user_confirmations_url(confirmation_token: unconfirmed_user_in_other_site.confirmation_token))
+      assert_redirected_to root_path
+      assert_equal "This URL doesn't seem to be valid",
+        flash[:alert]
+    end
+  end
+end

--- a/test/controllers/user/sessions_controller_test.rb
+++ b/test/controllers/user/sessions_controller_test.rb
@@ -44,6 +44,20 @@ class User::SessionsControllerTest < GobiertoControllerTest
     end
   end
 
+  def test_create_and_change_of_site
+    with_current_site(confirmed_user.site) do
+      post(
+        user_sessions_url,
+        params: { user_session: valid_session_params }
+      )
+    end
+    with_current_site(other_site) do
+      get(user_settings_url)
+      assert_equal "Register or sign in if you have an account to continue.",
+        flash[:alert]
+    end
+  end
+
   def test_create_with_referrer
     with_current_site(confirmed_user.site) do
       post(

--- a/test/controllers/user/sessions_controller_test.rb
+++ b/test/controllers/user/sessions_controller_test.rb
@@ -7,6 +7,10 @@ class User::SessionsControllerTest < GobiertoControllerTest
     @confirmed_user ||= users(:dennis)
   end
 
+  def other_site
+    @other_site ||= sites(:santander)
+  end
+
   def referrer_url
     "http://example.com/home"
   end
@@ -19,20 +23,36 @@ class User::SessionsControllerTest < GobiertoControllerTest
   end
 
   def test_create
-    post(
-      user_sessions_url,
-      params: { user_session: valid_session_params }
-    )
-    assert_redirected_to root_path
+    with_current_site(confirmed_user.site) do
+      post(
+        user_sessions_url,
+        params: { user_session: valid_session_params }
+      )
+      assert_redirected_to root_path
+    end
+  end
+
+  def test_create_in_other_site
+    with_current_site(other_site) do
+      post(
+        user_sessions_url,
+        params: { user_session: valid_session_params }
+      )
+      assert_response :success
+      assert_equal "The data you entered doesn't seem to be valid. Please try again.",
+        flash[:alert]
+    end
   end
 
   def test_create_with_referrer
-    post(
-      user_sessions_url,
-      params: {
-        user_session: valid_session_params.merge(referrer_url: referrer_url)
-      }
-    )
-    assert_redirected_to referrer_url
+    with_current_site(confirmed_user.site) do
+      post(
+        user_sessions_url,
+        params: {
+          user_session: valid_session_params.merge(referrer_url: referrer_url)
+        }
+      )
+      assert_redirected_to referrer_url
+    end
   end
 end

--- a/test/fixtures/user/verification/census_verifications.yml
+++ b/test/fixtures/user/verification/census_verifications.yml
@@ -38,4 +38,13 @@ peter_verified:
   version: 0
   verified: true
 
+janet_unverified:
+  user: janet
+  site: madrid
+  verification_type: <%= User::Verification.verification_types["census"] %>
+  verification_data: <%= {
+    "document_number" => "00000000F",
+    "date_of_birth" => "1946-01-04" }.to_yaml.inspect %>
+  version: 0
+  verified: false
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -80,4 +80,19 @@ charles:
   gender: <%= User.genders["female"] %>
   notification_frequency: <%= User.notification_frequencies["disabled"] %>
 
+janet:
+  email: janet@gobierto.dev
+  name: Janet Weiss
+  password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
+  site: madrid
+  confirmation_token:
+  reset_password_token:
+  created_at: 2016-11-02 00:02:00
+  updated_at: 2016-11-02 00:02:00
+  last_sign_in_at: 2016-12-01 00:02:00
+  last_sign_in_ip: 0.0.0.0
+  census_verified: false
+  date_of_birth: <%= Date.parse('1946-10-04') %>
+  gender: <%= User.genders["female"] %>
+  notification_frequency: <%= User.notification_frequencies["disabled"] %>
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,7 +2,7 @@ dennis:
   email: dennis@gobierto.dev
   name: Dennis Dunphy
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
-  source_site: madrid
+  site: madrid
   confirmation_token:
   reset_password_token: wadus
   created_at: 2016-11-02 00:00:00
@@ -18,7 +18,7 @@ reed:
   email: reed@gobierto.dev
   name: Reed Richards
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
-  source_site: madrid
+  site: madrid
   confirmation_token: wadus
   reset_password_token:
   created_at: 2016-11-02 00:01:00
@@ -36,7 +36,7 @@ susan:
   email: susan@gobierto.dev
   name: Susan Storm
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
-  source_site: santander
+  site: santander
   confirmation_token:
   reset_password_token:
   created_at: 2016-11-02 00:02:00
@@ -52,7 +52,7 @@ peter:
   email: peter@gobierto.dev
   name: Peter Parker
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
-  source_site: madrid
+  site: madrid
   confirmation_token:
   reset_password_token:
   created_at: 2016-11-02 00:02:00
@@ -68,7 +68,7 @@ charles:
   email: charles@gobierto.dev
   name: Charles Storm
   password_digest: <%= BCrypt::Password.create("gobierto", cost: 4) %>
-  source_site: santander
+  site: santander
   confirmation_token: charles_confirmation_token
   reset_password_token:
   created_at: 2016-11-02 00:02:00

--- a/test/forms/gobierto_admin/census_import_form_test.rb
+++ b/test/forms/gobierto_admin/census_import_form_test.rb
@@ -68,7 +68,7 @@ module GobiertoAdmin
     def test_user_verifications_recalculation
       assert user_verification.verified
 
-      assert_performed_jobs 2 do
+      assert_performed_jobs 3 do
         valid_user_census_import_form.save
       end
 

--- a/test/forms/user/confirmation_form_site_without_verification_test.rb
+++ b/test/forms/user/confirmation_form_site_without_verification_test.rb
@@ -12,7 +12,8 @@ class User::ConfirmationFormSiteWithoutVerificationTest < ActiveSupport::TestCas
       date_of_birth_year: 1992,
       date_of_birth_month: 1,
       date_of_birth_day: 1,
-      gender: unconfirmed_user.gender
+      gender: unconfirmed_user.gender,
+      site: unconfirmed_user.site
     )
   end
 
@@ -25,7 +26,8 @@ class User::ConfirmationFormSiteWithoutVerificationTest < ActiveSupport::TestCas
       date_of_birth_year: nil,
       date_of_birth_month: nil,
       date_of_birth_day: nil,
-      gender: nil
+      gender: nil,
+      site: nil
     )
   end
 

--- a/test/forms/user/confirmation_form_test.rb
+++ b/test/forms/user/confirmation_form_test.rb
@@ -17,7 +17,8 @@ class User::ConfirmationFormTest < ActiveSupport::TestCase
         madrid_custom_user_field_district.name => { "custom_user_field_id" => madrid_custom_user_field_district.id, "value" => madrid_custom_user_field_district.options.keys.first },
         madrid_custom_user_field_association.name => { "custom_user_field_id" => madrid_custom_user_field_association.id, "value" => "Foo" }
       },
-      document_number: "00000000A"
+      document_number: "00000000A",
+      site: unconfirmed_user.site
     )
   end
 
@@ -31,7 +32,8 @@ class User::ConfirmationFormTest < ActiveSupport::TestCase
       date_of_birth_month: nil,
       date_of_birth_day: nil,
       gender: nil,
-      document_number: nil
+      document_number: nil,
+      site: nil
     )
   end
 

--- a/test/forms/user/session_form_test.rb
+++ b/test/forms/user/session_form_test.rb
@@ -7,14 +7,16 @@ class User::SessionFormTest < ActiveSupport::TestCase
     @valid_user_session_form ||= User::SessionForm.new(
       email: confirmed_user.email,
       password: "gobierto",
-      referrer_url: "http://example.com/home"
+      referrer_url: "http://example.com/home",
+      site: confirmed_user.site
     )
   end
 
   def invalid_user_session_form
     @invalid_user_session_form ||= User::SessionForm.new(
       email: nil,
-      password: nil
+      password: nil,
+      site: nil
     )
   end
 
@@ -35,5 +37,6 @@ class User::SessionFormTest < ActiveSupport::TestCase
 
     assert_equal 1, invalid_user_session_form.errors.messages[:email].size
     assert_equal 1, invalid_user_session_form.errors.messages[:password].size
+    assert_equal 1, invalid_user_session_form.errors.messages[:site].size
   end
 end

--- a/test/integration/gobierto_admin/dirty_forms_test.rb
+++ b/test/integration/gobierto_admin/dirty_forms_test.rb
@@ -18,7 +18,7 @@ module GobiertoAdmin
     end
 
     def site
-      @site ||= user.source_site
+      @site ||= user.site
     end
 
     def test_dirty_forms

--- a/test/integration/gobierto_admin/session_test.rb
+++ b/test/integration/gobierto_admin/session_test.rb
@@ -72,7 +72,7 @@ module GobiertoAdmin
       end
     end
 
-    def test_sign_in_and_visit_other_site
+    def test_sign_in_mantains_session_across_sites
       with_current_site_with_host(site) do
         sign_in_admin(admin)
         assert_equal site.name, find('div#current-site-name').text
@@ -81,13 +81,8 @@ module GobiertoAdmin
       with_current_site_with_host(other_site) do
         visit @sign_in_path
 
-        assert has_content?("Log in")
-      end
-
-      with_current_site_with_host(site) do
-        visit @sign_in_path
-
         assert has_message?("You are already signed in")
+        assert_equal other_site.name, find('div#current-site-name').text
       end
     end
 
@@ -121,20 +116,18 @@ module GobiertoAdmin
         sign_in_admin(admin)
       end
 
-      with_current_site_with_host(other_site) do
-        sign_in_admin(admin)
-      end
-
       with_current_site_with_host(site) do
         visit admin_root_path
         click_link "admin-sign-out"
+        visit @sign_in_path
+
         assert has_content?("Log in")
       end
 
       with_current_site_with_host(other_site) do
         visit @sign_in_path
 
-        assert has_message?("You are already signed in")
+        assert has_content?("Log in")
       end
     end
   end

--- a/test/integration/gobierto_admin/session_test.rb
+++ b/test/integration/gobierto_admin/session_test.rb
@@ -9,6 +9,18 @@ module GobiertoAdmin
       @sign_in_path = new_admin_sessions_path
     end
 
+    def site
+      sites(:madrid)
+    end
+
+    def other_site
+      sites(:santander)
+    end
+
+    def unmanaged_site
+      sites(:huesca)
+    end
+
     def admin
       @admin ||= gobierto_admin_admins(:tony)
     end
@@ -54,6 +66,72 @@ module GobiertoAdmin
 
     def test_sign_in_when_already_signed_in
       with_signed_in_admin(admin) do
+        visit @sign_in_path
+
+        assert has_message?("You are already signed in")
+      end
+    end
+
+    def test_sign_in_and_visit_other_site
+      with_current_site_with_host(site) do
+        sign_in_admin(admin)
+        assert_equal site.name, find('div#current-site-name').text
+      end
+
+      with_current_site_with_host(other_site) do
+        visit @sign_in_path
+
+        assert has_content?("Log in")
+      end
+
+      with_current_site_with_host(site) do
+        visit @sign_in_path
+
+        assert has_message?("You are already signed in")
+      end
+    end
+
+    def test_sign_in_with_domain
+      with_site_host(site) do
+        sign_in_admin(admin)
+        assert_equal site.name, find('div#current-site-name').text
+        click_link "admin-sign-out"
+      end
+
+      with_site_host(other_site) do
+        sign_in_admin(admin)
+        assert_equal other_site.name, find('div#current-site-name').text
+        click_link "admin-sign-out"
+      end
+
+      with_site_host(unmanaged_site) do
+        sign_in_admin(admin)
+        assert_includes admin.sites.map(&:name), find('div#current-site-name').text
+        refute_equal unmanaged_site.name, find('div#current-site-name').text
+        click_link "admin-sign-out"
+      end
+
+      sign_in_admin(admin)
+      assert_includes admin.sites.map(&:name), find('div#current-site-name').text
+      click_link "admin-sign-out"
+    end
+
+    def test_sign_out
+      with_current_site_with_host(site) do
+        sign_in_admin(admin)
+      end
+
+      with_current_site_with_host(other_site) do
+        sign_in_admin(admin)
+      end
+
+      with_current_site_with_host(site) do
+        visit admin_root_path
+        click_link "admin-sign-out"
+        assert has_content?("Log in")
+      end
+
+      with_current_site_with_host(other_site) do
         visit @sign_in_path
 
         assert has_message?("You are already signed in")

--- a/test/integration/gobierto_admin/user_list_test.rb
+++ b/test/integration/gobierto_admin/user_list_test.rb
@@ -21,8 +21,16 @@ module GobiertoAdmin
       @site ||= sites(:madrid)
     end
 
+    def other_site
+      @other_site ||= sites(:santander)
+    end
+
     def users_in_site
       @users_in_site ||= User.by_site(site)
+    end
+
+    def users_in_other_site
+      @users_in_other_site ||= User.by_site(other_site)
     end
 
     def test_user_list
@@ -33,6 +41,9 @@ module GobiertoAdmin
           within "table.user-list tbody" do
             users_in_site.each do |user|
               assert has_selector?("tr#user-item-#{user.id}")
+            end
+            users_in_other_site.each do |user|
+              refute has_selector?("tr#user-item-#{user.id}")
             end
           end
         end

--- a/test/integration/gobierto_admin/user_list_test.rb
+++ b/test/integration/gobierto_admin/user_list_test.rb
@@ -22,7 +22,7 @@ module GobiertoAdmin
     end
 
     def users_in_site
-      @users_in_site ||= User.by_source_site(site)
+      @users_in_site ||= User.by_site(site)
     end
 
     def test_user_list

--- a/test/integration/gobierto_admin/user_password_change_test.rb
+++ b/test/integration/gobierto_admin/user_password_change_test.rb
@@ -13,7 +13,7 @@ module GobiertoAdmin
     end
 
     def site
-      @site ||= user.source_site
+      @site ||= user.site
     end
 
     def test_user_password_change

--- a/test/integration/gobierto_admin/user_show_test.rb
+++ b/test/integration/gobierto_admin/user_show_test.rb
@@ -18,7 +18,7 @@ module GobiertoAdmin
     end
 
     def site
-      @site ||= user.source_site
+      @site ||= user.site
     end
 
     def test_user_show

--- a/test/integration/gobierto_admin/user_update_test.rb
+++ b/test/integration/gobierto_admin/user_update_test.rb
@@ -13,7 +13,7 @@ module GobiertoAdmin
     end
 
     def site
-      @site ||= user.source_site
+      @site ||= user.site
     end
 
     def test_user_update

--- a/test/integration/gobierto_admin/user_welcome_message_create_test.rb
+++ b/test/integration/gobierto_admin/user_welcome_message_create_test.rb
@@ -13,7 +13,7 @@ module GobiertoAdmin
     end
 
     def site
-      @site ||= user.source_site
+      @site ||= user.site
     end
 
     def test_user_welcome_message_create

--- a/test/integration/gobierto_budget_consultations/consultation_index_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_index_test.rb
@@ -68,16 +68,14 @@ module GobiertoBudgetConsultations
     end
 
     def test_see_participated_consultations
-      with_current_site(site) do
-        with_signed_in_user(user) do
-          visit @path
+      with_signed_in_user(user) do
+        visit @path
 
-          assert has_selector?("h2", text: "Active consultations")
+        assert has_selector?("h2", text: "Active consultations")
 
-          within ".active-consultations" do
-            assert has_link?("Consulta sobre los presupuestos de Madrid (You already responded)")
-            assert has_link?("Consulta adjunta sobre los presupuestos de Madrid")
-          end
+        within ".active-consultations" do
+          assert has_link?("Consulta sobre los presupuestos de Madrid (You already responded)")
+          assert has_link?("Consulta adjunta sobre los presupuestos de Madrid")
         end
       end
     end

--- a/test/integration/gobierto_budget_consultations/consultation_response_create_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_response_create_test.rb
@@ -32,8 +32,8 @@ module GobiertoBudgetConsultations
       @user ||= users(:peter)
     end
 
-    def unverified_user
-      @unverified_user ||= users(:susan)
+    def site_unverified_user
+      @site_unverified_user ||= users(:janet)
     end
 
     def test_consultation_response_creation_when_not_signed_in
@@ -45,7 +45,7 @@ module GobiertoBudgetConsultations
     end
 
     def test_consultation_response_creation_when_user_is_not_verified
-      with_signed_in_user(unverified_user) do
+      with_signed_in_user(site_unverified_user) do
         # Force referer detection
         Capybara.current_session.driver.header "Referer", @path
         visit @path

--- a/test/integration/gobierto_budget_consultations/consultation_response_create_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_response_create_test.rb
@@ -45,103 +45,93 @@ module GobiertoBudgetConsultations
     end
 
     def test_consultation_response_creation_when_user_is_not_verified
-      with_current_site(site) do
-        with_signed_in_user(unverified_user) do
-          # Force referer detection
-          Capybara.current_session.driver.header "Referer", @path
-          visit @path
+      with_signed_in_user(unverified_user) do
+        # Force referer detection
+        Capybara.current_session.driver.header "Referer", @path
+        visit @path
 
-          assert has_content?("The process in which you want to participate requires to verify your register in")
+        assert has_content?("The process in which you want to participate requires to verify your register in")
 
-          assert has_content?("Confirm your identity")
+        assert has_content?("Confirm your identity")
 
-          fill_in :user_verification_document_number, with: "00000000D"
+        fill_in :user_verification_document_number, with: "00000000D"
 
-          select "1993", from: :user_verification_date_of_birth_1i
-          select "January", from: :user_verification_date_of_birth_2i
-          select "1", from: :user_verification_date_of_birth_3i
+        select "1993", from: :user_verification_date_of_birth_1i
+        select "January", from: :user_verification_date_of_birth_2i
+        select "1", from: :user_verification_date_of_birth_3i
 
-          click_on "Verify"
+        click_on "Verify"
 
-          assert has_content?("Your identity has been verified successfully")
+        assert has_content?("Your identity has been verified successfully")
 
-          assert_equal @path, page.current_path
-        end
+        assert_equal @path, page.current_path
       end
     end
 
     def test_consultation_response_creation_when_consultation_is_closed
-      with_current_site(site) do
-        with_signed_in_user(user) do
-          visit @closed_path
+      with_signed_in_user(user) do
+        visit @closed_path
 
-          assert has_content?("This consultation doesn't allow participations.")
-        end
+        assert has_content?("This consultation doesn't allow participations.")
       end
     end
 
     def test_consultation_response_creation_workflow
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
-            page.find("button", text: "Reduce").trigger("click")
-            assert_equal "Surplus", page.all(".budget-figure").last.text
-            sleep 2
-            page.find("button", text: "Increase").trigger("click")
-            assert_equal "Balanced", page.all(".budget-figure").last.text
+          page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
+          page.find("button", text: "Reduce").trigger("click")
+          assert_equal "Surplus", page.all(".budget-figure").last.text
+          sleep 2
+          page.find("button", text: "Increase").trigger("click")
+          assert_equal "Balanced", page.all(".budget-figure").last.text
 
-            assert page.find("a.budget-next i")["class"].include?("fa-check")
-            page.find("a.budget-next").trigger("click")
+          assert page.find("a.budget-next i")["class"].include?("fa-check")
+          page.find("a.budget-next").trigger("click")
 
-            assert has_content?("Thanks for your response")
-          end
+          assert has_content?("Thanks for your response")
         end
       end
     end
 
     def test_consultation_response_creation_workflow_deficit_and_balance_required
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
-            page.find("button", text: "Increase").trigger("click")
-            assert_equal "Deficit", page.all(".budget-figure").last.text
-            sleep 2
-            page.find("button", text: "Increase").trigger("click")
-            assert_equal "Deficit", page.all(".budget-figure").last.text
+          page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
+          page.find("button", text: "Increase").trigger("click")
+          assert_equal "Deficit", page.all(".budget-figure").last.text
+          sleep 2
+          page.find("button", text: "Increase").trigger("click")
+          assert_equal "Deficit", page.all(".budget-figure").last.text
 
-            assert page.find("a.budget-next i")["class"].include?("fa-times")
-            page.find("a.budget-next").trigger("click")
+          assert page.find("a.budget-next i")["class"].include?("fa-times")
+          page.find("a.budget-next").trigger("click")
 
-            refute has_content?("Estupendo, muchas gracias por tu aportación")
-          end
+          refute has_content?("Estupendo, muchas gracias por tu aportación")
         end
       end
     end
 
     def test_consultation_response_creation_workflow_deficit_and_balance_not_required
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit gobierto_budget_consultations_consultation_new_response_path(consultation_not_requiring_balance)
+        with_signed_in_user(user) do
+          visit gobierto_budget_consultations_consultation_new_response_path(consultation_not_requiring_balance)
 
-            page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
-            page.find("button", text: "Increase").trigger("click")
-            assert_equal "Deficit", page.all(".budget-figure").last.text
-            sleep 2
-            page.find("button", text: "Increase").trigger("click")
-            assert_equal "Deficit", page.all(".budget-figure").last.text
-            sleep 2
-            assert page.find("a.budget-next i")["class"].include?("fa-check")
-            page.find("a.budget-next").trigger("click")
+          page.find(".consultation-title", text: "Inversión en Instalaciones Deportivas").trigger("click")
+          page.find("button", text: "Increase").trigger("click")
+          assert_equal "Deficit", page.all(".budget-figure").last.text
+          sleep 2
+          page.find("button", text: "Increase").trigger("click")
+          assert_equal "Deficit", page.all(".budget-figure").last.text
+          sleep 2
+          assert page.find("a.budget-next i")["class"].include?("fa-check")
+          page.find("a.budget-next").trigger("click")
 
-            assert has_content?("Thanks for your response")
-          end
+          assert has_content?("Thanks for your response")
         end
       end
     end

--- a/test/integration/gobierto_budget_consultations/consultation_show_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_show_test.rb
@@ -37,8 +37,8 @@ module GobiertoBudgetConsultations
       @user_verified ||= users(:peter)
     end
 
-    def user_no_verified
-      @user_no_verified ||= users(:susan)
+    def site_unverified_user
+      @site_unverified_user ||= users(:janet)
     end
 
     def test_consultation_show
@@ -109,7 +109,7 @@ module GobiertoBudgetConsultations
     end
 
     def test_show_summary_and_items_with_session_no_verified
-      with_signed_in_user(user_no_verified) do
+      with_signed_in_user(site_unverified_user) do
         visit @path
 
         assert has_link?("Do you want to opinate?")

--- a/test/integration/gobierto_budget_consultations/consultation_show_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_show_test.rb
@@ -70,14 +70,12 @@ module GobiertoBudgetConsultations
     def test_draft_consultation_show
       consultation.draft!
 
-      with_current_site(site) do
-        with_signed_in_user(user) do
-          assert_raises(ActiveRecord::RecordNotFound) do
-            visit @path
-          end
-
-          refute has_link?("Do you want to opinate?")
+      with_signed_in_user(user) do
+        assert_raises(ActiveRecord::RecordNotFound) do
+          visit @path
         end
+
+        refute has_link?("Do you want to opinate?")
       end
     end
 
@@ -103,18 +101,37 @@ module GobiertoBudgetConsultations
     end
 
     def test_show_summary_and_items_with_session_already_participated
-      with_current_site(site) do
-        with_signed_in_user(user) do
-          visit @path
+      with_signed_in_user(user) do
+        visit @path
 
-          assert has_message?("You already replied to this consultation")
-        end
+        assert has_message?("You already replied to this consultation")
       end
     end
 
     def test_show_summary_and_items_with_session_no_verified
-      with_current_site(site) do
-        with_signed_in_user(user_no_verified) do
+      with_signed_in_user(user_no_verified) do
+        visit @path
+
+        assert has_link?("Do you want to opinate?")
+
+        click_link "Do you want to opinate?"
+
+        assert has_selector?(".consultation-title", text: "Inversión en Instalaciones Deportivas")
+        assert has_content?("10€")
+        assert has_selector?(".consultation-title", text: "Inversión en Bomberos y Protección Civil")
+        assert has_content?("40€")
+
+        within ".consultation-step" do
+          click_link "Start"
+        end
+
+        assert has_message?("The process in which you want to participate requires to verify your register in")
+      end
+    end
+
+    def test_show_summary_and_items_with_session_already_verified
+      with_javascript do
+        with_signed_in_user(user_verified) do
           visit @path
 
           assert has_link?("Do you want to opinate?")
@@ -126,34 +143,9 @@ module GobiertoBudgetConsultations
           assert has_selector?(".consultation-title", text: "Inversión en Bomberos y Protección Civil")
           assert has_content?("40€")
 
-          within ".consultation-step" do
-            click_link "Start"
-          end
+          click_link "Start"
 
-          assert has_message?("The process in which you want to participate requires to verify your register in")
-        end
-      end
-    end
-
-    def test_show_summary_and_items_with_session_already_verified
-      with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user_verified) do
-            visit @path
-
-            assert has_link?("Do you want to opinate?")
-
-            click_link "Do you want to opinate?"
-
-            assert has_selector?(".consultation-title", text: "Inversión en Instalaciones Deportivas")
-            assert has_content?("10€")
-            assert has_selector?(".consultation-title", text: "Inversión en Bomberos y Protección Civil")
-            assert has_content?("40€")
-
-            click_link "Start"
-
-            assert has_selector?(".consultation-title", text: "Inversión en Instalaciones Deportivas")
-          end
+          assert has_selector?(".consultation-title", text: "Inversión en Instalaciones Deportivas")
         end
       end
     end

--- a/test/integration/gobierto_participation/issues/issue_show_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_show_test.rb
@@ -117,20 +117,18 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow theme"
-            end
-
-            click_on "Follow theme"
-            assert has_link? "Theme followed!"
-
-            click_on "Theme followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow theme"
           end
+
+          click_on "Follow theme"
+          assert has_link? "Theme followed!"
+
+          click_on "Theme followed!"
+          assert has_link? "Follow theme"
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/poll_answers/poll_answers_create_test.rb
+++ b/test/integration/gobierto_participation/processes/poll_answers/poll_answers_create_test.rb
@@ -38,63 +38,59 @@ module GobiertoParticipation
 
       def test_answer_poll
         with_javascript do
-          with_current_site(site) do
-            with_signed_in_user(user) do
-              visit process_polls_path
+          with_signed_in_user(user) do
+            visit process_polls_path
 
-              within "#poll_#{poll.id}" do
-                click_link 'Participate in this poll'
-              end
-
-              # answer first question
-
-              find('label', text: 'Si').trigger(:click)
-
-              find('input.next_question').click
-
-              # answer second question
-
-              find('label', text: 'Horarios').trigger(:click)
-              find('label', text: 'Características de los cenadores').trigger(:click)
-
-              find('input.next_question').click
-
-              # answer third question
-
-              fill_in 'poll[questions_attributes][2][answers_attributes][0][text]', with: 'Some text…'
-
-              # submit poll answers
-
-              find('input.next_question').click
-
-              sleep 1
-
-              click_link 'x'
-
-              answers       = poll.answers.where(user: user)
-              fixed_answers = answers.fixed_answers
-              open_answers  = answers.open_answers
-
-              assert_equal 3, fixed_answers.size
-              assert_equal 1, open_answers.size
-
-              fixed_answers_text = fixed_answers.map{ |a| a.answer_template.text }
-
-              assert array_match(['Si', 'Horarios', 'Características de los cenadores'], fixed_answers_text)
-              assert_equal 'Some text…', open_answers.first.text
+            within "#poll_#{poll.id}" do
+              click_link 'Participate in this poll'
             end
+
+            # answer first question
+
+            find('label', text: 'Si').trigger(:click)
+
+            find('input.next_question').click
+
+            # answer second question
+
+            find('label', text: 'Horarios').trigger(:click)
+            find('label', text: 'Características de los cenadores').trigger(:click)
+
+            find('input.next_question').click
+
+            # answer third question
+
+            fill_in 'poll[questions_attributes][2][answers_attributes][0][text]', with: 'Some text…'
+
+            # submit poll answers
+
+            find('input.next_question').click
+
+            sleep 1
+
+            click_link 'x'
+
+            answers       = poll.answers.where(user: user)
+            fixed_answers = answers.fixed_answers
+            open_answers  = answers.open_answers
+
+            assert_equal 3, fixed_answers.size
+            assert_equal 1, open_answers.size
+
+            fixed_answers_text = fixed_answers.map{ |a| a.answer_template.text }
+
+            assert array_match(['Si', 'Horarios', 'Características de los cenadores'], fixed_answers_text)
+            assert_equal 'Some text…', open_answers.first.text
           end
         end
       end
 
       def test_answer_previously_answered_poll
-        with_current_site(site) do
-          with_signed_in_user(user_already_answered) do
+        with_signed_in_user(user_already_answered) do
 
-            visit answer_poll_path
+          visit answer_poll_path
 
-            assert has_message? 'You have already participated in this poll'
-          end
+          assert has_message? 'You have already participated in this poll'
         end
       end
 

--- a/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
@@ -42,11 +42,9 @@ module GobiertoParticipation
         end
 
         def assert_both_levels_appear_in_index
-          with_current_site(site) do
-            visit process_polls_path
-            assert has_content? 'General aspects of the ordinance'
-            assert has_content? 'What do the residents of the neighborhood think?'
-          end
+          visit process_polls_path
+          assert has_content? 'General aspects of the ordinance'
+          assert has_content? 'What do the residents of the neighborhood think?'
         end
 
         def test_polls_not_registered_index
@@ -84,37 +82,33 @@ module GobiertoParticipation
 
         def test_polls_registered_level_tries_to_answer
           with_signed_in_user(registered_level_user) do
-            with_current_site(site) do
-              visit process_polls_path
-              within "#poll_#{ registered_level_poll.id }" do
-                click_link 'Participate in this poll'
-              end
-              assert has_content? 'Do you think that the ordinance should be modified?'
-
-              visit process_polls_path
-              within "#poll_#{ verified_level_poll.id }" do
-                click_link 'Participate in this poll'
-              end
-              refute has_content? 'Do you mind if the carnival parade takes place next to your house?'
+            visit process_polls_path
+            within "#poll_#{ registered_level_poll.id }" do
+              click_link 'Participate in this poll'
             end
+            assert has_content? 'Do you think that the ordinance should be modified?'
+
+            visit process_polls_path
+            within "#poll_#{ verified_level_poll.id }" do
+              click_link 'Participate in this poll'
+            end
+            refute has_content? 'Do you mind if the carnival parade takes place next to your house?'
           end
         end
 
         def test_polls_verified_tries_to_answer
           with_signed_in_user(verified_level_user) do
-            with_current_site(site) do
-              visit process_polls_path
-              within "#poll_#{ registered_level_poll.id }" do
-                click_link 'Participate in this poll'
-              end
-              assert has_content? 'Do you think that the ordinance should be modified?'
-
-              visit process_polls_path
-              within "#poll_#{ verified_level_poll.id }" do
-                click_link 'Participate in this poll'
-              end
-              assert has_content? 'Do you mind if the carnival parade takes place next to your house?'
+            visit process_polls_path
+            within "#poll_#{ registered_level_poll.id }" do
+              click_link 'Participate in this poll'
             end
+            assert has_content? 'Do you think that the ordinance should be modified?'
+
+            visit process_polls_path
+            within "#poll_#{ verified_level_poll.id }" do
+              click_link 'Participate in this poll'
+            end
+            assert has_content? 'Do you mind if the carnival parade takes place next to your house?'
           end
         end
 

--- a/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
@@ -12,7 +12,7 @@ module GobiertoParticipation
         end
 
         def registered_level_user
-          @registered_level_user ||= users(:susan)
+          @registered_level_user ||= users(:janet)
         end
 
         def verified_level_user

--- a/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/permission_levels_test.rb
@@ -48,8 +48,10 @@ module GobiertoParticipation
         end
 
         def test_polls_not_registered_index
-          sign_out_user
-          assert_both_levels_appear_in_index
+          with_current_site(site) do
+            sign_out_user
+            assert_both_levels_appear_in_index
+          end
         end
 
         def test_polls_registered_index

--- a/test/integration/gobierto_participation/processes/polls/polls_index_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/polls_index_test.rb
@@ -48,17 +48,15 @@ module GobiertoParticipation
       end
 
       def test_disable_participate_link_for_already_answered_polls
-        with_current_site(site) do
-          with_signed_in_user(user_already_answered) do
+        with_signed_in_user(user_already_answered) do
 
-            visit process_polls_path
+          visit process_polls_path
 
-            within "#poll_#{poll.id}" do
-              assert has_content? 'You have already participated in this poll'
-              refute has_content? 'Participate in this poll'
-            end
-
+          within "#poll_#{poll.id}" do
+            assert has_content? 'You have already participated in this poll'
+            refute has_content? 'Participate in this poll'
           end
+
         end
       end
 

--- a/test/integration/gobierto_participation/processes/process_contribution_containers_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contribution_containers_show_test.rb
@@ -145,40 +145,36 @@ module GobiertoParticipation
 
     def test_vote_contribution
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit container_path
-            assert has_content? "What activities for children we can start up?"
+        with_signed_in_user(user) do
+          visit container_path
+          assert has_content? "What activities for children we can start up?"
 
-            page.find('[data-url="/participacion/p/ciudad-deportiva/aportaciones/children-contributions/contributions/carril-bici"]', visible: false).trigger("click")
-            assert has_content? "Carril bici para que los niños puedan llegar al parque desde cualquier punto de Barajas."
-            assert has_content? "Rate the idea"
-            page.find("a.action_button.love").trigger("click")
-            assert has_content? "It enchants to me"
+          page.find('[data-url="/participacion/p/ciudad-deportiva/aportaciones/children-contributions/contributions/carril-bici"]', visible: false).trigger("click")
+          assert has_content? "Carril bici para que los niños puedan llegar al parque desde cualquier punto de Barajas."
+          assert has_content? "Rate the idea"
+          page.find("a.action_button.love").trigger("click")
+          assert has_content? "It enchants to me"
 
-            find(".modal_like_control a", visible: false).click
-          end
+          find(".modal_like_control a", visible: false).click
         end
       end
     end
 
     def test_contribution_commments
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit container_path
+        with_signed_in_user(user) do
+          visit container_path
 
-            page.find('[data-url="/participacion/p/ciudad-deportiva/aportaciones/children-contributions/contributions/carril-bici"]', visible: false).trigger("click")
-            assert has_content? "Carril bici para que los niños puedan llegar al parque desde cualquier punto de Barajas."
+          page.find('[data-url="/participacion/p/ciudad-deportiva/aportaciones/children-contributions/contributions/carril-bici"]', visible: false).trigger("click")
+          assert has_content? "Carril bici para que los niños puedan llegar al parque desde cualquier punto de Barajas."
 
-            within "div.comments_container" do
-              contribution_comments.each do |comment|
-                assert has_selector?("div.comment div")
-              end
+          within "div.comments_container" do
+            contribution_comments.each do |comment|
+              assert has_selector?("div.comment div")
             end
-
-            find(".modal_like_control a", visible: false).click
           end
+
+          find(".modal_like_control a", visible: false).click
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_contribution_create_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contribution_create_test.rb
@@ -43,51 +43,47 @@ module GobiertoParticipation
 
     def test_contribution_create
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit container_path
+        with_signed_in_user(user) do
+          visit container_path
 
-            assert_equal contributions.size, 4
+          assert_equal contributions.size, 4
 
-            page.find("a", text: "Have an idea!").trigger("click")
+          page.find("a", text: "Have an idea!").trigger("click")
 
-            assert has_content? "WRITE YOUR IDEA CONCISE"
-            assert has_content? "DO YOU WANT TO GIVE THEM DETAILS? DEVELOP THE MAIN POINTS OF YOUR IDEA"
+          assert has_content? "WRITE YOUR IDEA CONCISE"
+          assert has_content? "DO YOU WANT TO GIVE THEM DETAILS? DEVELOP THE MAIN POINTS OF YOUR IDEA"
 
-            fill_in :contribution_title, with: "My contribution"
-            fill_in :contribution_description, with: "Contribution description"
+          fill_in :contribution_title, with: "My contribution"
+          fill_in :contribution_description, with: "Contribution description"
 
-            click_button "Create"
+          click_button "Create"
 
-            assert_equal site.contributions.size, 5
+          assert_equal site.contributions.size, 5
 
-            # Avoids the error of the test that verifies to be logged because it does not have layout
-            visit containers_path
-          end
+          # Avoids the error of the test that verifies to be logged because it does not have layout
+          visit containers_path
         end
       end
     end
 
     def test_contribution_errors
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit container_path
+        with_signed_in_user(user) do
+          visit container_path
 
-            assert_equal contributions.size, 4
+          assert_equal contributions.size, 4
 
-            page.find("a", text: "Have an idea!").trigger("click")
+          page.find("a", text: "Have an idea!").trigger("click")
 
-            assert has_content? "WRITE YOUR IDEA CONCISE"
-            assert has_content? "DO YOU WANT TO GIVE THEM DETAILS? DEVELOP THE MAIN POINTS OF YOUR IDEA"
+          assert has_content? "WRITE YOUR IDEA CONCISE"
+          assert has_content? "DO YOU WANT TO GIVE THEM DETAILS? DEVELOP THE MAIN POINTS OF YOUR IDEA"
 
-            click_button "Create"
+          click_button "Create"
 
-            assert has_alert?("Title can't be blank")
+          assert has_alert?("Title can't be blank")
 
-            # Avoids the error of the test that verifies to be logged because it does not have layout
-            visit containers_path
-          end
+          # Avoids the error of the test that verifies to be logged because it does not have layout
+          visit containers_path
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -36,12 +36,10 @@ module GobiertoParticipation
 
         def with_js_session_of_user(user)
           with_javascript do
-            with_current_site(site) do
-              visit root_path
-              sign_out_user unless has_content? "Sign in"
-              with_signed_in_user(user) do
-                yield
-              end
+            visit root_path
+            sign_out_user unless has_content? "Sign in"
+            with_signed_in_user(user) do
+              yield
             end
           end
         end

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -11,7 +11,7 @@ module GobiertoParticipation
         end
 
         def registered_level_user
-          @registered_level_user ||= users(:susan)
+          @registered_level_user ||= users(:janet)
         end
 
         def verified_level_user

--- a/test/integration/gobierto_participation/processes/process_events_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_events_index_test.rb
@@ -67,20 +67,18 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit process_events_path
+        with_signed_in_user(user) do
+          visit process_events_path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow process"
-            end
-
-            click_on "Follow process"
-            assert has_link? "Process followed!"
-
-            click_on "Process followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow process"
           end
+
+          click_on "Follow process"
+          assert has_link? "Process followed!"
+
+          click_on "Process followed!"
+          assert has_link? "Follow process"
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_events_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_events_show_test.rb
@@ -71,20 +71,18 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit process_event_path
+        with_signed_in_user(user) do
+          visit process_event_path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow process"
-            end
-
-            click_on "Follow process"
-            assert has_link? "Process followed!"
-
-            click_on "Process followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow process"
           end
+
+          click_on "Follow process"
+          assert has_link? "Process followed!"
+
+          click_on "Process followed!"
+          assert has_link? "Follow process"
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_pages_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_pages_index_test.rb
@@ -66,20 +66,18 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit process_pages_path
+        with_signed_in_user(user) do
+          visit process_pages_path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow process"
-            end
-
-            click_on "Follow process"
-            assert has_link? "Process followed!"
-
-            click_on "Process followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow process"
           end
+
+          click_on "Follow process"
+          assert has_link? "Process followed!"
+
+          click_on "Process followed!"
+          assert has_link? "Follow process"
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_pages_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_pages_show_test.rb
@@ -70,20 +70,18 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit process_page_path
+        with_signed_in_user(user) do
+          visit process_page_path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow process"
-            end
-
-            click_on "Follow process"
-            assert has_link? "Process followed!"
-
-            click_on "Process followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow process"
           end
+
+          click_on "Follow process"
+          assert has_link? "Process followed!"
+
+          click_on "Process followed!"
+          assert has_link? "Follow process"
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_show_test.rb
@@ -124,19 +124,17 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit process_path(gender_violence_process)
-            within ".slim_nav_bar" do
-              assert has_link? "Follow process"
-            end
-
-            click_on "Follow process"
-            assert has_link? "Process followed!"
-
-            click_on "Process followed!"
+        with_signed_in_user(user) do
+          visit process_path(gender_violence_process)
+          within ".slim_nav_bar" do
             assert has_link? "Follow process"
           end
+
+          click_on "Follow process"
+          assert has_link? "Process followed!"
+
+          click_on "Process followed!"
+          assert has_link? "Follow process"
         end
       end
     end

--- a/test/integration/gobierto_participation/scopes/scope_show_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_show_test.rb
@@ -125,20 +125,18 @@ module GobiertoParticipation
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow scope"
-            end
-
-            click_on "Follow scope"
-            assert has_link? "Scope followed!"
-
-            click_on "Scope followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow scope"
           end
+
+          click_on "Follow scope"
+          assert has_link? "Scope followed!"
+
+          click_on "Scope followed!"
+          assert has_link? "Follow scope"
         end
       end
     end

--- a/test/integration/gobierto_participation/welcome/welcome_index_test.rb
+++ b/test/integration/gobierto_participation/welcome/welcome_index_test.rb
@@ -119,13 +119,11 @@ module GobiertoParticipation
 
     def test_show_poll
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            assert has_link? poll.title
-            assert has_content? poll.questions.first.title
-          end
+          assert has_link? poll.title
+          assert has_content? poll.questions.first.title
         end
       end
     end

--- a/test/integration/gobierto_people/people/person_event_show_test.rb
+++ b/test/integration/gobierto_people/people/person_event_show_test.rb
@@ -82,20 +82,18 @@ module GobiertoPeople
 
       def test_subscription_block
         with_javascript do
-          with_current_site(site) do
-            with_signed_in_user(user) do
-              visit @path
+          with_signed_in_user(user) do
+            visit @path
 
-              within ".slim_nav_bar" do
-                assert has_link? "Follow event"
-              end
-
-              click_on "Follow event"
-              assert has_link? "Event followed!"
-
-              click_on "Event followed!"
+            within ".slim_nav_bar" do
               assert has_link? "Follow event"
             end
+
+            click_on "Follow event"
+            assert has_link? "Event followed!"
+
+            click_on "Event followed!"
+            assert has_link? "Follow event"
           end
         end
       end

--- a/test/integration/gobierto_people/people/person_message_test.rb
+++ b/test/integration/gobierto_people/people/person_message_test.rb
@@ -48,24 +48,22 @@ module GobiertoPeople
       end
 
       def test_send_message_as_logged_user
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            click_link "Send an email"
-            fill_in "gobierto_people_person_message_body", with: "This is my message"
-            click_button "Send"
+          click_link "Send an email"
+          fill_in "gobierto_people_person_message_body", with: "This is my message"
+          click_button "Send"
 
-            assert has_message?("Message sent successfully")
+          assert has_message?("Message sent successfully")
 
-            refute ActionMailer::Base.deliveries.empty?
-            email = ActionMailer::Base.deliveries.last
+          refute ActionMailer::Base.deliveries.empty?
+          email = ActionMailer::Base.deliveries.last
 
-            assert_equal ["admin@gobierto.dev"], email.from
-            assert_equal [user.email], email.reply_to
-            assert_equal [person.email], email.to
-            assert_equal "You have received a new message from Transparencia y Participción", email.subject
-          end
+          assert_equal ["admin@gobierto.dev"], email.from
+          assert_equal [user.email], email.reply_to
+          assert_equal [person.email], email.to
+          assert_equal "You have received a new message from Transparencia y Participción", email.subject
         end
       end
     end

--- a/test/integration/gobierto_people/person_profile_test.rb
+++ b/test/integration/gobierto_people/person_profile_test.rb
@@ -69,20 +69,18 @@ module GobiertoPeople
 
     def test_subscription_block
       with_javascript do
-        with_current_site(site) do
-          with_signed_in_user(user) do
-            visit @path
+        with_signed_in_user(user) do
+          visit @path
 
-            within ".slim_nav_bar" do
-              assert has_link? "Follow person"
-            end
-
-            click_on "Follow person"
-            assert has_link? "Person followed!"
-
-            click_on "Person followed!"
+          within ".slim_nav_bar" do
             assert has_link? "Follow person"
           end
+
+          click_on "Follow person"
+          assert has_link? "Person followed!"
+
+          click_on "Person followed!"
+          assert has_link? "Follow person"
         end
       end
     end

--- a/test/integration/user/census_verification_test.rb
+++ b/test/integration/user/census_verification_test.rb
@@ -21,59 +21,51 @@ class User::CensusVerificationTest < ActionDispatch::IntegrationTest
   end
 
   def test_successful_verification
-    with_current_site(site) do
-      with_signed_in_user(unverified_user) do
-        visit @verification_path
+    with_signed_in_user(unverified_user) do
+      visit @verification_path
 
-        fill_in :user_verification_document_number, with: " 00*00 00ñ00 a "
+      fill_in :user_verification_document_number, with: " 00*00 00ñ00 a "
 
-        click_on "Verify"
+      click_on "Verify"
 
-        assert has_content?("Your identity has been verified successfully")
-      end
+      assert has_content?("Your identity has been verified successfully")
     end
   end
 
   def test_invalid_verification_no_data
-    with_current_site(site) do
-      with_signed_in_user(unverified_user) do
-        visit @verification_path
+    with_signed_in_user(unverified_user) do
+      visit @verification_path
 
-        fill_in :user_verification_document_number, with: nil
+      fill_in :user_verification_document_number, with: nil
 
-        click_on "Verify"
+      click_on "Verify"
 
-        assert has_content?("Confirm your identity")
-        assert has_content?("We couldn't verify your identity. Please check your information and try again. If the problem persists, ask to your local adminsitration")
-      end
+      assert has_content?("Confirm your identity")
+      assert has_content?("We couldn't verify your identity. Please check your information and try again. If the problem persists, ask to your local adminsitration")
     end
   end
 
   def test_failed_verification
-    with_current_site(site) do
-      with_signed_in_user(unverified_user) do
-        visit @verification_path
+    with_signed_in_user(unverified_user) do
+      visit @verification_path
 
-        fill_in :user_verification_document_number, with: "00000000P"
+      fill_in :user_verification_document_number, with: "00000000P"
 
-        select "1990", from: :user_verification_date_of_birth_1i
-        select "October", from: :user_verification_date_of_birth_2i
-        select "19", from: :user_verification_date_of_birth_3i
+      select "1990", from: :user_verification_date_of_birth_1i
+      select "October", from: :user_verification_date_of_birth_2i
+      select "19", from: :user_verification_date_of_birth_3i
 
-        click_on "Verify"
+      click_on "Verify"
 
-        assert has_content?("Confirm your identity")
-      end
+      assert has_content?("Confirm your identity")
     end
   end
 
   def test_verification_when_already_verified
-    with_current_site(site) do
-      with_signed_in_user(verified_user) do
-        visit @verification_path
+    with_signed_in_user(verified_user) do
+      visit @verification_path
 
-        assert has_content?("Your account is already verified")
-      end
+      assert has_content?("Your account is already verified")
     end
   end
 end

--- a/test/integration/user/notification_index_test.rb
+++ b/test/integration/user/notification_index_test.rb
@@ -17,11 +17,9 @@ class User::NotificationIndexTest < ActionDispatch::IntegrationTest
   end
 
   def test_notification_index
-    with_current_site(site) do
-      with_signed_in_user(user) do
-        notifications = user.notifications
-        visit @path
-      end
+    with_signed_in_user(user) do
+      notifications = user.notifications
+      visit @path
     end
   end
 end

--- a/test/integration/user/registration_test.rb
+++ b/test/integration/user/registration_test.rb
@@ -16,6 +16,10 @@ class User::RegistrationTest < ActionDispatch::IntegrationTest
     @site ||= sites(:madrid)
   end
 
+  def other_site
+    @other_site ||= sites(:santander)
+  end
+
   def test_registration
     with_current_site(site) do
       visit @registration_path
@@ -59,6 +63,18 @@ class User::RegistrationTest < ActionDispatch::IntegrationTest
       click_on "Let's go"
 
       assert has_message?("That email is already registered. Try login in or recovering your password")
+    end
+  end
+
+  def test_registration_with_registered_user_in_other_site
+    with_current_site(other_site) do
+      visit @registration_path
+
+      fill_in :user_registration_email, with: user.email
+
+      click_on "Let's go"
+
+      assert has_message?("Please check your inbox to confirm your email address")
     end
   end
 end

--- a/test/integration/user/session_test.rb
+++ b/test/integration/user/session_test.rb
@@ -16,6 +16,14 @@ class User::SessionTest < ActionDispatch::IntegrationTest
     @site ||= sites(:madrid)
   end
 
+  def other_site
+    @other_site ||= sites(:santander)
+  end
+
+  def other_site_user
+    @other_site_user ||= users(:susan)
+  end
+
   def privacy_page
     @privacy_page ||= gobierto_cms_pages(:privacy)
   end
@@ -67,6 +75,62 @@ class User::SessionTest < ActionDispatch::IntegrationTest
 
         assert has_message?("You are already signed in.")
       end
+    end
+  end
+
+  def test_sign_in_when_signed_in_in_other_site
+    with_current_site(site) do
+      visit @sign_in_path
+
+      fill_in :user_session_email, with: user.email
+      fill_in :user_session_password, with: "gobierto"
+      click_on "Log in"
+    end
+
+    with_current_site(other_site) do
+      visit @sign_in_path
+
+      fill_in :user_session_email, with: user.email
+      fill_in :user_session_password, with: "gobierto"
+      click_on "Log in"
+
+      assert has_message?("The data you entered doesn't seem to be valid. Please try again.")
+    end
+
+    with_current_site(site) do
+      visit @sign_in_path
+
+      assert has_message?("You are already signed in.")
+    end
+  end
+
+  def test_session_is_mantained_on_each_host
+    with_current_site_with_host(site) do
+      visit @sign_in_path
+
+      fill_in :user_session_email, with: user.email
+      fill_in :user_session_password, with: "gobierto"
+      click_on "Log in"
+    end
+
+    with_current_site_with_host(other_site) do
+      visit @sign_in_path
+
+      fill_in :user_session_email, with: other_site_user.email
+      fill_in :user_session_password, with: "gobierto"
+      click_on "Log in"
+    end
+
+    with_current_site_with_host(site) do
+      visit @sign_in_path
+
+      assert has_message?("You are already signed in.")
+    end
+
+    with_current_site_with_host(other_site) do
+      visit @sign_in_path
+
+      assert has_message?("You are already signed in.")
     end
   end
 end

--- a/test/integration/user/session_test.rb
+++ b/test/integration/user/session_test.rb
@@ -104,7 +104,7 @@ class User::SessionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_session_is_mantained_on_each_host
+  def test_session_is_shared_between_hosts
     with_current_site_with_host(site) do
       visit @sign_in_path
 
@@ -113,6 +113,7 @@ class User::SessionTest < ActionDispatch::IntegrationTest
       click_on "Log in"
     end
 
+    # The session is replaced with the new one
     with_current_site_with_host(other_site) do
       visit @sign_in_path
 
@@ -124,7 +125,7 @@ class User::SessionTest < ActionDispatch::IntegrationTest
     with_current_site_with_host(site) do
       visit @sign_in_path
 
-      assert has_message?("You are already signed in.")
+      assert has_content?("Log in")
     end
 
     with_current_site_with_host(other_site) do

--- a/test/integration/user/settings_test.rb
+++ b/test/integration/user/settings_test.rb
@@ -17,40 +17,36 @@ class User::SettingsTest < ActionDispatch::IntegrationTest
   end
 
   def test_settings_page
-    with_current_site(site) do
-      with_signed_in_user(user) do
-        visit @path
+    with_signed_in_user(user) do
+      visit @path
 
-        fill_in :user_settings_name, with: "New name"
-        select "1992", from: :user_settings_date_of_birth_1i
-        select "January", from: :user_settings_date_of_birth_2i
-        select "1", from: :user_settings_date_of_birth_3i
-        choose "Male"
+      fill_in :user_settings_name, with: "New name"
+      select "1992", from: :user_settings_date_of_birth_1i
+      select "January", from: :user_settings_date_of_birth_2i
+      select "1", from: :user_settings_date_of_birth_3i
+      choose "Male"
 
-        click_on "Save"
-        assert has_message?("Settings saved successfully")
-      end
+      click_on "Save"
+      assert has_message?("Settings saved successfully")
     end
   end
 
   def test_settings_page_update_custom_fields
-    with_current_site(site) do
-      with_signed_in_user(user) do
-        visit @path
-        assert has_select?("Districts", selected: "Center")
+    with_signed_in_user(user) do
+      visit @path
+      assert has_select?("Districts", selected: "Center")
 
-        fill_in :user_settings_name, with: "New name"
-        select "1992", from: :user_settings_date_of_birth_1i
-        select "January", from: :user_settings_date_of_birth_2i
-        select "1", from: :user_settings_date_of_birth_3i
-        choose "Male"
-        select "Chamberi", from: "Districts"
+      fill_in :user_settings_name, with: "New name"
+      select "1992", from: :user_settings_date_of_birth_1i
+      select "January", from: :user_settings_date_of_birth_2i
+      select "1", from: :user_settings_date_of_birth_3i
+      choose "Male"
+      select "Chamberi", from: "Districts"
 
-        click_on "Save"
-        assert has_message?("Settings saved successfully")
+      click_on "Save"
+      assert has_message?("Settings saved successfully")
 
-        assert has_select?("Districts", selected: "Chamberi")
-      end
+      assert has_select?("Districts", selected: "Chamberi")
     end
   end
 end

--- a/test/integration/user/subscription_index_test.rb
+++ b/test/integration/user/subscription_index_test.rb
@@ -21,42 +21,38 @@ class User::SubscriptionIndexTest < ActionDispatch::IntegrationTest
   end
 
   def test_subscription_management
-    with_current_site(site) do
-      with_signed_in_user(user) do
-        visit @path
+    with_signed_in_user(user) do
+      visit @path
 
-        assert has_content?("Your alerts")
-        assert has_checked_field?("user_subscription_preferences_notification_frequency_hourly")
+      assert has_content?("Your alerts")
+      assert has_checked_field?("user_subscription_preferences_notification_frequency_hourly")
 
-        check "People"
-        check person.name
+      check "People"
+      check person.name
 
-        click_button "Save"
+      click_button "Save"
 
-        assert has_message?("Preferences updated successfully")
+      assert has_message?("Preferences updated successfully")
 
-        assert has_checked_field?("user_subscription_preferences_modules_gobierto_people")
-        assert has_checked_field?("user_subscription_preferences_gobierto_people_people_#{person.id}")
-      end
+      assert has_checked_field?("user_subscription_preferences_modules_gobierto_people")
+      assert has_checked_field?("user_subscription_preferences_gobierto_people_people_#{person.id}")
     end
   end
 
   def test_site_subscription
     with_javascript do
-      with_current_site(site) do
-        with_signed_in_user(user) do
-          visit @path
+      with_signed_in_user(user) do
+        visit @path
 
-          page.find("#user_subscription_preferences_site_to_subscribe", visible: false).trigger("click")
+        page.find("#user_subscription_preferences_site_to_subscribe", visible: false).trigger("click")
 
-          click_button "Save"
+        click_button "Save"
 
-          assert has_content?("Preferences updated successfully")
+        assert has_content?("Preferences updated successfully")
 
-          assert has_checked_field?("user_subscription_preferences_modules_gobierto_people", visible: false)
-          assert has_checked_field?("user_subscription_preferences_modules_gobierto_budget_consultations", visible: false)
-          assert has_checked_field?("user_subscription_preferences_gobierto_people_people_#{person.id}", visible: false)
-        end
+        assert has_checked_field?("user_subscription_preferences_modules_gobierto_people", visible: false)
+        assert has_checked_field?("user_subscription_preferences_modules_gobierto_budget_consultations", visible: false)
+        assert has_checked_field?("user_subscription_preferences_gobierto_people_people_#{person.id}", visible: false)
       end
     end
   end

--- a/test/models/user/verification/census_verification_test.rb
+++ b/test/models/user/verification/census_verification_test.rb
@@ -30,14 +30,14 @@ class User::Verification::CensusVerificationTest < ActiveSupport::TestCase
   def test_verify!
     refute unverified_user_verification.verified?
     refute unverified_user_verification.user.census_verified?
-    refute_equal user_verification.user.source_site, unverified_user_verification.site
+    refute_equal user_verification.user.site, unverified_user_verification.site
 
     unverified_user_verification.stub(:will_verify?, true) do
       unverified_user_verification.verify!
 
       assert unverified_user_verification.reload.verified?
       assert unverified_user_verification.user.reload.census_verified?
-      assert_equal unverified_user_verification.user.source_site, unverified_user_verification.site
+      assert_equal unverified_user_verification.user.site, unverified_user_verification.site
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -44,7 +44,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_by_user_site_scope
-    subject = User.by_source_site(madrid_site)
+    subject = User.by_site(madrid_site)
 
     assert_includes subject, madrid_user
     refute_includes subject, santander_user

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -39,6 +39,10 @@ class UserTest < ActiveSupport::TestCase
     @madrid_user ||= users(:dennis)
   end
 
+  def other_madrid_user
+    @other_madrid_user ||= users(:janet)
+  end
+
   def santander_user
     @santander_user ||= users(:susan)
   end
@@ -48,6 +52,15 @@ class UserTest < ActiveSupport::TestCase
 
     assert_includes subject, madrid_user
     refute_includes subject, santander_user
+  end
+
+  def test_email_unique_scoped_to_site
+    santander_user.email = madrid_user.email
+    other_madrid_user.email = madrid_user.email
+
+    assert santander_user.valid?
+    refute other_madrid_user.valid?
+    assert other_madrid_user.errors.include? :email
   end
 
   def test_valid

--- a/test/support/app_host_helpers.rb
+++ b/test/support/app_host_helpers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AppHostHelpers
+  def with_site_host(site)
+    original_host = Capybara.app_host
+    Capybara.app_host = root_url(host: site.domain)
+    yield
+  ensure
+    Capybara.app_host = original_host
+  end
+end

--- a/test/support/app_host_helpers.rb
+++ b/test/support/app_host_helpers.rb
@@ -3,7 +3,7 @@
 module AppHostHelpers
   def with_site_host(site)
     original_host = Capybara.app_host
-    Capybara.app_host = root_url(host: site.domain)
+    Capybara.app_host = root_url(host: site.domain).gsub(/\/$/, '')
     yield
   ensure
     Capybara.app_host = original_host

--- a/test/support/integration/authentication_helpers.rb
+++ b/test/support/integration/authentication_helpers.rb
@@ -9,9 +9,11 @@ module Integration
     end
 
     def with_signed_in_user(user)
-      sign_in_user(user)
-      yield
-      sign_out_user
+      with_current_site(user.site) do
+        sign_in_user(user)
+        yield
+        sign_out_user
+      end
     end
 
     private

--- a/test/support/integration/request_authentication_helpers.rb
+++ b/test/support/integration/request_authentication_helpers.rb
@@ -12,9 +12,11 @@ module Integration
     end
 
     def with_signed_in_user(user)
-      sign_in_user(user)
-      yield
-      sign_out_user
+      with_current_site(user.site) do
+        sign_in_user(user)
+        yield
+        sign_out_user
+      end
     end
 
     def sign_in_admin(admin)

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -2,6 +2,7 @@
 
 module SiteSessionHelpers
   def with_current_site(site)
+    raise(Exception, 'GobiertoSiteConstraint.matches? already stubbed. Maybe with_current_site is in use outside this block?') if GobiertoSiteConstraint.new.public_methods.include?(:__minitest_any_instance_stub__matches?)
     GobiertoSiteConstraint.stub_any_instance(:matches?, true) do
       ApplicationController.stub_any_instance(:current_site, site) do
         GobiertoAdmin::BaseController.stub_any_instance(:current_site, SiteDecorator.new(site)) do

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -6,7 +6,9 @@ module SiteSessionHelpers
     GobiertoSiteConstraint.stub_any_instance(:matches?, true) do
       ApplicationController.stub_any_instance(:current_site, site) do
         GobiertoAdmin::BaseController.stub_any_instance(:current_site, SiteDecorator.new(site)) do
-          yield
+          with_site_host(site) do
+            yield
+          end
         end
       end
     end

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -6,9 +6,7 @@ module SiteSessionHelpers
     GobiertoSiteConstraint.stub_any_instance(:matches?, true) do
       ApplicationController.stub_any_instance(:current_site, site) do
         GobiertoAdmin::BaseController.stub_any_instance(:current_site, SiteDecorator.new(site)) do
-          with_site_host(site) do
-            yield
-          end
+          yield
         end
       end
     end

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -11,4 +11,12 @@ module SiteSessionHelpers
       end
     end
   end
+
+  def with_current_site_with_host(site)
+    with_current_site(site) do
+      with_site_host(site) do
+        yield
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,7 @@ require "webmock/minitest"
 require "support/common_helpers"
 require "support/session_helpers"
 require "support/site_session_helpers"
+require "support/app_host_helpers"
 require "support/message_delivery_helpers"
 require "support/gobierto_site_constraint_helpers"
 require "support/asymmetric_encryptor_helpers"
@@ -79,6 +80,7 @@ ActiveRecord::Migration.maintain_test_schema!
 class ActiveSupport::TestCase
   include CommonHelpers
   include SessionHelpers
+  include AppHostHelpers
   include SiteSessionHelpers
   include ActiveJob::TestHelper
 


### PR DESCRIPTION
Related with #1312

### What does this PR do?
* Renames the source_site attribute of users with site.
* Changes the association between `User` and `Site` adding a `has_many :users, dependent: :nullify`.
* Removes the unique database index for `email` on users and creates a new one unique for `email` and `site_id`.
* Defines a validation of uniqueness of `email` scoped to site in User model.
* In `sessions_controller` a user will only be able to sign in in their site. This is implemented by including the site in the `User::SessionsForm`.
* Refactor tests taking into account the site and includes some test:
  * Verifies a user can't use email/password to sign in in wrong site.
  * Verifies the list of users in admin/users only displays users of the site.
  * Test that `User::SessionsForm` must include the site to be valid.


### How should this be manually tested?
Register with the same email in different sites, try to sign in with the credentials of one site in other. As admin user take a look to the list of users of a site.

### Does this PR changes any configuration file?

No