### PR TITLE
#1343: Add missing translation

### DIFF
--- a/config/locales/user/views/census_verifications/ca.yml
+++ b/config/locales/user/views/census_verifications/ca.yml
@@ -16,6 +16,11 @@ ca:
             que estàs empadronat/ada a %{site_name}. Confirma les teves dades per
             continuar (seran verificades amb el padró, si no estàs empadronat/ada,
             no et podrem verificar)
+        contributions:
+          not_verified: La contribució en que vols participar exigeix que verifiquis
+            que estàs empadronat/ada a %{site_name}. Confirma les teves dades per
+            continuar (seran verificades amb el padró, si no estàs empadronat/ada,
+            no et podrem verificar)
         flags:
           not_verified: La contribució en que vols participar exigeix que verifiquis
             que estàs empadronat/ada a %{site_name}. Confirma les teves dades per

--- a/config/locales/user/views/census_verifications/en.yml
+++ b/config/locales/user/views/census_verifications/en.yml
@@ -16,6 +16,11 @@ en:
             your register in %{site_name}. Please, confirm your data to continue (they'll
             be verified against the register, if you are not registered we won't be
             abile to verify yourself)
+        contributions:
+          not_verified: The contribution in which you want to participate requires
+            to verify your register in %{site_name}. Please, confirm your data to
+            continue (they'll be verified against the register, if you are not registered
+            we won't be abile to verify yourself)
         flags:
           not_verified: The contribution in which you want to participate requires
             to verify your register in %{site_name}. Please, confirm your data to

--- a/config/locales/user/views/census_verifications/es.yml
+++ b/config/locales/user/views/census_verifications/es.yml
@@ -16,6 +16,11 @@ es:
             que estás empadronado/a en %{site_name}. Confirma tus datos para continuar
             (serán verificados contra el padrón, si no estás empadronado/a, no te
             podremos verificar)
+        contributions:
+          not_verified: La contribución en la que deseas participar exige que verifiques
+            que estás empadronado/a en %{site_name}. Confirma tus datos para continuar
+            (serán verificados contra el padrón, si no estás empadronado/a, no te
+            podremos verificar)
         flags:
           not_verified: La contribución en la que deseas participar exige que verifiques
             que estás empadronado/a en %{site_name}. Confirma tus datos para continuar


### PR DESCRIPTION
Closes #1343

### What does this PR do?
Adds missing translations when a user is trying to add a contribution and requires census verification


### How should this be manually tested?
Visit http://madrid.gobify.net/participacion/p/grandes-ideas/aportaciones/dadme-ideas and try to add an idea as not verified user


### Does this PR changes any configuration file?
No