### PR TITLE
Error with archived elements

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_attachments/file_attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/file_attachments_controller.rb
@@ -61,7 +61,7 @@ module GobiertoAdmin
 
       def destroy
         @file_attachment = find_file_attachment
-        @file_attachment.archive
+        @file_attachment.destroy
         process = find_process if params[:process_id]
 
         if process

--- a/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
@@ -72,7 +72,7 @@ module GobiertoAdmin
 
       def destroy
         @event = find_event
-        @event.archive
+        @event.destroy
         process = find_process if params[:process_id]
 
         if process

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -61,7 +61,7 @@ module GobiertoAdmin
 
       def destroy
         @page = find_page
-        @page.archive
+        @page.destroy
         process = find_process if params[:process_id]
 
         if process

--- a/app/controllers/gobierto_admin/gobierto_participation/processes/polls_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/polls_controller.rb
@@ -56,7 +56,7 @@ module GobiertoAdmin
 
         def destroy
           @poll = find_poll
-          @poll.archive
+          @poll.destroy
           process = find_process if params[:process_id]
 
           redirect_to admin_participation_process_polls_path(process_id: process), notice: t(".success")

--- a/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
@@ -78,7 +78,7 @@ module GobiertoAdmin
 
         def destroy
           @contribution_container = find_contribution_container
-          @contribution_container.archive
+          @contribution_container.destroy
           process = find_process if params[:process_id]
 
           redirect_to admin_participation_process_contribution_containers_path(process_id: process), notice: t(".success")

--- a/app/controllers/gobierto_admin/gobierto_participation/processes_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes_controller.rb
@@ -66,7 +66,7 @@ module GobiertoAdmin
 
       def destroy
         @process = find_process
-        @process.archive
+        @process.destroy
 
         redirect_to admin_participation_path, notice: t(".success")
       end

--- a/app/models/concerns/gobierto_common/sluggable.rb
+++ b/app/models/concerns/gobierto_common/sluggable.rb
@@ -12,7 +12,7 @@ module GobiertoCommon
     private
 
     def set_slug
-      if slug.present? && !slug.include?("-slug-archived")
+      if slug.present? && !slug.include?("archived-")
         self.slug = self.slug.tr("_", " ").parameterize
         return
       end
@@ -39,7 +39,7 @@ module GobiertoCommon
 
     def add_archived_to_slug
       unless destroyed?
-        update_attribute(:slug, slug + "-slug-archived")
+        update_attribute(:slug, "archived-" + id.to_s)
       end
     end
   end

--- a/app/models/concerns/gobierto_common/sluggable.rb
+++ b/app/models/concerns/gobierto_common/sluggable.rb
@@ -6,12 +6,13 @@ module GobiertoCommon
 
     included do
       before_create :set_slug
+      after_destroy :add_archived_to_slug
     end
 
     private
 
     def set_slug
-      if slug.present?
+      if slug.present? && !slug.include?("-slug-archived")
         self.slug = self.slug.tr("_", " ").parameterize
         return
       end
@@ -34,6 +35,12 @@ module GobiertoCommon
       end
 
       self.slug = new_slug
+    end
+
+    def add_archived_to_slug
+      unless destroyed?
+        update_attribute(:slug, slug + "-slug-archived")
+      end
     end
   end
 end

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -50,7 +50,7 @@ module GobiertoAttachments
 
     after_create :add_item_to_collection
     before_validation :update_file_attributes
-    after_restore :restore_slug
+    after_restore :set_slug
 
     scope :inverse_sorted, -> { order(id: :asc) }
     scope :sorted, -> { order(id: :desc) }

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -50,6 +50,7 @@ module GobiertoAttachments
 
     after_create :add_item_to_collection
     before_validation :update_file_attributes
+    after_restore :restore_slug
 
     scope :inverse_sorted, -> { order(id: :asc) }
     scope :sorted, -> { order(id: :desc) }
@@ -129,6 +130,10 @@ module GobiertoAttachments
       if collection
         collection.append(self)
       end
+    end
+
+    def restore_slug
+      send(:set_slug)
     end
 
     private

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -132,10 +132,6 @@ module GobiertoAttachments
       end
     end
 
-    def restore_slug
-      send(:set_slug)
-    end
-
     private
 
     # This method is error-prone and should be REMOVED.

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -34,6 +34,7 @@ module GobiertoCalendars
     has_many :attendees, class_name: "EventAttendee", dependent: :destroy
 
     after_create :add_item_to_collection
+    after_restore :restore_slug
 
     scope :past,     -> { published.where("starts_at <= ?", Time.zone.now) }
     scope :upcoming, -> { published.where("starts_at > ?", Time.zone.now) }
@@ -115,6 +116,10 @@ module GobiertoCalendars
 
     def add_item_to_collection
       collection.append(self)
+    end
+
+    def restore_slug
+      send(:set_slug)
     end
 
     def to_path

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -34,7 +34,7 @@ module GobiertoCalendars
     has_many :attendees, class_name: "EventAttendee", dependent: :destroy
 
     after_create :add_item_to_collection
-    after_restore :restore_slug
+    after_restore :set_slug
 
     scope :past,     -> { published.where("starts_at <= ?", Time.zone.now) }
     scope :upcoming, -> { published.where("starts_at > ?", Time.zone.now) }

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -118,10 +118,6 @@ module GobiertoCalendars
       collection.append(self)
     end
 
-    def restore_slug
-      send(:set_slug)
-    end
-
     def to_path
       if collection.container_type == "GobiertoParticipation::Process"
         url_helpers.gobierto_participation_process_event_path({ id: slug, process_id: collection.container.slug })

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -34,7 +34,7 @@ module GobiertoCms
     has_many :process_stage_pages, class_name: "GobiertoParticipation::ProcessStagePage"
 
     after_create :add_item_to_collection
-    after_restore :restore_slug
+    after_restore :set_slug
 
     enum visibility_level: { draft: 0, active: 1 }
 

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -130,9 +130,5 @@ module GobiertoCms
     def searchable_body
       searchable_translated_attribute(body_translations)
     end
-
-    def restore_slug
-      send(:set_slug)
-    end
   end
 end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -34,6 +34,7 @@ module GobiertoCms
     has_many :process_stage_pages, class_name: "GobiertoParticipation::ProcessStagePage"
 
     after_create :add_item_to_collection
+    after_restore :restore_slug
 
     enum visibility_level: { draft: 0, active: 1 }
 
@@ -128,6 +129,10 @@ module GobiertoCms
 
     def searchable_body
       searchable_translated_attribute(body_translations)
+    end
+
+    def restore_slug
+      send(:set_slug)
     end
   end
 end

--- a/app/models/gobierto_participation/contribution_container.rb
+++ b/app/models/gobierto_participation/contribution_container.rb
@@ -51,9 +51,5 @@ module GobiertoParticipation
     def days_left
       (ends - Date.current).to_i
     end
-
-    def restore_slug
-      send(:set_slug)
-    end
   end
 end

--- a/app/models/gobierto_participation/contribution_container.rb
+++ b/app/models/gobierto_participation/contribution_container.rb
@@ -18,7 +18,7 @@ module GobiertoParticipation
     belongs_to :admin, class_name: "GobiertoAdmin::Admin"
     has_many :contributions
 
-    after_restore :restore_slug
+    after_restore :set_slug
 
     enum visibility_level: { draft: 0, active: 1 }
     enum contribution_type: { idea: 0, question: 1, proposal: 2 }

--- a/app/models/gobierto_participation/contribution_container.rb
+++ b/app/models/gobierto_participation/contribution_container.rb
@@ -18,6 +18,8 @@ module GobiertoParticipation
     belongs_to :admin, class_name: "GobiertoAdmin::Admin"
     has_many :contributions
 
+    after_restore :restore_slug
+
     enum visibility_level: { draft: 0, active: 1 }
     enum contribution_type: { idea: 0, question: 1, proposal: 2 }
 
@@ -48,6 +50,10 @@ module GobiertoParticipation
 
     def days_left
       (ends - Date.current).to_i
+    end
+
+    def restore_slug
+      send(:set_slug)
     end
   end
 end

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -39,6 +39,7 @@ module GobiertoParticipation
     scope :sorted, -> { order(id: :desc) }
 
     after_create :create_collections
+    after_restore :restore_slug
 
     def to_s
       title
@@ -112,6 +113,10 @@ module GobiertoParticipation
 
     def resource_path
       url_helpers.gobierto_participation_process_url({ id: slug }.merge(host: site.domain))
+    end
+
+    def restore_slug
+      send(:set_slug)
     end
 
     private

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -115,10 +115,6 @@ module GobiertoParticipation
       url_helpers.gobierto_participation_process_url({ id: slug }.merge(host: site.domain))
     end
 
-    def restore_slug
-      send(:set_slug)
-    end
-
     private
 
     def create_collections

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -39,7 +39,7 @@ module GobiertoParticipation
     scope :sorted, -> { order(id: :desc) }
 
     after_create :create_collections
-    after_restore :restore_slug
+    after_restore :set_slug
 
     def to_s
       title

--- a/db/data/20180117140628_modify_slug_in_archived_objects.rb
+++ b/db/data/20180117140628_modify_slug_in_archived_objects.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ModifySlugInArchivedObjects < ActiveRecord::Migration[5.1]
+  def up
+    ::GobiertoCalendars::Event.only_archived.each do |event|
+      event.update_attribute(:slug, event.slug + "-slug-archived")
+    end
+
+    ::GobiertoCms::Page.only_archived.each do |page|
+      page.update_attribute(:slug, page.slug + "-slug-archived")
+    end
+
+    ::GobiertoParticipation::ContributionContainer.only_archived.each do |contribution_container|
+      contribution_container.update_attribute(:slug, contribution_container.slug + "-slug-archived")
+    end
+
+    ::GobiertoParticipation::Process.only_archived.each do |process|
+      process.update_attribute(:slug, process.slug + "-slug-archived")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20180117140628_modify_slug_in_archived_objects.rb
+++ b/db/data/20180117140628_modify_slug_in_archived_objects.rb
@@ -3,19 +3,19 @@
 class ModifySlugInArchivedObjects < ActiveRecord::Migration[5.1]
   def up
     ::GobiertoCalendars::Event.only_archived.each do |event|
-      event.update_attribute(:slug, event.slug + "-slug-archived")
+      event.update_attribute(:slug, event.slug + "archived-" + event.id.to_s)
     end
 
     ::GobiertoCms::Page.only_archived.each do |page|
-      page.update_attribute(:slug, page.slug + "-slug-archived")
+      page.update_attribute(:slug, page.slug + "archived-" + page.id.to_s)
     end
 
     ::GobiertoParticipation::ContributionContainer.only_archived.each do |contribution_container|
-      contribution_container.update_attribute(:slug, contribution_container.slug + "-slug-archived")
+      contribution_container.update_attribute(:slug, "archived-" + contribution_container.id.to_s)
     end
 
     ::GobiertoParticipation::Process.only_archived.each do |process|
-      process.update_attribute(:slug, process.slug + "-slug-archived")
+      process.update_attribute(:slug, "archived-" + process.id.to_s)
     end
   end
 

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180115142954)
+DataMigrate::Data.define(version: 20180117140628)

--- a/test/models/gobierto_attachments/attachment_test.rb
+++ b/test/models/gobierto_attachments/attachment_test.rb
@@ -174,5 +174,11 @@ module GobiertoAttachments
       assert_equal "", attachment.extension
       assert_equal "pdf", txt_pdf_attachment.extension
     end
+
+    def test_destroy
+      attachment.destroy
+
+      assert attachment.slug.include?("-slug-archived")
+    end
   end
 end

--- a/test/models/gobierto_attachments/attachment_test.rb
+++ b/test/models/gobierto_attachments/attachment_test.rb
@@ -178,7 +178,7 @@ module GobiertoAttachments
     def test_destroy
       attachment.destroy
 
-      assert attachment.slug.include?("-slug-archived")
+      assert attachment.slug.include?("archived-")
     end
   end
 end

--- a/test/models/gobierto_calendars/event_test.rb
+++ b/test/models/gobierto_calendars/event_test.rb
@@ -124,5 +124,11 @@ module GobiertoCalendars
       new_event = ::GobiertoCalendars::Event.new
       assert_equal "", new_event.searchable_description
     end
+
+    def test_destroy
+      event.destroy
+
+      assert event.slug.include?("-slug-archived")
+    end
   end
 end

--- a/test/models/gobierto_calendars/event_test.rb
+++ b/test/models/gobierto_calendars/event_test.rb
@@ -128,7 +128,7 @@ module GobiertoCalendars
     def test_destroy
       event.destroy
 
-      assert event.slug.include?("-slug-archived")
+      assert event.slug.include?("archived-")
     end
   end
 end

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -35,7 +35,7 @@ module GobiertoCms
     def test_destroy
       page.destroy
 
-      assert page.slug.include?("-slug-archived")
+      assert page.slug.include?("archived-")
     end
   end
 end

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -31,5 +31,11 @@ module GobiertoCms
       assert_equal "", new_page.searchable_body
       assert_equal "", new_page.searchable_body
     end
+
+    def test_destroy
+      page.destroy
+
+      assert page.slug.include?("-slug-archived")
+    end
   end
 end

--- a/test/models/gobierto_participation/contribution_container_test.rb
+++ b/test/models/gobierto_participation/contribution_container_test.rb
@@ -24,5 +24,11 @@ module GobiertoParticipation
     def test_valid
       assert contribution_container.valid?
     end
+
+    def test_destroy
+      contribution_container.destroy
+
+      assert contribution_container.slug.include?("-slug-archived")
+    end
   end
 end

--- a/test/models/gobierto_participation/contribution_container_test.rb
+++ b/test/models/gobierto_participation/contribution_container_test.rb
@@ -28,7 +28,7 @@ module GobiertoParticipation
     def test_destroy
       contribution_container.destroy
 
-      assert contribution_container.slug.include?("-slug-archived")
+      assert contribution_container.slug.include?("archived-")
     end
   end
 end

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 
 module GobiertoCms
   class ProcessTest < ActiveSupport::TestCase
-
     def green_city_group
       @green_city_group ||= gobierto_participation_processes(:green_city_group)
     end
@@ -53,25 +52,30 @@ module GobiertoCms
 
     def test_current_stage
       assert_nil group_without_stages.current_stage
-      assert_equal 'sugiere-idea', process_with_one_open_stage.current_stage.slug
-      assert_equal 'dialogo', process_with_several_open_stages.current_stage.slug  # within active and open stages, the one which finishes the latest
-      assert_equal 'encuestas', process_with_only_current_stage.current_stage.slug
+      assert_equal "sugiere-idea", process_with_one_open_stage.current_stage.slug
+      assert_equal "dialogo", process_with_several_open_stages.current_stage.slug # within active and open stages, the one which finishes the latest
+      assert_equal "encuestas", process_with_only_current_stage.current_stage.slug
     end
 
     def test_next_stage
       assert_nil group_without_stages.next_stage
       assert_nil process_with_one_open_stage.next_stage
-      assert_equal 'presentacion', process_with_several_open_stages.next_stage.slug
+      assert_equal "presentacion", process_with_several_open_stages.next_stage.slug
       assert_nil process_with_only_current_stage.next_stage
     end
 
     def test_create_process_creates_collections
-      process = site.processes.create! title: 'Foo'
+      process = site.processes.create! title: "Foo"
 
       assert process.news_collection.present?
       assert process.events_collection.present?
       assert process.attachments_collection.present?
     end
 
+    def test_destroy
+      green_city_group.destroy
+
+      assert green_city_group.slug.include?("-slug-archived")
+    end
   end
 end

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -75,7 +75,7 @@ module GobiertoCms
     def test_destroy
       green_city_group.destroy
 
-      assert green_city_group.slug.include?("-slug-archived")
+      assert green_city_group.slug.include?("archived-")
     end
   end
 end


### PR DESCRIPTION
Closes #1340 

### What does this PR do?

When events are synchronized and there is an archived event with same slug, it gives an error when making the insert.

The after_destroy I was able to put it in the concern but not the callback after_restore.

Besides, as there is an index I have to put another slug for the archived item, adding "-slug-archived"

### How should this be manually tested?

Error doesn't repeat https://rollbar.com/Populate/gobierto/items/725/?item_page=0&#instances

You can archive an event (see the slug from edition) and then restore the event.