### PR TITLE
Remove filtering text option

### DIFF
--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -65,10 +65,13 @@ input[type=text]:focus, input[type=email]:focus, input[type=submit]:focus, input
 .select_control.select_compact {
   font-size: .85em;
   margin: 0 0 .5em 0;
-  select {
+  select, input {
     margin-top: 0;
     padding: 2px 10px;
     height: initial;
+  }
+  input {
+    height: 40px;
   }
 }
 .select_control.selects_inline {
@@ -463,7 +466,7 @@ option, select {
     .option_suboptions {
       padding: 0 0 0 3em;
       .option {
-        
+
       }
     }
   }

--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -82,7 +82,7 @@ module GobiertoAdmin
           :microsoft_exchange_pwd,
           :microsoft_exchange_url,
           :clear_calendar_configuration,
-          filtering_rules_attributes: [:id, :field, :condition, :value, :action, :_destroy],
+          filtering_rules_attributes: [:id, :field, :condition, :value, :action, :_destroy, :remove_filtering_text],
           calendars: []
         )
       end

--- a/app/models/gobierto_calendars/filtering_result.rb
+++ b/app/models/gobierto_calendars/filtering_result.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_calendars"
+
+module GobiertoCalendars
+  class FilteringResult
+    attr_accessor :action
+    attr_accessor :event_attributes
+
+    def initialize(event_attributes, action)
+      @event_attributes = event_attributes
+      @action = action
+    end
+  end
+end

--- a/app/models/gobierto_calendars/filtering_rule.rb
+++ b/app/models/gobierto_calendars/filtering_rule.rb
@@ -31,5 +31,11 @@ module GobiertoCalendars
 
       fullfills ? action : false
     end
+
+    def update_event_attributes(event_attributes)
+      event_attributes.symbolize_keys!
+      event_attributes[field.to_sym] = event_attributes[field.to_sym].gsub(value, "").gsub(/\s+/, " ").strip if event_attributes[field.to_sym].present?
+      event_attributes
+    end
   end
 end

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -36,7 +36,7 @@ module GobiertoPeople
           description: ibm_notes_event.description,
         }, configuration.filtering_rules)
 
-        state = filter_result == GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING ?
+        state = filter_result.action == GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING ?
           GobiertoCalendars::Event.states[:pending] :
           GobiertoCalendars::Event.states[:published]
 
@@ -50,8 +50,8 @@ module GobiertoPeople
           site_id: ibm_notes_event.person.site.id,
           external_id: ibm_notes_event.id,
           person_id: ibm_notes_event.person.id,
-          title: ibm_notes_event.title,
-          description: ibm_notes_event.description,
+          title: filter_result.event_attributes[:title],
+          description: filter_result.event_attributes[:description],
           starts_at: ibm_notes_event.starts_at,
           ends_at: ibm_notes_event.ends_at,
           state: state,
@@ -61,7 +61,7 @@ module GobiertoPeople
           recurring: recurring
         }
 
-        if filter_result == GobiertoCalendars::FilteringRuleApplier::REMOVE
+        if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
           GobiertoPeople::PersonEventForm.new(person_event_params).destroy
           nil
         else

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -62,38 +62,41 @@ module GobiertoPeople
         target_folder.expanded_items(SYNC_RANGE)
       end
 
-      def sync_event(item)
+      def sync_event(event)
         filter_result = GobiertoCalendars::FilteringRuleApplier.filter({
-          title: item.subject,
+          title: event.subject,
           description: "" # TODO: https://github.com/PopulateTools/gobierto/issues/1127
         }, configuration.filtering_rules)
 
-        filter_result = GobiertoCalendars::FilteringRuleApplier::REMOVE if is_private?(item)
+        filter_result.action = GobiertoCalendars::FilteringRuleApplier::REMOVE if is_private?(event)
 
-        state = filter_result == GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING ?
+        state = (filter_result.action == GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING) ?
           GobiertoCalendars::Event.states[:pending] :
           GobiertoCalendars::Event.states[:published]
 
         event_params = {
-          starts_at: item.start,
-          ends_at: item.end,
+          starts_at: event.start,
+          ends_at: event.end,
           state: state,
-          external_id: item.id,
-          title: item.subject,
+          external_id: event.id,
+          title: filter_result.event_attributes[:title],
+          description: filter_result.event_attributes[:description],
           site_id: site.id,
           person_id: person.id
         }
 
-        if item.location.present?
-          event_params.merge!(locations_attributes: { "0" => { name: item.location } })
+        if event.location.present?
+          event_params.merge!(locations_attributes: { "0" => { name: event.location } })
         else
           event_params.merge!(locations_attributes: { "0" => { "_destroy" => "1" } })
         end
 
-        if filter_result == GobiertoCalendars::FilteringRuleApplier::REMOVE
+        if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
           GobiertoPeople::PersonEventForm.new(event_params).destroy
         else
-          GobiertoPeople::PersonEventForm.new(event_params).save
+          unless GobiertoPeople::PersonEventForm.new(event_params).save
+            Rails.logger.info "[Microsoft Exchange Integration] Invalid event: #{event_params}"
+          end
         end
       end
 

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -76,8 +76,11 @@
                 </td>
                 <td>
                   <div class="p_0_5">
-                    <%= filtering_rule_form.label :remove_filtering_text %>
                     <%= filtering_rule_form.check_box :remove_filtering_text %>
+                    <%= filtering_rule_form.label :remove_filtering_text do %>
+                      <span></span>
+                      <%= filtering_rule_form.object.class.human_attribute_name(:remove_filtering_text) %>
+                    <% end %>
                   </div>
                 </td>
                 <td>

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -48,61 +48,52 @@
         <table class="med_bg dynamic-content-wrapper" id="filtering-rules">
           <%= f.fields_for :filtering_rules do |filtering_rule_form| %>
             <tbody class="dynamic-content-record-wrapper content-block-record-<%= filtering_rule_form.object.id || "new" %>">
-              <tr class="dynamic-content-record-form">
+              <tr class="dynamic-content-record-form" style="vertical-align:middle">
+                <td width="7%">
+                  <%= t('.filter_events_label') %>
+                </td>
                 <td>
-                  <div class="inline p_0_5">Si el</div>
-                  <div class="select_control select_compact inline">
+                  <div class="select_control select_compact">
                     <%= filtering_rule_form.select :field, options_for_enum(filtering_rule_form.object, :field), prompt: true %>
                   </div>
                 </td>
                 <td>
-                  <div class="p_0_5">
-                    <div class="select_control select_compact ">
-                      <%= filtering_rule_form.select :condition, options_for_enum(filtering_rule_form.object, :condition), prompt: true %>
-                    </div>
+                  <div class="select_control select_compact">
+                    <%= filtering_rule_form.select :condition, options_for_enum(filtering_rule_form.object, :condition), prompt: true %>
                   </div>
                 </td>
                 <td>
-                  <div class="p_0_5">
-                    <%= filtering_rule_form.text_field :value, class: "slim" %>
+                  <div class="select_control select_compact">
+                    <%= filtering_rule_form.text_field :value, placeholder: t('.placeholders.filter_text') %>
                   </div>
                 </td>
                 <td>
-                  <div class="p_0_5">
-                    <div class="select_control select_compact">
-                      <%= filtering_rule_form.select :action, options_for_enum(filtering_rule_form.object, :action), prompt: true %>
-                    </div>
+                  <div class="select_control select_compact">
+                    <%= filtering_rule_form.select :action, options_for_enum(filtering_rule_form.object, :action), prompt: true %>
                   </div>
                 </td>
-                <td>
-                  <div class="p_0_5">
-                    <%= filtering_rule_form.check_box :remove_filtering_text %>
-                    <%= filtering_rule_form.label :remove_filtering_text do %>
-                      <span></span>
-                      <%= filtering_rule_form.object.class.human_attribute_name(:remove_filtering_text) %>
-                    <% end %>
-                  </div>
+                <td width="25%">
+                  <%= filtering_rule_form.check_box :remove_filtering_text %>
+                  <%= filtering_rule_form.label :remove_filtering_text do %>
+                    <span></span>
+                    <%= filtering_rule_form.object.class.human_attribute_name(:remove_filtering_text) %>
+                  <% end %>
                 </td>
                 <td>
-                  <div class="p_0_5">
-                    <%= filtering_rule_form.check_box :_destroy, class: "hidden destroy-content-block-record" %>
-
-                    <%= link_to "#", data: { behavior: "delete_record" } do %>
-                      <i class="fa fa-trash"></i>
-                    <% end %>
-                  </div>
+                  <%= filtering_rule_form.check_box :_destroy, class: "hidden destroy-content-block-record" %>
+                  <%= link_to "#", data: { behavior: "delete_record" } do %>
+                    <i class="fa fa-trash"></i>
+                  <% end %>
                 </td>
               </tr>
             </tbody>
           <% end %>
 
           <tr>
-            <td colspan="5">
-              <div class="p_1">
-                <%= link_to "#", data: { behavior: "add_child" } do %>
-                  <%== %Q{<i class="fa fa-plus-circle"></i> #{t('.add_rule')}} %>
-                <% end %>
-              </div>
+            <td colspan="7" class="p_1">
+              <%= link_to "#", data: { behavior: "add_child" } do %>
+                <%== %Q{<i class="fa fa-plus-circle"></i> #{t('.add_rule')}} %>
+              <% end %>
             </td>
           </tr>
         </table>

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -76,6 +76,12 @@
                 </td>
                 <td>
                   <div class="p_0_5">
+                    <%= filtering_rule_form.label :remove_filtering_text %>
+                    <%= filtering_rule_form.check_box :remove_filtering_text %>
+                  </div>
+                </td>
+                <td>
+                  <div class="p_0_5">
                     <%= filtering_rule_form.check_box :_destroy, class: "hidden destroy-content-block-record" %>
 
                     <%= link_to "#", data: { behavior: "delete_record" } do %>

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -9,6 +9,7 @@ ca:
           confirm_sync: Estàs segur?
           filter_events: Filtrat d'esdeveniments
           filter_events_desc: Quan s'importa un esdeveniment...
+          filter_events_label: Si el
           google_calendar: Google Calendar
           ibm_notes: IBM Notes
           labels:
@@ -24,6 +25,7 @@ ca:
             ibm_notes_url: ex. https://example.com/mail/abc.nsf/api/calendar/events
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. perico85
+            filter_text: Text pel qual filtrar
           remove_configuration: Eliminar configuració
           sync: Sincronitzar ara
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -22,10 +22,10 @@ ca:
           last_sync: Darrera sincronització
           microsoft_exchange: Microsoft Exchange
           placeholders:
+            filter_text: Text pel qual filtrar
             ibm_notes_url: ex. https://example.com/mail/abc.nsf/api/calendar/events
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. perico85
-            filter_text: Text pel qual filtrar
           remove_configuration: Eliminar configuració
           sync: Sincronitzar ara
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -9,6 +9,7 @@ en:
           confirm_sync: Are you sure?
           filter_events: Filter events
           filter_events_desc: When an event is imported...
+          filter_events_label: If the
           google_calendar: Google Calendar
           ibm_notes: IBM Notes
           labels:
@@ -24,6 +25,7 @@ en:
             ibm_notes_url: ex. https://example.com/mail/abc.nsf/api/calendar/events
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. someone85
+            filter_text: Text to be filtered
           remove_configuration: Remove calendar configuration
           sync: Sync now
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -22,10 +22,10 @@ en:
           last_sync: Last sync
           microsoft_exchange: Microsoft Exchange
           placeholders:
+            filter_text: Text to be filtered
             ibm_notes_url: ex. https://example.com/mail/abc.nsf/api/calendar/events
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. someone85
-            filter_text: Text to be filtered
           remove_configuration: Remove calendar configuration
           sync: Sync now
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -9,6 +9,7 @@ es:
           confirm_sync: "¿Estás seguro?"
           filter_events: Filtrado de eventos
           filter_events_desc: Cuando se importa un evento...
+          filter_events_label: Si el
           google_calendar: Google Calendar
           ibm_notes: IBM Notes
           labels:
@@ -24,6 +25,7 @@ es:
             ibm_notes_url: ej. https://ejemplo.com/mail/abc.nsf/api/calendar/events
             microsoft_exchange_url: ej. https://ejemplo.com/ews/exchange.asmx
             username: ej. perico85
+            filter_text: Texto por el que filtrar
           remove_configuration: Eliminar configuración de calendario
           sync: Sincronizar ahora
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -22,10 +22,10 @@ es:
           last_sync: Última sincronización
           microsoft_exchange: Microsoft Exchange
           placeholders:
+            filter_text: Texto por el que filtrar
             ibm_notes_url: ej. https://ejemplo.com/mail/abc.nsf/api/calendar/events
             microsoft_exchange_url: ej. https://ejemplo.com/ews/exchange.asmx
             username: ej. perico85
-            filter_text: Texto por el que filtrar
           remove_configuration: Eliminar configuración de calendario
           sync: Sincronizar ahora
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_calendars/models/ca.yml
+++ b/config/locales/gobierto_calendars/models/ca.yml
@@ -9,6 +9,7 @@ ca:
       gobierto_calendars/event_location:
         address: Adreça
         name: Nom
+      remove_filtering_text: Eliminar text filtrat
     enums:
       gobierto_calendars/filtering_rule:
         action:

--- a/config/locales/gobierto_calendars/models/ca.yml
+++ b/config/locales/gobierto_calendars/models/ca.yml
@@ -9,7 +9,8 @@ ca:
       gobierto_calendars/event_location:
         address: Adreça
         name: Nom
-      remove_filtering_text: Eliminar text filtrat
+      gobierto_calendars/filtering_rule:
+        remove_filtering_text: Eliminar text filtrat
     enums:
       gobierto_calendars/filtering_rule:
         action:

--- a/config/locales/gobierto_calendars/models/en.yml
+++ b/config/locales/gobierto_calendars/models/en.yml
@@ -9,7 +9,8 @@ en:
       gobierto_calendars/event_location:
         address: Address
         name: Name
-      remove_filtering_text: Remove filtering text
+      gobierto_calendars/filtering_rule:
+        remove_filtering_text: Remove filtering text
     enums:
       gobierto_calendars/filtering_rule:
         action:

--- a/config/locales/gobierto_calendars/models/en.yml
+++ b/config/locales/gobierto_calendars/models/en.yml
@@ -9,6 +9,7 @@ en:
       gobierto_calendars/event_location:
         address: Address
         name: Name
+      remove_filtering_text: Remove filtering text
     enums:
       gobierto_calendars/filtering_rule:
         action:

--- a/config/locales/gobierto_calendars/models/es.yml
+++ b/config/locales/gobierto_calendars/models/es.yml
@@ -9,6 +9,7 @@ es:
       gobierto_calendars/event_location:
         address: Dirección
         name: Nombre
+      remove_filtering_text: Eliminar texto filtrado
     enums:
       gobierto_calendars/filtering_rule:
         action:

--- a/config/locales/gobierto_calendars/models/es.yml
+++ b/config/locales/gobierto_calendars/models/es.yml
@@ -9,7 +9,8 @@ es:
       gobierto_calendars/event_location:
         address: Dirección
         name: Nombre
-      remove_filtering_text: Eliminar texto filtrado
+      gobierto_calendars/filtering_rule:
+        remove_filtering_text: Eliminar texto filtrado
     enums:
       gobierto_calendars/filtering_rule:
         action:

--- a/db/migrate/20180118103147_add_filter_text_option_to_filtering_rules.rb
+++ b/db/migrate/20180118103147_add_filter_text_option_to_filtering_rules.rb
@@ -1,0 +1,5 @@
+class AddFilterTextOptionToFilteringRules < ActiveRecord::Migration[5.1]
+  def change
+    add_column :gc_filtering_rules, :remove_filtering_text, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180115112209) do
+ActiveRecord::Schema.define(version: 20180118103147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -338,6 +338,7 @@ ActiveRecord::Schema.define(version: 20180115112209) do
     t.integer "action", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "remove_filtering_text", default: false
     t.index ["calendar_configuration_id"], name: "index_gc_filtering_rules_on_calendar_configuration_id"
   end
 

--- a/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_filtering_rules_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_filtering_rules_test.rb
@@ -49,6 +49,7 @@ module GobiertoAdmin
               select "Contains", from: "calendar_configuration_filtering_rules_attributes_0_condition"
               fill_in "calendar_configuration_filtering_rules_attributes_0_value", with: "@"
               select "Ignore", from: "calendar_configuration_filtering_rules_attributes_0_action"
+              check "calendar_configuration_filtering_rules_attributes_0_remove_filtering_text"
 
               click_link "Create rule"
 
@@ -58,6 +59,7 @@ module GobiertoAdmin
               select "Contains", from: "calendar_configuration_filtering_rules_attributes_#{new_node_id}_condition"
               fill_in "calendar_configuration_filtering_rules_attributes_#{new_node_id}_value", with: "[draft]"
               select "Ignore", from: "calendar_configuration_filtering_rules_attributes_#{new_node_id}_action"
+              check "calendar_configuration_filtering_rules_attributes_#{new_node_id}_remove_filtering_text"
 
               click_button "Update"
 

--- a/test/models/gobierto_calendars/filtering_rule_test.rb
+++ b/test/models/gobierto_calendars/filtering_rule_test.rb
@@ -46,5 +46,10 @@ module GobiertoCalendars
       assert_equal false, filtering_rule.apply({title: "@ Foo Bar"})
       assert_equal "ignore", filtering_rule.apply({title: "Foo @ Bar"})
     end
+
+    def test_update_event_attributes
+      updated_event_attributes = filtering_rule.update_event_attributes({title: "Foo @ Bar"})
+      assert_equal "Foo Bar", updated_event_attributes[:title]
+    end
   end
 end

--- a/test/services/gobierto_calendars/filtering_rule_applier_test.rb
+++ b/test/services/gobierto_calendars/filtering_rule_applier_test.rb
@@ -5,22 +5,25 @@ require "test_helper"
 module GobiertoCalendars
   class FilteringRuleApplierTest < ActiveSupport::TestCase
     def test_filter_two_rules
-      rule1 = GobiertoCalendars::FilteringRule.new field: :title, action: :ignore, value: "@", condition: :contains
-      rule2 = GobiertoCalendars::FilteringRule.new field: :title, action: :import_as_draft, value: "@", condition: :contains
+      rule1 = GobiertoCalendars::FilteringRule.new field: :title, action: :ignore, value: "@", condition: :contains, remove_filtering_text: true
+      rule2 = GobiertoCalendars::FilteringRule.new field: :title, action: :import_as_draft, value: "@", condition: :contains, remove_filtering_text: false
 
-      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule1, rule2])
-      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule1])
-      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule2])
-      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [])
-      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo Bar"}, [rule1, rule2])
-      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: nil}, [rule1, rule2])
+      result = GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule1, rule2])
+      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, result.action
+      assert_equal "Foo Bar", result.event_attributes[:title]
+      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule1, rule2]).action
+      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule1]).action
+      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, [rule2]).action
+      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo @ Bar"}, []).action
+      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo Bar"}, [rule1, rule2]).action
+      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: nil}, [rule1, rule2]).action
     end
 
     def test_filter_single_rule
       rule1 = GobiertoCalendars::FilteringRule.new field: :title, action: :ignore, value: "[Wadus]", condition: :not_contains
 
-      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: "[Wadus]"}, [rule1])
-      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo"}, [rule1])
+      assert_equal GobiertoCalendars::FilteringRuleApplier::CREATE, GobiertoCalendars::FilteringRuleApplier.filter({title: "[Wadus]"}, [rule1]).action
+      assert_equal GobiertoCalendars::FilteringRuleApplier::REMOVE, GobiertoCalendars::FilteringRuleApplier.filter({title: "Foo"}, [rule1]).action
     end
   end
 end

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -222,6 +222,7 @@ module GobiertoPeople
         filtering_rule.condition = :not_contains
         filtering_rule.action = :ignore
         filtering_rule.value = "@"
+        filtering_rule.remove_filtering_text = true
         filtering_rule.save!
 
         assert_difference "GobiertoCalendars::Event.count", 1 do
@@ -230,7 +231,7 @@ module GobiertoPeople
 
         # Event 2 checks
         event = richard.events.find_by external_id: "event2"
-        assert_equal "@ Event 2", event.title
+        assert_equal "Event 2", event.title
         assert_equal richard, event.collection.container
         assert_empty event.locations
         assert_equal 2, event.attendees.size

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -359,6 +359,7 @@ module GobiertoPeople
         filtering_rule.condition = :not_contains
         filtering_rule.value = "@"
         filtering_rule.action = :ignore
+        filtering_rule.remove_filtering_text = true
         filtering_rule.save!
 
         VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
@@ -371,7 +372,7 @@ module GobiertoPeople
         assert_equal 1, non_recurrent_events.count
         assert_equal 8, recurrent_events_instances.count
 
-        assert_equal "@ rom evento", non_recurrent_events.first.title
+        assert_equal "rom evento", non_recurrent_events.first.title
         assert_equal "CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated", non_recurrent_events.first.external_id
         assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
       end

--- a/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
+++ b/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
@@ -213,6 +213,7 @@ module GobiertoPeople
         filtering_rule.condition = :not_contains
         filtering_rule.action = :ignore
         filtering_rule.value = "@"
+        filtering_rule.remove_filtering_text = true
         filtering_rule.save!
 
         event_1 = {
@@ -241,7 +242,7 @@ module GobiertoPeople
 
         # event 1 checks
         event = richard.events.find_by(external_id: 'external-id-1')
-        assert_equal '@ Event 1', event.title
+        assert_equal 'Event 1', event.title
         assert_equal 1, event.locations.size
         assert_equal 'Location 1', event.first_location.name
       end


### PR DESCRIPTION
Closes #1339

### What does this PR do?

This PR adds a new option to filtering rules to remove the text used to filter in the processed event.

It's not finished since I need some help with the CSS @furilo @Crashillo:

![screen shot 2018-01-18 at 15 06 06](https://user-images.githubusercontent.com/17616/35101814-296647dc-fc61-11e7-9474-ec75ccb84bf4.png)

### How should this be manually tested?

1. Create a rule
2. Activate the new option
3. Check the text is removed from the title or the description
