### PR TITLE
Remove database cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,6 @@ group :test do
   gem "capybara"
   gem "capybara-email"
   gem "codecov", "~> 0.1.9", require: false
-  gem "database_cleaner"
   gem "launchy"
   gem "minitest-rails"
   gem "minitest-rails-capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,6 @@ GEM
     dalli (2.7.6)
     data_migrate (3.3.0)
       rails (>= 4.0)
-    database_cleaner (1.6.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
     docile (1.1.5)
@@ -503,7 +502,6 @@ DEPENDENCIES
   d3-rails (~> 4.8)
   dalli
   data_migrate
-  database_cleaner
   elasticsearch
   elasticsearch-extensions
   exchanger

--- a/test/integration/gobierto_admin/gobierto_common/content_block_records/content_block_record_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_block_records/content_block_record_create_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module ContentBlockRecords
+      class ContentBlockRecordCreateTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = edit_admin_people_person_path(gobierto_people_people(:richard))
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def accomplishments_content_block
+          "div[data-title='Accomplishments']"
+        end
+
+        def test_content_block_record_create
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                # Create new record with attachment
+
+                within accomplishments_content_block do
+                  find("a[data-behavior=add_child]").click
+
+                  within ".dynamic-content-record-form" do
+                    fill_in "Title", with: "Accomplishment 1 Title"
+                    attach_file find("input[type='file']")[:id], "test/fixtures/files/gobierto_common/document-1.pdf"
+                  end
+                end
+
+                FileUploader::S3.any_instance.stubs(:call).returns("http://www.madrid.es/assets/documents/document-1.pdf")
+
+                click_button "Update"
+
+                # Assert it's created, and attachment is present
+
+                within accomplishments_content_block do
+                  assert_text "Accomplishment 1 Title"
+                  assert_text "document-1.pdf"
+                end
+
+                # Create new record without attachment
+
+                within accomplishments_content_block do
+                  find("a[data-behavior=add_child]").click
+
+                  within ".dynamic-content-record-form" do
+                    fill_in "Title", with: "Accomplishment 2 Title"
+                  end
+                end
+
+                click_button "Update"
+
+                # Assert it's created without attachment
+
+                within accomplishments_content_block do
+                  assert has_text? "Accomplishment 1 Title"
+                  assert has_text? "Accomplishment 2 Title"
+                  assert has_content?("document-1.pdf", count: 1)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/content_block_records/content_block_record_delete_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_block_records/content_block_record_delete_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module ContentBlockRecords
+      class ContentBlockRecordTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = edit_admin_people_person_path(gobierto_people_people(:richard))
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def accomplishments_content_block
+          "div[data-title='Accomplishments']"
+        end
+
+        def test_content_block_record_delete
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                # Delete second record
+
+                within accomplishments_content_block do
+                  delete_links = all("a[data-behavior=delete_record]", visible: false)
+                  delete_links[1].trigger(:click)
+                end
+
+                click_button "Update"
+
+                within accomplishments_content_block do
+                  assert has_content? "Nobel Prize in Chemistry"
+                  assert has_content? "nobel_prize.pdf"
+
+                  refute has_content? "Ran New York marathon"
+                  refute has_content? "marathon_certificate.pdf"
+
+                  assert has_content? "Ate 33 meatballs in 45 minutes"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/content_block_records/content_block_record_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/content_block_records/content_block_record_update_test.rb
@@ -23,59 +23,7 @@ module GobiertoAdmin
           "div[data-title='Accomplishments']"
         end
 
-        def test_content_block_record_create
-          with_javascript do
-            with_signed_in_admin(admin) do
-              with_current_site(site) do
-                visit @path
-
-                # Create new record with attachment
-
-                within accomplishments_content_block do
-                  find("a[data-behavior=add_child]").click
-
-                  within ".dynamic-content-record-form" do
-                    fill_in "Title", with: "Accomplishment 1 Title"
-                    attach_file find("input[type='file']")[:id], "test/fixtures/files/gobierto_common/document-1.pdf"
-                  end
-                end
-
-                FileUploader::S3.any_instance.stubs(:call).returns("http://www.madrid.es/assets/documents/document-1.pdf")
-
-                click_button "Update"
-
-                # Assert it's created, and attachment is present
-
-                within accomplishments_content_block do
-                  assert_text "Accomplishment 1 Title"
-                  assert_text "document-1.pdf"
-                end
-
-                # Create new record without attachment
-
-                within accomplishments_content_block do
-                  find("a[data-behavior=add_child]").click
-
-                  within ".dynamic-content-record-form" do
-                    fill_in "Title", with: "Accomplishment 2 Title"
-                  end
-                end
-
-                click_button "Update"
-
-                # Assert it's created without attachment
-
-                within accomplishments_content_block do
-                  assert has_text? "Accomplishment 1 Title"
-                  assert has_text? "Accomplishment 2 Title"
-                  assert has_content?("document-1.pdf", count: 1)
-                end
-              end
-            end
-          end
-        end
-
-        def test_content_block_record_update
+        def test_content_block_record_update_records
           with_javascript do
             with_signed_in_admin(admin) do
               with_current_site(site) do
@@ -103,11 +51,6 @@ module GobiertoAdmin
                     attach_file find("input[type='file']")[:id], "test/fixtures/files/gobierto_common/document-2.pdf"
                     find("a[data-behavior=add_record]").click
                   end
-
-                  # Remove attachment for third record
-                  edit_links[2].trigger(:click)
-                  # WARNING: it's third record inside accomplishments, but fifth record in total
-                  find("#person_content_block_records_attributes_8_remove_attachment", visible: false).trigger(:click)
                 end
 
                 FileUploader::S3.any_instance.stubs(:call).returns("http://www.madrid.es/assets/documents/document-1.pdf", "http://www.madrid.es/assets/documents/document-2.pdf")
@@ -117,43 +60,39 @@ module GobiertoAdmin
                 within accomplishments_content_block do
                   assert has_content? "Accomplishment 1 Edited Title"
                   assert has_content? "document-1.pdf"
-                  refute has_content? "nobel_prize.pdf"
 
                   assert has_content? "Accomplishment 2 Edited Title"
                   assert has_content? "document-2.pdf"
-                  refute has_content? "marathon_certificate.pdf"
-
-                  assert has_content? "Ate 33 meatballs in 45 minutes"
-                  refute has_content? "meatballs_photo.png"
                 end
               end
             end
           end
         end
 
-        def test_content_block_record_delete
+        def test_content_block_record_remove_attachments
           with_javascript do
             with_signed_in_admin(admin) do
               with_current_site(site) do
                 visit @path
 
-                # Delete second record
-
                 within accomplishments_content_block do
-                  delete_links = all("a[data-behavior=delete_record]", visible: false)
-                  delete_links[1].trigger(:click)
+                  edit_links = all("a[data-behavior=edit_record]", visible: false)
+                  content_block_records = all(".dynamic-content-record-wrapper")
+
+
+                  row = all("td.content-block-record-value", text: "Ate 33 meatballs in 45 minutes").first
+                  parent = row.find(:xpath, '..')
+                  parent.find("a[data-behavior=edit_record]", visible: false).trigger(:click)
+                  table = parent.find(:xpath, '..')
+                  sibling = table.all("tr").last
+                  remove_atachment = sibling.first("input[data-behavior=remove_attachment]", visible: false).trigger(:click)
                 end
 
                 click_button "Update"
 
                 within accomplishments_content_block do
-                  assert has_content? "Nobel Prize in Chemistry"
-                  assert has_content? "nobel_prize.pdf"
-
-                  refute has_content? "Ran New York marathon"
-                  refute has_content? "marathon_certificate.pdf"
-
                   assert has_content? "Ate 33 meatballs in 45 minutes"
+                  refute has_content? "meatballs_photo.png"
                 end
               end
             end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,6 @@ require "rails/test_help"
 require "minitest/rails"
 require "minitest/mock"
 require "minitest/reporters"
-require "database_cleaner"
 require "spy/integration"
 require "webmock/minitest"
 require "support/common_helpers"
@@ -123,19 +122,14 @@ class ActionDispatch::IntegrationTest
   Capybara.javascript_driver = :poltergeist_custom
   Capybara.default_host = "http://gobierto.test"
 
-  self.use_transactional_tests = false
-
-  DatabaseCleaner.strategy = :transaction
-  DatabaseCleaner.clean_with :truncation
+  self.use_transactional_tests = true
 
   def setup
     $redis.flushdb
-    DatabaseCleaner.start
     Capybara.current_driver = Capybara.default_driver
   end
 
   def teardown
-    DatabaseCleaner.clean
     Capybara.reset_session!
   end
 


### PR DESCRIPTION
### What does this PR do?

This PR removes Database cleaner gem, and activates transactional fixtures, reducing the time from 20min to 10 min.


### How should this be manually tested?

Is the build green?
