### PR TITLE
Use same sync_range for all kinds of events and for all different integrations

### DIFF
--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -14,14 +14,13 @@ module GobiertoPeople
       :state,
       :notify,
       :locations,
-      :attendees,
-      :recurring
+      :attendees
     )
 
     delegate :persisted?, to: :person_event
 
     validates :external_id, :title, :starts_at, :ends_at, :site, :collection, presence: true
-    validate :recurring_event_in_window
+    validate :event_in_sync_range_window
 
     trackable_on :person_event
 
@@ -39,10 +38,6 @@ module GobiertoPeople
 
     def site
       @site ||= Site.find_by(id: site_id)
-    end
-
-    def recurring?
-      @recurring ||= false
     end
 
     def person_event
@@ -147,10 +142,8 @@ module GobiertoPeople
       ::GobiertoPeople::Person
     end
 
-    def recurring_event_in_window
-      if recurring?
-        errors.add(:starts_at) if starts_at > 3.months.from_now || starts_at < 1.year.ago
-      end
+    def event_in_sync_range_window
+      errors.add(:starts_at) unless GobiertoCalendars.sync_range.cover?(starts_at)
     end
 
     def save_person_event

--- a/app/models/gobierto_calendars.rb
+++ b/app/models/gobierto_calendars.rb
@@ -8,4 +8,16 @@ module GobiertoCalendars
     [ GobiertoCalendars::Event ]
   end
 
+  def self.sync_range_start
+    DateTime.now - 2.days
+  end
+
+  def self.sync_range_end
+    DateTime.now + 1.year
+  end
+
+  def self.sync_range
+    sync_range_start..sync_range_end
+  end
+
 end

--- a/app/models/gobierto_calendars.rb
+++ b/app/models/gobierto_calendars.rb
@@ -9,7 +9,7 @@ module GobiertoCalendars
   end
 
   def self.sync_range_start
-    DateTime.now - 2.days
+    DateTime.now - 5.days
   end
 
   def self.sync_range_end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -49,7 +49,7 @@ module GobiertoPeople
       end
 
       def sync_calendar_events(calendar)
-        response = service.list_events(calendar.id, always_include_email: true, time_min: 2.days.ago.iso8601)
+        response = service.list_events(calendar.id, always_include_email: true, time_min: GobiertoCalendars.sync_range_start.iso8601)
         response.items.each do |event|
           next if is_private?(event)
 
@@ -105,8 +105,7 @@ module GobiertoPeople
           ends_at: parse_date(event.end),
           state: state,
           attendees: event_attendees(event),
-          notify: i.nil? || i == 0,
-          recurring: i.present?
+          notify: i.nil? || i == 0
         }
 
         if event.location.present?

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -6,11 +6,6 @@ module GobiertoPeople
 
       attr_reader :person, :site, :configuration
 
-      SYNC_RANGE = {
-        start_date: DateTime.now - 2.days,
-        end_date:   DateTime.now + 1.year
-      }
-
       TARGET_CALENDAR_NAME = 'gobierto'
 
       def self.sync_person_events(person)
@@ -59,7 +54,7 @@ module GobiertoPeople
 
         log_missing_folder_error(TARGET_CALENDAR_NAME) and return if target_folder.nil?
 
-        target_folder.expanded_items(SYNC_RANGE)
+        target_folder.expanded_items(start_date: GobiertoCalendars.sync_range_start, end_date: GobiertoCalendars.sync_range_end)
       end
 
       def sync_event(item)
@@ -105,7 +100,7 @@ module GobiertoPeople
         if calendar_items && calendar_items.any?
           received_external_ids = calendar_items.map(&:id)
           person.events
-                .where(starts_at: SYNC_RANGE[:start_date]..SYNC_RANGE[:end_date])
+                .where(starts_at: GobiertoCalendars.sync_range)
                 .where.not(external_id: nil)
                 .where.not(external_id: received_external_ids)
                 .update_all(state: GobiertoCalendars::Event.states[:pending])

--- a/test/forms/gobierto_people/person_event_form_test.rb
+++ b/test/forms/gobierto_people/person_event_form_test.rb
@@ -4,8 +4,21 @@ require "test_helper"
 
 module GobiertoPeople
   class PersonEventFormTest < ActiveSupport::TestCase
-    def valid_event_form
-      @valid_event_form ||= PersonEventForm.new(
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def event
+      @event ||= gobierto_calendars_events(:richard_published)
+    end
+
+    def person
+      @person ||= gobierto_people_people(:richard)
+    end
+
+    def event_attributes
+      @event_attributes ||= {
         external_id: "123",
         site_id: site.id,
         person_id: person.id,
@@ -16,23 +29,11 @@ module GobiertoPeople
         state: event.state,
         locations: [],
         attendees: []
-      )
+      }
     end
 
-    def invalid_recurring_event_form
-      @valid_event_form ||= PersonEventForm.new(
-        external_id: "123",
-        site_id: site.id,
-        person_id: person.id,
-        title: event.title,
-        description: event.description,
-        starts_at: 4.months.from_now,
-        ends_at: 4.months.from_now,
-        state: event.state,
-        locations: [],
-        attendees: [],
-        recurring: true
-      )
+    def valid_event_form
+      @valid_event_form ||= PersonEventForm.new(event_attributes)
     end
 
     def invalid_event_form
@@ -50,18 +51,6 @@ module GobiertoPeople
       )
     end
 
-    def site
-      @site ||= sites(:madrid)
-    end
-
-    def event
-      @event ||= gobierto_calendars_events(:richard_published)
-    end
-
-    def person
-      @person ||= gobierto_people_people(:richard)
-    end
-
     def test_save_with_valid_attributes
       assert valid_event_form.save
     end
@@ -76,10 +65,15 @@ module GobiertoPeople
       assert_equal 1, invalid_event_form.errors.messages[:ends_at].size
     end
 
-    def test_error_messages_with_invalid_recurring_event
-      invalid_recurring_event_form.save
+    def test_save_event_out_of_sync_range
+      very_future_date = ::GobiertoCalendars.sync_range_end + 1.day
+      very_old_date    = ::GobiertoCalendars.sync_range_start - 1.day
 
-      assert_equal 1, invalid_recurring_event_form.errors.messages[:starts_at].size
+      very_future_event = PersonEventForm.new(event_attributes.merge(starts_at: very_future_date))
+      very_old_event    = PersonEventForm.new(event_attributes.merge(starts_at: very_old_date))
+
+      refute very_future_event.save
+      refute very_old_event.save
     end
 
     def test_destroy

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -32,8 +32,6 @@ module GobiertoPeople
         date1.stubs(date_time: Time.now)
         date2 = mock
         date2.stubs(date_time: 1.hour.from_now)
-        invalid_date = mock
-        invalid_date.stubs(date_time: Time.now + 4.months)
 
         # Private event, ignored
         event1 = mock
@@ -87,10 +85,6 @@ module GobiertoPeople
         event6.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_2",
                      summary: "Event 6", start: date1, end: date2, attendees: [attendee1, attendee2], description: "")
 
-        # Instance 3 of recurring event event4
-        event8 = mock
-        event8.stubs(visibility: nil, location: nil, creator: creator_event3, recurrence: nil, id: "event4_instance_3",
-                     summary: "Event 8", start: invalid_date, end: invalid_date, attendees: [], description: "")
 
         calendar1 = mock
         calendar1.stubs(id: google_calendar_id, primary?: true)
@@ -111,7 +105,7 @@ module GobiertoPeople
         calendar_3_items_response.stubs(:items).returns([event7])
 
         event_4_instances_response = mock
-        event_4_instances_response.stubs(:items).returns([event5, event6, event8])
+        event_4_instances_response.stubs(:items).returns([event5, event6])
 
         calendar_items_response = mock
         calendar_items_response.stubs(:items).returns([calendar1, calendar2, calendar3])

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -8,6 +8,10 @@ module GobiertoPeople
     class CalendarIntegrationTest < ActiveSupport::TestCase
       include ::CalendarIntegrationHelpers
 
+      def freeze_date
+        Time.zone.parse("2016-12-05 01:00:00")
+      end
+
       def filtering_rule
         @filtering_rule ||= gobierto_calendars_filtering_rules(:richard_calendar_configuration_filter)
       end
@@ -118,102 +122,110 @@ module GobiertoPeople
       end
 
       def test_sync_events_v9
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
+        Timecop.freeze(freeze_date) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
+          recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$")
+
+          assert_equal 2, non_recurrent_events.count
+          assert_equal 1, recurrent_events_instances.count
+
+          assert_equal "Buscar alcaldessa al seu despatx i Sortida cap a l'acte Gran Via Corts Catalanes, 400", non_recurrent_events.first.title
+          assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_events.first.starts_at.utc
+
+          assert_equal "Lliurament Premis Rac", non_recurrent_events.second.title
+          assert_equal rst_to_utc("2017-05-04 19:30:00"), non_recurrent_events.second.starts_at.utc
+
+          assert_equal "CAEM", recurrent_events_instances.first.title
+          assert_equal rst_to_utc("2017-05-05 09:00:00"), recurrent_events_instances.first.starts_at
         end
-
-        non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
-        recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$")
-
-        assert_equal 2, non_recurrent_events.count
-        assert_equal 1, recurrent_events_instances.count
-
-        assert_equal "Buscar alcaldessa al seu despatx i Sortida cap a l'acte Gran Via Corts Catalanes, 400", non_recurrent_events.first.title
-        assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_events.first.starts_at.utc
-
-        assert_equal "Lliurament Premis Rac", non_recurrent_events.second.title
-        assert_equal rst_to_utc("2017-05-04 19:30:00"), non_recurrent_events.second.starts_at.utc
-
-        assert_equal "CAEM", recurrent_events_instances.first.title
-        assert_equal rst_to_utc("2017-05-05 09:00:00"), recurrent_events_instances.first.starts_at
       end
 
       def test_sync_events_updates_event_attributes
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
+        Timecop.freeze(freeze_date) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          # Change arbitrary data, and check it gets  updated accordingly after the
+          # next synchronization
+
+          non_recurrent_event = richard.events.find_by(external_id: "BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated")
+          non_recurrent_event.title = "Old non recurrent event title"
+          non_recurrent_event.starts_at = utc_time("2017-05-05 10:00:00")
+          non_recurrent_event.save!
+
+          recurrent_event_instance = richard.events.find_by(external_id: "D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z")
+          recurrent_event_instance.title = "Old recurrent event instance title"
+          recurrent_event_instance.locations.first.update_attributes!(name: "Old location")
+          recurrent_event_instance.save!
+
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          non_recurrent_event.reload
+          recurrent_event_instance.reload
+
+          assert_equal "Buscar alcaldessa al seu despatx i Sortida cap a l'acte Gran Via Corts Catalanes, 400", non_recurrent_event.title
+          assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_event.starts_at
+
+          assert_equal "CAEM", recurrent_event_instance.title
+          assert_equal "Sala de juntes 1a. planta Ajuntament", recurrent_event_instance.locations.first.name
+          assert_equal 1, recurrent_event_instance.locations.size
         end
-
-        # Change arbitrary data, and check it gets  updated accordingly after the
-        # next synchronization
-
-        non_recurrent_event = richard.events.find_by(external_id: "BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated")
-        non_recurrent_event.title = "Old non recurrent event title"
-        non_recurrent_event.starts_at = utc_time("2017-05-05 10:00:00")
-        non_recurrent_event.save!
-
-        recurrent_event_instance = richard.events.find_by(external_id: "D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z")
-        recurrent_event_instance.title = "Old recurrent event instance title"
-        recurrent_event_instance.locations.first.update_attributes!(name: "Old location")
-        recurrent_event_instance.save!
-
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
-        end
-
-        non_recurrent_event.reload
-        recurrent_event_instance.reload
-
-        assert_equal "Buscar alcaldessa al seu despatx i Sortida cap a l'acte Gran Via Corts Catalanes, 400", non_recurrent_event.title
-        assert_equal rst_to_utc("2017-05-04 18:45:00"), non_recurrent_event.starts_at
-
-        assert_equal "CAEM", recurrent_event_instance.title
-        assert_equal "Sala de juntes 1a. planta Ajuntament", recurrent_event_instance.locations.first.name
-        assert_equal 1, recurrent_event_instance.locations.size
       end
 
       def test_sync_events_removes_deleted_event_attributes
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
+        Timecop.freeze(freeze_date) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          # Add new data to events, and check it is removed after sync
+          event = richard.events.find_by(external_id: "BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated")
+          GobiertoCalendars::EventLocation.create!(event: event, name: "I'll be deleted")
+
+          assert 1, event.locations.size
+
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          event.reload
+          assert event.locations.empty?
         end
-
-        # Add new data to events, and check it is removed after sync
-        event = richard.events.find_by(external_id: "BD5EA243F9F715AAC1258116003ED56C-Lotus_Notes_Generated")
-        GobiertoCalendars::EventLocation.create!(event: event, name: "I'll be deleted")
-
-        assert 1, event.locations.size
-
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
-        end
-
-        event.reload
-        assert event.locations.empty?
       end
 
       # Se piden eventos en el intervalo [1,3], 1 y 3 son recurrentes y son el mismo, el 2 es uno no recurrente
       # De las 9 instancias del evento recurrente, la que tiene recurrenceId=20170407T113000Z (la segunda) da 404
       def test_sync_events_v8
-        VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
+        Timecop.freeze(freeze_date) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
+          recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$").order(:external_id)
+
+          assert_equal 1, non_recurrent_events.count
+          assert_equal 8, recurrent_events_instances.count
+
+          assert_equal "@ rom evento", non_recurrent_events.first.title
+          assert_equal "CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated", non_recurrent_events.first.external_id
+          assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
+
+          assert_equal "@ Coordinació Política Igualtat + dinar", recurrent_events_instances.first.title
+          assert_equal "EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170303T110000Z", recurrent_events_instances.first.external_id
+          assert_equal rst_to_utc("2017-03-03 12:00:00"), recurrent_events_instances.first.starts_at
+
+          assert_equal "@ Coordinació Política Igualtat + dinar", recurrent_events_instances.second.title
+          assert_equal "EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170505T100000Z", recurrent_events_instances.second.external_id
+          assert_equal rst_to_utc("2017-05-05 12:00:00"), recurrent_events_instances.second.starts_at
         end
-
-        non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
-        recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$").order(:external_id)
-
-        assert_equal 1, non_recurrent_events.count
-        assert_equal 8, recurrent_events_instances.count
-
-        assert_equal "@ rom evento", non_recurrent_events.first.title
-        assert_equal "CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated", non_recurrent_events.first.external_id
-        assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
-
-        assert_equal "@ Coordinació Política Igualtat + dinar", recurrent_events_instances.first.title
-        assert_equal "EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170303T110000Z", recurrent_events_instances.first.external_id
-        assert_equal rst_to_utc("2017-03-03 12:00:00"), recurrent_events_instances.first.starts_at
-
-        assert_equal "@ Coordinació Política Igualtat + dinar", recurrent_events_instances.second.title
-        assert_equal "EE3C4CEA30187126C12580A300468AEF-Lotus_Notes_Generated/20170505T100000Z", recurrent_events_instances.second.external_id
-        assert_equal rst_to_utc("2017-05-05 12:00:00"), recurrent_events_instances.second.starts_at
       end
 
       # Only v8 will return past events instances, but use v9 cassette for simplicity
@@ -247,111 +259,118 @@ module GobiertoPeople
       end
 
       def test_sync_event_creates_new_event_with_location
-        refute GobiertoCalendars::Event.exists?(external_id: new_ibm_notes_event.id)
+        Timecop.freeze(freeze_date) do
+          refute GobiertoCalendars::Event.exists?(external_id: new_ibm_notes_event.id)
 
-        created_event_external_id = CalendarIntegration.sync_event(new_ibm_notes_event, richard)
+          created_event_external_id = CalendarIntegration.sync_event(new_ibm_notes_event, richard)
 
-        assert GobiertoCalendars::Event.exists?(external_id: new_ibm_notes_event.id)
-        assert_equal created_event_external_id, new_ibm_notes_event.id
+          assert GobiertoCalendars::Event.exists?(external_id: new_ibm_notes_event.id)
+          assert_equal created_event_external_id, new_ibm_notes_event.id
 
-        gobierto_event = GobiertoCalendars::Event.find_by(external_id: new_ibm_notes_event.id)
+          gobierto_event = GobiertoCalendars::Event.find_by(external_id: new_ibm_notes_event.id)
 
-        assert_equal new_ibm_notes_event.title, gobierto_event.title
-        assert_equal richard, gobierto_event.collection.container
+          assert_equal new_ibm_notes_event.title, gobierto_event.title
+          assert_equal richard, gobierto_event.collection.container
 
-        assert_equal "Ibm Notes new event location", gobierto_event.locations.first.name
+          assert_equal "Ibm Notes new event location", gobierto_event.locations.first.name
+        end
       end
 
       def test_sync_event_updates_existing_event
-        CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
+        Timecop.freeze(freeze_date) do
+          CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
 
-        updated_gobierto_event = GobiertoCalendars::Event.find_by(external_id: outdated_ibm_notes_event.id)
+          updated_gobierto_event = GobiertoCalendars::Event.find_by(external_id: outdated_ibm_notes_event.id)
 
-        assert updated_gobierto_event.published?
-        assert_equal "Ibm Notes outdated event title - THIS HAS CHANGED", updated_gobierto_event.title
+          assert updated_gobierto_event.published?
+          assert_equal "Ibm Notes outdated event title - THIS HAS CHANGED", updated_gobierto_event.title
+        end
       end
 
       def test_sync_event_doesnt_create_duplicated_events
-        CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
-
-        assert_no_difference "GobiertoCalendars::Event.count" do
+        Timecop.freeze(freeze_date) do
           CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
+
+          assert_no_difference "GobiertoCalendars::Event.count" do
+            CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
+          end
         end
       end
 
       def test_sync_event_creates_updates_and_removes_location_for_existing_gobierto_event
-        outdated_ibm_notes_event_gobierto_event.save!
-        ibm_notes_event_gobierto_event.save!
+        Timecop.freeze(freeze_date) do
+          outdated_ibm_notes_event_gobierto_event.save!
+          ibm_notes_event_gobierto_event.save!
 
-        ibm_notes_event = create_ibm_notes_event(location: nil)
-        gobierto_event = GobiertoCalendars::Event.find_by!(external_id: ibm_notes_event.id)
+          ibm_notes_event = create_ibm_notes_event(location: nil)
+          gobierto_event = GobiertoCalendars::Event.find_by!(external_id: ibm_notes_event.id)
 
-        CalendarIntegration.sync_event(ibm_notes_event, richard)
+          CalendarIntegration.sync_event(ibm_notes_event, richard)
 
-        gobierto_event.reload
-        assert gobierto_event.locations.empty?
+          gobierto_event.reload
+          assert gobierto_event.locations.empty?
 
-        ibm_notes_event.location = "Location name added afterwards"
+          ibm_notes_event.location = "Location name added afterwards"
 
-        CalendarIntegration.sync_event(ibm_notes_event, richard)
-        gobierto_event.reload
+          CalendarIntegration.sync_event(ibm_notes_event, richard)
+          gobierto_event.reload
 
-        assert_equal "Location name added afterwards", gobierto_event.locations.first.name
+          assert_equal "Location name added afterwards", gobierto_event.locations.first.name
 
-        ibm_notes_event.location = "Location name updated afterwards"
+          ibm_notes_event.location = "Location name updated afterwards"
 
-        CalendarIntegration.sync_event(ibm_notes_event, richard)
-        gobierto_event.reload
+          CalendarIntegration.sync_event(ibm_notes_event, richard)
+          gobierto_event.reload
 
-        assert_equal "Location name updated afterwards", gobierto_event.locations.first.name
+          assert_equal "Location name updated afterwards", gobierto_event.locations.first.name
 
-        ibm_notes_event.location = nil
+          ibm_notes_event.location = nil
 
-        CalendarIntegration.sync_event(ibm_notes_event, richard)
-        gobierto_event.reload
+          CalendarIntegration.sync_event(ibm_notes_event, richard)
+          gobierto_event.reload
 
-        assert gobierto_event.locations.empty?
+          assert gobierto_event.locations.empty?
+        end
       end
 
       def test_sync_attendees
-        # Cassette contains one confirmed attendee and two requested participants.
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
+        Timecop.freeze(freeze_date) do
+          # Cassette contains one confirmed attendee and two requested participants.
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          event = richard.events.find_by(external_id: "D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z")
+          attendees = event.attendees
+
+          assert_equal 4, attendees.size
+
+          assert_equal "Josep M. Farreras", attendees.first.name
+          assert_equal "Horatio Nelson", attendees.second.person.name
+          assert_equal nelson, attendees.second.person
+          assert_equal richard, attendees.fourth.person
+
+          # Check if Nelson accepts afterwards, Josep is not duplicated on second sync
+
+          event.attendees.second.delete
+
+          VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          assert_equal 4, attendees.reload.size
         end
-
-        event = richard.events.find_by(external_id: "D2E5B40E6AAEAED4C125808E0035A6A0-Lotus_Notes_Generated/20170503T073000Z")
-        attendees = event.attendees
-
-        assert_equal 4, attendees.size
-
-        assert_equal "Josep M. Farreras", attendees.first.name
-        assert_equal "Horatio Nelson", attendees.second.person.name
-        assert_equal nelson, attendees.second.person
-        assert_equal richard, attendees.fourth.person
-
-        # Check if Nelson accepts afterwards, Josep is not duplicated on second sync
-
-        event.attendees.second.delete
-
-        VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
-        end
-
-        assert_equal 4, attendees.reload.size
       end
 
-      def test_sync_invalid_recurring_event
+      def test_sync_event_outside_range
         ibm_notes_event = create_ibm_notes_event_recurring_invalid_event(location: nil)
 
-        CalendarIntegration.sync_event(ibm_notes_event, richard, true)
+        Timecop.freeze(freeze_date) do
+          CalendarIntegration.sync_event(ibm_notes_event, richard)
 
-        gobierto_event = GobiertoCalendars::Event.find_by(external_id: ibm_notes_event.id)
-        assert gobierto_event.nil?
-
-        CalendarIntegration.sync_event(ibm_notes_event, richard, false)
-
-        gobierto_event = GobiertoCalendars::Event.find_by(external_id: ibm_notes_event.id)
-        assert gobierto_event.present?
+          gobierto_event = GobiertoCalendars::Event.find_by(external_id: ibm_notes_event.id)
+          assert gobierto_event.nil?
+        end
       end
 
       def test_filter_events
@@ -361,19 +380,21 @@ module GobiertoPeople
         filtering_rule.action = :ignore
         filtering_rule.save!
 
-        VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
-          CalendarIntegration.sync_person_events(richard)
+        Timecop.freeze(freeze_date) do
+          VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
+            CalendarIntegration.sync_person_events(richard)
+          end
+
+          non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
+          recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$").order(:external_id)
+
+          assert_equal 1, non_recurrent_events.count
+          assert_equal 8, recurrent_events_instances.count
+
+          assert_equal "@ rom evento", non_recurrent_events.first.title
+          assert_equal "CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated", non_recurrent_events.first.external_id
+          assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
         end
-
-        non_recurrent_events = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated$")
-        recurrent_events_instances = richard.events.where("external_id ~* ?", "-Lotus_Notes_Generated/\\d{8}T\\d{6}Z$").order(:external_id)
-
-        assert_equal 1, non_recurrent_events.count
-        assert_equal 8, recurrent_events_instances.count
-
-        assert_equal "@ rom evento", non_recurrent_events.first.title
-        assert_equal "CD1B539AEB0D44D7C1258110003BB81E-Lotus_Notes_Generated", non_recurrent_events.first.external_id
-        assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
       end
 
     end


### PR DESCRIPTION
### What does this PR do?

Uses same sync range for recurrent and non-recurrent events and for all different calendar integrations, since this *"uncoherent"* behavior was creating confussion for some users.

### How should this be manually tested?

Now events older than 5 days should not be imported / updated

### Does this PR changes any configuration file?

No
