### PR TITLE
Elaboration details

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/components/budgetLineBreadcrumb.js
+++ b/app/assets/javascripts/gobierto_budgets/components/budgetLineBreadcrumb.js
@@ -35,7 +35,6 @@ function limit_length(input, length) {
           }
           this.renderLevel(level + 2, currentCode);
         }.bind(this));
-
       }.bind(this));
     });
 
@@ -51,11 +50,13 @@ function limit_length(input, length) {
       this.selectedCategories.push(I18n.t('gobierto_budgets.visualizations.' + this.currentKind + '_' + this.areaName));
 
       this.states.slice(2, this.states.length - 1).forEach(function(segment){
-        if(segment.indexOf('-') === -1 || segment.length == 6) {
-          var categoryName = categories[this.states[1]][segment];
-          if(categoryName !== undefined) {
-            this.selectedCategories.push(categoryName);
-            html += '<a href="/presupuestos/partidas/'+segment+'/'+this.currentYear+'/'+this.areaName+'/' + this.states[1] + '">' + categoryName + '</a> »';
+        if(this.areaName != 'custom' || segment.length > 2) {
+          if(segment.indexOf('-') === -1 || segment.length == 6) {
+            var categoryName = categories[this.states[1]][segment];
+            if(categoryName !== undefined) {
+              this.selectedCategories.push(categoryName);
+              html += '<a href="/presupuestos/partidas/'+segment+'/'+this.currentYear+'/'+this.areaName+'/' + this.states[1] + '">' + categoryName + '</a> »';
+            }
           }
         }
       }.bind(this));
@@ -185,7 +186,6 @@ function limit_length(input, length) {
       if(level > 2){
         url += '?parent_code=' + currentCode;
       }
-
 
       var that = this;
       var $el = $('[data-level="'+level+'"] table');

--- a/app/controllers/gobierto_budgets/budgets_elaboration_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_elaboration_controller.rb
@@ -15,6 +15,9 @@ class GobiertoBudgets::BudgetsElaborationController < GobiertoBudgets::Applicati
     @interesting_expenses_previous_year = GobiertoBudgets::BudgetLine.all(where: { site: current_site, place: @place, level: 2, year: @year - 1, kind: @kind, area_name: @area_name })
     @place_budget_lines = GobiertoBudgets::BudgetLine.all(where: { site: current_site, place: @place, level: 1, year: @year, kind: @kind, area_name: @area_name })
 
+    @any_custom_income_budget_lines  = GobiertoBudgets::BudgetLine.any_data?(site: current_site, year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area: GobiertoBudgets::CustomArea)
+    @any_custom_expense_budget_lines = GobiertoBudgets::BudgetLine.any_data?(site: current_site, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::CustomArea)
+
     respond_to do |format|
       format.html
       format.js

--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -19,7 +19,7 @@
 
   <div class="pure-g metric_boxes">
 
-    <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant_tooltip') %>">
+    <div id="metric_box_1" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant_tooltip') %>">
       <!--  metric_box should be flexbox -->
       <div class="inner">
         <h3><%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant') %></h3>
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.total_expenses_tooltip') %>">
+    <div id="metric_box_2" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.total_expenses_tooltip') %>">
       <div class="inner">
         <h3><%= t('gobierto_budgets.budgets_elaboration.index.total_expenses') %></h3>
         <div class="metric"><%= format_currency @site_stats.total_budget %></div>
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.net_savings_tooltip') %>">
+    <div id="metric_box_3" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.net_savings_tooltip') %>">
       <div class="inner">
         <h3><%= t('gobierto_budgets.budgets_elaboration.index.net_savings') %></h3>
         <div class="metric"><%= format_currency @site_stats.net_savings %></div>
@@ -44,7 +44,7 @@
       </div>
     </div>
 
-    <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.debt_level_tooltip') %>">
+    <div id="metric_box_4" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.debt_level_tooltip') %>">
       <div class="inner">
         <h3><%= t('gobierto_budgets.budgets_elaboration.index.debt_level') %></h3>
         <div class="metric"><%= format_currency @site_stats.debt_level %></div>
@@ -52,7 +52,7 @@
       </div>
     </div>
 
-    <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.auto_funding_tooltip') %>">
+    <div id="metric_box_5" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.auto_funding_tooltip') %>">
       <div class="inner">
         <h3><%= t('gobierto_budgets.budgets_elaboration.index.auto_funding') %></h3>
         <div class="metric"><%= format_currency @site_stats.auto_funding %></div>

--- a/app/views/gobierto_budgets/shared/_data_updated_at.html.erb
+++ b/app/views/gobierto_budgets/shared/_data_updated_at.html.erb
@@ -1,5 +1,5 @@
 <p>
   <% if @budgets_data_updated_at %>
-    <strong><%= t('.last_update') %></strong>: <%= l(@budgets_data_updated_at, format: '%d %B %Y') %>.
+    <strong><%= t('.last_update') %></strong>: <%= l(@budgets_data_updated_at, format: '%d %B %Y').downcase %>.
   <% end %>
 </p>


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR fixes a few things in elaboration module:

- custom categories are displayed from the beginning in the budgets explorer
- custom categories breadcrumb was totally wrong
- update date is now in small letters
- metric boxes have an id to allow them to be removed
