### PR TITLE
213 improve budgets data download

### DIFF
--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -40,7 +40,7 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
                                                                           area_name: area.area_name,
                                                                           kind: kind,
                                                                           index: index },
-                                                                 include: [:index],
+                                                                 include: [:index, :updated_at],
                                                                  presenter: presenter)
             index_budget_lines.each do |line|
               if idx = place_budget_lines.index { |global_line| global_line.id == line.id }

--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -1,6 +1,6 @@
 class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationController
   before_action :load_place
-  before_action :load_year, except: [:guide, :export]
+  before_action :load_year, except: [:guide]
 
   def index
     @kind = GobiertoBudgets::BudgetLine::INCOME
@@ -21,43 +21,6 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
 
     @any_custom_income_budget_lines  = GobiertoBudgets::BudgetLine.any_data?(site: current_site, year: @year, kind: GobiertoBudgets::BudgetLine::INCOME, area: GobiertoBudgets::CustomArea)
     @any_custom_expense_budget_lines = GobiertoBudgets::BudgetLine.any_data?(site: current_site, year: @year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area: GobiertoBudgets::CustomArea)
-  end
-
-  def export
-    year = params[:year].to_i
-
-    presenter = GobiertoBudgets::BudgetLineExportPresenter
-    indexes = presenter::INDEX_KEYS
-
-    place_budget_lines = []
-    GobiertoBudgets::BudgetLine.all_kinds. each do |kind|
-      GobiertoBudgets::BudgetArea.all_areas.each do |area|
-        indexes.each do |index, attribute|
-          if area.available_kinds.include?(kind)
-            index_budget_lines = GobiertoBudgets::BudgetLine.all(where: { year: year,
-                                                                          site: current_site,
-                                                                          place: @place,
-                                                                          area_name: area.area_name,
-                                                                          kind: kind,
-                                                                          index: index },
-                                                                 include: [:index, :updated_at],
-                                                                 presenter: presenter)
-            index_budget_lines.each do |line|
-              if idx = place_budget_lines.index { |global_line| global_line.id == line.id }
-                place_budget_lines[idx].merge!(line)
-              else
-                place_budget_lines << line
-              end
-            end
-          end
-        end
-      end
-    end
-
-    respond_to do |format|
-      format.json { render json: place_budget_lines }
-      format.csv { render csv: GobiertoExports::CSVRenderer.new(place_budget_lines).to_csv, filename: "budget_lines_#{year}" }
-    end
   end
 
   def guide

--- a/app/jobs/gobierto_budgets/generate_annual_lines_job.rb
+++ b/app/jobs/gobierto_budgets/generate_annual_lines_job.rb
@@ -3,9 +3,11 @@ class GobiertoBudgets::GenerateAnnualLinesJob < ActiveJob::Base
 
   def perform(*sites)
     sites.each do |site|
-      GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
-        data = GobiertoBudgets::Data::Annual.new(site: site, year: year)
-        data.generate_files if data.any_data?
+      if site.place
+        GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
+          data = GobiertoBudgets::Data::Annual.new(site: site, year: year)
+          data.generate_files if data.any_data?
+        end
       end
     end
   end

--- a/app/jobs/gobierto_budgets/generate_annual_lines_job.rb
+++ b/app/jobs/gobierto_budgets/generate_annual_lines_job.rb
@@ -1,0 +1,12 @@
+class GobiertoBudgets::GenerateAnnualLinesJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(*sites)
+    sites.each do |site|
+      GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
+        data = GobiertoBudgets::Data::Annual.new(site: site, year: year)
+        data.generate_files if data.any_data?
+      end
+    end
+  end
+end

--- a/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
@@ -164,6 +164,10 @@ module GobiertoBudgets
         included_attrs = {}
         if includes.present?
           included_attrs[:index] = index if includes.include? :index
+          included_attrs[:updated_at] = if includes.include?(:updated_at) && conditions[:year] && conditions[:site]
+                                          GobiertoBudgets::SiteStats.new(site: conditions[:site], year: conditions[:year]).budgets_data_updated_at ||
+                                            Date.new(conditions[:year])
+                                        end
         end
 
         merge_includes = included_attrs.present? ? ->(row) { row.merge(included_attrs) } : ->(row) { row }

--- a/app/models/gobierto_budgets/data/annual.rb
+++ b/app/models/gobierto_budgets/data/annual.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module GobiertoBudgets
+  module Data
+    class Annual
+      class UnsupportedFormat < StandardError; end
+
+      FORMATS = {
+        json: { serializer: ->(data) { data.to_json } },
+        csv:  { serializer: ->(data) { GobiertoExports::CSVRenderer.new(data).to_csv } }
+      }
+
+      attr_accessor :site, :year
+
+      def initialize(options = {})
+        @year = options[:year]
+        @site = options[:site]
+      end
+
+      def any_data?
+        GobiertoBudgets::BudgetLine.any_data?(site: site, year: year)
+      end
+
+      def get_url(format)
+        file = FileUploader::S3.new(file_name: filename(format))
+        file.uploaded_file_exists? && file.call
+      end
+
+      def generate_files
+        calculate_place_budget_lines
+
+        FORMATS.each do |format_key, configuration|
+          FileUploader::S3.new(
+            file_name: filename(format_key),
+            content: configuration[:serializer].call(@place_budget_lines)
+          ).upload!
+        end
+      end
+
+      protected
+
+      def place
+        site.place
+      end
+
+      def filename(format)
+        raise UnsupportedFormat if !FORMATS.keys.include?(format.to_sym)
+        ["gobierto_budgets", place.id, "data", "annual", "#{year}.#{format}"].join("/")
+      end
+
+      def calculate_place_budget_lines
+        presenter = GobiertoBudgets::BudgetLineExportPresenter
+        indexes = presenter::INDEX_KEYS
+
+        @place_budget_lines = []
+        GobiertoBudgets::BudgetLine.all_kinds. each do |kind|
+          GobiertoBudgets::BudgetArea.all_areas.each do |area|
+            indexes.each_key do |index|
+              next unless area.available_kinds.include?(kind)
+              index_budget_lines = GobiertoBudgets::BudgetLine.all(where: { year: year,
+                                                                            site: site,
+                                                                            place: place,
+                                                                            area_name: area.area_name,
+                                                                            kind: kind,
+                                                                            index: index },
+                                                                            include: [:index, :updated_at],
+                                                                            presenter: presenter)
+              index_budget_lines.each do |line|
+                if (idx = @place_budget_lines.index { |global_line| global_line.id == line.id })
+                  @place_budget_lines[idx].merge!(line)
+                else
+                  @place_budget_lines << line
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/gobierto_budgets/budget_line_export_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_export_presenter.rb
@@ -40,8 +40,12 @@ module GobiertoBudgets
     end
 
     def updated_at
-      SiteStats.new(site: @attributes[:site], year: @attributes[:year]).budgets_data_updated_at ||
-        Date.new(@attributes[:year])
+      @updated_at ||=
+        begin
+          @attributes[:updated_at] ||
+            SiteStats.new(site: @attributes[:site], year: @attributes[:year]).budgets_data_updated_at ||
+            Date.new(@attributes[:year])
+        end
     end
 
     def index

--- a/app/views/gobierto_budgets/exports/_index.html.erb
+++ b/app/views/gobierto_budgets/exports/_index.html.erb
@@ -9,11 +9,14 @@
     <div class="data_block subblock">
       <p><%= t("gobierto_budgets.exports.description") %></p>
       <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
-        <% if GobiertoBudgets::BudgetLine.any_data?(site: current_site, year: year) %>
+        <% data = GobiertoBudgets::Data::Annual.new(site: current_site, year: year) %>
+        <% if data.any_data? %>
           <div class="data_subitem">
             <h3> <%= year %> </h3>
-            <%= link_to 'CSV', gobierto_budgets_budgets_export_path(year, format: :csv), class: 'button small', role: 'button' %>
-            <%= link_to 'JSON', gobierto_budgets_budgets_export_path(year, format: :json), class: 'button small', role: 'button' %>
+            <% GobiertoBudgets::Data::Annual::FORMATS.keys.each do |format| %>
+              <% url = data.get_url(format) %>
+              <%= link_to(format.to_s.upcase, url, target: '_blank', class: 'button small', role: 'button') if url %>
+            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,7 +266,6 @@ Rails.application.routes.draw do
       resources :featured_budget_lines, only: [:show]
 
       get "resumen(/:year)" => "budgets#index", as: :budgets
-      get "datos(/:year)" => "budgets#export", as: :budgets_export
       get "partidas/:year/:area_name/:kind" => "budget_lines#index", as: :budget_lines
       get "partidas/:id/:year/:area_name/:kind" => "budget_lines#show", as: :budget_line
       get "budget_line_descendants/:year/:area_name/:kind" => "budget_line_descendants#index", as: :budget_line_descendants

--- a/test/integration/gobierto_admin/site_create_test.rb
+++ b/test/integration/gobierto_admin/site_create_test.rb
@@ -63,7 +63,9 @@ YAML
             end
 
             with_stubbed_s3_file_upload do
-              click_button "Create"
+              with_stubbed_s3_upload! do
+                click_button "Create"
+              end
             end
           end
 

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -69,7 +69,9 @@ YAML
             select "GobiertoParticipation", from: "site_home_page"
 
             with_stubbed_s3_file_upload do
-              click_button "Update"
+              with_stubbed_s3_upload! do
+                click_button "Update"
+              end
             end
           end
 
@@ -114,7 +116,9 @@ YAML
           select about_site.title, from: "site_home_page_item_id"
 
           with_stubbed_s3_file_upload do
-            click_button "Update"
+            with_stubbed_s3_upload! do
+              click_button "Update"
+            end
           end
         end
 

--- a/test/integration/gobierto_exports/exports_page_test.rb
+++ b/test/integration/gobierto_exports/exports_page_test.rb
@@ -19,10 +19,12 @@ module GobiertoExports
 
     def test_index
       with_current_site(site) do
-        visit @path
+        with_stubbed_s3_file_upload do
+          visit @path
 
-        assert has_selector?("h1", text: "Download data")
-        assert has_selector?("h2", text: "Officials and Agendas")
+          assert has_selector?("h1", text: "Download data")
+          assert has_selector?("h2", text: "Officials and Agendas")
+        end
       end
     end
 
@@ -30,10 +32,12 @@ module GobiertoExports
       gp_enabled_submodules.delete("statements")
 
       with_current_site(site) do
-        visit @path
+        with_stubbed_s3_file_upload do
+          visit @path
 
-        assert has_selector?("h3", text: "Agendas")
-        refute has_selector?("h3", text: "Statements")
+          assert has_selector?("h3", text: "Agendas")
+          refute has_selector?("h3", text: "Statements")
+        end
       end
     end
 
@@ -44,8 +48,10 @@ module GobiertoExports
       gp_enabled_submodules.delete("statements")
 
       with_current_site(site) do
-        visit @path
-        assert has_content? "There aren't any active submodules"
+        with_stubbed_s3_file_upload do
+          visit @path
+          assert has_content? "There aren't any active submodules"
+        end
       end
     end
   end

--- a/test/integration/gobierto_exports/exports_page_test.rb
+++ b/test/integration/gobierto_exports/exports_page_test.rb
@@ -24,6 +24,10 @@ module GobiertoExports
 
           assert has_selector?("h1", text: "Download data")
           assert has_selector?("h2", text: "Officials and Agendas")
+          assert has_selector?("h2", text: "Budget lines")
+          GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
+            assert has_selector?("h3", text: year)
+          end
         end
       end
     end

--- a/test/integration/gobierto_exports/exports_page_test.rb
+++ b/test/integration/gobierto_exports/exports_page_test.rb
@@ -25,9 +25,7 @@ module GobiertoExports
           assert has_selector?("h1", text: "Download data")
           assert has_selector?("h2", text: "Officials and Agendas")
           assert has_selector?("h2", text: "Budget lines")
-          GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
-            assert has_selector?("h3", text: year)
-          end
+          assert has_selector?("h3", text: GobiertoBudgets::SearchEngineConfiguration::Year.last)
         end
       end
     end

--- a/test/support/file_uploader_helpers.rb
+++ b/test/support/file_uploader_helpers.rb
@@ -7,6 +7,12 @@ module FileUploaderHelpers
     end
   end
 
+  def with_stubbed_s3_upload!
+    FileUploader::S3.stub_any_instance(:upload, nil) do
+      yield
+    end
+  end
+
   def public_url
     "http://www.madrid.es/assets/images/logo-madrid.png"
   end

--- a/test/support/file_uploader_helpers.rb
+++ b/test/support/file_uploader_helpers.rb
@@ -3,7 +3,9 @@
 module FileUploaderHelpers
   def with_stubbed_s3_file_upload
     FileUploader::S3.stub_any_instance(:call, public_url) do
-      yield
+      FileUploader::S3.stub_any_instance(:uploaded_file_exists?, true) do
+        yield
+      end
     end
   end
 


### PR DESCRIPTION
Related with #213

### What does this PR do?
* Optimizes the generation of data required to generate Gobierto budgets annual export files
* Instead of creating the files on each request, a model has been added to generate the files and upload them to AWS and return their url for the exports page.
* Also a job is called to generate all the export files for a site once created or when the `municipality_id` of the site is changed in admin


### How should this be manually tested?
Visit http://madrid.gobify.net/datos. If no links appear, change the location for the site from admin. The urls of the sites should be in S3.


### Does this PR changes any configuration file?
No
