### PR TITLE
1368 annual budgets data generation

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_budgets/options_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_budgets/options_controller.rb
@@ -20,6 +20,13 @@ module GobiertoAdmin
         redirect_to admin_gobierto_budgets_options_path
       end
 
+      def update_annual_data
+        site = Site.find(current_site.id)
+        ::GobiertoBudgets::GenerateAnnualLinesJob.perform_later(@site.object)
+        flash[:notice] = t(".success")
+        redirect_to admin_gobierto_budgets_options_path
+      end
+
       private
 
       def gobierto_budgets_params

--- a/app/importers/gobierto_budgets/budget_lines_importer.rb
+++ b/app/importers/gobierto_budgets/budget_lines_importer.rb
@@ -10,6 +10,7 @@ module GobiertoBudgets
     def import!
       calculate_totals
       calculate_bubbles
+      calculate_annual_data
       reset_cache
       publish_event
     end
@@ -24,6 +25,10 @@ module GobiertoBudgets
 
     def calculate_bubbles
       GobiertoBudgets::Data::Bubbles.dump(site.place)
+    end
+
+    def calculate_annual_data
+      GobiertoBudgets::Data::Annual.new(site: site, year: year).generate_files
     end
 
     def reset_cache

--- a/app/models/gobierto_budgets/data/annual.rb
+++ b/app/models/gobierto_budgets/data/annual.rb
@@ -27,6 +27,7 @@ module GobiertoBudgets
       end
 
       def generate_files
+        return file_urls unless any_data?
         calculate_place_budget_lines
 
         FORMATS.each do |format_key, configuration|

--- a/app/models/gobierto_budgets/data/annual.rb
+++ b/app/models/gobierto_budgets/data/annual.rb
@@ -27,15 +27,17 @@ module GobiertoBudgets
       end
 
       def generate_files
+        file_urls = []
         return file_urls unless any_data?
         calculate_place_budget_lines
 
         FORMATS.each do |format_key, configuration|
-          FileUploader::S3.new(
+          file_urls << FileUploader::S3.new(
             file_name: filename(format_key),
             content: configuration[:serializer].call(@place_budget_lines)
           ).upload!
         end
+        file_urls
       end
 
       protected

--- a/app/views/gobierto_admin/gobierto_budgets/options/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_budgets/options/index.html.erb
@@ -1,4 +1,8 @@
 <%= render 'gobierto_admin/gobierto_budgets/shared/tabs' %>
+<%= link_to update_annual_data_admin_gobierto_budgets_options_path, method: :put, data: { confirm: t(".confirm_update_annual_data") } do %>
+  <i class="fa fa-refresh"></i>
+  <%= t('.update_annual_data') %>
+<% end %>
 
 <div class="pure-g">
 <%= form_for @options_form, url: admin_gobierto_budgets_options_path, as: :gobierto_budgets_options, method: :put do |f| %>

--- a/config/locales/gobierto_admin/gobierto_budgets/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/controllers/ca.yml
@@ -6,3 +6,6 @@ ca:
         update:
           error: 'No s''han pogut guardar les opcions: %{validation_errors}'
           success: Opcions desades correctament
+        update_annual_data:
+          success: S'ha llançat un procés per generar els fitxers de partides del
+            pressupost per any

--- a/config/locales/gobierto_admin/gobierto_budgets/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/controllers/en.yml
@@ -6,3 +6,5 @@ en:
         update:
           error: 'Settings couldn''t be saved: %{validation_errors}'
           success: Settings saved successfully
+        update_annual_data:
+          success: Process to generate files of budget lines by year launched

--- a/config/locales/gobierto_admin/gobierto_budgets/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/controllers/es.yml
@@ -6,3 +6,6 @@ es:
         update:
           error: 'No se han podido guardar las opciones: %{validation_errors}'
           success: Opciones guardadas correctamente
+        update_annual_data:
+          success: Se ha lanzado un proceso para generar los ficheros de partidas
+            presupuestarias por año

--- a/config/locales/gobierto_admin/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/views/ca.yml
@@ -24,6 +24,8 @@ ca:
           comparison_show_widget_desc: 'Facilita l''accés a la ferramenta de comparació
             de pressupostos de Gobierto: presupuestos.gobierto.es'
           comparison_tool_enabled_desc: Habilita ferramentes de comparació
+          confirm_update_annual_data: Començarà un procés en segon pla per actualitzar
+            els fitxers. Continuar?
           elaboration: Elaboració
           elaboration_desc1: Habilita la secció d'Elaboració del pressupost
           elaboration_desc2_html: "<strong>Important:</strong> es necessari carregar
@@ -39,6 +41,7 @@ ca:
           receipt_desc1: Habilita la sección El recibo de tus impuestos
           receipt_desc2_html: "<strong>Importante:</strong> debes de rellenar el JSON
             con los datos."
+          update_annual_data: Generar fitxers de partides del pressupost per any
       shared:
         tabs:
           budgets: Pressupost

--- a/config/locales/gobierto_admin/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/views/en.yml
@@ -24,6 +24,8 @@ en:
           comparison_show_widget_desc: 'Enable the acces to the Gobierto budgets comparison
             tool: presupuestos.gobierto.es'
           comparison_tool_enabled_desc: Enable comparison tools
+          confirm_update_annual_data: A background process will start to update files.
+            Continue?
           elaboration: Elaboration
           elaboration_desc1: Enable budgets elaboration section
           elaboration_desc2_html: "<strong>Important:</strong> it's necessary to load
@@ -38,6 +40,7 @@ en:
           receipt_desc1: Enable budgets taxes receipt section
           receipt_desc2_html: "<strong>Important:</strong> it's necessary to fill
             the JSON with the data."
+          update_annual_data: Generate budget lines by year files
       shared:
         tabs:
           budgets: Budgets

--- a/config/locales/gobierto_admin/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/views/es.yml
@@ -24,6 +24,8 @@ es:
           comparison_show_widget_desc: 'Facilita el acceso a la herramienta de comparación
             de presupuestos de Gobierto: presupuestos.gobierto.es'
           comparison_tool_enabled_desc: Habilita herramientas de comparación
+          confirm_update_annual_data: Comenzará un proceso en segundo plano para actualizar
+            los ficheros. ¿Continuar?
           elaboration: Elaboración
           elaboration_desc1: Habilita la sección de Elaboración del presupuesto.
           elaboration_desc2_html: "<strong>Importante:</strong> es necesario que se
@@ -39,6 +41,7 @@ es:
           receipt_desc1: Habilita la sección El recibo de tus impuestos
           receipt_desc2_html: "<strong>Importante:</strong> debes de rellenar el JSON
             con los datos."
+          update_annual_data: Generar ficheros de partidas presupuestarias por año
       shared:
         tabs:
           budgets: Presupuestos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       resources :options, only: [:index] do
         collection do
           put :update
+          put :update_annual_data
         end
       end
       resources :feedback, only: [:index]

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -24,9 +24,9 @@ module FileUploader
     def call
       if !uploaded_file_exists? && @file
         upload
+      else
+        object.public_url
       end
-
-      object.public_url
     end
 
     def upload
@@ -43,6 +43,7 @@ module FileUploader
       if @tmp_file
         @tmp_file.unlink
       end
+      object.public_url
     end
 
     def uploaded_file_exists?

--- a/lib/tasks/gobierto_budgets/data/annual.rake
+++ b/lib/tasks/gobierto_budgets/data/annual.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :gobierto_budgets do
+  namespace :data do
+    desc "Generate annual budgets data files for all sites"
+    task sites_annual: :environment do
+      Site.all.each do |site|
+        place = site.place
+        next if place.nil?
+        file_urls = []
+        GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
+          file_urls += GobiertoBudgets::Data::Annual.new(site: site, year: year).generate_files
+        end
+
+        puts "\n- Data calculated for site #{site.domain} and place #{place.name} - #{place.id}: " +
+          (file_urls.any? ? "#{file_urls.count} files uploaded:" : "No files generated.")
+        file_urls.each do |file_url|
+          puts "\t+ #{file_url}"
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_budgets/options_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budgets/options_test.rb
@@ -44,6 +44,20 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_update_annual_budgets_data
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            with_stubbed_s3_upload! do
+              visit @path
+
+              click_link("Generate budget lines by year files")
+
+              assert has_message?("Process to generate files of budget lines by year launched")
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Related with #1368

### What does this PR do?
* Includes the generation of gobierto budgets annual data files on `GobiertoBudgets::BudgetLinesImporter` `import!` method
* Adds a `rails gobierto_budgets:data:sites_annual` task to generate files for all the sites.
* Adds a link in admin/gobierto_budgets/options to enqueue the files generation job.

### How should this be manually tested?
visit http://gobify.net/admin/gobierto_budgets/options

### Does this PR changes any configuration file?
No