### PR TITLE
1369 - New field type (URL) for content blocks

### DIFF
--- a/app/assets/javascripts/admin/app/components/dynamic_content_component.js
+++ b/app/assets/javascripts/admin/app/components/dynamic_content_component.js
@@ -246,7 +246,14 @@ this.GobiertoAdmin.DynamicContentComponent = (function() {
     });
 
     wrapper.find(".dynamic-content-record-view .content-block-record-value").each(function(index) {
-      $(this).html(formState[index]);
+      var fieldText = formState[index];
+      var urlPattern = new RegExp('^https?:\/\/.*$')
+
+      if (urlPattern.test(fieldText)) {
+        $(this).html('<a href="' + fieldText + '">' + fieldText + '</a>');
+      } else {
+        $(this).html(fieldText);
+      }
     });
   }
 

--- a/app/models/gobierto_common/content_block_field.rb
+++ b/app/models/gobierto_common/content_block_field.rb
@@ -10,7 +10,7 @@ module GobiertoCommon
 
     scope :sorted, -> { order(position: :asc) }
 
-    enum field_type: { text: 0, date: 1, currency: 2 }
+    enum field_type: { text: 0, date: 1, currency: 2, url: 3 }
 
     def label_components
       available_locales.map do |locale|

--- a/app/models/gobierto_common/content_block_record_field.rb
+++ b/app/models/gobierto_common/content_block_record_field.rb
@@ -9,5 +9,10 @@ module GobiertoCommon
       :label,
       :field_type
     )
+
+    def url?
+      field_type == 'url'
+    end
+
   end
 end

--- a/app/views/gobierto_admin/gobierto_common/dynamic_content/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/dynamic_content/_form.html.erb
@@ -35,8 +35,9 @@
         <tbody id="content-block-record-<%= content_block_record_form.object.id %>" class="dynamic-content-record-wrapper content-block-record-<%= content_block_record_form.object.id || "new" %>">
           <tr class="dynamic-content-record-view <%= cycle("odd", "even") %>">
             <% content_block_record_form.object.fields.each do |record_field| %>
+              <% field_value = record_field.value %>
               <td class="content-block-record-value">
-                <%= link_to_if record_field.url?, record_field.value, record_field.value %>
+                <%= link_to_if (field_value && record_field.url?), field_value, field_value %>
               </td>
             <% end %>
 

--- a/app/views/gobierto_admin/gobierto_common/dynamic_content/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/dynamic_content/_form.html.erb
@@ -35,7 +35,9 @@
         <tbody id="content-block-record-<%= content_block_record_form.object.id %>" class="dynamic-content-record-wrapper content-block-record-<%= content_block_record_form.object.id || "new" %>">
           <tr class="dynamic-content-record-view <%= cycle("odd", "even") %>">
             <% content_block_record_form.object.fields.each do |record_field| %>
-              <td class="content-block-record-value"><%= record_field.value %></td>
+              <td class="content-block-record-value">
+                <%= link_to_if record_field.url?, record_field.value, record_field.value %>
+              </td>
             <% end %>
 
             <td>

--- a/app/views/gobierto_common/dynamic_content/_table_component.html.erb
+++ b/app/views/gobierto_common/dynamic_content/_table_component.html.erb
@@ -20,7 +20,9 @@
                   <% field_value = content_block_record_field.value.presence %>
                   <td>
                     <% if content_block_record_field.url? && field_value %>
-                      <%= link_to t('.view_content'), field_value %>
+                      <%= link_to field_value, target: '_blank' do %>
+                        <button class="small"><i class="fa fa-external-link"></i> <%= t('.view_content') %></button>
+                      <% end %>
                     <% else %>
                       <%= field_value %>
                     <% end %>

--- a/app/views/gobierto_common/dynamic_content/_table_component.html.erb
+++ b/app/views/gobierto_common/dynamic_content/_table_component.html.erb
@@ -17,11 +17,12 @@
             <% Array(content_block.records).each do |content_block_record| %>
               <tr>
                 <% Array(content_block_record.fields).each do |content_block_record_field| %>
+                  <% field_value = content_block_record_field.value %>
                   <td>
-                    <% if content_block_record_field.url? %>
-                      <%= link_to t('.view_content'), content_block_record_field.value %>
+                    <% if content_block_record_field.url? && field_value %>
+                      <%= link_to t('.view_content'), field_value %>
                     <% else %>
-                      <%= content_block_record_field.value %>
+                      <%= field_value %>
                     <% end %>
                   </td>
                 <% end %>

--- a/app/views/gobierto_common/dynamic_content/_table_component.html.erb
+++ b/app/views/gobierto_common/dynamic_content/_table_component.html.erb
@@ -17,7 +17,7 @@
             <% Array(content_block.records).each do |content_block_record| %>
               <tr>
                 <% Array(content_block_record.fields).each do |content_block_record_field| %>
-                  <% field_value = content_block_record_field.value %>
+                  <% field_value = content_block_record_field.value.presence %>
                   <td>
                     <% if content_block_record_field.url? && field_value %>
                       <%= link_to t('.view_content'), field_value %>

--- a/app/views/gobierto_common/dynamic_content/_table_component.html.erb
+++ b/app/views/gobierto_common/dynamic_content/_table_component.html.erb
@@ -17,7 +17,13 @@
             <% Array(content_block.records).each do |content_block_record| %>
               <tr>
                 <% Array(content_block_record.fields).each do |content_block_record_field| %>
-                  <td><%= content_block_record_field.value %></td>
+                  <td>
+                    <% if content_block_record_field.url? %>
+                      <%= link_to t('.view_content'), content_block_record_field.value %>
+                    <% else %>
+                      <%= content_block_record_field.value %>
+                    <% end %>
+                  </td>
                 <% end %>
                 <td>
                   <% if content_block_record.attachment_url.present? %>

--- a/config/locales/gobierto_admin/gobierto_common/content_blocks/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/content_blocks/models/ca.yml
@@ -11,5 +11,6 @@ ca:
           currency: Moneda
           date: Data
           text: Tipus de camp
+          url: URL
     models:
       gobierto_common/content_block_field: Camp

--- a/config/locales/gobierto_admin/gobierto_common/content_blocks/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/content_blocks/models/en.yml
@@ -11,5 +11,6 @@ en:
           currency: Currency
           date: Date
           text: Text
+          url: URL
     models:
       gobierto_common/content_block_field: Field

--- a/config/locales/gobierto_admin/gobierto_common/content_blocks/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/content_blocks/models/es.yml
@@ -11,5 +11,6 @@ es:
           currency: Moneda
           date: Fecha
           text: Texto
+          url: URL
     models:
       gobierto_common/content_block_field: Campo

--- a/config/locales/gobierto_common/views/ca.yml
+++ b/config/locales/gobierto_common/views/ca.yml
@@ -6,6 +6,7 @@ ca:
         attachment: Adjunt
         download: Descarregar
         download_attachment: Descarregar adjunt
+        view_content: Veure contingut
     events:
       gobierto_common_collection_created: Col·lecció creat
       gobierto_common_collection_updated: Col·lecció actualizat

--- a/config/locales/gobierto_common/views/en.yml
+++ b/config/locales/gobierto_common/views/en.yml
@@ -6,6 +6,7 @@ en:
         attachment: Attachment
         download: Download
         download_attachment: Download attachment
+        view_content: View content
     events:
       gobierto_common_collection_created: Collection created
       gobierto_common_collection_updated: Collection updated

--- a/config/locales/gobierto_common/views/es.yml
+++ b/config/locales/gobierto_common/views/es.yml
@@ -6,6 +6,7 @@ es:
         attachment: Documento
         download: Descargar
         download_attachment: Descargar documento
+        view_content: Ver contenido
     events:
       gobierto_common_collection_created: Colección creada
       gobierto_common_collection_updated: Colección actualizada


### PR DESCRIPTION
Closes #1369 

### What does this PR do?

Implements new content block record field type URL, which displays links in the front.

### How should this be manually tested?

Edit biography or a person statement content block, add a new column of type URL and check in the front the "View content" link is displayed.

Examples:

* [http://madrid.gobify.net/personas/rafa-garcia/biografia](http://madrid.gobify.net/personas/rafa-garcia/biografia)

### Does this PR changes any configuration file?

No
