### PR TITLE
Add index to domain column

### DIFF
--- a/db/migrate/20180125152553_add_index_to_sites_domain.rb
+++ b/db/migrate/20180125152553_add_index_to_sites_domain.rb
@@ -1,0 +1,5 @@
+class AddIndexToSitesDomain < ActiveRecord::Migration[5.1]
+  def change
+    add_index :sites, :domain, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123093747) do
+ActiveRecord::Schema.define(version: 20180125152553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -733,6 +733,7 @@ ActiveRecord::Schema.define(version: 20180123093747) do
     t.integer "municipality_id"
     t.jsonb "name_translations"
     t.jsonb "title_translations"
+    t.index ["domain"], name: "index_sites_on_domain", unique: true
     t.index ["name_translations"], name: "index_sites_on_name_translations", using: :gin
     t.index ["title_translations"], name: "index_sites_on_title_translations", using: :gin
   end


### PR DESCRIPTION
Unexpected

### What does this PR do?

This PR adds an index to the column domain of `sites` table, because it's the most common way to load a site.
