### PR TITLE
1372 unsubscribe globally subscribed

### DIFF
--- a/app/models/concerns/user/subscriber.rb
+++ b/app/models/concerns/user/subscriber.rb
@@ -1,11 +1,11 @@
 module User::Subscriber
   extend ActiveSupport::Concern
 
-  def subscribed_to?(subscribable, site)
+  def subscribed_to?(subscribable, site, finder_method = :user_subscribed_to?)
     if subscribable.is_a?(Class) || subscribable.is_a?(Module)
-      User::Subscription::Finder.user_subscribed_to?(self, subscribable.name, nil, site.id)
+      User::Subscription::Finder.send(finder_method, self, subscribable.name, nil, site.id)
     else
-      User::Subscription::Finder.user_subscribed_to?(self, subscribable.class.name, subscribable.id, site.id)
+      User::Subscription::Finder.send(finder_method, self, subscribable.class.name, subscribable.id, site.id)
     end
   end
 

--- a/app/services/user/subscription/finder.rb
+++ b/app/services/user/subscription/finder.rb
@@ -3,13 +3,17 @@ class User::Subscription::Finder
     find_user_subscriptions_for(subscribable_type, subscribable_id, site_id).include?(user.id)
   end
 
+  def self.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site_id)
+    find_broader_user_subscriptions_for(subscribable_type, subscribable_id, site_id).include?(user.id)
+  end
+
   def self.subscriptions_for(subscribable_type, subscribable_id, site_id)
     find_user_subscriptions_for(subscribable_type, subscribable_id, site_id)
   end
 
   private
 
-  def self.find_user_subscriptions_for(subject_type, subject_id, site_id)
+  def self.subscriptions_scope_for(subject_type, subject_id, site_id)
     conditions = [{subscribable_type: subject_type, subscribable_id: subject_id, site_id: site_id}]
 
     if subject_id.present?
@@ -33,7 +37,17 @@ class User::Subscription::Finder
     while conditions.any?
       scoped = scoped.or(User::Subscription.where(conditions.pop))
     end
-    scoped.pluck(:user_id).uniq
+    scoped
+  end
+  private_class_method :subscriptions_scope_for
+
+  def self.find_broader_user_subscriptions_for(subject_type, subject_id, site_id)
+    subscriptions_scope_for(subject_type, subject_id, site_id).where(site_id: site_id).where.not(subscribable_type: subject_type, subscribable_id: subject_id).pluck(:user_id).uniq
+  end
+  private_class_method :find_broader_user_subscriptions_for
+
+  def self.find_user_subscriptions_for(subject_type, subject_id, site_id)
+    subscriptions_scope_for(subject_type, subject_id, site_id).pluck(:user_id).uniq
   end
   private_class_method :find_user_subscriptions_for
 

--- a/app/views/gobierto_people/people/_subscription_button.html.erb
+++ b/app/views/gobierto_people/people/_subscription_button.html.erb
@@ -1,5 +1,5 @@
 <% user_subscription_form = User::SubscriptionForm.new(subscribable: person) %>
-  <% if !user_signed_in? || !current_user.subscribed_to?(person, current_site) %>
+  <% if !user_signed_in? || !current_user.subscribed_to?(person, current_site, :user_subscribed_by_broader_subscription_to?) %>
     <% if user_signed_in? %>
       <div class="follow_item">
         <%= button_to(

--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -1,6 +1,6 @@
 <% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
 
-<% if !user_signed_in? || !current_user.subscribed_to?(subscribable, current_site) %>
+<% if !user_signed_in? || !current_user.subscribed_to?(subscribable, current_site, :user_subscribed_by_broader_subscription_to?) %>
 
 <div class="subscribable-box slim_box box">
   <div class="inner">

--- a/app/views/user/subscriptions/_subscribable_button.html.erb
+++ b/app/views/user/subscriptions/_subscribable_button.html.erb
@@ -1,17 +1,38 @@
 <% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
 <% subscribed = user_signed_in? ? current_user.subscribed_to?(subscribable, current_site) : false %>
+<% subscribed_by_broader_subscription = subscribed && current_user.subscribed_to?(subscribable, current_site, :user_subscribed_by_broader_subscription_to?) %>
 
 <% if user_signed_in? %>
   <% if subscribed %>
-    <% user_subscription = User::Subscription.find_by(user: current_user,
-                                                      subscribable_id: user_subscription_form.subscribable_id,
-                                                      subscribable_type: user_subscription_form.subscribable_type.to_s) %>
-    <%= link_to(user_subscription_path(user_subscription),
-      remote: true,
-      method: :delete,
-      class: "button button-feed") do %>
-        <i class="fa fa-star"></i>
-        <%= t(".#{subscribable.class.name.demodulize.downcase}_followed") %>
+    <% if subscribed_by_broader_subscription %>
+      <div class="pure-menu pure-menu-horizontal">
+        <ul class="pure-menu-list left">
+          <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+            <%= link_to "#", class: "button button-feed" do %>
+              <i class="fa fa-star"></i>
+              <%= t(".#{subscribable.class.name.demodulize.downcase}_followed") %>
+            <% end %>
+            <ul class="pure-menu-children">
+              <li class="pure-menu-item">
+                <%= link_to(user_subscriptions_path, class: "pure-menu-link") do %>
+                  <%= t(".manage_subscriptions") %>
+                <% end %>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    <% else %>
+      <% user_subscription = User::Subscription.find_by(user: current_user,
+                                                        subscribable_id: user_subscription_form.subscribable_id,
+                                                        subscribable_type: user_subscription_form.subscribable_type.to_s) %>
+      <%= link_to(user_subscription_path(user_subscription),
+        remote: true,
+        method: :delete,
+        class: "button button-feed") do %>
+          <i class="fa fa-star"></i>
+          <%= t(".#{subscribable.class.name.demodulize.downcase}_followed") %>
+      <% end %>
     <% end %>
   <% else %>
     <%= link_to(

--- a/config/locales/user/views/subscriptions/ca.yml
+++ b/config/locales/user/views/subscriptions/ca.yml
@@ -38,6 +38,7 @@ ca:
         follow_process: Segueix el procés
         follow_scope: Segueix l´àmbit
         issue_followed: Tema seguit!
+        manage_subscriptions: Gestionar les teves alertes
         person_followed: Persona seguida!
         process_followed: Procés seguit!
         scope_followed: Àmbit seguit!

--- a/config/locales/user/views/subscriptions/en.yml
+++ b/config/locales/user/views/subscriptions/en.yml
@@ -38,6 +38,7 @@ en:
         follow_process: Follow process
         follow_scope: Follow scope
         issue_followed: Theme followed!
+        manage_subscriptions: Manage your alerts
         person_followed: Person followed!
         process_followed: Process followed!
         scope_followed: Scope followed!

--- a/config/locales/user/views/subscriptions/es.yml
+++ b/config/locales/user/views/subscriptions/es.yml
@@ -38,6 +38,7 @@ es:
         follow_process: Seguir proceso
         follow_scope: Seguir ámbito
         issue_followed: "¡Tema seguido!"
+        manage_subscriptions: Gestionar tus alertas
         person_followed: "¡Persona seguida!"
         process_followed: "¡Proceso seguido!"
         scope_followed: "¡Ámbito seguido!"

--- a/test/integration/gobierto_participation/processes/process_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_show_test.rb
@@ -139,6 +139,24 @@ module GobiertoParticipation
       end
     end
 
+    def test_site_subscription
+      with_signed_in_user(user) do
+
+        visit process_path(gender_violence_process)
+        within ".slim_nav_bar" do
+          assert has_link? "Follow process"
+        end
+
+        within 'footer' do
+          click_on "Subscribe"
+        end
+
+        assert has_content? "Process followed!"
+        assert has_link? "Manage your alerts"
+
+      end
+    end
+
     def test_process
       with_current_site(site) do
         visit process_path(gender_violence_process)

--- a/test/services/user/subscription/finder_test.rb
+++ b/test/services/user/subscription/finder_test.rb
@@ -49,6 +49,23 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
     end
+
+    [
+      ["GobiertoCalendars::Event", person_event.id],
+      ["GobiertoCalendars::Event", nil],
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil]
+    ].each do |subscribable_type, subscribable_id|
+      assert subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+
+    [
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+
   end
 
   def test_user_subscribed_to_when_subscribed_to_module
@@ -98,6 +115,7 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::Person", person.id]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
     end
 


### PR DESCRIPTION
Fixes #1372 

### What does this PR do?
Avoids exceptions accessing to resources like participation processes when the user is subscribed to whole site. With the fix, if a user has no subscriptions of broader level which includes the resource, a button switching between subscribe/unsubscribe appears. Otherwise, a text indicating that the user is subscribed to the resource appears, and a link to subscriptions settings is available below:

![image](https://user-images.githubusercontent.com/446459/35458211-c7644a4e-02db-11e8-819e-a0e1a43ff37d.png)

Also the fix has been extended to make available unsubscribe buttons in some pages of people or even the global subscription button in the footer (previously the subscription option was the only available):

![image](https://user-images.githubusercontent.com/446459/35458292-112f10be-02dc-11e8-95be-2525f51bcb0f.png)

![image](https://user-images.githubusercontent.com/446459/35458482-de979c24-02dc-11e8-810e-4f8ae6bf97a3.png)

### How should this be manually tested?
Visit any participation process page, subscribe to whole site and check the upper bar. This also works with people profiles. 


### Does this PR changes any configuration file?
No