### PR TITLE
Minor fixes: 253, 254 and 1402

### DIFF
--- a/app/views/gobierto_participation/shared/events/_event.html.erb
+++ b/app/views/gobierto_participation/shared/events/_event.html.erb
@@ -8,9 +8,9 @@
 
       <div class="ib p_h_r_0_5">
         <% if event.starts_at.day == event.ends_at.day %>
-          <strong><%= l(event.starts_at, format: '%e %b') %></strong>
+          <strong><%= l(event.starts_at, format: '%e %b %Y') %></strong>
         <% else %>
-          <strong><%= t('.from_to', starts: l(event.starts_at, format: '%e %b'), ends: l(event.ends_at, format: '%e %b')) %></strong>
+          <strong><%= t('.from_to', starts: l(event.starts_at, format: '%e %b %Y'), ends: l(event.ends_at, format: '%e %b %Y')) %></strong>
         <% end %>
       </div>
 

--- a/app/views/gobierto_people/people/person_posts/show.html.erb
+++ b/app/views/gobierto_people/people/person_posts/show.html.erb
@@ -29,8 +29,4 @@
 
 <div class="separator"></div>
 
-<%= render("user/subscriptions/subscribable_box",
-           subscribable: @post,
-           title: t(".subscribable_box.title")) %>
-
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>

--- a/app/views/gobierto_people/people/person_statements/show.html.erb
+++ b/app/views/gobierto_people/people/person_statements/show.html.erb
@@ -46,8 +46,4 @@
 
 <%= render "gobierto_common/dynamic_content/table_component", content_blocks: @statement_content_blocks %>
 
-<%= render("user/subscriptions/subscribable_box",
-           subscribable: @statement,
-           title: t(".subscribable_box.title")) %>
-
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>

--- a/app/views/gobierto_people/person_post_tags/show.html.erb
+++ b/app/views/gobierto_people/person_post_tags/show.html.erb
@@ -21,18 +21,6 @@
 
   </div>
 
-  <div class="pure-g">
-
-    <div class="pure-u-1 pure-u-md-1-2 description">
-
-      <%= render("user/subscriptions/subscribable_box",
-                 subscribable: GobiertoPeople::PersonPost,
-                 title: t(".subscribable_box.title")) %>
-
-    </div>
-
-  </div>
-
 </div>
 
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>

--- a/config/locales/gobierto_observatory/views/ca.yml
+++ b/config/locales/gobierto_observatory/views/ca.yml
@@ -62,8 +62,8 @@ ca:
         title: Impost sobre els Béns Immobles
       income:
         first_column: ''
-        second_column: Renda bruta
-        third_column: Renda disponible
+        second_column: Bruta
+        third_column: Disponible
         title: Renda municipal
       income_overview:
         figure_first: "%{province}"

--- a/config/locales/gobierto_observatory/views/en.yml
+++ b/config/locales/gobierto_observatory/views/en.yml
@@ -62,8 +62,8 @@ en:
         title: Land value tax
       income:
         first_column: ''
-        second_column: Gross income
-        third_column: Net income
+        second_column: Gross
+        third_column: Net
         title: Municipality income
       income_overview:
         figure_first: "%{province}"

--- a/config/locales/gobierto_observatory/views/es.yml
+++ b/config/locales/gobierto_observatory/views/es.yml
@@ -62,8 +62,8 @@ es:
         title: Impuesto sobre bienes inmuebles
       income:
         first_column: ''
-        second_column: Renta bruta
-        third_column: Renta disponible
+        second_column: Bruta
+        third_column: Disponible
         title: Renta municipal
       income_overview:
         figure_first: "%{province}"

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -91,8 +91,6 @@ ca:
           no_posts: Encara no hi ha posts publicats.
           title: El blog de %{person_name}, %{person_charge}
         show:
-          subscribable_box:
-            title: Rebeix actualitzacions al teu correu-e
           title: El blog de %{person_name}, %{person_charge}
       person_statements:
         index:
@@ -100,8 +98,6 @@ ca:
           title: Béns i activitats de %{person_name}
         show:
           download: Descarregar declaració (%{file_size})
-          subscribable_box:
-            title: Rebeix actualitzacions al teu correu-e
           title: Béns i activitats de %{person_name}
           view_previous: Veure anteriors
       show:
@@ -146,8 +142,6 @@ ca:
       show:
         filtering_by_tag: Filtrant per "%{tag}"
         go_back: Tornar
-        subscribable_box:
-          title: Rebeix una alerta al teu correu-e
     person_posts:
       index:
         subscribable_box:

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -90,8 +90,6 @@ en:
           no_posts: There aren't posts published.
           title: "%{person_name}, %{person_charge}'s blog"
         show:
-          subscribable_box:
-            title: Receive updates in your inbox
           title: "%{person_name}, %{person_charge}'s blog"
       person_statements:
         index:
@@ -99,8 +97,6 @@ en:
           title: "%{person_name}'s goods and Activities"
         show:
           download: Download statement (%{file_size})
-          subscribable_box:
-            title: Receive updates in your inbox
           title: "%{person_name}'s goods and Activities"
           view_previous: View previous
       show:
@@ -145,8 +141,6 @@ en:
       show:
         filtering_by_tag: Filtering by "%{tag}"
         go_back: Go back
-        subscribable_box:
-          title: Receive alerts in your inbox
     person_posts:
       index:
         subscribable_box:

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -91,8 +91,6 @@ es:
           no_posts: Todavía no se ha publicado ningún post.
           title: El blog de %{person_name}, %{person_charge}
         show:
-          subscribable_box:
-            title: Recibe actualizaciones
           title: El blog de %{person_name}, %{person_charge}
       person_statements:
         index:
@@ -101,8 +99,6 @@ es:
           title: Bienes y Actividades de %{person_name}
         show:
           download: Descargar declaración (%{file_size})
-          subscribable_box:
-            title: Recibe actualizaciones
           title: Bienes y Actividades de %{person_name}
           view_previous: Ver anteriores
       show:
@@ -147,8 +143,6 @@ es:
       show:
         filtering_by_tag: Filtrando por "%{tag}"
         go_back: Volver
-        subscribable_box:
-          title: Recibe alertas en tu correo-e
     person_posts:
       index:
         subscribable_box:


### PR DESCRIPTION
### Closes #1402 

Shows year in participation event show. See it [here](http://newalcobendas.gobify.net/participacion/agendas/2018-02-06-reunion-del-pleno-del-consejo-social-de-la-ciudad)

### Closes [#253](https://github.com/PopulateTools/issues/issues/253)

Changes literals for Observatory rent. See it in [http://getafe.gobify.net/observatorio](http://getafe.gobify.net/observatorio) (check the three locales)

### Closes [#254](https://github.com/PopulateTools/issues/issues/254)

Removes subscribable box from:

* Post tags show - check [http://getafe.gobify.net/blogs/tags/tom](http://getafe.gobify.net/blogs/tags/tom)
* Person statement show - check [http://getafe.gobify.net/declaraciones/tom/2017-11-16-casa-en-hollywood](http://getafe.gobify.net/declaraciones/tom/2017-11-16-casa-en-hollywood)
* Person post show - check [http://getafe.gobify.net/blogs/tom/2018-02-05-un-post](http://getafe.gobify.net/blogs/tom/2018-02-05-un-post)

### Does this PR changes any configuration file?

No
