### PR TITLE
Fix last year calculation when elaboration is enabled

### DIFF
--- a/app/models/gobierto_budgets/search_engine_configuration.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration.rb
@@ -3,7 +3,13 @@ module GobiertoBudgets
     class Year
       def self.last
         Date.today.year.downto(first) do |year|
-          return year if GobiertoCore::CurrentScope.current_site.present? && GobiertoBudgets::BudgetLine.any_data?(site: GobiertoCore::CurrentScope.current_site, index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, year: year)
+          if GobiertoCore::CurrentScope.current_site.present?
+            if GobiertoBudgets::BudgetLine.any_data?(site: GobiertoCore::CurrentScope.current_site, index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, year: year)
+              if year == Date.today.year && (GobiertoCore::CurrentScope.current_site.gobierto_budgets_settings && !GobiertoCore::CurrentScope.current_site.gobierto_budgets_settings.settings["budgets_elaboration"])
+                return year
+              end
+            end
+          end
         end
         2017
       end

--- a/test/models/gobierto_budgets/year_test.rb
+++ b/test/models/gobierto_budgets/year_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GobiertoBudgets::SearchEngineConfiguration::YearTest < ActiveSupport::TestCase
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def setup
+    super
+    ::GobiertoCore::CurrentScope.current_site = site
+  end
+
+  def test_last_year_when_no_data
+    assert_equal 2017, GobiertoBudgets::SearchEngineConfiguration::Year.last
+  end
+
+  def test_last_year_when_data_and_elaboration_enabled
+    GobiertoBudgets::BudgetLine.stub(:any_data?, true) do
+      site.gobierto_budgets_settings.settings["budgets_elaboration"] = true
+      site.save!
+      assert_equal 2017, GobiertoBudgets::SearchEngineConfiguration::Year.last
+    end
+  end
+
+  def test_last_year_when_data_and_elaboration_disabled
+    GobiertoBudgets::BudgetLine.stub(:any_data?, true) do
+      assert_equal 2018, GobiertoBudgets::SearchEngineConfiguration::Year.last
+    end
+  end
+end


### PR DESCRIPTION
Bugfix

### What does this PR do?

This PR fixes a but introduced in #1374 when the elaboration was enabled.

### How should this be manually tested?

You need to check three scenarios (covered with new tests):

- in a site with elaboration enabled (http://mataro.gobify.net), check that:
  - the elaboration is shown with data from 2018
  - the budgets summary last year of data is 2017

- in a site without elaboration enabled and with 2018 data check (http://getafe.gobify.net):
  - the budgets summary last year of data is 2018

- in a site without elaboration enabled and withiout 2018 data check (http://madrid.gobify.net):
  - the budgets summary last year of data is 2017
