### PR TITLE
Renaming a slug in edition

### DIFF
--- a/app/models/concerns/gobierto_common/sluggable.rb
+++ b/app/models/concerns/gobierto_common/sluggable.rb
@@ -5,7 +5,7 @@ module GobiertoCommon
     extend ActiveSupport::Concern
 
     included do
-      before_create :set_slug
+      before_validation :set_slug
       after_destroy :add_archived_to_slug
     end
 

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -111,7 +111,7 @@ module GobiertoCalendars
     end
 
     def attributes_for_slug
-      [starts_at.strftime('%F'), title]
+      [Time.now.strftime("%F"), title]
     end
 
     def add_item_to_collection

--- a/app/models/gobierto_participation/process_stage.rb
+++ b/app/models/gobierto_participation/process_stage.rb
@@ -145,9 +145,5 @@ module GobiertoParticipation
     def url_helpers
       Rails.application.routes.url_helpers
     end
-
-    def attributes_for_slug
-      [title]
-    end
   end
 end

--- a/app/models/gobierto_people/person_post.rb
+++ b/app/models/gobierto_people/person_post.rb
@@ -34,7 +34,7 @@ module GobiertoPeople
     end
 
     def attributes_for_slug
-      [created_at.strftime("%F"), title]
+      [Time.now.strftime("%F"), title]
     end
 
     def resource_path

--- a/app/models/gobierto_people/person_statement.rb
+++ b/app/models/gobierto_people/person_statement.rb
@@ -46,7 +46,7 @@ module GobiertoPeople
     end
 
     def attributes_for_slug
-      [published_on.strftime("%F"), title]
+      [Time.now.strftime("%F"), title]
     end
 
     def resource_path

--- a/test/integration/gobierto_admin/gobierto_participation/processes/create_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/create_process_test.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module GobiertoAdmin
   module GobiertoParticipation
     class CreateProcessTest < ActionDispatch::IntegrationTest
-
       def setup
         super
         @path = admin_participation_path
@@ -25,42 +24,44 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
 
-              click_link 'New'
+              click_link "New"
 
-              fill_in 'process_title_translations_en', with: 'New process title'
-              fill_in 'process_body_translations_en', with: 'New process body'
+              fill_in "process_title_translations_en", with: "New process title"
+              fill_in "process_body_translations_en", with: "New process body"
 
-              click_link 'ES'
+              click_link "ES"
 
-              fill_in 'process_title_translations_es', with: 'Título del nuevo proceso'
-              fill_in 'process_body_translations_es', with: 'Descripción del nuevo proceso'
+              fill_in "process_title_translations_es", with: "Título del nuevo proceso"
+              fill_in "process_body_translations_es", with: "Descripción del nuevo proceso"
+              fill_in "process_body_translations_es", with: "Descripción del nuevo proceso"
+              fill_in "process_slug", with: ""
 
-              select 'Culture', from: 'process_issue_id'
+              select "Culture", from: "process_issue_id"
 
-              select 'Old town', from: 'process_scope_id'
+              select "Old town", from: "process_scope_id"
 
-              find('#process_has_duration', visible: false).trigger(:click)
+              find("#process_has_duration", visible: false).trigger(:click)
 
-              fill_in 'process_starts', with: '2017-01-01'
-              fill_in 'process_ends', with: '2017-01-30'
+              fill_in "process_starts", with: "2017-01-01"
+              fill_in "process_ends", with: "2017-01-30"
 
-              find('#process_process_type_process', visible: false).trigger(:click)
+              find("#process_process_type_process", visible: false).trigger(:click)
 
-              click_button 'Create'
+              click_button "Create"
 
-              assert has_message? 'Process was successfully created'
+              assert has_message? "Process was successfully created"
 
               process = site.processes.process.last
 
-              assert_equal 'New process title', process.title
-              assert_equal 'New process body', process.body
-              assert_equal 'Título del nuevo proceso', process.title_es
-              assert_equal 'Descripción del nuevo proceso', process.body_es
-              assert_equal 'Culture', process.issue.name
-              assert_equal 'Old town', process.scope.name
+              assert_equal "New process title", process.title
+              assert_equal "New process body", process.body
+              assert_equal "Título del nuevo proceso", process.title_es
+              assert_equal "Descripción del nuevo proceso", process.body_es
+              assert_equal "Culture", process.issue.name
+              assert_equal "Old town", process.scope.name
 
               # check slug gets auto-filled in server
-              assert_equal 'new-process-title', process.slug
+              assert_equal "new-process-title", process.slug
 
               # check information stage are created
               assert_equal 1, process.stages.size

--- a/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
@@ -171,6 +171,27 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_update_process_with_empty_slug
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit edit_admin_participation_process_path(process)
+
+            assert_equal "pacto-social-fin-vilencia-de-genero", process.slug
+
+            fill_in "process_slug", with: ""
+
+            click_button "Update"
+
+            assert has_message? "Process was successfully updated"
+
+            process.reload
+
+            refute_equal "pacto-social-fin-vilencia-de-genero", process.slug
+            assert_equal "social-agreement-against-gender-violence", process.slug
+          end
+        end
+      end
     end
   end
 end

--- a/test/models/gobierto_calendars/sluggable_test.rb
+++ b/test/models/gobierto_calendars/sluggable_test.rb
@@ -8,13 +8,13 @@ module GobiertoCalendars
     include ::EventHelpers
 
     def test_assign_slug_with_date
-      event_1 = create_event(title: "_* (Title)-", starts_at: "2017-01-02 18:00:00")
-      event_2 = create_event(title: "_* (Title)--", starts_at: "2017-01-02 20:00:00")
-      event_3 = create_event(title: "_* (Title)_2", starts_at: "2017-01-02")
+      event_one = create_event(title: "_* (Title)-", starts_at: "2017-01-02 18:00:00")
+      event_two = create_event(title: "_* (Title)--", starts_at: "2017-01-02 20:00:00")
+      event_three = create_event(title: "_* (Title)_2", starts_at: "2017-01-02")
 
-      assert_equal "2017-01-02-title", event_1.slug
-      assert_equal "2017-01-02-title-2", event_2.slug
-      assert_equal "2017-01-02-title-2-2", event_3.slug
+      assert_equal "#{Time.now.to_date.to_s}-title", event_one.slug
+      assert_equal "#{Time.now.to_date.to_s}-title-2", event_two.slug
+      assert_equal "#{Time.now.to_date.to_s}-title-2-2", event_three.slug
     end
   end
 end


### PR DESCRIPTION
Closes #1404 

### What does this PR do?

- With this PR slugs can be renamed in the edition
- I cleaned a repeated function and adapted the slug attributes of some models that had no attributes before_validation

### How should this be manually tested?

You can create or edit slugs of pages, processes, issues, etc.
Available in staging
