### PR TITLE
1373 subscriptions edition

### DIFF
--- a/app/assets/javascripts/user/app/controllers/user_subscription_preferences_controller.js
+++ b/app/assets/javascripts/user/app/controllers/user_subscription_preferences_controller.js
@@ -3,24 +3,60 @@ this.User.SubscriptionPreferencesController = (function() {
 
   SubscriptionPreferencesController.prototype.index = function(){
     _handleSiteSelected();
+    _handleAreaSelected('gobierto_budget_consultations');
+    _handleAreaSelected('gobierto_people');
+    _handleAreaSelected('gobierto_participation');
   };
 
   function _handleSiteSelected(){
     $('#user_subscription_preferences_site_to_subscribe').on('change', function(e){
       if($(this).is(':checked') === false){
-        _uncheckAllOptions();
+        _uncheckAllModuleOptions();
       } else {
-        _checkAllOoptions();
+
+        _checkAllModuleOptions();
       }
     });
   }
 
-  function _checkAllOoptions(){
-    $('input[data-selected]').prop('checked', 'checked');
+  function _handleAreaSelected(area_name){
+    $('#user_subscription_preferences_modules_'.concat(area_name)).on('change', function(e){
+      if($(this).is(':checked') === false){
+        _uncheckAllAreaOptions(area_name);
+      } else {
+        _checkAllAreaOptions(area_name);
+      }
+    });
   }
 
-  function _uncheckAllOptions(){
-    $('input[data-selected]').each(function(){
+  function _checkAllModuleOptions(){
+    $('#modules_selection input[data-selected]').each(function(){
+      $(this).prop('checked', 'checked');
+      $(this).prop('disabled', true);
+      _checkAllAreaOptions($(this).data('area'));
+    });
+  }
+
+  function _uncheckAllModuleOptions(){
+    $('#modules_selection input[data-selected]').each(function(){
+      $(this).prop('disabled', false);
+      if($(this).data('selected') === false){
+        $(this).prop('checked', null);
+        _uncheckAllAreaOptions($(this).data('area'))
+      }
+    });
+  }
+
+  function _checkAllAreaOptions(area_name){
+    $('#area_'.concat(area_name, ' input[data-selected]')).each(function(){
+      $(this).prop('checked', 'checked');
+      $(this).prop('disabled', true);
+    });
+  }
+
+  function _uncheckAllAreaOptions(area_name){
+    $('#area_'.concat(area_name, ' input[data-selected]')).each(function(){
+      $(this).prop('disabled', false);
       if($(this).data('selected') === false){
         $(this).prop('checked', null);
       }

--- a/app/controllers/user/subscription_preferences_controller.rb
+++ b/app/controllers/user/subscription_preferences_controller.rb
@@ -28,7 +28,7 @@ class User::SubscriptionPreferencesController < User::BaseController
       gobierto_people_people: [],
       gobierto_budget_consultations_consultations: [],
       gobierto_participation_issue: [],
-      gobierto_participation_process: []
+      gobierto_participation_processes: []
     )
   end
 end

--- a/app/controllers/user/subscriptions_controller.rb
+++ b/app/controllers/user/subscriptions_controller.rb
@@ -6,6 +6,7 @@ class User::SubscriptionsController < User::BaseController
     @user_notification_modules = get_user_notification_modules
     @user_notification_gobierto_people_people = get_user_notification_gobierto_people_people
     @user_notification_gobierto_budget_consultations_consultations = get_user_notification_gobierto_budget_consultations_consultations
+    @user_notification_gobierto_participation_processes = get_user_notification_gobierto_participation_processes
     @user_subscription_preferences_form = User::SubscriptionPreferencesForm.new(
       user: current_user,
       site: current_site,
@@ -13,7 +14,8 @@ class User::SubscriptionsController < User::BaseController
       site_to_subscribe: get_current_user_subsciption_to_site,
       modules: get_current_user_subscribed_modules,
       gobierto_people_people: get_current_user_subscribed_gobierto_people_people,
-      gobierto_budget_consultations_consultations: get_current_user_subscribed_gobierto_budet_consultations_consultations
+      gobierto_budget_consultations_consultations: get_current_user_subscribed_gobierto_budet_consultations_consultations,
+      gobierto_participation_processes: get_current_user_subscribed_gobierto_participation_processes
     )
   end
 
@@ -114,9 +116,21 @@ class User::SubscriptionsController < User::BaseController
     current_site.budget_consultations.active
   end
 
+  def get_user_notification_gobierto_participation_processes
+    current_site.processes.active
+  end
+
   def get_current_user_subscribed_gobierto_budet_consultations_consultations
     get_user_notification_gobierto_budget_consultations_consultations.select do |consultation|
       current_user.subscribed_to?(consultation, current_site)
     end.map(&:id)
+  end
+
+  def get_current_user_subscribed_gobierto_participation_processes
+    if current_user.subscribed_to?(GobiertoParticipation::Process.new, current_site, :user_subscribed_by_broader_subscription_to?)
+      get_user_notification_gobierto_participation_processes.map(&:id)
+    else
+      current_user.subscriptions.specific.where(subscribable_type: "GobiertoParticipation::Process", site: current_site).pluck(:subscribable_id)
+    end
   end
 end

--- a/app/forms/user/subscription_preferences_form.rb
+++ b/app/forms/user/subscription_preferences_form.rb
@@ -27,10 +27,11 @@ class User::SubscriptionPreferencesForm
     if @user.valid?
       @user.save
 
-      update_subscriptions_to_modules(modules)
-      update_subscriptions_to_people(gobierto_people_people)
-      update_subscription_to_site(site_to_subscribe)
-      update_subscriptions_to_consultations(gobierto_budget_consultations_consultations)
+      update_subscription_to_site(site_to_subscribe) || begin
+        update_subscriptions_to_modules(modules)
+        update_subscriptions_to_people(gobierto_people_people)
+        update_subscriptions_to_consultations(gobierto_budget_consultations_consultations)
+      end
 
       @user
     else
@@ -82,11 +83,13 @@ class User::SubscriptionPreferencesForm
   end
 
   def update_subscription_to_site(site_to_subscribe_id)
-    if site_to_subscribe_id != "0"
+    site_subscription = site_to_subscribe_id != "0"
+    if site_subscription
       @user.subscribe_to!(site, site)
     else
       @user.unsubscribe_from!(site, site)
     end
+    site_subscription
   end
 
   def update_subscriptions_to_consultations(budget_consultations)

--- a/app/forms/user/subscription_preferences_form.rb
+++ b/app/forms/user/subscription_preferences_form.rb
@@ -62,6 +62,7 @@ class User::SubscriptionPreferencesForm
 
   def update_subscriptions_to_people(people)
     people = Array(people)
+    return if broader_level_subscription_to?(GobiertoPeople::Person.new)
 
     people.each do |person_id|
       next if person_id.blank?
@@ -90,6 +91,7 @@ class User::SubscriptionPreferencesForm
 
   def update_subscriptions_to_consultations(budget_consultations)
     budget_consultations = Array(budget_consultations)
+    return if broader_level_subscription_to?(GobiertoBudgetConsultations::Consultation.new)
 
     budget_consultations.each do |consultation_id|
       next if consultation_id.blank?

--- a/app/forms/user/subscription_preferences_form.rb
+++ b/app/forms/user/subscription_preferences_form.rb
@@ -18,6 +18,14 @@ class User::SubscriptionPreferencesForm
     save_subscriptions if valid?
   end
 
+  def specific_subscriptions
+    @specific_subscriptions ||= filter_subscriptions_by_available_modules(user.subscriptions.specific.where(site: site)).map(&:subscribable)
+  end
+
+  def module_level_subscriptions
+    @module_level_subscriptions ||= filter_subscriptions_by_available_modules(user.subscriptions.specific.where(site: site)).map { |m| m.subscribable_type.underscore }
+  end
+
   private
 
   def modules_classes
@@ -120,5 +128,12 @@ class User::SubscriptionPreferencesForm
 
   def broader_level_subscription_to?(subscribable)
     user.subscribed_to?(subscribable, site, :user_subscribed_by_broader_subscription_to?)
+  end
+
+  def filter_subscriptions_by_available_modules(subscriptions)
+    available_modules_regexp = Regexp.new("^[#{site.configuration.modules_with_notifications.join("|")}]")
+    subscriptions.select do |sub|
+      available_modules_regexp.match?(sub.subscribable_type)
+    end
   end
 end

--- a/app/forms/user/subscription_preferences_form.rb
+++ b/app/forms/user/subscription_preferences_form.rb
@@ -23,7 +23,7 @@ class User::SubscriptionPreferencesForm
   end
 
   def module_level_subscriptions
-    @module_level_subscriptions ||= filter_subscriptions_by_available_modules(user.subscriptions.specific.where(site: site)).map { |m| m.subscribable_type.underscore }
+    @module_level_subscriptions ||= filter_subscriptions_by_available_modules(user.subscriptions.generic.where(site: site)).map { |m| m.subscribable_type.underscore }
   end
 
   private

--- a/app/forms/user/subscription_preferences_form.rb
+++ b/app/forms/user/subscription_preferences_form.rb
@@ -8,6 +8,7 @@ class User::SubscriptionPreferencesForm
     :modules,
     :gobierto_people_people,
     :gobierto_budget_consultations_consultations,
+    :gobierto_participation_processes,
     :site_to_subscribe
   )
 
@@ -37,6 +38,7 @@ class User::SubscriptionPreferencesForm
         update_subscriptions_to_modules
         update_subscriptions_to_people(gobierto_people_people)
         update_subscriptions_to_consultations(gobierto_budget_consultations_consultations)
+        update_subscriptions_to_participation
       end
 
       @user
@@ -105,6 +107,14 @@ class User::SubscriptionPreferencesForm
 
       consultation = site.budget_consultations.find(consultation_id)
       @user.unsubscribe_from!(consultation, site)
+    end
+  end
+
+  def update_subscriptions_to_participation
+    return if broader_level_subscription_to?(GobiertoParticipation::Process.new)
+
+    site.processes.active.each do |process|
+      gobierto_participation_processes.include?(process.id.to_s) ? user.subscribe_to!(process, site) : user.unsubscribe_from!(process, site)
     end
   end
 

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -22,7 +22,7 @@ class SiteConfiguration
 
   DEFAULT_LOGO_PATH = "sites/logo-default.png".freeze
 
-  MODULES_WITH_NOTIFICATONS = ["GobiertoPeople", "GobiertoBudgetConsultations"]
+  MODULES_WITH_NOTIFICATONS = ["GobiertoPeople", "GobiertoBudgetConsultations", "GobiertoParticipation"]
 
   attr_accessor *PROPERTIES
 

--- a/app/services/user/subscription/finder.rb
+++ b/app/services/user/subscription/finder.rb
@@ -13,8 +13,8 @@ class User::Subscription::Finder
 
   private
 
-  def self.subscriptions_scope_for(subject_type, subject_id, site_id)
-    conditions = [{subscribable_type: subject_type, subscribable_id: subject_id, site_id: site_id}]
+  def self.subscriptions_scope_for(subject_type, subject_id, site_id, exclude_specific_subscription: false)
+    conditions = exclude_specific_subscription ? [] : [{subscribable_type: subject_type, subscribable_id: subject_id, site_id: site_id}]
 
     if subject_id.present?
       conditions.push({subscribable_type: subject_type, subscribable_id: nil, site_id: site_id})
@@ -42,7 +42,7 @@ class User::Subscription::Finder
   private_class_method :subscriptions_scope_for
 
   def self.find_broader_user_subscriptions_for(subject_type, subject_id, site_id)
-    subscriptions_scope_for(subject_type, subject_id, site_id).where(site_id: site_id).where.not(subscribable_type: subject_type, subscribable_id: subject_id).pluck(:user_id).uniq
+    subscriptions_scope_for(subject_type, subject_id, site_id, exclude_specific_subscription: true).pluck(:user_id).uniq
   end
   private_class_method :find_broader_user_subscriptions_for
 

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -42,7 +42,7 @@
                   <%= t('.whole_site') %>
                 <% end %>
               </div>
-              <% if @user_notification_modules.length > 1 %>
+              <% if @user_notification_modules.any? %>
                 <div id="modules_selection">
                   <hr>
                   <%= f.collection_check_boxes(:modules, @user_notification_modules, :first, :last) do |b| %>

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -43,15 +43,18 @@
                 <% end %>
               </div>
               <% if @user_notification_modules.length > 1 %>
-                <%= f.collection_check_boxes(:modules, @user_notification_modules, :first, :first) do |b| %>
-                  <div class="option ">
-                    <%= b.check_box({"data-selected" => f.object.modules.include?(b.value)}) %>
-                    <%= b.label do %>
-                      <span></span>
-                      <%= t(".modules.#{b.text}") %>
-                    <% end %>
-                  </div>
-                <% end %>
+                <div id="modules_selection">
+                  <hr>
+                  <%= f.collection_check_boxes(:modules, @user_notification_modules, :first, :last) do |b| %>
+                    <div class="option ">
+                      <%= b.check_box({"data-selected" => f.object.module_level_subscriptions.include?(b.value), "data-area" => b.value}) %>
+                      <%= b.label do %>
+                        <span></span>
+                        <%= t(".modules.#{b.text}") %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
               <% end %>
             </div>
           </div>
@@ -62,11 +65,11 @@
         <div class="padded padded_line_box compact">
           <% if current_site.configuration.gobierto_budget_consultations_enabled? && @user_notification_gobierto_budget_consultations_consultations.any? %>
             <h3><%= t('.consultations') %></h3>
-            <div class="form_item">
+            <div class="form_item" id="area_gobierto_budget_consultations">
               <div class="options compact">
                 <%= f.collection_check_boxes(:gobierto_budget_consultations_consultations, @user_notification_gobierto_budget_consultations_consultations, :id, :title) do |b| %>
                   <div class="option ">
-                    <%= b.check_box({"data-selected" => f.object.gobierto_budget_consultations_consultations.include?(b.value)}) %>
+                    <%= b.check_box({"data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
                     <%= b.label do %>
                       <span></span>
                       <%= b.text %>
@@ -79,11 +82,30 @@
 
           <% if current_site.configuration.gobierto_people_enabled? && @user_notification_gobierto_people_people.any? %>
             <h3><%= t('.people') %></h3>
-            <div class="form_item">
+            <div class="form_item" id="area_gobierto_people">
               <div class="options compact">
                 <%= f.collection_check_boxes(:gobierto_people_people, @user_notification_gobierto_people_people, :id, :name) do |b| %>
                   <div class="option ">
-                    <%= b.check_box({"data-selected" => f.object.gobierto_people_people.include?(b.value)}) %>
+                    <%= b.check_box({"data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
+                    <%# <%= b.check_box({"data-selected" => f.object.gobierto_people_people.include?(b.value)}) %1> %>
+                    <%= b.label do %>
+                      <span></span>
+                      <%= b.text %>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <% if current_site.configuration.gobierto_participation_enabled? && @user_notification_gobierto_participation_processes.any? %>
+            <h3><%= t('.participation') %></h3>
+            <div class="form_item" id="area_gobierto_participation">
+              <div class="options compact">
+                <%= f.collection_check_boxes(:gobierto_participation_processes, @user_notification_gobierto_participation_processes, :id, :title) do |b| %>
+                  <div class="option ">
+                    <%= b.check_box({"data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
+                    <%# <%= b.check_box({"data-selected" => f.object.gobierto_participation_processes.include?(b.value)}) %1> %>
                     <%= b.label do %>
                       <span></span>
                       <%= b.text %>

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -43,11 +43,12 @@
                 <% end %>
               </div>
               <% if @user_notification_modules.any? %>
+                <% site_subscription = @user_subscription_preferences_form.site_to_subscribe.present? %>
                 <div id="modules_selection">
                   <hr>
                   <%= f.collection_check_boxes(:modules, @user_notification_modules, :first, :last) do |b| %>
                     <div class="option ">
-                      <%= b.check_box({"data-selected" => f.object.module_level_subscriptions.include?(b.value), "data-area" => b.value}) %>
+                      <%= b.check_box({"disabled" => site_subscription, "data-selected" => f.object.module_level_subscriptions.include?(b.value), "data-area" => b.value}) %>
                       <%= b.label do %>
                         <span></span>
                         <%= t(".modules.#{b.text}") %>
@@ -64,12 +65,14 @@
       <div class="pure-u-1 pure-u-md-1-3 ">
         <div class="padded padded_line_box compact">
           <% if current_site.configuration.gobierto_budget_consultations_enabled? && @user_notification_gobierto_budget_consultations_consultations.any? %>
+            <% mod_name = "gobierto_budget_consultations"
+               disabled = site_subscription || @user_subscription_preferences_form.module_level_subscriptions.include?(mod_name) %>
             <h3><%= t('.consultations') %></h3>
-            <div class="form_item" id="area_gobierto_budget_consultations">
+            <div class="form_item" id="<%= "area_#{mod_name}" %>">
               <div class="options compact">
                 <%= f.collection_check_boxes(:gobierto_budget_consultations_consultations, @user_notification_gobierto_budget_consultations_consultations, :id, :title) do |b| %>
                   <div class="option ">
-                    <%= b.check_box({"data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
+                    <%= b.check_box({"disabled" => disabled, "data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
                     <%= b.label do %>
                       <span></span>
                       <%= b.text %>
@@ -81,13 +84,14 @@
           <% end %>
 
           <% if current_site.configuration.gobierto_people_enabled? && @user_notification_gobierto_people_people.any? %>
+            <% mod_name = "gobierto_people"
+               disabled = site_subscription || @user_subscription_preferences_form.module_level_subscriptions.include?(mod_name) %>
             <h3><%= t('.people') %></h3>
-            <div class="form_item" id="area_gobierto_people">
+            <div class="form_item" id="<%= "area_#{mod_name}" %>">
               <div class="options compact">
                 <%= f.collection_check_boxes(:gobierto_people_people, @user_notification_gobierto_people_people, :id, :name) do |b| %>
                   <div class="option ">
-                    <%= b.check_box({"data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
-                    <%# <%= b.check_box({"data-selected" => f.object.gobierto_people_people.include?(b.value)}) %1> %>
+                    <%= b.check_box({"disabled" => disabled, "data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
                     <%= b.label do %>
                       <span></span>
                       <%= b.text %>
@@ -99,13 +103,14 @@
           <% end %>
 
           <% if current_site.configuration.gobierto_participation_enabled? && @user_notification_gobierto_participation_processes.any? %>
+            <% mod_name = "gobierto_participation"
+               disabled = site_subscription || @user_subscription_preferences_form.module_level_subscriptions.include?(mod_name) %>
             <h3><%= t('.participation') %></h3>
-            <div class="form_item" id="area_gobierto_participation">
+            <div class="form_item" id="<%= "area_#{mod_name}" %>">
               <div class="options compact">
                 <%= f.collection_check_boxes(:gobierto_participation_processes, @user_notification_gobierto_participation_processes, :id, :title) do |b| %>
                   <div class="option ">
-                    <%= b.check_box({"data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
-                    <%# <%= b.check_box({"data-selected" => f.object.gobierto_participation_processes.include?(b.value)}) %1> %>
+                    <%= b.check_box({"disabled" => disabled, "data-selected" => f.object.specific_subscriptions.include?(b.object)}) %>
                     <%= b.label do %>
                       <span></span>
                       <%= b.text %>

--- a/config/locales/user/views/subscriptions/ca.yml
+++ b/config/locales/user/views/subscriptions/ca.yml
@@ -19,6 +19,7 @@ ca:
           immediate: Inmediates
           submit: Desa
           weekly: Resum setmanal
+        participation: Participació
         people: Persones
         submit: Desa
         title: Les teves alertes

--- a/config/locales/user/views/subscriptions/en.yml
+++ b/config/locales/user/views/subscriptions/en.yml
@@ -19,6 +19,7 @@ en:
           immediate: Inmediate
           submit: Save
           weekly: Weekly digest
+        participation: Participation
         people: People
         submit: Save
         title: Your alerts

--- a/config/locales/user/views/subscriptions/es.yml
+++ b/config/locales/user/views/subscriptions/es.yml
@@ -19,6 +19,7 @@ es:
           immediate: Inmediatas
           submit: Guardar
           weekly: Resumen semanal
+        participation: Participación
         people: Personas
         submit: Guardar
         title: Tus alertas

--- a/test/services/user/subscription/finder_test.rb
+++ b/test/services/user/subscription/finder_test.rb
@@ -49,23 +49,6 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
     end
-
-    [
-      ["GobiertoCalendars::Event", person_event.id],
-      ["GobiertoCalendars::Event", nil],
-      ["GobiertoPeople::Person", person.id],
-      ["GobiertoPeople::Person", nil],
-      ["GobiertoPeople", nil]
-    ].each do |subscribable_type, subscribable_id|
-      assert subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
-    end
-
-    [
-      ["Site", site.id]
-    ].each do |subscribable_type, subscribable_id|
-      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
-    end
-
   end
 
   def test_user_subscribed_to_when_subscribed_to_module
@@ -115,7 +98,6 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
       ["GobiertoPeople::Person", person.id]
     ].each do |subscribable_type, subscribable_id|
       assert subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
-      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
     end
 
@@ -170,6 +152,101 @@ class User::Subscription::FinderTest < ActiveSupport::TestCase
     ].each do |subscribable_type, subscribable_id|
       refute subject.user_subscribed_to?(user, subscribable_type, subscribable_id, site.id)
       refute subject.user_subscribed_to?(other_user, subscribable_type, subscribable_id, site.id)
+    end
+  end
+
+  def test_subscribed_to_by_broader_subscription_when_subscribed_to_site
+    User::Subscription.create! user: user, site: site, subscribable: site
+
+    [
+      ["GobiertoCalendars::Event", person_event.id],
+      ["GobiertoCalendars::Event", nil],
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil],
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      assert subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+  end
+
+  def test_subscribed_to_by_broader_subscription_when_subscribed_to_module
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople"
+
+    [
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil]
+    ].each do |subscribable_type, subscribable_id|
+      assert subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+    [
+      ["GobiertoPeople", nil],
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+  end
+
+  def test_subscribed_to_by_broader_subscription_when_subscribed_to_class
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::Person"
+    [
+      ["GobiertoPeople::Person", person.id]
+    ].each do |subscribable_type, subscribable_id|
+      assert subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+    [
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil],
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+  end
+
+  def test_subscribed_to_by_broader_subscription_when_subscribed_to_sublcass
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoCalendars::Event"
+
+    [
+      ["GobiertoCalendars::Event", person_event.id]
+    ].each do |subscribable_type, subscribable_id|
+      assert subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+    [
+      ["GobiertoCalendars::Event", nil],
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil],
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+  end
+
+  def test_subscribed_to_by_broader_subscription_when_subscribed_to_class_instance
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoPeople::Person", subscribable_id: person.id
+
+    [
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil],
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
+    end
+  end
+
+  def test_subscribed_to_by_broader_subscription_when_subscribed_to_subclass_instance
+    User::Subscription.create! user: user, site: site, subscribable_type: "GobiertoCalendars::Event", subscribable_id: person_event.id
+
+    [
+      ["GobiertoCalendars::Event", person_event.id],
+      ["GobiertoCalendars::Event", nil],
+      ["GobiertoPeople::Person", person.id],
+      ["GobiertoPeople::Person", nil],
+      ["GobiertoPeople", nil],
+      ["Site", site.id]
+    ].each do |subscribable_type, subscribable_id|
+      refute subject.user_subscribed_by_broader_subscription_to?(user, subscribable_type, subscribable_id, site.id)
     end
   end
 


### PR DESCRIPTION
Related with #1373

### What does this PR do?
* Adds a global participation area item and individual processes subscription items to user subscription preferences form
* When a user checks "Whole site" or a module the dependent checkboxes are marked and disabled
* If a user marks, for example, whole site and saves, only the site subscription is saved, and the other checked options are ignored, since "whole site" option has priority over the rest of subscriptions. The same occurs with module subscriptions.
* If a user unmarks "Whole site" or a module, if there was a previous subscription on a dependent item, the item appears as marked, because the subscription remains, and now will be used.

#### Pending:
* ~~Include individual `GobiertoCommon::Scope` and `Issue` instances in right subscription column~~

### How should this be manually tested?
Visit http://madrid.gobify.net/user/subscriptions as signed in user

### Does this PR changes any configuration file?
No

