### PR TITLE
265 - Order person statements by person position

### DIFF
--- a/app/controllers/gobierto_people/person_statements_controller.rb
+++ b/app/controllers/gobierto_people/person_statements_controller.rb
@@ -5,7 +5,7 @@ module GobiertoPeople
 
     def index
       @people = current_site.people.active
-      @statements = current_site.person_statements.active.sorted
+      @statements = current_site.person_statements.active.sorted_by_person_position
 
       respond_to do |format|
         format.html

--- a/app/models/gobierto_people/person_statement.rb
+++ b/app/models/gobierto_people/person_statement.rb
@@ -25,7 +25,7 @@ module GobiertoPeople
     belongs_to :site
 
     scope :sorted, -> { order(published_on: :desc, created_at: :desc) }
-    scope :sorted_by_person_position, -> { joins(:person).order('gp_people.position ASC, published_on DESC, gp_person_statements.created_at DESC') }
+    scope :sorted_by_person_position, -> { joins(:person).order("#{Person.table_name}.position ASC, published_on DESC, #{table_name}.created_at DESC") }
 
     enum visibility_level: { draft: 0, active: 1 }
 

--- a/app/models/gobierto_people/person_statement.rb
+++ b/app/models/gobierto_people/person_statement.rb
@@ -25,6 +25,7 @@ module GobiertoPeople
     belongs_to :site
 
     scope :sorted, -> { order(published_on: :desc, created_at: :desc) }
+    scope :sorted_by_person_position, -> { joins(:person).order('gp_people.position ASC, published_on DESC, gp_person_statements.created_at DESC') }
 
     enum visibility_level: { draft: 0, active: 1 }
 

--- a/app/views/gobierto_people/person_statements/_person_statement.html.erb
+++ b/app/views/gobierto_people/person_statements/_person_statement.html.erb
@@ -13,7 +13,7 @@
   <div class="pure-u-md-2-3">
 
     <h3><%= link_to person_statement.title, gobierto_people_person_statement_path(person_statement.person.slug, person_statement.slug) %></h3>
-    <div class="soft"><small><%= l(person_statement.updated_at, format: :long) %></small></div>
+    <div class="soft"><small><%= l(person_statement.published_on, format: :long) %></small></div>
 
   </div>
 

--- a/test/fixtures/gobierto_people/person_statements.yml
+++ b/test/fixtures/gobierto_people/person_statements.yml
@@ -36,3 +36,26 @@ richard_draft:
   attachment_size:
   published_on: <%= 1.year.ago.to_date %>
   visibility_level: <%= GobiertoPeople::PersonStatement.visibility_levels["draft"] %>
+
+tamara_current:
+  person: tamara
+  site: madrid
+  title_translations: <%= {
+    'en' => 'Declaración de Tamara',
+    'es' => 'Declaración de Tamara'
+  }.to_json %>
+  slug: <%= "#{Date.current.strftime('%F')}-declaracion-de-tamara" %>
+  # published before nelson_current
+  published_on: <%= 1.day.ago %>
+  visibility_level: <%= GobiertoPeople::PersonStatement.visibility_levels["active"] %>
+
+nelson_current:
+  person: nelson
+  site: madrid
+  title_translations: <%= {
+    'en' => 'Declaración de Nelson',
+    'es' => 'Declaración de Nelson'
+  }.to_json %>
+  slug: <%= "#{Date.current.strftime('%F')}-declaracion-de-nelson" %>
+  published_on: <%= 10.days.ago %>
+  visibility_level: <%= GobiertoPeople::PersonStatement.visibility_levels["active"] %>

--- a/test/models/gobierto_people/person_statement_test.rb
+++ b/test/models/gobierto_people/person_statement_test.rb
@@ -9,10 +9,27 @@ module GobiertoPeople
     include User::SubscribableTest
     include GobiertoCommon::SluggableTestModule
 
+    def madrid
+      @madrid ||= sites(:madrid)
+    end
+
     def person_statement
       @person_statement ||= gobierto_people_person_statements(:richard_current)
     end
+    alias richard_statement person_statement
     alias subscribable person_statement
+
+    def richard_past_statement
+      @richard_past ||= gobierto_people_person_statements(:richard_past)
+    end
+
+    def nelson_statement
+      @nelson_statement ||= gobierto_people_person_statements(:nelson_current)
+    end
+
+    def tamara_statement
+      @tamara_statement ||= gobierto_people_person_statements(:tamara_current)
+    end
 
     def new_person_statement
       GobiertoPeople::PersonStatement.create!(
@@ -27,5 +44,13 @@ module GobiertoPeople
     def test_valid
       assert person_statement.valid?
     end
+
+    def test_sorted_by_person_scope
+      sorted_statements_ids = madrid.person_statements.active.sorted_by_person_position.pluck(:id)
+
+      # should be ordered by person position, and within the same person recent statements appear first
+      assert_equal [richard_statement.id, richard_past_statement.id, nelson_statement.id, tamara_statement.id], sorted_statements_ids
+    end
+
   end
 end


### PR DESCRIPTION
Closes [#265](https://github.com/PopulateTools/issues/issues/265)

### What does this PR do?

Orders person statements so statements of people with the highest position appear first.

### How should this be manually tested?

I've created the "Most important person" and "Least important person" in [http://madrid.gobify.net/admin/people/people](http://madrid.gobify.net/admin/people/people), each with one statement and the one of "Least important person" was published later.

In [http://madrid.gobify.net/declaraciones](http://madrid.gobify.net/declaraciones) "
Declaración de la persona más importante" should appear first.

### Does this PR changes any configuration file?

No
