### PR TITLE
Complete welcome participation test

### DIFF
--- a/app/views/gobierto_participation/welcome/_participation_themes_list_a.html.erb
+++ b/app/views/gobierto_participation/welcome/_participation_themes_list_a.html.erb
@@ -12,7 +12,7 @@
       <div class="pure-u-1 pure-u-md-2-3 groups">
         <div class="pure-g three_by_three">
           <% @issues.each do |issue| %>
-            <%= render 'gobierto_participation/issues/theme_teaser', issue: issue, meta: true %>
+            <%= render 'gobierto_participation/issues/issue_teaser', issue: issue, meta: true %>
           <% end %>
         </div>
       </div>

--- a/test/fixtures/gobierto_core/site_templates.yml
+++ b/test/fixtures/gobierto_core/site_templates.yml
@@ -1,4 +1,7 @@
 madrid_participation_index:
-  markup: "<div class='gradient-bg'>My Template {% show_poll(poll_id: 353021530) %}</div>"
+  markup: "<div class='gradient-bg'>My Template {% show_poll(poll_id: 353021530) %}</div>
+           {% render_partial 'gobierto_participation/welcome/participation_latest_info' %}
+           {% render_partial 'gobierto_participation/welcome/participation_proccesses' %}
+           {% render_partial 'gobierto_participation/welcome/participation_themes_list_a' %}"
   template: participation_index
   site: madrid

--- a/test/integration/gobierto_participation/welcome/welcome_index_test.rb
+++ b/test/integration/gobierto_participation/welcome/welcome_index_test.rb
@@ -21,6 +21,14 @@ module GobiertoParticipation
       @poll ||= gobierto_participation_polls(:ordinance_of_terraces_published)
     end
 
+    def issues
+      @issues ||= site.issues.sorted
+    end
+
+    def processes
+      @processes ||= site.processes.process.active
+    end
+
     def test_breadcrumb_items
       with_current_site(site) do
         visit @path
@@ -133,8 +141,20 @@ module GobiertoParticipation
         visit @path
 
         assert has_content?("My Template")
-        assert has_no_content?("Ongoing processes")
-        assert has_no_content?("Themes")
+
+        assert has_content?("Diary")
+        assert has_content?("The last")
+        assert has_content?("News")
+
+        assert has_content?("Themes")
+        issues.each do |issue|
+          assert has_link?(issue.name)
+        end
+
+        assert has_content?("Ongoing processes")
+        processes.each do |process|
+          assert has_link?(process.title)
+        end
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

I have completed the tests for the welcome to participate page. By default, the participation welcome template comes with some partials that had changed.

### How should this be manually tested?

You can access to /participation and won't appear

`
Liquid error: internal
`