### PR TITLE
Scope password reset to site users

### DIFF
--- a/app/controllers/user/passwords_controller.rb
+++ b/app/controllers/user/passwords_controller.rb
@@ -18,10 +18,10 @@ class User::PasswordsController < User::BaseController
   end
 
   def edit
-    user = User.confirmed.find_by_reset_password_token(params[:reset_password_token])
+    user = current_site.users.confirmed.find_by_reset_password_token(params[:reset_password_token])
 
     if user
-      @user_password_form = User::EditPasswordForm.new(user_id: user.id)
+      @user_password_form = User::EditPasswordForm.new(user_id: user.id, site: current_site)
     else
       redirect_to new_user_sessions_path, alert: t(".error")
     end
@@ -29,7 +29,7 @@ class User::PasswordsController < User::BaseController
 
   def update
     @user_password_form = User::EditPasswordForm.new(
-      user_edit_password_params
+      user_edit_password_params.merge(site: current_site)
     )
 
     if @user_password_form.save

--- a/app/forms/user/edit_password_form.rb
+++ b/app/forms/user/edit_password_form.rb
@@ -1,7 +1,7 @@
 class User::EditPasswordForm
   include ActiveModel::Model
 
-  attr_accessor :user_id, :password, :password_confirmation
+  attr_accessor :user_id, :password, :password_confirmation, :site
   attr_reader :user
 
   validates :user, :password, presence: true
@@ -12,7 +12,7 @@ class User::EditPasswordForm
   end
 
   def user
-    @user ||= User.find_by(id: user_id)
+    @user ||= site.users.find_by(id: user_id)
   end
 
   private

--- a/app/forms/user/new_password_form.rb
+++ b/app/forms/user/new_password_form.rb
@@ -18,7 +18,7 @@ class User::NewPasswordForm
   end
 
   def user
-    @user ||= User.find_by(email: email)
+    @user ||= site.users.find_by(email: email)
   end
 
   private

--- a/test/forms/user/edit_password_form_test.rb
+++ b/test/forms/user/edit_password_form_test.rb
@@ -6,17 +6,36 @@ class User::EditPasswordFormTest < ActiveSupport::TestCase
   def valid_user_edit_password_form
     @valid_user_edit_password_form ||= User::EditPasswordForm.new(
       user_id: user.id,
+      site: site,
       password: "wadus",
       password_confirmation: "wadus"
     )
+  end
+
+  def invalid_user_edit_password_form
+    @invalid_user_edit_password_form ||= User::EditPasswordForm.new(
+      user_id: other_site_user.id,
+      site: site,
+      password: "wadus",
+      password_confirmation: "wadus"
+    )
+  end
+
+  def site
+    @site ||= sites(:madrid)
   end
 
   def user
     @user ||= users(:reed)
   end
 
+  def other_site_user
+    @other_site_user ||= users(:charles)
+  end
+
   def test_validation
     assert valid_user_edit_password_form.valid?
+    refute invalid_user_edit_password_form.valid?
   end
 
   def test_save

--- a/test/forms/user/new_password_form_test.rb
+++ b/test/forms/user/new_password_form_test.rb
@@ -10,8 +10,19 @@ class User::NewPasswordFormTest < ActiveSupport::TestCase
     )
   end
 
+  def invalid_user_new_password_form
+    @invalid_user_new_password_form ||= User::NewPasswordForm.new(
+      email: other_site_user.email,
+      site: site
+    )
+  end
+
   def user
     @user ||= users(:reed)
+  end
+
+  def other_site_user
+    @other_site_user ||= users(:charles)
   end
 
   def site
@@ -20,6 +31,7 @@ class User::NewPasswordFormTest < ActiveSupport::TestCase
 
   def test_validation
     assert valid_user_new_password_form.valid?
+    refute invalid_user_new_password_form.valid?
   end
 
   def test_save

--- a/test/integration/user/password_reset_test.rb
+++ b/test/integration/user/password_reset_test.rb
@@ -13,6 +13,10 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
     @user ||= users(:dennis)
   end
 
+  def other_site_user
+    @other_site_user ||= users(:charles)
+  end
+
   def recoverable_user
     @recoverable_user ||= users(:dennis)
   end
@@ -104,6 +108,18 @@ class User::PasswordResetTest < ActionDispatch::IntegrationTest
       click_on "Recover"
 
       assert has_message?("Please check your inbox to get instructions")
+    end
+  end
+
+  def test_password_reset_request_from_other_site_user
+    with_current_site(site) do
+      visit @password_request_path
+
+      fill_in :user_password_email, with: other_site_user.email
+
+      click_button "Recover"
+
+      assert has_message?("The email address specified doesn't seem to be valid")
     end
   end
 end


### PR DESCRIPTION
Closes #1414 

### What does this PR do?

Filters users to a given site when trying to reset or update their password.

### How should this be manually tested?

Try to recover the password in a site different from users site. You should get an error message.

![screen shot 2018-02-09 at 16 40 30](https://user-images.githubusercontent.com/17616/36035700-f9edfa00-0db7-11e8-831d-fe29a529cc6d.png)
