### PR TITLE
Pluralize items properly in level plans

### DIFF
--- a/app/assets/javascripts/gobierto_plans/app/controllers/plans_controller.js
+++ b/app/assets/javascripts/gobierto_plans/app/controllers/plans_controller.js
@@ -106,8 +106,9 @@ this.GobiertoPlans.PlansController = (function() {
               this.isOpen = !this.isOpen;
             }
           },
-          getLabel: function(level) {
-            return this.level["level" + (level + 1)]
+          getLabel: function(level, number_of_elements) {
+            var key = this.level["level" + (level + 1)]
+            return (number_of_elements == 1 ? key["one"] : key["other"])
           }
         }
       });

--- a/app/helpers/gobierto_plans/plan_helper.rb
+++ b/app/helpers/gobierto_plans/plan_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  module PlanHelper
+    def level_name_pluralize(number_of_elements, translation_key)
+      count = number_of_elements == 1 ? "one" : "other"
+
+      "#{number_of_elements} #{translation_key[count][I18n.locale.to_s]}"
+    end
+  end
+end

--- a/app/views/gobierto_plans/plans/show.html.erb
+++ b/app/views/gobierto_plans/plans/show.html.erb
@@ -44,11 +44,11 @@
         <div class="header-detail">
           <% for i in 0..(@levels) %>
             <div>
-              <%= @plan.categories.where(level: i).size %> <%= @plan.configuration_data["level" + i.to_s][I18n.locale.to_s] %>
+              <%= level_name_pluralize(@plan.categories.where(level: i).size, @plan.configuration_data["level" + i.to_s]) %>
             </div>
           <% end %>
           <div>
-            <%= @node_number %> <%= @plan.configuration_data["level" + (@levels + 1).to_s][I18n.locale.to_s] %>
+            <%= level_name_pluralize(@node_number, @plan.configuration_data["level" + (@levels + 1).to_s]) %>
           </div>
         </div>
 
@@ -64,7 +64,8 @@
 
         <section class="level_1" v-if="isOpen(1)" :class="['cat_' + color() ]">
           <div class="lines-header">
-            <div>{{ (activeNode.children || []).length }} <%= @plan.configuration_data["level" + (@levels - 1).to_s][I18n.locale.to_s] %></div>
+            <div><%= level_name_pluralize(@plan.categories.where(level: 1).size, @plan.configuration_data["level1"]) %></div>
+
             <div><%= t(".percentage_progress") %></div>
           </div>
 
@@ -92,7 +93,7 @@
                   <div><i class="fa fa-caret-down"></i></div>
                   <h3>{{ (activeNode.attributes || {}).title | translate }}</h3>
                 </div>
-                <div>{{ (activeNode.children || []).length }} <%= @plan.configuration_data["level" + @levels.to_s][I18n.locale.to_s] %></div>
+                <div><%= level_name_pluralize(@plan.categories.where(level: 2).size, @plan.configuration_data["level2"]) %></div>
                 <div>{{ (activeNode.attributes || {}).progress || 0 | percent }}</div>
               </div>
 
@@ -203,7 +204,7 @@
       <div><i class="fa" :class="[(isOpen) ? 'fa-caret-down' : 'fa-caret-right']"></i></div>
       <h3><a @click.stop="setActive" data-turbolinks="false">{{ model.attributes.title | translate }}</a></h3>
     </div>
-    <div>{{ (model.children || []).length }} {{ getLabel(model.level) | translate }}</div>
+    <div>{{ (model.children || []).length }} {{ getLabel(model.level, (model.children || []).length) | translate }}</div>
     <div>{{ (model.attributes || {}).progress || 0 | percent }}</div>
   </div>
 </script>

--- a/test/fixtures/gobierto_plans/plans.yml
+++ b/test/fixtures/gobierto_plans/plans.yml
@@ -10,10 +10,14 @@ strategic_plan:
   updated_at: 2016-11-01 00:02:00
   plan_type: pam
   configuration_data: <%= {
-    "level0" => {"ca"=>"eixos", "es"=>"ejes", "en"=>"axes"},
-    "level1" => {"ca"=>"línies d'actuació", "es"=>"líneas de actuación", "en"=>"lines of action"},
-    "level2" => {"ca"=>"actuacions", "es"=>"actuaciones", "en"=>"actions"},
-    "level3" => {"ca"=>"projectes", "es"=>"proyectos", "en"=>"projects"},
+    "level0" => {"one" => {"ca"=>"eix", "es"=>"eje", "en"=>"axis"},
+                 "other" => {"ca"=>"eixos", "es"=>"ejes", "en"=>"axes"}},
+    "level1" => {"one" => {"ca"=>"línia d'actuació", "es"=>"línea de actuación", "en"=>"line of action"},
+                 "other" => {"ca"=>"línies d'actuació", "es"=>"líneas de actuación", "en"=>"lines of action"}},
+    "level2" => {"one" => {"ca"=>"actuació", "es"=>"actuación", "en"=>"action"},
+                 "other" => {"ca"=>"actuacions", "es"=>"actuaciones", "en"=>"actions"}},
+    "level3" => {"one" => {"ca"=>"projecte", "es"=>"proyecto", "en"=>"project"},
+                 "other" => {"ca"=>"projectes", "es"=>"proyectos", "en"=>"projects"}},
     "level0_options" => [ { "slug" => "people-and-families",
                             "logo" => "http://gobierto.es/assets/v2/logo-gobierto.svg" },
                           { "slug" => "city",

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -43,7 +43,7 @@ module GobiertoPlans
           assert has_content? "Latest update: November 01, 2016"
 
           assert has_content? "#{axes.size} axes"
-          assert has_content? "#{action_lines.size} lines of action"
+          assert has_content? "1 line of action"
           assert has_content? "#{actions.size} actions"
           assert has_content? "#{projects.size} projects"
 
@@ -89,11 +89,11 @@ module GobiertoPlans
           within ".planification-content" do
             within "section.level_1.cat_3" do
               within ".lines-header" do
-                assert has_content?("#{action_lines.size} lines of action")
+                assert has_content?("1 line of action")
               end
               within ".lines-list" do
                 assert has_content?(action_lines.first.name)
-                assert has_content?("#{actions.size} actions")
+                assert has_content?("2 actions")
 
                 assert has_content?((projects.sum(:progress) / projects.size) / 100)
               end


### PR DESCRIPTION
Closes #1428 

### What does this PR do?

Pluralize level keys in categories and nodes, ex. line of actuation/lines of actuation depending on the number of elements.

![captura de pantalla 2018-02-12 a las 16 49 49](https://user-images.githubusercontent.com/69764/36105429-d614a4e4-1014-11e8-93ce-5bf6252be199.png)

### How should this be manually tested?

http://esplugues.gobify.net/planes/projectes-del-pam