### PR TITLE
Mark unreceived events as drafts in Google Calendar integration

### DIFF
--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -6,8 +6,8 @@ require 'fileutils'
 module GobiertoPeople
   module GoogleCalendar
     class CalendarIntegration
-      CLIENT_SECRETS_PATH = Rails.root.join('config', 'google_calendar_integration_client_secret.json')
-      USERNAME = 'default'
+      CLIENT_SECRETS_PATH = Rails.root.join("config", "google_calendar_integration_client_secret.json")
+      USERNAME = "default"
       SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 
       def self.sync_person_events(person)
@@ -16,19 +16,8 @@ module GobiertoPeople
 
       def sync!
         set_google_calendar_id!
-
-        received_events_ids = []
-        service.list_calendar_lists(max_results: 100).items.each do |calendar|
-          if configuration.calendars.present? && configuration.calendars.include?(calendar.id)
-            received_events_ids.concat sync_calendar_events(calendar)
-          end
-        end
-
-        person.events.upcoming.synchronized.each do |event|
-          unless received_events_ids.include?(event.external_id)
-            event.pending!
-          end
-        end
+        import_events!
+        delete_unreceived_events!
       end
 
       def calendars
@@ -44,9 +33,10 @@ module GobiertoPeople
         @service = Google::Apis::CalendarV3::CalendarService.new
         @service.client_options.application_name = person.site.name
         @service.authorization = authorize(person)
+        @received_event_ids = []
       end
 
-      attr_reader :person, :configuration, :service
+      attr_reader :person, :configuration, :service, :received_event_ids
 
       def set_google_calendar_id!
         if @configuration.google_calendar_id.nil?
@@ -56,24 +46,18 @@ module GobiertoPeople
       end
 
       def sync_calendar_events(calendar)
-        received_events_ids = []
-
         response = service.list_events(calendar.id, always_include_email: true, time_min: GobiertoCalendars.sync_range_start.iso8601)
         response.items.each do |event|
-          received_events_ids.push event.id
           next if is_private?(event)
 
           if is_recurring?(event)
             service.list_event_instances(calendar.id, event.id).items.each_with_index do |event, i|
-              received_events_ids.push event.id
               sync_event(event, i)
             end
           else
             sync_event(event)
           end
         end
-
-        received_events_ids
       end
 
       def is_private?(event)
@@ -130,7 +114,10 @@ module GobiertoPeople
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
           GobiertoPeople::PersonEventForm.new(event_params).destroy
         else
-          unless GobiertoPeople::PersonEventForm.new(event_params).save
+          gobierto_event = GobiertoPeople::PersonEventForm.new(event_params)
+          if gobierto_event.save
+            received_event_ids.push(event.id)
+          else
             Rails.logger.info "[Google Calendar Integration] Invalid event: #{event_params}"
           end
         end
@@ -151,6 +138,20 @@ module GobiertoPeople
         if time_attribute
           time_attribute.date_time || DateTime.parse(time_attribute.date)
         end
+      end
+
+      def import_events!
+        service.list_calendar_lists(max_results: 100).items.each do |calendar|
+          if configuration.calendars.present? && configuration.calendars.include?(calendar.id)
+            sync_calendar_events(calendar)
+          end
+        end
+      end
+
+      def delete_unreceived_events!
+        person.events.upcoming.synchronized.
+          where.not(external_id: received_event_ids).
+          each(&:pending!)
       end
     end
   end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -65,6 +65,7 @@ module GobiertoPeople
 
           if is_recurring?(event)
             service.list_event_instances(calendar.id, event.id).items.each_with_index do |event, i|
+              received_events_ids.push event.id
               sync_event(event, i)
             end
           else
@@ -72,7 +73,7 @@ module GobiertoPeople
           end
         end
 
-        received_events_ids.compact
+        received_events_ids
       end
 
       def is_private?(event)

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -29,13 +29,13 @@ module GobiertoPeople
 
         ## Mocks
         date1 = mock
-        date1.stubs(date_time: Time.now)
+        date1.stubs(date_time: 48.hours.from_now)
         date2 = mock
-        date2.stubs(date_time: 1.hour.from_now)
+        date2.stubs(date_time: 49.hours.from_now)
 
         # Private event, ignored
         event1 = mock
-        event1.stubs(visibility: "private")
+        event1.stubs(visibility: "private", id: "event1")
 
         creator_event2 = mock
         creator_event2.stubs(email: google_calendar_id)
@@ -233,6 +233,44 @@ module GobiertoPeople
         assert_nil event.attendees.second.person
         assert_equal "Wadus person", event.attendees.second.name
         assert_equal "Event 2 description", event.description
+      end
+
+      def test_sync_events_removes_deleted_events
+        CalendarIntegration.sync_person_events(richard)
+        event = richard.events.find_by external_id: "event2"
+        assert event.published?
+
+        ## Update mocks to remove event2
+        event1 = mock
+        event1.stubs(visibility: "private", id: "event1")
+
+        calendar1 = mock
+        calendar1.stubs(id: google_calendar_id, primary?: true)
+
+        calendar_1_items_response = mock
+        calendar_1_items_response.stubs(:items).returns([event1])
+
+        client_options = mock
+        client_options.stubs(:application_name=).returns(true)
+
+        calendar_items_response = mock
+        calendar_items_response.stubs(:items).returns([calendar1])
+
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_calendar_lists).returns(calendar_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_events).with(calendar1.id, instance_of(Hash)).returns(calendar_1_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:client_options).returns(client_options)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:authorization=).returns(true)
+
+        ## Configure site and person
+        configure_google_calendar_integration(
+          collection: richard.calendar,
+          data: { calendars: [calendar1.id] }
+        )
+
+        CalendarIntegration.sync_person_events(richard)
+
+        event.reload
+        refute event.published?
       end
     end
   end


### PR DESCRIPTION
Bugfix
Closes [#268](/PopulateTools/issues/268)

### What does this PR do?

This PR un-publishes the events not received from the Google Calendar API.
This behaviour was already present in the other integrations, wer forgot to add it to this integration.

### How should this be manually tested?

In an account with a Google calendar synchronized and events imported, remove a published event from the future and check that in Gobierto the event gets unpublished.
