### PR TITLE
Fix element reloaded after ajax request

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people/person_events_controller.rb
@@ -5,7 +5,7 @@ module GobiertoAdmin
         def index
           @collection = @person.events_collection
           @events_presenter = GobiertoAdmin::GobiertoCalendars::EventsPresenter.new(@collection)
-          @events = @person.events.sorted_backwards
+          @events = @person.events.sorted
           @archived_events = @person.events.only_archived.sorted_backwards
         end
       end

--- a/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
@@ -95,7 +95,6 @@
       <% end %>
     </tbody>
   </table>
-</div>
 
   <% unless @archived_events.empty? %>
     <div class="m_v_1 right">
@@ -139,22 +138,22 @@
               </td>
               <td>
                 <%= link_to t("gobierto_admin.shared.recover.element"),
-                            admin_calendars_event_recover_path(event, process_id: (current_process.id if !defined?(current_process).nil?)),
-                            title: t("gobierto_admin.shared.recover.element"),
-                            method: :put,
-                            data: { confirm: t("gobierto_admin.shared.recover.confirm") } %>
+                  admin_calendars_event_recover_path(event, process_id: (current_process.id if !defined?(current_process).nil?)),
+                  title: t("gobierto_admin.shared.recover.element"),
+                  method: :put,
+                  data: { confirm: t("gobierto_admin.shared.recover.confirm") } %>
 
-              </td>
+            </td>
             </tr>
           <% end %>
         </tbody>
       </table>
     </div>
   <% end %>
-
+</div>
 
 <%= javascript_tag do %>
-  $('a[data-toggle]').on('click', function(e){
-     $("div#archived-list").toggle();
-  });
+$('a[data-toggle]').on('click', function(e){
+  $("div#archived-list").toggle();
+});
 <% end %>

--- a/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/people/person_events/index.html.erb
@@ -4,4 +4,4 @@
 
 <%= render "gobierto_admin/gobierto_people/people/navigation" %>
 
-<%= render partial: "gobierto_admin/gobierto_calendars/events/index", locals: {collection: @collection} %>
+<%= render "gobierto_admin/gobierto_calendars/events/index", { collection: @collection } %>

--- a/test/integration/gobierto_admin/gobierto_calendars/archive_event_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/archive_event_test.rb
@@ -49,6 +49,28 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_single_archive_link
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "#person-event-item-#{themes_event.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("Event was successfully archived")
+
+              assert has_link?("Archived elements")
+
+              click_link "Published events"
+
+              assert_equal 1, page.all("a").select{ |a| a.text == "Archived elements" }.length
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_calendars/archive_event_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/archive_event_test.rb
@@ -66,6 +66,8 @@ module GobiertoAdmin
 
               click_link "Published events"
 
+              sleep 1
+
               assert_equal 1, page.all("a").select{ |a| a.text == "Archived elements" }.length
             end
           end


### PR DESCRIPTION
Closes #1442

### What does this PR do?

This PR fixes the HTML element returned by the Ajax request.

### How should this be manually tested?

Navigate the events filters, and you shouldn't see the archived elements link duplicated.
