### PR TITLE
Agendas make it optional event description

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -82,6 +82,7 @@ module GobiertoAdmin
           :microsoft_exchange_pwd,
           :microsoft_exchange_url,
           :clear_calendar_configuration,
+          :without_description,
           filtering_rules_attributes: [:id, :field, :condition, :value, :action, :_destroy, :remove_filtering_text],
           calendars: []
         )

--- a/app/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form.rb
+++ b/app/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form.rb
@@ -18,7 +18,8 @@ module GobiertoAdmin
         :microsoft_exchange_url,
         :clear_calendar_configuration,
         :calendars,
-        :filtering_rules
+        :filtering_rules,
+        :without_description
       )
 
       validates(
@@ -100,6 +101,12 @@ module GobiertoAdmin
         @ibm_notes_url ||= if calendar_configuration.respond_to?(:ibm_notes_url)
                              calendar_configuration.ibm_notes_url.try(:strip)
                            end
+      end
+
+      def without_description
+        @without_description ||= if calendar_configuration.respond_to?(:without_description)
+                                   calendar_configuration.without_description
+                                 end
       end
 
       def microsoft_exchange_usr
@@ -254,7 +261,8 @@ module GobiertoAdmin
         {
           ibm_notes_usr: ibm_notes_usr,
           ibm_notes_pwd: encrypted_ibm_notes_pwd,
-          ibm_notes_url: ibm_notes_url
+          ibm_notes_url: ibm_notes_url,
+          without_description: without_description
         }
       end
 
@@ -262,7 +270,8 @@ module GobiertoAdmin
         {
           microsoft_exchange_usr: microsoft_exchange_usr,
           microsoft_exchange_pwd: encrypted_microsoft_exchange_pwd,
-          microsoft_exchange_url: microsoft_exchange_url
+          microsoft_exchange_url: microsoft_exchange_url,
+          without_description: without_description
         }
       end
 
@@ -270,7 +279,8 @@ module GobiertoAdmin
         {
           calendars: calendars.select { |c| !c.blank? },
           google_calendar_credentials: calendar_configuration.google_calendar_credentials,
-          google_calendar_id: calendar_configuration.google_calendar_id
+          google_calendar_id: calendar_configuration.google_calendar_id,
+          without_description: without_description
         }
       end
 

--- a/app/models/gobierto_calendars/calendar_configuration.rb
+++ b/app/models/gobierto_calendars/calendar_configuration.rb
@@ -10,5 +10,13 @@ module GobiertoCalendars
     belongs_to :collection, class_name: "GobiertoCommon::Collection"
 
     validates :collection_id, :integration_name, :data, presence: true
+
+    def without_description
+      data['without_description']
+    end
+
+    def without_description=(without_description)
+      data['without_description'] = without_description
+    end
   end
 end

--- a/app/models/gobierto_calendars/google_calendar_configuration.rb
+++ b/app/models/gobierto_calendars/google_calendar_configuration.rb
@@ -2,7 +2,6 @@
 
 module GobiertoCalendars
   class GoogleCalendarConfiguration < CalendarConfiguration
-
     def google_calendar_credentials
       data['google_calendar_credentials']
     end
@@ -26,6 +25,5 @@ module GobiertoCalendars
     def calendars
       data['calendars']
     end
-
   end
 end

--- a/app/models/gobierto_calendars/ibm_notes_calendar_configuration.rb
+++ b/app/models/gobierto_calendars/ibm_notes_calendar_configuration.rb
@@ -2,7 +2,6 @@
 
 module GobiertoCalendars
   class IbmNotesCalendarConfiguration < CalendarConfiguration
-
     def ibm_notes_usr
       data['ibm_notes_usr']
     end
@@ -26,6 +25,5 @@ module GobiertoCalendars
     def ibm_notes_url=(ibm_notes_url)
       data['ibm_notes_url'] = ibm_notes_url
     end
-
   end
 end

--- a/app/models/gobierto_calendars/microsoft_exchange_calendar_configuration.rb
+++ b/app/models/gobierto_calendars/microsoft_exchange_calendar_configuration.rb
@@ -2,7 +2,6 @@
 
 module GobiertoCalendars
   class MicrosoftExchangeCalendarConfiguration < CalendarConfiguration
-
     def microsoft_exchange_usr
       data['microsoft_exchange_usr']
     end
@@ -26,6 +25,5 @@ module GobiertoCalendars
     def microsoft_exchange_url=(microsoft_exchange_url)
       data['microsoft_exchange_url'] = microsoft_exchange_url
     end
-
   end
 end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -86,7 +86,7 @@ module GobiertoPeople
       def sync_event(event, i = nil)
         filter_result = GobiertoCalendars::FilteringRuleApplier.filter({
           title: event.summary,
-          description: event.description
+          description: (event.description unless configuration.without_description == "1")
         }, configuration.filtering_rules)
 
         filter_result.action = GobiertoCalendars::FilteringRuleApplier::REMOVE if is_private?(event)

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -33,7 +33,7 @@ module GobiertoPeople
 
         filter_result = GobiertoCalendars::FilteringRuleApplier.filter({
           title: ibm_notes_event.title,
-          description: ibm_notes_event.description,
+          description: (ibm_notes_event.description unless configuration.without_description == "1"),
         }, configuration.filtering_rules)
 
         state = filter_result.action == GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING ?

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -68,7 +68,7 @@ module GobiertoPeople
       def sync_event(event)
         filter_result = GobiertoCalendars::FilteringRuleApplier.filter({
           title: event.subject,
-          description: event.body.text
+          description: (event.body.text unless configuration.without_description == "1")
         }, configuration.filtering_rules)
 
         filter_result.action = GobiertoCalendars::FilteringRuleApplier::REMOVE if is_private?(event)

--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/edit.html.erb
@@ -34,10 +34,10 @@
 
       <% if integration_name.present? %>
         <div class="option">
-          <%= f.check_box :clear_calendar_configuration %>
-          <%= f.label :clear_calendar_configuration do %>
+          <%= f.check_box :without_description %>
+          <%= f.label :without_description do %>
             <span></span>
-            <%= t('.remove_configuration') %>
+            <%= t('.without_description') %>
           <% end %>
         </div>
 
@@ -97,6 +97,16 @@
             </td>
           </tr>
         </table>
+
+        <h3><%= t('.manage') %></h3>
+
+        <div class="option">
+          <%= f.check_box :clear_calendar_configuration %>
+          <%= f.label :clear_calendar_configuration do %>
+            <span></span>
+            <%= t('.remove_configuration') %>
+          <% end %>
+        </div>
       <% end %>
     </div>
 

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -20,6 +20,7 @@ ca:
             microsoft_exchange_url: URL del calendari
             microsoft_exchange_usr: Compte de Microsoft Exchange
           last_sync: Darrera sincronització
+          manage: Gestiona la configuració del calendari
           microsoft_exchange: Microsoft Exchange
           placeholders:
             filter_text: Text pel qual filtrar
@@ -29,7 +30,6 @@ ca:
           remove_configuration: Eliminar configuració
           sync: Sincronitzar ara
           without_description: No importar la descripció de l'esdeveniment
-          manage: Gestiona la configuració del calendari
         gobierto_people_person_navigation:
           calendar_configuration: Configuració del calendari
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/ca.yml
@@ -28,6 +28,8 @@ ca:
             username: ex. perico85
           remove_configuration: Eliminar configuració
           sync: Sincronitzar ara
+          without_description: No importar la descripció de l'esdeveniment
+          manage: Gestiona la configuració del calendari
         gobierto_people_person_navigation:
           calendar_configuration: Configuració del calendari
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -27,7 +27,9 @@ en:
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. someone85
           remove_configuration: Remove calendar configuration
+          manage: Manage calendar configuration
           sync: Sync now
+          without_description: Don't import event description
         gobierto_people_person_navigation:
           calendar_configuration: Calendar configuration
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/en.yml
@@ -20,6 +20,7 @@ en:
             microsoft_exchange_url: Calendar URL
             microsoft_exchange_usr: Microsoft Exchange account
           last_sync: Last sync
+          manage: Manage calendar configuration
           microsoft_exchange: Microsoft Exchange
           placeholders:
             filter_text: Text to be filtered
@@ -27,7 +28,6 @@ en:
             microsoft_exchange_url: ex. https://example.com/ews/exchange.asmx
             username: ex. someone85
           remove_configuration: Remove calendar configuration
-          manage: Manage calendar configuration
           sync: Sync now
           without_description: Don't import event description
         gobierto_people_person_navigation:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -28,6 +28,8 @@ es:
             username: ej. perico85
           remove_configuration: Eliminar configuración de calendario
           sync: Sincronizar ahora
+          without_description: No importar la descripción del evento
+          manage: Administrar la configuración del calendario
         gobierto_people_person_navigation:
           calendar_configuration: Configuración de calendario
         google_calendar_fields:

--- a/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/calendar_configuration/es.yml
@@ -20,6 +20,7 @@ es:
             microsoft_exchange_url: URL del calendario
             microsoft_exchange_usr: Cuenta de Microsoft Exchange
           last_sync: Última sincronización
+          manage: Administrar la configuración del calendario
           microsoft_exchange: Microsoft Exchange
           placeholders:
             filter_text: Texto por el que filtrar
@@ -29,7 +30,6 @@ es:
           remove_configuration: Eliminar configuración de calendario
           sync: Sincronizar ahora
           without_description: No importar la descripción del evento
-          manage: Administrar la configuración del calendario
         gobierto_people_person_navigation:
           calendar_configuration: Configuración de calendario
         google_calendar_fields:

--- a/test/fixtures/gobierto_calendars/calendar_configurations.yml
+++ b/test/fixtures/gobierto_calendars/calendar_configurations.yml
@@ -4,7 +4,8 @@ richard_calendar_configuration:
     data: <%= {
         ibm_notes_usr: "ibm-notes-usr",
         ibm_notes_pwd: SecretAttribute.encrypt("ibm-notes-pwd"),
-        ibm_notes_url: "http://calendar/richard"
+        ibm_notes_url: "http://calendar/richard",
+        without_description: "0"
     }.to_json %>
 
 tamara_calendar_configuration:
@@ -13,5 +14,6 @@ tamara_calendar_configuration:
     data: <%= {
         microsoft_exchange_usr: "microsoft-exchange-usr",
         microsoft_exchange_pwd: SecretAttribute.encrypt("microsoft-exchange-pwd"),
-        microsoft_exchange_url: "http://calendar/tamara"
+        microsoft_exchange_url: "http://calendar/tamara",
+        without_description: "0"
     }.to_json %>

--- a/test/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_calendars/calendar_configuration_form_test.rb
@@ -23,7 +23,8 @@ module GobiertoAdmin
           calendar_integration: 'ibm_notes',
           ibm_notes_usr: 'ibm-username',
           ibm_notes_pwd: 'ibm-password',
-          ibm_notes_url: 'http://calendar-endpoint.com'
+          ibm_notes_url: 'http://calendar-endpoint.com',
+          without_description: '0'
         }
       end
 
@@ -31,7 +32,8 @@ module GobiertoAdmin
         @microsoft_exchange_configuration ||= {
           microsoft_exchange_usr: 'me-username',
           microsoft_exchange_pwd: 'me-password',
-          microsoft_exchange_url: 'http://example.com/ews/exchange.asmx'
+          microsoft_exchange_url: 'http://example.com/ews/exchange.asmx',
+          without_description: '0'
         }
       end
 
@@ -90,8 +92,8 @@ module GobiertoAdmin
 
         calendar_configuration = collection.calendar_configuration
 
-        microsoft_exchange_keys = ['microsoft_exchange_usr', 'microsoft_exchange_pwd', 'microsoft_exchange_url']
-        ibm_notes_keys = ['ibm_notes_usr', 'ibm_notes_pwd', 'ibm_notes_url']
+        microsoft_exchange_keys = ['microsoft_exchange_usr', 'microsoft_exchange_pwd', 'microsoft_exchange_url', 'without_description']
+        ibm_notes_keys = ['ibm_notes_usr', 'ibm_notes_pwd', 'ibm_notes_url', 'without_description']
 
         assert array_match(microsoft_exchange_keys, calendar_configuration.data.keys)
 
@@ -139,7 +141,6 @@ module GobiertoAdmin
         calendar_configuration_form = CalendarConfigurationForm.new(ibm_notes_calendar_configuration_attributes)
         assert_equal ::GobiertoPeople::IbmNotes::CalendarIntegration, calendar_configuration_form.calendar_integration_class
       end
-
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
@@ -18,7 +18,8 @@ module GobiertoAdmin
         @ibm_notes_configuration ||= {
           ibm_notes_usr: 'ibm-notes-usr',
           ibm_notes_pwd: 'ibm-notes-pwd',
-          ibm_notes_url: 'http://ibm-calendar/richard'
+          ibm_notes_url: 'http://ibm-calendar/richard',
+          without_description: '0'
         }
       end
 
@@ -26,13 +27,15 @@ module GobiertoAdmin
         @microsoft_exchange_configuration ||= {
           microsoft_exchange_usr: 'microsoft-exchange-usr',
           microsoft_exchange_pwd: 'microsoft-exchange-pwd',
-          microsoft_exchange_url: 'http://me-calendar/richard'
+          microsoft_exchange_url: 'http://me-calendar/richard',
+          without_description: '0'
         }
       end
 
       def google_calendar_configuration
         @google_calendar_configuration ||= {
-          google_calendar_credentials: 'person_credentials'
+          google_calendar_credentials: 'person_credentials',
+          without_description: '0'
         }
       end
 
@@ -45,16 +48,39 @@ module GobiertoAdmin
         calendar1 = mock
         calendar1.stubs(id: google_calendar_id, primary?: true, summary: 'Calendar 1')
 
+        creator_event2 = mock
+        creator_event2.stubs(email: google_calendar_id)
+
+        date1 = mock
+        date1.stubs(date_time: Time.now)
+        date2 = mock
+        date2.stubs(date_time: 1.hour.from_now)
+
+        # Single event, organized by richard, with two attendees
+        event2 = mock
+        event2.stubs(visibility: nil, location: nil, creator: creator_event2, recurrence: nil, id: "event2",
+                     summary: "@ Event 2", start: date1, end: date2, attendees: [], description: "Event 2 description")
+
+        calendar_1_items_response = mock
+        calendar_1_items_response.stubs(:items).returns([event2])
+
         calendar2 = mock
         calendar2.stubs(id: 2, primary?: false, summary: 'Calendar 2')
 
         calendar3 = mock
         calendar3.stubs(id: 3, primary?: false, summary: 'Calendar 3')
 
-        @calendars_mock = mock
-        @calendars_mock.stubs(:calendars).returns([calendar1, calendar2, calendar3])
-        @calendars_mock.stubs(:sync!).returns(nil)
-        ::GobiertoPeople::GoogleCalendar::CalendarIntegration.stubs(:new).returns(@calendars_mock)
+        calendar_items_response = mock
+        calendar_items_response.stubs(:items).returns([calendar1, calendar2, calendar3])
+
+        client_options = mock
+        client_options.stubs(:application_name=).returns(true)
+
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_calendar_lists).returns(calendar_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:list_events).with(calendar1.id, instance_of(Hash)).returns(calendar_1_items_response)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:client_options).returns(client_options)
+        ::Google::Apis::CalendarV3::CalendarService.any_instance.stubs(:authorization=).returns(true)
+        ::Google::Auth::UserAuthorizer.any_instance.stubs(:get_credentials).returns(true)
 
         setup_authorizable_resource_test(gobierto_admin_admins(:steve), @person_events_path)
        end
@@ -153,12 +179,14 @@ module GobiertoAdmin
 
         with_signed_in_admin(admin) do
           with_current_site(site) do
-            @calendars_mock.expects(:sync!).at_least_once
-
             visit @person_events_path
 
             click_link 'Agenda'
             click_link 'Configuration'
+
+            check 'Calendar 1'
+
+            click_button 'Update'
 
             assert has_link?('Sync now')
             refute has_text? 'Last sync:'
@@ -167,6 +195,48 @@ module GobiertoAdmin
             end
 
             assert has_text? 'Last sync: less than a minute ago'
+
+            refute_nil person.events.find_by external_id: "event2"
+          end
+        end
+      end
+
+      def test_sync_calendars_without_description
+        configure_google_calendar_integration(
+          collection: person.calendar,
+          data: google_calendar_configuration
+        )
+
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @person_events_path
+
+            click_link 'Agenda'
+            click_link 'Configuration'
+
+            check 'Calendar 1'
+            check "Don't import event description"
+
+            click_button 'Update'
+
+            click_link 'Sync now'
+
+            assert has_text? 'Last sync: less than a minute ago'
+
+            event = person.events.find_by external_id: "event2"
+            refute_nil event
+            assert_nil event.description
+
+            check 'Calendar 1'
+            uncheck "Don't import event description"
+
+            click_button 'Update'
+            click_link 'Sync now'
+            assert has_text? 'Last sync: less than a minute ago'
+
+            event = person.events.find_by external_id: "event2"
+            refute_nil event
+            assert_equal "Event 2 description", event.description
           end
         end
       end

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -16,11 +16,31 @@ module GobiertoPeople
         @filtering_rule ||= gobierto_calendars_filtering_rules(:richard_calendar_configuration_filter)
       end
 
-     def ibm_notes_configuration
+      def configure_ibm_notes_calendar_with_description
+        @configure_ibm_notes_calendar_with_description ||= configure_ibm_notes_calendar_integration(collection: richard.calendar,
+                                                                                                    data: ibm_notes_configuration_with_description)
+      end
+
+      def ibm_notes_configuration_with_description
         @ibm_notes_configuration ||= {
           ibm_notes_usr: 'ibm-notes-usr',
           ibm_notes_pwd: 'ibm-notes-pwd',
-          ibm_notes_url: 'https://host.wadus.com/mail/foo.nsf/api/calendar/events'
+          ibm_notes_url: 'https://host.wadus.com/mail/foo.nsf/api/calendar/events',
+          without_description: '0'
+        }
+      end
+
+      def configure_ibm_notes_calendar_without_description
+        @configure_ibm_notes_calendar_without_description ||= configure_ibm_notes_calendar_integration(collection: richard.calendar,
+                                                                                                       data: ibm_notes_configuration_without_description)
+      end
+
+      def ibm_notes_configuration_without_description
+        @ibm_notes_configuration ||= {
+          ibm_notes_usr: 'ibm-notes-usr',
+          ibm_notes_pwd: 'ibm-notes-pwd',
+          ibm_notes_url: 'https://host.wadus.com/mail/foo.nsf/api/calendar/events',
+          without_description: '1'
         }
       end
 
@@ -43,14 +63,6 @@ module GobiertoPeople
 
       def rst_to_utc(date)
         ActiveSupport::TimeZone["Madrid"].parse(date).utc
-      end
-
-      def setup
-        super
-        configure_ibm_notes_calendar_integration(
-          collection: richard.calendar,
-          data: ibm_notes_configuration
-        )
       end
 
       def create_ibm_notes_event(params = {})
@@ -122,6 +134,8 @@ module GobiertoPeople
       end
 
       def test_sync_events_v9
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             CalendarIntegration.sync_person_events(richard)
@@ -145,6 +159,8 @@ module GobiertoPeople
       end
 
       def test_sync_events_updates_event_attributes
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             CalendarIntegration.sync_person_events(richard)
@@ -180,6 +196,8 @@ module GobiertoPeople
       end
 
       def test_sync_events_removes_deleted_event_attributes
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             CalendarIntegration.sync_person_events(richard)
@@ -203,6 +221,8 @@ module GobiertoPeople
       # Se piden eventos en el intervalo [1,3], 1 y 3 son recurrentes y son el mismo, el 2 es uno no recurrente
       # De las 9 instancias del evento recurrente, la que tiene recurrenceId=20170407T113000Z (la segunda) da 404
       def test_sync_events_v8
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           VCR.use_cassette("ibm_notes/person_events_collection_v8", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             CalendarIntegration.sync_person_events(richard)
@@ -230,6 +250,8 @@ module GobiertoPeople
 
       # Only v8 will return past events instances, but use v9 cassette for simplicity
       def test_sync_events_marks_unreceived_upcoming_events_as_pending
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(Time.zone.parse("2017-05-03")) do
           VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
             # Returns 3 events, all of them upcoming
@@ -259,6 +281,8 @@ module GobiertoPeople
       end
 
       def test_sync_event_creates_new_event_with_location
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           refute GobiertoCalendars::Event.exists?(external_id: new_ibm_notes_event.id)
 
@@ -277,6 +301,8 @@ module GobiertoPeople
       end
 
       def test_sync_event_updates_existing_event
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
 
@@ -288,6 +314,8 @@ module GobiertoPeople
       end
 
       def test_sync_event_doesnt_create_duplicated_events
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           CalendarIntegration.sync_event(outdated_ibm_notes_event, richard)
 
@@ -298,6 +326,8 @@ module GobiertoPeople
       end
 
       def test_sync_event_creates_updates_and_removes_location_for_existing_gobierto_event
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           outdated_ibm_notes_event_gobierto_event.save!
           ibm_notes_event_gobierto_event.save!
@@ -334,6 +364,8 @@ module GobiertoPeople
       end
 
       def test_sync_attendees
+        configure_ibm_notes_calendar_with_description
+
         Timecop.freeze(freeze_date) do
           # Cassette contains one confirmed attendee and two requested participants.
           VCR.use_cassette("ibm_notes/person_events_collection_v9", decode_compressed_response: true, match_requests_on: [:host, :path]) do
@@ -363,6 +395,8 @@ module GobiertoPeople
       end
 
       def test_sync_event_outside_range
+        configure_ibm_notes_calendar_with_description
+
         ibm_notes_event = create_ibm_notes_event_recurring_invalid_event(location: nil)
 
         Timecop.freeze(freeze_date) do
@@ -374,6 +408,8 @@ module GobiertoPeople
       end
 
       def test_filter_events
+        configure_ibm_notes_calendar_with_description
+
         # Create a rule with contains condition
         filtering_rule.condition = :not_contains
         filtering_rule.value = "@"
@@ -397,7 +433,6 @@ module GobiertoPeople
           assert_equal rst_to_utc("2017-05-05 16:00:00"), non_recurrent_events.first.starts_at
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
Closes #1429 

### What does this PR do?

- Add a checkbox: "Don't import event description"
- Also, move the "delete this calendar conf" to the bottom of the page
- I have completed the tests to import with description and without description

### How should this be manually tested?

From Agenda configuration change the attribute and then in events, you will see them without description

![captura de pantalla 2018-02-13 a las 17 35 18](https://user-images.githubusercontent.com/69764/36161579-5564bd72-10e4-11e8-99db-4e3db653b91c.png)
