### PR TITLE
Run calendar sync in the site default locale

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -35,6 +35,8 @@ module GobiertoAdmin
       end
 
       def sync_calendars
+        I18n.locale = current_site.configuration.default_locale
+
         @calendar_configuration_form = CalendarConfigurationForm.new(current_site: current_site, collection: @collection)
         if (calendar_integration = @calendar_configuration_form.calendar_integration_class).present?
           calendar_integration.sync_person_events(@calendar_configuration_form.collection_container)

--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -147,14 +147,28 @@ module GobiertoPeople
       errors.add(:starts_at, 'is out of sync range') unless GobiertoCalendars.sync_range.cover?(starts_at)
     end
 
+    def title_translations
+      h = available_locales_to_hash
+      h.merge({site.configuration.default_locale => title})
+    end
+
+    def description_translations
+      h = available_locales_to_hash
+      h.merge({site.configuration.default_locale => description})
+    end
+
+    def available_locales_to_hash
+      Hash[I18n.available_locales.map {|x| [x, nil]}]
+    end
+
     def save_person_event
       @person_event = person_event.tap do |person_event_attributes|
         person_event_attributes.site_id = site_id
         person_event_attributes.external_id = external_id
         person_event_attributes.collection = collection
         person_event_attributes.state = state
-        person_event_attributes.title = title
-        person_event_attributes.description = description
+        person_event_attributes.title_translations = title_translations
+        person_event_attributes.description_translations = description_translations
         person_event_attributes.starts_at = starts_at
         person_event_attributes.ends_at = ends_at
         person_event_attributes.locations = locations


### PR DESCRIPTION
Closes #1451 and #1452

### What does this PR do?

Sync calendar in the site default locale and clean title/description in the rest of locales.

### How should this be manually tested?

- Show the default_locale in the site
- Sync events
- You should show title and description in default locale
