### PR TITLE
View all documents/events link in participation/processes

### DIFF
--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -44,10 +44,7 @@ module GobiertoParticipation
     end
 
     def container_events
-      module_events = GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation")
-      processes_events = GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation::Process")
-
-      @container_events = module_events.merge(processes_events)
+      @container_events = GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation")
     end
 
     def find_events_by_date(date)

--- a/app/models/concerns/gobierto_common/collectionable.rb
+++ b/app/models/concerns/gobierto_common/collectionable.rb
@@ -18,7 +18,10 @@ module GobiertoCommon
         collection_container.container_path
       end
 
+      def process
+        collection_item = GobiertoCommon::CollectionItem.by_container_type("GobiertoParticipation::Process").where(item_id: id).first
+        collection_item.present? ? collection_item.container : nil
+      end
     end
-
   end
 end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -58,11 +58,6 @@ module GobiertoCms
       end
     end
 
-    def process
-      collection_item = GobiertoCommon::CollectionItem.pages_and_news.by_container_type("GobiertoParticipation::Process").where(item_id: id).first
-      collection_item.present? ? collection_item.container : nil
-    end
-
     def template
       collection.item_type.split('::').last.downcase
     end

--- a/app/views/gobierto_participation/attachments/index.html.erb
+++ b/app/views/gobierto_participation/attachments/index.html.erb
@@ -10,7 +10,14 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.documents_for', container: t('gobierto_participation.shared.participation')) %>
           </h2>
+
           <%= render 'gobierto_participation/shared/attachments/attachments_filter', { issues: @issues } %>
+
+          <% if params["issue_id"] %>
+            <div>
+              <small><%= link_to t('gobierto_participation.shared.all_attachments'), gobierto_participation_attachments_path %></small>
+            </div>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/gobierto_participation/attachments/show.html.erb
+++ b/app/views/gobierto_participation/attachments/show.html.erb
@@ -10,7 +10,12 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.documents_for', container: t('gobierto_participation.shared.participation')) %>
           </h2>
+
           <%= render 'gobierto_participation/shared/attachments/attachments_filter', { issues: @issues } %>
+
+          <div>
+            <small><%= link_to t('gobierto_participation.shared.all_attachments'), gobierto_participation_attachments_path %></small>
+          </div>
         </div>
       </div>
       <div class='pure-u-1 pure-u-lg-2-3'>

--- a/app/views/gobierto_participation/events/index.html.erb
+++ b/app/views/gobierto_participation/events/index.html.erb
@@ -15,11 +15,6 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.diary_for', container: t('gobierto_participation.shared.participation')) %>
           </h2>
-          <% if @issue %>
-            <div>
-              <small><%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_events_path %></small>
-            </div>
-          <% end %>
 
           <%= render 'gobierto_participation/shared/events/calendar_component', events: @events %>
 
@@ -33,6 +28,13 @@
             <% end %>
           </ul>
 
+          <% if params[:issue_id] %>
+            <div>
+              <small>
+                <%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_events_path %>
+              </small>
+            </div>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/gobierto_participation/issues/_issue_teaser.html.erb
+++ b/app/views/gobierto_participation/issues/_issue_teaser.html.erb
@@ -1,16 +1,16 @@
 <div class="pure-u-1 pure-u-md-1-3">
   <%= link_to gobierto_participation_issue_path(issue.slug), class: 'content_block themed' do %>
     <div class="circle_teaser"></div>
-      <h3><%= issue.name %></h3>
-      <p class="soft">
-        <%= issue.description %>
-      </p>
+    <h3><%= issue.name %></h3>
+    <p class="soft">
+      <%= issue.description %>
+    </p>
 
-      <% if meta %>
-        <div class="meta right">
-          <div class="ib"><i class="fa fa-comment"></i><%= issue.number_contributions %></div>
-          <div class="ib"><i class="fa fa-users"></i><%= issue.number_contributing_neighbours %></div>
-        </div>
-      <% end %>
+    <% if meta %>
+      <div class="meta right">
+        <div class="ib"><i class="fa fa-comment"></i><%= issue.number_contributions %></div>
+        <div class="ib"><i class="fa fa-users"></i><%= issue.number_contributing_neighbours %></div>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/gobierto_participation/issues/attachments/index.html.erb
+++ b/app/views/gobierto_participation/issues/attachments/index.html.erb
@@ -20,6 +20,11 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.documents_for', container: @issue.name) %>
           </h2>
+
+          <div>
+            <small><%= link_to t('gobierto_participation.shared.all_attachments'), gobierto_participation_attachments_path %></small>
+          </div>
+
           <% pending do %>
             <%= render 'gobierto_participation/shared/attachments/attachments_filter', { issues: @issues } %>
           <% end %>

--- a/app/views/gobierto_participation/issues/attachments/show.html.erb
+++ b/app/views/gobierto_participation/issues/attachments/show.html.erb
@@ -20,6 +20,11 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.documents_for', container: @issue.name) %>
           </h2>
+
+          <div>
+            <small><%= link_to t('gobierto_participation.shared.all_attachments'), gobierto_participation_attachments_path %></small>
+          </div>
+
           <% pending do %>
             <%= render 'gobierto_participation/shared/attachments/attachments_filter', { issues: @issues } %>
           <% end %>

--- a/app/views/gobierto_participation/issues/events/index.html.erb
+++ b/app/views/gobierto_participation/issues/events/index.html.erb
@@ -25,9 +25,6 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.diary_for', container: @issue.name) %>
           </h2>
-          <div>
-            <small><%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_issue_events_path %></small>
-          </div>
 
           <%= render 'gobierto_participation/shared/events/calendar_component', events: @events %>
 
@@ -42,6 +39,10 @@
               <% end %>
             </ul>
           <% end %>
+
+          <div>
+            <small><%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_events_path %></small>
+          </div>
         </div>
       </div>
 

--- a/app/views/gobierto_participation/processes/attachments/index.html.erb
+++ b/app/views/gobierto_participation/processes/attachments/index.html.erb
@@ -24,9 +24,26 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.documents_for', container: current_process.title) %>
           </h2>
-          <% pending do %>
-            <%= render 'gobierto_participation/shared/attachments/attachments_filter', { issues: @issues } %>
-          <% end %>
+
+          <h4 class="with_light_separator m_t_1"><%= t('gobierto_participation.shared.filter_by_theme') %></h4>
+
+          <ul class="link_list">
+            <% @issues.each do |issue| %>
+              <li>
+                <%= link_to issue.name,
+                            gobierto_participation_process_attachments_path(process_id: current_process.slug,
+                                                                            issue_id: issue.slug) %>
+              </li>
+            <% end %>
+          </ul>
+
+          <div>
+            <small>
+              <%= link_to t('gobierto_participation.shared.all_attachments'),
+                          params[:issue_id] ? gobierto_participation_process_attachments_path :
+                                              gobierto_participation_attachments_path %>
+            </small>
+          </div>
         </div>
       </div>
 

--- a/app/views/gobierto_participation/processes/attachments/show.html.erb
+++ b/app/views/gobierto_participation/processes/attachments/show.html.erb
@@ -26,7 +26,7 @@
           </h2>
 
           <div>
-            <small><%= link_to t('gobierto_participation.participation_attachments'), gobierto_participation_process_attachments_path(process_id: current_process.slug) %></small>
+            <small><%= link_to t('gobierto_participation.all_attachments'), gobierto_participation_process_attachments_path(process_id: current_process.slug) %></small>
           </div>
 
           <% pending do %>

--- a/app/views/gobierto_participation/processes/events/index.html.erb
+++ b/app/views/gobierto_participation/processes/events/index.html.erb
@@ -25,23 +25,28 @@
           <h2 class='with_separator'>
             <%= t('gobierto_participation.shared.diary_for', container: current_process.title) %>
           </h2>
-          <div>
-            <small><%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_process_events_path %></small>
-          </div>
 
           <%= render 'gobierto_participation/shared/events/calendar_component', events: @events %>
 
-          <% pending do %>
-            <h4 class="with_light_separator m_t_1">Filtrar por tema</h4>
+          <h4 class="with_light_separator m_t_1"><%= t('gobierto_participation.shared.filter_by_theme') %></h4>
 
-            <ul class="link_list">
-              <% @issues.each do |issue| %>
-                <li>
-                  <%= link_to issue.name , gobierto_participation_process_events_path(process_id: current_process.slug, issue_id: issue.slug) %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
+          <ul class="link_list">
+            <% @issues.each do |issue| %>
+              <li>
+                <%= link_to issue.name,
+                            gobierto_participation_process_events_path(process_id: current_process.slug,
+                                                                       issue_id: issue.slug) %>
+              </li>
+            <% end %>
+          </ul>
+
+          <div>
+            <small>
+              <%= link_to t('gobierto_participation.shared.all_events'),
+                          (params[:date] || params[:issue_id]) ? gobierto_participation_process_events_path :
+                                                               gobierto_participation_events_path %>
+            </small>
+          </div>
         </div>
       </div>
 

--- a/app/views/gobierto_participation/processes/events/show.html.erb
+++ b/app/views/gobierto_participation/processes/events/show.html.erb
@@ -26,7 +26,7 @@
 
         <%= render 'gobierto_participation/shared/events/calendar_component', events: @events %>
         <div>
-          <small><%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_events_path %></small>
+          <small><%= link_to t('gobierto_participation.shared.all_events'), gobierto_participation_process_events_path(current_process.slug) %></small>
         </div>
       </div>
 

--- a/app/views/gobierto_participation/scopes/_scope_teaser.html.erb
+++ b/app/views/gobierto_participation/scopes/_scope_teaser.html.erb
@@ -1,16 +1,16 @@
 <div class="pure-u-1 pure-u-md-1-3">
   <%= link_to gobierto_participation_scope_path(scope.slug), class: 'content_block themed' do %>
     <div class="circle_teaser"></div>
-      <h3><%= scope.name %></h3>
-      <p class="soft">
-        <%= scope.description %>
-      </p>
+    <h3><%= scope.name %></h3>
+    <p class="soft">
+      <%= scope.description %>
+    </p>
 
-      <% if meta %>
-        <div class="meta right">
-          <div class="ib"><i class="fa fa-comment"></i><%= scope.number_contributions %></div>
-          <div class="ib"><i class="fa fa-users"></i><%= scope.number_contributing_neighbours %></div>
-        </div>
-      <% end %>
+    <% if meta %>
+      <div class="meta right">
+        <div class="ib"><i class="fa fa-comment"></i><%= scope.number_contributions %></div>
+        <div class="ib"><i class="fa fa-users"></i><%= scope.number_contributing_neighbours %></div>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/gobierto_participation/shared/attachments/_attachment_teaser.html.erb
+++ b/app/views/gobierto_participation/shared/attachments/_attachment_teaser.html.erb
@@ -1,6 +1,8 @@
 <div class='news_teaser'>
   <h3>
-    <% if try(:current_process).present? %>
+    <% if try(:current_process).present? || attachment.process %>
+      <% current_process ||= !attachment.process.nil? ? attachment.process : try(:current_process) %>
+
       <%= link_to gobierto_participation_process_attachment_path(process_id: current_process.slug, id: attachment.slug) do %>
         <%= filetype_icon(attachment) %><%= attachment.name %>
       <% end %>

--- a/app/views/gobierto_participation/shared/attachments/_attachments_filter.html.erb
+++ b/app/views/gobierto_participation/shared/attachments/_attachments_filter.html.erb
@@ -1,7 +1,3 @@
-<div>
-  <small><%= link_to t('gobierto_participation.shared.all_attachments'), gobierto_participation_attachments_path %></small>
-</div>
-
 <% if issues %>
   <h4 class='with_light_separator m_t_1'><%= t('gobierto_participation.shared.filter_by_theme') %></h4>
   <ul class='link_list'>

--- a/app/views/gobierto_participation/shared/events/_event_teaser.html.erb
+++ b/app/views/gobierto_participation/shared/events/_event_teaser.html.erb
@@ -7,7 +7,9 @@
 
   <div class="pure-u-1 pure-u-md-5-6 event-content">
     <h3>
-      <% if try(:current_process).present? %>
+      <% if try(:current_process).present? || event.process %>
+        <% current_process ||= !event.process.nil? ? event.process : try(:current_process) %>
+
         <%= link_to(event.title, gobierto_participation_process_event_path(event.slug, process_id: current_process.slug)) %>
       <% elsif current_module == "gobierto_participation" %>
         <%= link_to(event.title, gobierto_participation_event_path(event.slug)) %>

--- a/config/locales/gobierto_participation/views/ca.yml
+++ b/config/locales/gobierto_participation/views/ca.yml
@@ -1,6 +1,7 @@
 ---
 ca:
   gobierto_participation:
+    all_attachments: Mostra tots les documents
     comments:
       comment:
         comments_html: "<strong>%{comments}</strong> comentaris"
@@ -73,7 +74,6 @@ ca:
     pages:
       show:
         pages: Pàgines
-    participation_attachments: Mostra tots les documents de Participació
     processes:
       contribution_containers:
         show:

--- a/config/locales/gobierto_participation/views/en.yml
+++ b/config/locales/gobierto_participation/views/en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   gobierto_participation:
+    all_attachments: See all documents
     comments:
       comment:
         comments_html: "<strong>%{comments}</strong> comments"
@@ -25,7 +26,7 @@ en:
       gobierto_participation_process_updated: Process / group updated
       index:
         agenda_for_container: Diary for %{container_title}
-        all_events: View all events
+        all_events: See all events
         displaying_events_of: Displaying events of %{date}
         go_back: Go back
       show:
@@ -75,7 +76,6 @@ en:
     pages:
       show:
         pages: Pages
-    participation_attachments: See all the documents of Participation
     processes:
       contribution_containers:
         show:
@@ -223,7 +223,7 @@ en:
         and make conclusions accessible.
       all_activities: See all updates
       all_attachments: See all documents
-      all_events: View all events
+      all_events: See all events
       all_news: Show all news
       consultation_processes: Consult and participate in specific processes.
       diary_for: Diary for %{container}

--- a/config/locales/gobierto_participation/views/es.yml
+++ b/config/locales/gobierto_participation/views/es.yml
@@ -1,6 +1,7 @@
 ---
 es:
   gobierto_participation:
+    all_attachments: Ver todos los documentos
     comments:
       comment:
         comments_html: "<strong>%{comments}</strong> comentarios"
@@ -75,7 +76,6 @@ es:
     pages:
       show:
         pages: Páginas
-    participation_attachments: Ver todos los documentos de Participación
     processes:
       contribution_containers:
         show:

--- a/test/fixtures/gobierto_attachments/attachments.yml
+++ b/test/fixtures/gobierto_attachments/attachments.yml
@@ -25,6 +25,20 @@ pdf_collection_attachment:
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
+pdf_on_participation:
+  name: PDF Collection On Participation
+  file_size: 10025
+  file_name: pdf-on-participation.pdf
+  file_digest: 44036997d456028a88d634afa64037ae2e
+  url: http://host.com/attachments/super-long-and-ugly-aws-id/pdf-on-participation.pdf
+  description: Description of a Participation PDF attachment
+  current_version: 2
+  site: madrid
+  slug: pdf-on-participation-slug
+  collection: participation_documents
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
 xlsx_attachment:
   name: XLSX Attachment Name
   file_size: 3604

--- a/test/fixtures/gobierto_calendars/events.yml
+++ b/test/fixtures/gobierto_calendars/events.yml
@@ -182,3 +182,19 @@ swimming_lessons:
   starts_at: <%= 2.days.from_now %>
   ends_at: <%= 2.days.from_now + 1.hour %>
   state: <%= GobiertoCalendars::Event.states["published"] %>
+
+innovation_event:
+  site: madrid
+  collection: participation_calendar
+  title_translations: <%= {
+    'en' => 'Innovation course',
+    'es' => 'Curso de innovación'
+  }.to_json %>
+  slug: <%= "#{2.days.from_now.strftime('%F')}-innovation_event" %>
+  description_translations: <%= {
+    'en' => 'Innovation course description',
+    'es' => 'Curso de innovación descripción'
+  }.to_json %>
+  starts_at: <%= 2.days.from_now %>
+  ends_at: <%= 2.days.from_now + 1.hour %>
+  state: <%= GobiertoCalendars::Event.states["published"] %>

--- a/test/fixtures/gobierto_common/collection_items.yml
+++ b/test/fixtures/gobierto_common/collection_items.yml
@@ -56,6 +56,18 @@ xlsx_attachment_event_on_scope:
   item: xlsx_attachment_event (GobiertoAttachments::Attachment)
   container: old_town (GobiertoCommon::Scope)
 
+# participation_documents
+
+pdf_on_participation_on_site:
+  collection: participation_documents
+  item: pdf_on_participation (GobiertoAttachments::Attachment)
+  container: madrid (Site)
+
+pdf_on_participation_on_participation:
+  collection: participation_documents
+  item: pdf_on_participation (GobiertoAttachments::Attachment)
+  container_type: GobiertoParticipation
+
 ## /end Attachments collection items
 
 ## Pages collection items
@@ -417,7 +429,7 @@ swimming_lessons_on_site:
   item: swimming_lessons (GobiertoCalendars::Event)
   container: madrid (Site)
 
-swimming_lessons_on_process:
+swimming_lessons_on_participation:
   collection: gender_violence_process_calendar
   item: swimming_lessons (GobiertoCalendars::Event)
   container_type: GobiertoParticipation
@@ -431,5 +443,17 @@ swimming_lessons_on_scope:
   collection: gender_violence_process_calendar
   item: swimming_lessons (GobiertoCalendars::Event)
   container: old_town (GobiertoCommon::Scope)
+
+# participation_calendar
+
+innovation_event_on_site:
+  collection: participation_calendar
+  item: innovation_event (GobiertoCalendars::Event)
+  container: madrid (Site)
+
+innovation_event_on_participation:
+  collection: participation_calendar
+  item: innovation_event (GobiertoCalendars::Event)
+  container_type: GobiertoParticipation
 
 ## /end Events collection items

--- a/test/fixtures/gobierto_common/collections.yml
+++ b/test/fixtures/gobierto_common/collections.yml
@@ -93,3 +93,24 @@ site_pages:
   item_type: GobiertoCms::Page
 
 ## /end
+
+## Participation collections of events
+
+participation_calendar:
+  site: madrid
+  title_translations: <%= {'en' => 'Participation events', 'es' => 'Eventos de participación' }.to_json %>
+  slug: participation-calendar
+  container_type: GobiertoParticipation
+  item_type: GobiertoCalendars::Event
+
+
+## Participation collections of documents
+
+participation_documents:
+  site: madrid
+  title_translations: <%= {'en' => 'Participation documents', 'es' => 'Documentos de participación' }.to_json %>
+  slug: participation-documents
+  container_type: GobiertoParticipation
+  item_type: GobiertoAttachments::Attachment
+
+## /end

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -6,6 +6,14 @@ pdf_attachment_create:
   object:
   created_at: <%= Time.now %>
 
+pdf_on_participation_create:
+  item_type: GobiertoAttachments::Attachment
+  item_id: <%= ActiveRecord::FixtureSet.identify(:pdf_on_participation) %>
+  event: create
+  whodunnit:
+  object:
+  created_at: <%= Time.now %>
+
 xlsx_attachment_create:
   item_type: GobiertoAttachments::Attachment
   item_id: <%= ActiveRecord::FixtureSet.identify(:xlsx_attachment) %>

--- a/test/integration/gobierto_participation/participation_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/participation_attachments_index_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoParticipation
+  class ParticipationAttachmentsIndexTest < ActionDispatch::IntegrationTest
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def user
+      @user ||= users(:peter)
+    end
+
+    def participation_attachments_path
+      @participation_attachments_path ||= gobierto_participation_attachments_path
+    end
+
+    def participation_attachments
+      @participation_attachments ||= ::GobiertoAttachments::Attachment.attachments_in_collections_and_container_type(site, "GobiertoParticipation")
+    end
+
+    def test_secondary_nav
+      with_current_site(site) do
+        visit participation_attachments_path
+
+        within "nav.sub-nav menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
+        end
+      end
+    end
+
+    def test_participation_attachments_index
+      with_current_site(site) do
+        visit participation_attachments_path
+
+        assert_equal participation_attachments.size, all(".news_teaser").size
+
+        refute has_content? "See all documents"
+
+        assert has_link? "PDF Collection On Participation"
+        assert has_link? "XLSX Attachment Event"
+        assert has_link? "PDF Collection Attachment Name"
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/participation_attachments_show_test.rb
+++ b/test/integration/gobierto_participation/participation_attachments_show_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoParticipation
+  class ParticipationAttachmentsShowTest < ActionDispatch::IntegrationTest
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def user
+      @user ||= users(:peter)
+    end
+
+    def participation_attachment
+      @participation_attachment ||= gobierto_attachments_attachments(:pdf_on_participation)
+    end
+
+    def participation_attachment_path
+      @participation_attachment_path ||= gobierto_participation_attachment_path(participation_attachment.slug)
+    end
+
+    def test_secondary_nav
+      with_current_site(site) do
+        visit participation_attachment_path
+
+        within "nav.sub-nav menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
+        end
+      end
+    end
+
+    def test_participation_attachment_show
+      with_current_site(site) do
+        visit participation_attachment_path
+
+        assert has_content? "PDF Collection On Participation"
+
+        click_link "See all documents"
+
+        refute has_content? "Documents on Participation"
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/participation_events_index_test.rb
+++ b/test/integration/gobierto_participation/participation_events_index_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoParticipation
+  class ParticipationEventsIndexTest < ActionDispatch::IntegrationTest
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def user
+      @user ||= users(:peter)
+    end
+
+    def participation_events_path
+      @participation_events_path ||= gobierto_participation_events_path
+    end
+
+    def participation_events
+      @participation_events ||= ::GobiertoCalendars::Event.events_in_collections_and_container_type(site, "GobiertoParticipation")
+    end
+
+    def test_secondary_nav
+      with_current_site(site) do
+        visit participation_events_path
+
+        within "nav.sub-nav menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
+        end
+      end
+    end
+
+    def test_participation_events_index
+      with_current_site(site) do
+        visit participation_events_path
+
+        assert_equal participation_events.size, all(".event-content").size
+
+        assert has_link? "Swimming lessons for elders"
+        assert has_link? "Innovation course"
+        assert has_link? "Intensive reading club in english"
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/participation_events_show_test.rb
+++ b/test/integration/gobierto_participation/participation_events_show_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoParticipation
+  class ParticipationEventsShowTest < ActionDispatch::IntegrationTest
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def user
+      @user ||= users(:peter)
+    end
+
+    def participation_event
+      @participation_event ||= gobierto_calendars_events(:innovation_event)
+    end
+
+    def participation_event_path
+      @participation_event_path ||= gobierto_participation_event_path(participation_event.slug)
+    end
+
+    def test_secondary_nav
+      with_current_site(site) do
+        visit participation_event_path
+
+        within "nav.sub-nav menu.secondary_nav" do
+          assert has_link? "News"
+          assert has_link? "Agenda"
+          assert has_link? "Documents"
+          assert has_link? "Activity"
+        end
+      end
+    end
+
+    def test_participation_event_show
+      with_current_site(site) do
+        visit participation_event_path
+
+        assert has_content? "Innovation course"
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/processes/polls/polls_index_test.rb
+++ b/test/integration/gobierto_participation/processes/polls/polls_index_test.rb
@@ -37,7 +37,7 @@ module GobiertoParticipation
           visit process_polls_path
 
           # published open polls apear
-          assert has_content? 'Should the main street be pedestrianized?'
+          assert has_content? 'What do the residents of the neighborhood think?'
           assert has_content? 'General aspects of the ordinance'
 
           # draft, future and past polls are hidden

--- a/test/integration/gobierto_participation/processes/process_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_attachments_index_test.rb
@@ -90,5 +90,19 @@ module GobiertoParticipation
         assert has_content? "PDF Collection Attachment Name"
       end
     end
+
+    def test_process_event_show_see_all_events
+      with_current_site(site) do
+        visit process_attachments_path
+
+        click_link "See all documents"
+
+        assert has_content? "Documents for Participation"
+
+        assert has_link? "PDF Collection On Participation"
+        assert has_link? "XLSX Attachment Event"
+        assert has_link? "PDF Collection Attachment Name"
+      end
+    end
   end
 end

--- a/test/integration/gobierto_participation/processes/process_attachments_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_attachments_show_test.rb
@@ -93,6 +93,10 @@ module GobiertoParticipation
           assert has_content? "Description of a PDF attachment"
           assert has_content? "PDF · 9,8 KB"
         end
+
+        click_link "See all documents"
+
+        assert has_content? "Documents for #{process.title}"
       end
     end
   end

--- a/test/integration/gobierto_participation/processes/process_events_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_events_index_test.rb
@@ -97,5 +97,24 @@ module GobiertoParticipation
         end
       end
     end
+
+    def test_process_event_show_see_all_events
+      with_current_site(site) do
+        visit process_events_path
+
+        click_link "See all events"
+
+        assert has_content? "Diary for Participation"
+
+        assert has_link? "Innovation course"
+        assert has_content? "Innovation course description"
+
+        assert has_link? "Swimming lessons for elders"
+        assert has_content? "Swimming lessons for elders description"
+
+        assert has_link? "Intensive reading club in english"
+        assert has_content? "Intensive reading club in english description"
+      end
+    end
   end
 end

--- a/test/integration/gobierto_participation/processes/process_events_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_events_show_test.rb
@@ -104,5 +104,15 @@ module GobiertoParticipation
         # TODO: refute has_content? "Agenda for #{process.title}"
       end
     end
+
+    def test_process_event_show_see_all_events
+      with_current_site(site) do
+        visit process_event_path
+
+        click_link "See all events"
+
+        assert_equal process.events.size, all(".event-content").size
+      end
+    end
   end
 end

--- a/test/integration/gobierto_participation/processes/process_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_show_test.rb
@@ -212,7 +212,7 @@ module GobiertoParticipation
 
         events_titles = gender_violence_process.events.map(&:title)
 
-        assert array_match ["Intensive reading club in english",], events_titles
+        assert array_match ["Intensive reading club in english", "Swimming lessons for elders"], events_titles
       end
     end
 

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -36,7 +36,7 @@ module GobiertoParticipation
     end
 
     def process_events
-      [gobierto_calendars_events(:reading_club)]
+      [gobierto_calendars_events(:reading_club), gobierto_calendars_events(:swimming_lessons)]
     end
 
     def test_valid


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/270

### What does this PR do?

- In show/event/attachment (process): see al events of process
- In index/event/attachment (process): see al events of participation
- Fix url of events/attachments if belong to a process

**Extra:**

- I have placed the link at the bottom
- I have reviewed the filters by issue and their respective links
- I have added pending tests for Participation
- I've unified the texts
- I've unified the filtering by issue

### How should this be manually tested?

Navigating through the events and documents of Participation/Processes.

### Pending

- [ ] The documents part would be pending