### PR TITLE
1438 - Refactor IBM Notes calendar integration

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -39,7 +39,7 @@ module GobiertoAdmin
 
         @calendar_configuration_form = CalendarConfigurationForm.new(current_site: current_site, collection: @collection)
         if (calendar_integration = @calendar_configuration_form.calendar_integration_class).present?
-          calendar_integration.sync_person_events(@calendar_configuration_form.collection_container)
+          calendar_integration.new(@calendar_configuration_form.collection_container).sync!
           publish_calendar_sync_activity(@calendar_configuration_form)
         end
         redirect_to(

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -12,8 +12,14 @@ module GobiertoPeople
 
       include CalendarServiceHelpers
 
-      def self.sync_person_events(person)
-        new(person).sync!
+      def initialize(person)
+        @person = person
+        @configuration = GobiertoCalendars::GoogleCalendarConfiguration.find_by(collection_id: person.calendar.id)
+
+        @service = Google::Apis::CalendarV3::CalendarService.new
+        @service.client_options.application_name = person.site.name
+        @service.authorization = authorize(person)
+        @received_event_ids = []
       end
 
       def sync!
@@ -29,16 +35,6 @@ module GobiertoPeople
       end
 
       private
-
-      def initialize(person)
-        @person = person
-        @configuration = GobiertoCalendars::GoogleCalendarConfiguration.find_by(collection_id: person.calendar.id)
-
-        @service = Google::Apis::CalendarV3::CalendarService.new
-        @service.client_options.application_name = person.site.name
-        @service.authorization = authorize(person)
-        @received_event_ids = []
-      end
 
       attr_reader :person, :configuration, :service, :received_event_ids
 

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "#{Rails.root}/lib/ibm_notes/api"
 
 module GobiertoPeople
   module IbmNotes
@@ -6,20 +7,38 @@ module GobiertoPeople
 
       include CalendarServiceHelpers
 
-      def self.sync_person_events(person)
-        logger.log_synchronization_start(person_id: person.id, person_name: person.name)
+      attr_reader :person, :calendar_configuration
 
-        received_events_ids = get_person_events_urls(person).map do |event_url|
-          response_data = ::IbmNotes::Api.get_event(request_params_for_event_request(person, event_url))
+      def self.recurring_event?(event_data)
+        event_data['links'].present? && has_instances_link?(event_data['links'])
+      end
+
+      def self.has_instances_link?(links_data)
+        links_data.each do |element|
+          return true if (element['rel'].present? && element['rel'] == 'instances')
+        end
+        false
+      end
+
+      def initialize(person)
+        @person = person
+        @calendar_configuration = find_calendar_configuration
+      end
+
+      def sync!
+        log_synchronization_start(person_id: person.id, person_name: person.name)
+
+        received_events_ids = get_person_events_urls.map do |event_url|
+          response_data = ::IbmNotes::Api.get_event(request_params_for_event_request(event_url))
 
           next if response_data.nil? || response_data['events'].blank?
 
           event_data = response_data['events'][0]
 
-          process_event(event_data, event_url, person)
+          process_event(event_data, event_url)
         end.compact.flatten
 
-        logger.log_available_events_count(received_events_ids.size)
+        log_available_events_count(received_events_ids.size)
 
         person.events.upcoming.synchronized.each do |event|
           unless received_events_ids.include?(event.external_id)
@@ -27,22 +46,20 @@ module GobiertoPeople
           end
         end
       rescue ::IbmNotes::InvalidCredentials
-        logger.log_message("Invalid credentials for site")
+        log_message("Invalid credentials for site")
       rescue ::IbmNotes::ServiceUnavailable
-        logger.log_message("IBM Notes calendar API is down")
+        log_message("IBM Notes calendar API is down")
       rescue ::JSON::ParserError
-        logger.log_message("JSON parser error")
+        log_message("JSON parser error")
       ensure
-        logger.log_synchronization_end(person_id: person.id, person_name: person.name)
+        log_synchronization_end(person_id: person.id, person_name: person.name)
       end
 
-      def self.sync_event(ibm_notes_event, person)
-        configuration = person_calendar_configuration(person)
-
+      def sync_event(ibm_notes_event)
         filter_result = GobiertoCalendars::FilteringRuleApplier.filter({
           title: ibm_notes_event.title,
-          description: (ibm_notes_event.description unless configuration.without_description == "1"),
-        }, configuration.filtering_rules)
+          description: (ibm_notes_event.description unless calendar_configuration.without_description == "1"),
+        }, calendar_configuration.filtering_rules)
 
         state = filter_result.action == GobiertoCalendars::FilteringRuleApplier::CREATE_PENDING ?
           GobiertoCalendars::Event.states[:pending] :
@@ -71,46 +88,19 @@ module GobiertoPeople
         event_form = GobiertoPeople::PersonEventForm.new(person_event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
-          logger.log_destroy_rule
+          log_destroy_rule
           event_form.destroy
           nil
         else
-          if !event_form.save then logger.log_invalid_event(event_form.errors.messages) end
+          if !event_form.save then log_invalid_event(event_form.errors.messages) end
           event_form.external_id
         end
       end
 
-      # Private methods
+      private
 
-      def self.create_and_sync_ibm_notes_event(person, event_data)
-        event = ::IbmNotes::PersonEvent.new(person, event_data)
-        sync_event(event, person)
-      end
-      private_class_method :create_and_sync_ibm_notes_event
-
-      def self.process_event(event_data, event_url, person)
-        processed_events_ids = []
-
-        if recurring_event?(event_data)
-          instances_urls = get_person_event_instances_urls(person, event_url)
-
-          instances_urls.each do |event_url|
-            response_event = ::IbmNotes::Api.get_event(request_params_for_event_request(person, event_url))
-
-            if response_event && response_event['events'].present?
-              processed_events_ids << create_and_sync_ibm_notes_event(person, response_event['events'][0])
-            end
-          end
-        else
-          processed_events_ids << create_and_sync_ibm_notes_event(person, event_data)
-        end
-
-        processed_events_ids
-      end
-      private_class_method :process_event
-
-      def self.get_person_events_urls(person)
-        response_events = ::IbmNotes::Api.get_person_events(request_params_for_events(person))
+      def get_person_events_urls
+        response_events = ::IbmNotes::Api.get_person_events(request_params_for_events)
 
         # some APIs return an empty array when no events instead of a hash
         if response_events && response_events.is_a?(Hash) && response_events['events'].present?
@@ -119,10 +109,9 @@ module GobiertoPeople
           []
         end
       end
-      private_class_method :get_person_events_urls
 
-      def self.get_person_event_instances_urls(person, href)
-        response_data = ::IbmNotes::Api.get_recurrent_event_instances(request_params_for_event_request(person, href))
+      def get_person_event_instances_urls(href)
+        response_data = ::IbmNotes::Api.get_recurrent_event_instances(request_params_for_event_request(href))
 
         if response_data && response_data['instances'].present?
           response_data['instances'].map { |instance_data| instance_data['href'] }
@@ -130,61 +119,56 @@ module GobiertoPeople
           []
         end
       end
-      private_class_method :get_person_event_instances_urls
 
-      def self.recurring_event?(event_data)
-        event_data['links'].present? && has_instances_link?(event_data['links'])
-      end
-      private_class_method :recurring_event?
-
-      def self.has_instances_link?(links_data)
-        links_data.each do |element|
-          return true if (element['rel'].present? && element['rel'] == 'instances')
-        end
-        false
-      end
-      private_class_method :has_instances_link?
-
-      def self.request_params_for_events(person)
-        configuration = person_calendar_configuration(person)
+      def request_params_for_events
         {
-          endpoint: configuration.ibm_notes_url.concat("?since=#{sync_range_start}"),
-          username: configuration.ibm_notes_usr,
-          password: plain_text_password(person)
+          endpoint: calendar_configuration.ibm_notes_url.concat("?since=#{sync_range_start}"),
+          username: calendar_configuration.ibm_notes_usr,
+          password: plain_text_password
         }
       end
-      private_class_method :request_params_for_events
 
-      def self.request_params_for_event_request(person, event_path)
-        configuration = person_calendar_configuration(person)
-        uri = URI.parse(configuration.ibm_notes_url)
-
+      def request_params_for_event_request(event_path)
+        uri = URI.parse(calendar_configuration.ibm_notes_url)
         {
           endpoint: "#{uri.scheme}://#{uri.host}#{event_path}",
-          username: configuration.ibm_notes_usr,
-          password: plain_text_password(person)
+          username: calendar_configuration.ibm_notes_usr,
+          password: plain_text_password
         }
       end
-      private_class_method :request_params_for_event_request
 
-      def self.plain_text_password(person)
-        SecretAttribute.decrypt(person_calendar_configuration(person).ibm_notes_pwd)
+      def process_event(event_data, event_url)
+        processed_events_ids = []
+
+        if self.class.recurring_event?(event_data)
+          instances_urls = get_person_event_instances_urls(event_url)
+
+          instances_urls.each do |event_url|
+            response_event = ::IbmNotes::Api.get_event(request_params_for_event_request(event_url))
+
+            if response_event && response_event['events'].present?
+              ibm_event = ::IbmNotes::PersonEvent.new(person, response_event['events'][0])
+              processed_events_ids << sync_event(ibm_event)
+            end
+          end
+        else
+          ibm_event = ::IbmNotes::PersonEvent.new(person, event_data)
+          processed_events_ids << sync_event(ibm_event)
+        end
+
+        processed_events_ids
       end
-      private_class_method :plain_text_password
 
-      def self.sync_range_start
+      def sync_range_start
         GobiertoCalendars.sync_range_start.iso8601.split('+')[0].concat('Z')
       end
-      private_class_method :sync_range_start
 
-      def self.person_calendar_configuration(person)
-        ::GobiertoCalendars::IbmNotesCalendarConfiguration.find_by(collection_id: person.calendar.id)
+      def plain_text_password
+        SecretAttribute.decrypt(calendar_configuration.ibm_notes_pwd)
       end
-      private_class_method :person_calendar_configuration
 
-      # HACK - Refactor IBM Notes service so it uses instance methods
-      def self.logger
-        CalendarIntegration.new
+      def find_calendar_configuration
+        ::GobiertoCalendars::IbmNotesCalendarConfiguration.find_by(collection_id: person.calendar.id)
       end
 
     end

--- a/app/services/gobierto_people/remote_calendars.rb
+++ b/app/services/gobierto_people/remote_calendars.rb
@@ -12,7 +12,7 @@ module GobiertoPeople
 
         I18n.locale = site.configuration.default_locale
 
-        calendar_integration.sync_person_events(container)
+        calendar_integration.new(container).sync!
         Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: '127.0.0.1',  subject: container, site_id: site.id })
       end
     end

--- a/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
+++ b/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
@@ -101,6 +101,10 @@ module GobiertoPeople
         }
       end
 
+      def calendar_service
+        CalendarIntegration.new(richard)
+      end
+
       def test_sync_returns_nil
         configure_microsoft_exchange_calendar_with_description
 
@@ -113,7 +117,7 @@ module GobiertoPeople
         Exchanger::Folder.stubs(:find).returns(root_folder)
 
         assert_difference 'GobiertoCalendars::Event.count', 0 do
-          CalendarIntegration.sync_person_events(richard)
+          calendar_service.sync!
         end
       end
 
@@ -134,7 +138,7 @@ module GobiertoPeople
         setup_mocks_for_synchronization([event_1, event_2])
 
         assert_difference 'GobiertoCalendars::Event.count', 1 do
-          CalendarIntegration.sync_person_events(richard)
+          calendar_service.sync!
         end
 
         # event 1 checks
@@ -163,7 +167,7 @@ module GobiertoPeople
         setup_mocks_for_synchronization([event_1, event_2])
 
         assert_difference 'GobiertoCalendars::Event.count', 1 do
-          CalendarIntegration.sync_person_events(richard)
+          calendar_service.sync!
         end
 
         # event 1 checks
@@ -179,7 +183,7 @@ module GobiertoPeople
         configure_microsoft_exchange_calendar_with_description
 
         setup_mocks_for_synchronization([event_attributes])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         # simulate attributes are updated from OWA
 
@@ -190,7 +194,7 @@ module GobiertoPeople
         )
 
         setup_mocks_for_synchronization([event_1])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         # assert attributes get updated in Gobierto
 
@@ -206,7 +210,7 @@ module GobiertoPeople
         configure_microsoft_exchange_calendar_with_description
 
         setup_mocks_for_synchronization([event_attributes])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         event_1 = event_attributes.merge(
           subject: 'Updated event',
@@ -216,7 +220,7 @@ module GobiertoPeople
 
         setup_mocks_for_synchronization([event_1])
         assert_difference 'GobiertoCalendars::Event.count', -1 do
-          CalendarIntegration.sync_person_events(richard)
+          calendar_service.sync!
         end
 
         # assert attributes get updated in Gobierto
@@ -235,7 +239,7 @@ module GobiertoPeople
         event_2 = event_attributes.merge(id: 'external-id-2')
 
         setup_mocks_for_synchronization([event_1, event_2])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         event = richard.events.find_by(external_id: 'external-id-1')
 
@@ -244,7 +248,7 @@ module GobiertoPeople
         # sync, only receiving the second event
 
         setup_mocks_for_synchronization([event_2])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         # check first event is unpublished
 
@@ -261,7 +265,7 @@ module GobiertoPeople
 
         # syncrhonize event with location
         setup_mocks_for_synchronization([event_attributes])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         event = richard.events.find_by(external_id: 'external-id-1')
         assert_equal 1, event.locations.size
@@ -271,7 +275,7 @@ module GobiertoPeople
         event_1 = event_attributes.merge(location: '')
 
         setup_mocks_for_synchronization([event_1])
-        CalendarIntegration.sync_person_events(richard)
+        calendar_service.sync!
 
         # assert location is deleted in Gobierto
 
@@ -306,7 +310,7 @@ module GobiertoPeople
         setup_mocks_for_synchronization([event_1, event_2])
 
         assert_difference 'GobiertoCalendars::Event.count', 1 do
-          CalendarIntegration.sync_person_events(richard)
+          calendar_service.sync!
         end
 
         # event 1 checks


### PR DESCRIPTION
Closes #1438 

## :v: What does this PR do?

Refactors IBM Notes service to work as an instantiable class, so the API is similar to the other calendar services.

## :mag: How should this be manually tested?

All calendar integrations should continue to work. I've created one person for each service in this site: [http://calendarios.gobify.net/admin/people/people](http://calendarios.gobify.net/admin/people/people) (Exchange won't work in staging), you can sync them manually.

## :shipit: Does this PR changes any configuration file?

No
