### PR TITLE
Add task to delete people activities on a site

### DIFF
--- a/lib/tasks/gobierto_people/delete_activities.rake
+++ b/lib/tasks/gobierto_people/delete_activities.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :gobierto_people do
+  desc "Delete people activities on a site"
+  task :delete_activities, [:site_domain] => [:environment] do |_t, args|
+    site = Site.find_by!(domain: args[:site_domain])
+
+    activities = site.activities.where(recipient_type: 'GobiertoPeople::Person')
+    activities_count = activities.count
+    site.activities.where(recipient_type: 'GobiertoPeople::Person').destroy_all
+    puts "== Deleted #{activities_count - activities.count} people activities on site #{site.domain}"
+  end
+end


### PR DESCRIPTION

## :v: What does this PR do?
Adds a task to delete all people activities on a site.

## :mag: How should this be manually tested?
Call from console:
```
./bin/rails gobierto_people:delete_activities[subdomain.gobify.net]
```

## :shipit: Does this PR changes any configuration file?
No