### PR TITLE
213 budgets data export files content type

### DIFF
--- a/app/models/gobierto_budgets/data/annual.rb
+++ b/app/models/gobierto_budgets/data/annual.rb
@@ -6,8 +6,10 @@ module GobiertoBudgets
       class UnsupportedFormat < StandardError; end
 
       FORMATS = {
-        json: { serializer: ->(data) { data.to_json } },
-        csv:  { serializer: ->(data) { GobiertoExports::CSVRenderer.new(data).to_csv } }
+        json: { serializer: ->(data) { data.to_json },
+                content_type: 'application/json; charset=utf-8' },
+        csv:  { serializer: ->(data) { GobiertoExports::CSVRenderer.new(data).to_csv },
+                content_type: 'text/csv; charset=utf-8' }
       }
 
       attr_accessor :site, :year
@@ -34,7 +36,8 @@ module GobiertoBudgets
         FORMATS.each do |format_key, configuration|
           file_urls << FileUploader::S3.new(
             file_name: filename(format_key),
-            content: configuration[:serializer].call(@place_budget_lines)
+            content: configuration[:serializer].call(@place_budget_lines),
+            content_type: configuration[:content_type]
           ).upload!
         end
         file_urls

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -6,7 +6,7 @@ module FileUploader
   class S3
     attr_reader :file, :file_name
 
-    def initialize(file_name:, content: nil, file: nil, content_disposition: nil, bucket_name: nil)
+    def initialize(file_name:, content: nil, file: nil, content_disposition: nil, content_type: nil, bucket_name: nil)
       @file = if content.present?
                 @tmp_file = Tempfile.new
                 @tmp_file.binmode
@@ -19,6 +19,7 @@ module FileUploader
       @file_name = file_name
       @bucket_name = bucket_name
       @content_disposition = content_disposition
+      @content_type = content_type
     end
 
     def call
@@ -37,6 +38,7 @@ module FileUploader
       File.open(file.tempfile, 'rb') do |file_body|
         options = { body: file_body }
         options[:content_disposition] = @content_disposition if @content_disposition.present?
+        options[:content_type] = @content_type if @content_type.present?
 
         object.put(options)
       end


### PR DESCRIPTION
## :v: What does this PR do?
* Adds a content_type argument to `FileUploader::S3`, allowing the uploading of files specifying charset and mime-type.
* Includes the content_type uploading budget data export files, both in csv and json formats.

## :mag: How should this be manually tested?
First, the budget data export files should be created by calling the task:
```
./bin/rails gobierto_budgets:data:sites_annual
```
The output of the task shows the url of the uploaded files. Also they can be accessed for example in
http://madrid.gobify.net/datos

The csv files should be downloaded and viewed with the correct encoding

## :shipit: Does this PR changes any configuration file?
No