### PR TITLE
Add executed amount in budget execution

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_lines_execution.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_lines_execution.js
@@ -371,6 +371,8 @@ var VisLinesExecution = Class.extend({
     if(d.budget_updated !== null)
       tooltipHtml += '<div class="line-name">' + I18n.t('gobierto_budgets.budgets_execution.index.vis.tooltip_budgeted_updated')  + ': ' + accounting.formatMoney(d.budget_updated, "€", 0, ".", ",") + '</div>';
 
+    tooltipHtml += '<div class="line-name">' + I18n.t('gobierto_budgets.budgets_execution.index.vis.tooltip_executed_amount')  + ': ' + accounting.formatMoney(d.executed, "€", 0, ".", ",") + '</div>';
+
     tooltipHtml += '<div>' + I18n.t('gobierto_budgets.budgets_execution.index.vis.tooltip') + ' ' + this.pctFormat(d.pct_executed) + ' %</div>';
 
     this.tooltip.html(tooltipHtml);

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -417,6 +417,7 @@ ca:
           tooltip: S'ha executat un
           tooltip_budgeted: Pressupostat inicial
           tooltip_budgeted_updated: Pressupostat actualitzat
+          tooltip_executed_amount: Import executat
       widget_template_deviation:
         expense: Despeses
         income: Ingressos

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -397,6 +397,7 @@ en:
           tooltip: It has been executed by a
           tooltip_budgeted: Initial budget
           tooltip_budgeted_updated: Updated budget
+          tooltip_executed_amount: Executed amount
       widget_template_deviation:
         expense: Expense
         income: Income

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -409,6 +409,7 @@ es:
           tooltip: Se ha ejecutado un
           tooltip_budgeted: Presupuestado inicial
           tooltip_budgeted_updated: Presupuestado actualizado
+          tooltip_executed_amount: Importe ejecutado
       widget_template_deviation:
         expense: Gastos
         income: Ingresos


### PR DESCRIPTION
Closes https://app.zenhub.com/workspace/o/populatetools/issues/issues/280

## :v: What does this PR do?

Add executed amount in budget execution.

Data is good and it's about updated budgets.

## :mag: How should this be manually tested?

/presupuestos/ejecucion

## :eyes: Screenshots

### Before this PR

![captura de pantalla 2018-03-02 a las 15 36 58](https://user-images.githubusercontent.com/69764/36903995-a9e7fd20-1e2f-11e8-850d-009655684eff.png)

### After this PR

![captura de pantalla 2018-03-02 a las 15 36 00](https://user-images.githubusercontent.com/69764/36904000-ad35211a-1e2f-11e8-89c6-cefb8bd66e6a.png)

## :shipit: Does this PR changes any configuration file?
-