### PR TITLE
Force attachment box open if page has attachments

### DIFF
--- a/app/assets/javascripts/admin/app/controllers/gobierto_attachments_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/gobierto_attachments_controller.js
@@ -412,12 +412,17 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
         return {
           attachments: [],
           showFiles: true,
-          fileListClass: 'fa-caret-down'
         }
       },
       computed: {
-        fetchfileListClass: function(){
-          this.modifyfileListClass();
+        fileListClass: function(){
+          if(this.attachments.length == 0)
+            return "";
+
+          if(this.showFiles)
+            return 'fa-caret-down';
+          else
+            return 'fa-caret-right';
         }
       },
       methods: {
@@ -440,31 +445,15 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
 
                 if(response.attachments.length > 0) {
                   self.showFiles = true;
-                  self.fileListClass = 'fa-caret-down';
                 } else {
                   self.showFiles = false;
-                  self.fileListClass = '';
                 }
               }
             }
           });
         },
-        modifyfileListClass: function(){
-          var self = this;
-
-          if(self.attachments.length > 0) {
-            if(self.showFiles) {
-              self.fileListClass = 'fa-caret-down';
-            } else {
-              self.fileListClass = 'fa-caret-right';
-            }
-          }
-        },
         toggleList: function(){
-          var self = this;
-
-          self.showFiles = !self.showFiles;
-          this.modifyfileListClass();
+          this.showFiles = !this.showFiles;
         }
       },
       mounted: function() {

--- a/app/assets/javascripts/admin/app/controllers/gobierto_attachments_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/gobierto_attachments_controller.js
@@ -411,7 +411,8 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
       data: function(){
         return {
           attachments: [],
-          showFiles: false
+          showFiles: true,
+          fileListClass: 'fa-caret-down'
         }
       },
       methods: {
@@ -431,10 +432,30 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
             success: function(response, textStatus, jqXHR){
               if(jqXHR.status == 200){
                 Vue.set(self, 'attachments', response.attachments);
+
+                if(response.attachments.length > 0) {
+                  self.showFiles = true;
+                  self.fileListClass = 'fa-caret-down';
+                } else {
+                  self.showFiles = false;
+                  self.fileListClass = '';
+                }
               }
-            },
+            }
           });
         },
+        toggleList: function(){
+          var self = this;
+
+          self.showFiles = self.showFiles
+          if(self.attachments.length > 0) {
+            if(self.showFiles) {
+              self.fileListClass = 'fa-caret-down';
+            } else {
+              self.fileListClass = 'fa-caret-right';
+            }
+          }
+        }
       },
       mounted: function() {
         var self = this;
@@ -457,6 +478,10 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
           self.attachments.splice(index, 1);
           self.showFiles = true;
         });
+      },
+      created: function () {
+        var self = this;
+        self.fetchData();
       }
     })
 

--- a/app/assets/javascripts/admin/app/controllers/gobierto_attachments_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/gobierto_attachments_controller.js
@@ -415,6 +415,11 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
           fileListClass: 'fa-caret-down'
         }
       },
+      computed: {
+        fetchfileListClass: function(){
+          this.modifyfileListClass();
+        }
+      },
       methods: {
         popover: function(e) {
           bus.$emit('file-popover:load', {id: $(e.target).data('attachment-id')});
@@ -444,10 +449,9 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
             }
           });
         },
-        toggleList: function(){
+        modifyfileListClass: function(){
           var self = this;
 
-          self.showFiles = self.showFiles
           if(self.attachments.length > 0) {
             if(self.showFiles) {
               self.fileListClass = 'fa-caret-down';
@@ -455,6 +459,12 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
               self.fileListClass = 'fa-caret-right';
             }
           }
+        },
+        toggleList: function(){
+          var self = this;
+
+          self.showFiles = !self.showFiles;
+          this.modifyfileListClass();
         }
       },
       mounted: function() {
@@ -478,10 +488,6 @@ this.GobiertoAdmin.GobiertoAttachmentsController = (function() {
           self.attachments.splice(index, 1);
           self.showFiles = true;
         });
-      },
-      created: function () {
-        var self = this;
-        self.fetchData();
       }
     })
 

--- a/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
@@ -117,11 +117,11 @@
 <script type="text/x-template" id="file-list-template">
   <small>
     <a @click.prevent="showFiles = !showFiles" href="#" class="tool_title show-files">
-      <i :class="[showFiles ? 'fa-caret-down' : 'fa-caret-right']" class="fa p_h_r_0_25 soft" aria-hidden="true" v-if="attachments.length"></i>
+      <i class="fa fa-caret-down p_h_r_0_25 soft" aria-hidden="true" v-if="attachments.length"></i>
       <strong><%= t('.attachments') %></strong>
     </a>
 
-    <div class="file-list" v-if="showFiles">
+    <div class="file-list" v-if="attachments.length">
       <ul>
         <li v-for="attachment in attachments" :key="attachment.id">
           <a @mouseover="popover" :href="attachment.human_readable_path" target="_blank" :data-attachment-id="attachment.id">{{attachment.name || attachment.file_name}}</a>

--- a/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
@@ -116,7 +116,7 @@
 
 <script type="text/x-template" id="file-list-template">
   <small>
-    <a @click.prevent="showFiles = !showFiles" @click="toggleList" href="#" class="tool_title show-files">
+    <a @click.prevent="toggleList" href="#" class="tool_title show-files">
       <i :class="fileListClass" class="fa p_h_r_0_25 soft" aria-hidden="true"></i>
       <strong><%= t('.attachments') %></strong>
     </a>

--- a/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
@@ -116,12 +116,12 @@
 
 <script type="text/x-template" id="file-list-template">
   <small>
-    <a @click.prevent="showFiles = !showFiles" href="#" class="tool_title show-files">
-      <i class="fa fa-caret-down p_h_r_0_25 soft" aria-hidden="true" v-if="attachments.length"></i>
+    <a @click.prevent="showFiles = !showFiles" @click="toggleList" href="#" class="tool_title show-files">
+      <i :class="fileListClass" class="fa p_h_r_0_25 soft" aria-hidden="true"></i>
       <strong><%= t('.attachments') %></strong>
     </a>
 
-    <div class="file-list" v-if="attachments.length">
+    <div class="file-list" v-show="showFiles">
       <ul>
         <li v-for="attachment in attachments" :key="attachment.id">
           <a @mouseover="popover" :href="attachment.human_readable_path" target="_blank" :data-attachment-id="attachment.id">{{attachment.name || attachment.file_name}}</a>

--- a/test/integration/gobierto_admin/gobierto_calendars/event_attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_attachments_test.rb
@@ -38,8 +38,6 @@ module GobiertoAdmin
 
               click_link event.title
 
-              assert has_no_content?("XLSX Attachment Name")
-              page.find("a.show-files").trigger("click")
               assert has_content?("XLSX Attachment Name")
             end
           end

--- a/test/integration/gobierto_admin/gobierto_cms/page_attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/page_attachments_test.rb
@@ -30,8 +30,6 @@ module GobiertoAdmin
 
               click_link cms_page.title
 
-              assert has_no_content?("XLSX Attachment Name")
-              page.find("a.show-files").trigger("click")
               assert has_content?("XLSX Attachment Name")
             end
           end


### PR DESCRIPTION
Closes #1227 


## :v: What does this PR do?

Previously, if you were editing a page or event that had a file you had to click on Attachments to display the files, now the list of attachments will appear if there are any.

## :mag: How should this be manually tested?

Add files to news or events

## :eyes: Screenshots

### Before this PR

![captura de pantalla 2018-03-05 a las 18 41 17](https://user-images.githubusercontent.com/69764/36990467-137280cc-20a5-11e8-9542-d14582a3e888.png)

### After this PR

![captura de pantalla 2018-03-05 a las 18 41 35](https://user-images.githubusercontent.com/69764/36990426-f9b6203a-20a4-11e8-81d8-f46dc3d22ad5.png)
