### PR TITLE
Clear Gobierto Budgets comparator options

### DIFF
--- a/app/assets/javascripts/admin/app/controllers/gobierto_budgets_controller.js
+++ b/app/assets/javascripts/admin/app/controllers/gobierto_budgets_controller.js
@@ -1,6 +1,11 @@
 this.GobiertoAdmin.GobiertoBudgetsController = (function() {
   function GobiertoBudgetsController() {}
 
+  GobiertoBudgetsController.prototype.options = function(options) {
+    _handleMunicipalitiesAutocomplete(options);
+    _comparison_tool_checkboxes();
+  };
+
   function _handleMunicipalitiesAutocomplete(options) {
     var $field = $("#gobierto_budgets_options_comparison_compare_municipalities");
     console.log(options);
@@ -27,9 +32,15 @@ this.GobiertoAdmin.GobiertoBudgetsController = (function() {
     });
   }
 
-  GobiertoBudgetsController.prototype.options = function(options) {
-    _handleMunicipalitiesAutocomplete(options);
-  };
+  function _comparison_tool_checkboxes() {
+    $("input[name='gobierto_budgets_options[comparison_tool_enabled]']").change(function () {
+      if(!($("input[name='gobierto_budgets_options[comparison_tool_enabled]']").is(':checked'))) {
+        $("input[name='gobierto_budgets_options[comparison_context_table_enabled]']").removeAttr('checked');
+        $("input[name='gobierto_budgets_options[comparison_compare_municipalities_enabled]']").removeAttr('checked');
+        $("input[name='gobierto_budgets_options[comparison_show_widget]']").removeAttr('checked');
+      }
+    });
+  }
 
   return GobiertoBudgetsController;
 })();

--- a/test/integration/gobierto_admin/gobierto_budgets/options_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budgets/options_test.rb
@@ -19,30 +19,39 @@ module GobiertoAdmin
       end
 
       def test_enable_options
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            assert has_content?("Options")
+              assert has_content?("Options")
 
-            assert has_no_checked_field?("gobierto_budgets_options_elaboration_enabled")
-            assert has_no_checked_field?("gobierto_budgets_options_budget_lines_feedback_enabled")
+              refute find("#gobierto_budgets_options_elaboration_enabled", visible: false).checked?
+              refute find("#gobierto_budgets_options_budget_lines_feedback_enabled", visible: false).checked?
+              assert find("#gobierto_budgets_options_receipt_enabled", visible: false).checked?
+              refute find("#gobierto_budgets_options_comparison_tool_enabled", visible: false).checked?
+              refute find("#gobierto_budgets_options_providers_enabled", visible: false).checked?
 
-            check "gobierto_budgets_options_elaboration_enabled"
-            check "gobierto_budgets_options_budget_lines_feedback_enabled"
-            fill_in "gobierto_budgets_options_feedback_emails", with: "email@example.com"
-            check "gobierto_budgets_options_receipt_enabled"
-            fill_in "gobierto_budgets_options_receipt_configuration", with: "{}"
-            check "gobierto_budgets_options_providers_enabled"
-            click_button "Save"
+              find("#gobierto_budgets_options_elaboration_enabled", visible: false).trigger(:click)
+              find("#gobierto_budgets_options_budget_lines_feedback_enabled", visible: false).trigger(:click)
+              fill_in "gobierto_budgets_options_feedback_emails", with: "email@example.com"
+              fill_in "gobierto_budgets_options_receipt_configuration", with: "{}"
 
-            assert has_checked_field?("gobierto_budgets_options_elaboration_enabled")
-            assert has_checked_field?("gobierto_budgets_options_budget_lines_feedback_enabled")
-            assert has_field?("gobierto_budgets_options_feedback_emails", with: "email@example.com")
-            assert has_field?("gobierto_budgets_options_receipt_configuration", with: "{}")
-            assert has_checked_field?("gobierto_budgets_options_providers_enabled")
+              find("#gobierto_budgets_options_comparison_tool_enabled", visible: false).trigger(:click)
+              find("#gobierto_budgets_options_comparison_context_table_enabled", visible: false).trigger(:click)
+              find("#gobierto_budgets_options_comparison_tool_enabled", visible: false).trigger(:click)
 
-            assert has_message?("Settings saved successfully")
+              click_button "Save"
+
+              assert has_message?("Settings saved successfully")
+              assert find("#gobierto_budgets_options_elaboration_enabled", visible: false).checked?
+              assert find("#gobierto_budgets_options_budget_lines_feedback_enabled", visible: false).checked?
+              assert has_field?("gobierto_budgets_options_feedback_emails", with: "email@example.com")
+              assert find("#gobierto_budgets_options_receipt_enabled", visible: false).checked?
+              assert has_field?("gobierto_budgets_options_receipt_configuration", with: "{}")
+              refute find("#gobierto_budgets_options_comparison_tool_enabled", visible: false).checked?
+              refute find("#gobierto_budgets_options_comparison_context_table_enabled", visible: false).checked?
+            end
           end
         end
       end


### PR DESCRIPTION
Closes #https://github.com/PopulateTools/issues/issues/238

## :v: What does this PR do?

Disabling the parent, all the children are unchecked .

## :mag: How should this be manually tested?

From /admin/gobierto_budgets/options

## :eyes: Screenshots

### Before this PR

<img width="990" alt="captura de pantalla 2018-02-28 a las 23 57 27" src="https://user-images.githubusercontent.com/17616/36888104-5912fdfe-1df4-11e8-8d84-6cabcf6feec3.gif">

### After this PR

<img width="990" alt="captura de pantalla 2018-02-28 a las 23 57 27" src="https://user-images.githubusercontent.com/69764/37036303-896920c4-214f-11e8-93c7-769f5164a438.gif">
