### PR TITLE
Wrong url privacy page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,8 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::UnknownFormat, with: :render_404
 
   helper_method :helpers, :load_current_module_sub_sections, :current_site, :current_module,
-                :current_module_body_class, :available_locales, :gobierto_people_event_preview_url
+                :current_module_body_class, :available_locales, :gobierto_people_event_preview_url,
+                :gobierto_cms_page_or_new_path
 
   before_action :set_current_site, :authenticate_user_in_site, :set_locale
 
@@ -108,5 +109,13 @@ class ApplicationController < ActionController::Base
       options.merge!(preview_token: current_admin.preview_token)
     end
     gobierto_people_person_event_url(@person.slug, event.slug, options)
+  end
+
+  def gobierto_cms_page_or_new_path(page, options = {})
+    if page.collection.item_type == "GobiertoCms::Page"
+      gobierto_cms_page_path(page.slug, options)
+    elsif page.collection.item_type == "GobiertoCms::News"
+      gobierto_cms_news_path(page.slug, options)
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :helpers, :load_current_module_sub_sections, :current_site, :current_module,
                 :current_module_body_class, :available_locales, :gobierto_people_event_preview_url,
-                :gobierto_cms_page_or_new_path
+                :gobierto_cms_page_or_news_path
 
   before_action :set_current_site, :authenticate_user_in_site, :set_locale
 
@@ -111,7 +111,7 @@ class ApplicationController < ActionController::Base
     gobierto_people_person_event_url(@person.slug, event.slug, options)
   end
 
-  def gobierto_cms_page_or_new_path(page, options = {})
+  def gobierto_cms_page_or_news_path(page, options = {})
     if page.collection.item_type == "GobiertoCms::Page"
       gobierto_cms_page_path(page.slug, options)
     elsif page.collection.item_type == "GobiertoCms::News"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
 
   def privacy_policy_page_link
     if current_site && current_site.configuration.privacy_page?
-      link_to t("layouts.accept_privacy_policy_signup"), current_site.configuration.privacy_page
+      link_to t("layouts.accept_privacy_policy_signup"), gobierto_cms_page_or_new_path(current_site.configuration.privacy_page)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
 
   def privacy_policy_page_link
     if current_site && current_site.configuration.privacy_page?
-      link_to t("layouts.accept_privacy_policy_signup"), gobierto_cms_page_or_new_path(current_site.configuration.privacy_page)
+      link_to t("layouts.accept_privacy_policy_signup"), gobierto_cms_page_or_news_path(current_site.configuration.privacy_page)
     end
   end
 

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -9,6 +9,7 @@ madrid:
     "default_locale" => "en",
     "available_locales" => ["en", "es"],
     "home_page" => "GobiertoParticipation",
+    "privacy_page_id" => "58988811",
     "google_analytics_id" => "UA-000000-01" }.to_yaml.inspect %>
   location_name: Madrid
   municipality_id: <%= INE::Places::Place.find_by_slug("madrid").id %>

--- a/test/integration/home_page_test.rb
+++ b/test/integration/home_page_test.rb
@@ -16,6 +16,10 @@ class HomePageTest < ActionDispatch::IntegrationTest
     @faq_page ||= gobierto_cms_pages(:consultation_faq)
   end
 
+  def privacy_page
+    @privacy_page ||= gobierto_cms_pages(:privacy)
+  end
+
   def test_greeting_to_first_active_module
     with_current_site(site) do
       visit @path
@@ -33,6 +37,16 @@ class HomePageTest < ActionDispatch::IntegrationTest
       visit @path
 
       assert has_content?("Consultation page FAQ")
+    end
+  end
+
+  def test_privacy_page
+    with_current_site(site) do
+      visit @path
+
+      assert has_link?("By signing up you agree to the Privacy Policy")
+      privacy_page_link = find("a", text: "By signing up you agree to the Privacy Policy")
+      assert privacy_page_link[:href].include?(gobierto_cms_page_path(privacy_page.slug))
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/283

## :v: What does this PR do?

The privacy page didn't have the correct url generation.

## :mag: How should this be manually tested?

Enable the privacy page from the site edition and you will be able to access it.

## :eyes: Screenshots

### Before this PR

Not applicable

### After this PR

Not applicable

## :shipit: Does this PR changes any configuration file?

No