### PR TITLE
Check if module is available

### DIFF
--- a/app/forms/user/subscription_preferences_form.rb
+++ b/app/forms/user/subscription_preferences_form.rb
@@ -120,6 +120,7 @@ class User::SubscriptionPreferencesForm
 
   def update_subscriptions_to_participation
     return if broader_level_subscription_to?(GobiertoParticipation::Process.new)
+    return if gobierto_participation_processes.nil?
 
     site.processes.active.each do |process|
       gobierto_participation_processes.include?(process.id.to_s) ? user.subscribe_to!(process, site) : user.unsubscribe_from!(process, site)

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -42,6 +42,10 @@ class SiteConfiguration
     @modules.select { |site_module| SITE_MODULES.include?(site_module) }
   end
 
+  def available_module?(site_module)
+    modules.include?(site_module)
+  end
+
   def auth_modules
     return DEFAULT_MISSING_MODULES.map(&:name) if @auth_modules.nil?
 
@@ -106,7 +110,7 @@ class SiteConfiguration
   #
   SITE_MODULES.each do |site_module|
     define_method "#{site_module.underscore}_enabled?" do
-      modules.include?(site_module)
+      available_module?(site_module)
     end
   end
 end

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -64,7 +64,7 @@
 
       <div class="pure-u-1 pure-u-md-1-3 ">
         <div class="padded padded_line_box compact">
-          <% if current_site.configuration.gobierto_budget_consultations_enabled? && @user_notification_gobierto_budget_consultations_consultations.any? %>
+          <% if current_site.configuration.available_module?("GobiertoBudgetConsultations") && current_site.configuration.gobierto_budget_consultations_enabled? && @user_notification_gobierto_budget_consultations_consultations.any? %>
             <% mod_name = "gobierto_budget_consultations"
                disabled = site_subscription || @user_subscription_preferences_form.module_level_subscriptions.include?(mod_name) %>
             <h3><%= t('.consultations') %></h3>
@@ -83,7 +83,7 @@
             </div>
           <% end %>
 
-          <% if current_site.configuration.gobierto_people_enabled? && @user_notification_gobierto_people_people.any? %>
+          <% if current_site.configuration.available_module?("GobiertoPeople") && current_site.configuration.gobierto_people_enabled? && @user_notification_gobierto_people_people.any? %>
             <% mod_name = "gobierto_people"
                disabled = site_subscription || @user_subscription_preferences_form.module_level_subscriptions.include?(mod_name) %>
             <h3><%= t('.people') %></h3>
@@ -102,7 +102,7 @@
             </div>
           <% end %>
 
-          <% if current_site.configuration.gobierto_participation_enabled? && @user_notification_gobierto_participation_processes.any? %>
+          <% if current_site.configuration.available_module?("GobiertoParticipation") && current_site.configuration.gobierto_participation_enabled? && @user_notification_gobierto_participation_processes.any? %>
             <% mod_name = "gobierto_participation"
                disabled = site_subscription || @user_subscription_preferences_form.module_level_subscriptions.include?(mod_name) %>
             <h3><%= t('.participation') %></h3>

--- a/test/models/site_configuration_test.rb
+++ b/test/models/site_configuration_test.rb
@@ -25,6 +25,10 @@ class SiteConfigurationTest < ActiveSupport::TestCase
     assert_equal ["GobiertoDevelopment"], site_configuration.modules
   end
 
+  def test_available_modules?
+    assert site_configuration.available_module?("GobiertoDevelopment")
+  end
+
   def test_modules?
     assert site_configuration.modules?
   end
@@ -90,7 +94,7 @@ class SiteConfigurationTest < ActiveSupport::TestCase
   def site_configuration_params
     @site_configuration_params ||= begin
       {
-        "modules"           => %w(Wadus GobiertoDevelopment), # Note that the "Wadus" module is not standard
+        "modules"           => ["Wadus", "GobiertoDevelopment"], # Note that the "Wadus" module is not standard
         "logo"              => "gobierto_development.png",
         "links_markup"      => %(<a href="http://madrid.es">Ayuntamiento de Madrid</a>),
         "demo"              => true,


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/248

## :v: What does this PR do?

We check if the module is available because there are helpers with meta programming that don't know it.

I haven't tested it because it's a bit complex with a global variable from the initializer.

## :mag: How should this be manually tested?

Disabling modules in config/application.yml

## :eyes: Screenshots

### Before this PR

No

### After this PR

No

## :shipit: Does this PR changes any configuration file?

No