### PR TITLE
286 wrong links for liquid generated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::UnknownFormat, with: :render_404
 
   helper_method :helpers, :load_current_module_sub_sections, :current_site, :current_module,
-                :current_module_body_class, :available_locales, :gobierto_people_event_preview_url,
-                :gobierto_cms_page_or_news_path
+                :current_module_body_class, :available_locales, :gobierto_people_event_preview_url
 
   before_action :set_current_site, :authenticate_user_in_site, :set_locale
 
@@ -109,13 +108,5 @@ class ApplicationController < ActionController::Base
       options.merge!(preview_token: current_admin.preview_token)
     end
     gobierto_people_person_event_url(@person.slug, event.slug, options)
-  end
-
-  def gobierto_cms_page_or_news_path(page, options = {})
-    if page.collection.item_type == "GobiertoCms::Page"
-      gobierto_cms_page_path(page.slug, options)
-    elsif page.collection.item_type == "GobiertoCms::News"
-      gobierto_cms_news_path(page.slug, options)
-    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,4 +83,12 @@ module ApplicationHelper
     end
     yield
   end
+
+  def gobierto_cms_page_or_news_path(page, options = {})
+    if page.collection.item_type == "GobiertoCms::Page"
+      gobierto_cms_page_path(page.slug, options)
+    elsif page.collection.item_type == "GobiertoCms::News"
+      gobierto_cms_news_path(page.slug, options)
+    end
+  end
 end

--- a/lib/liquid/gobierto_cms/tags/list_children_pages.rb
+++ b/lib/liquid/gobierto_cms/tags/list_children_pages.rb
@@ -26,6 +26,15 @@ class ListChildrenPages < Liquid::Tag
     return ""
   end
 
+  def gobierto_cms_page_or_news_path(page, options = {})
+    url_helpers = Rails.application.routes.url_helpers
+    if page.collection.item_type == "GobiertoCms::Page"
+      url_helpers.gobierto_cms_page_path(page.slug, options)
+    elsif page.collection.item_type == "GobiertoCms::News"
+      url_helpers.gobierto_cms_news_path(page.slug, options)
+    end
+  end
+
   def children_pages(nodes, level)
     html = []
     if level.positive?
@@ -33,8 +42,9 @@ class ListChildrenPages < Liquid::Tag
         html << "<div class='page_children'>"
         nodes.each do |node|
           html << "<div class='page_child'>"
-          html << "<a href='" + node.item.to_path + "'>" + node.item.title + "</a>"
-          if node.children.any? && level.positive?
+          html << ActionController::Base.helpers.link_to(node.item.title,
+                                                          gobierto_cms_page_or_news_path(node.item))
+          if node.children.any?
             html << children_pages(node.children, level - 1)
           end
           html << "</div>"

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -1,6 +1,7 @@
 site_news_1:
   title_translations: <%= { 'en' => 'Site news 1', 'es' => 'Noticias sitio 1' }.to_json %>
   body_translations: <%= { 'en' => 'Site news 1', 'es' => 'Noticias sitio 1' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Site news 1', 'es' => 'Noticias sitio 1' }.to_json %>
   slug: 'site-news-1'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -9,6 +10,7 @@ site_news_1:
 consultation_faq:
   title_translations: <%= { 'en' => 'Consultation page FAQ', 'es' => 'FAQ consultas' }.to_json %>
   body_translations: <%= { 'en' => 'This is the <strong>body</strong> of the page', 'es' => 'Cuerpo <strong>página</strong> consultas' }.to_json %>
+  body_source_translations: <%= { 'en' => 'This is the <strong>body</strong> of the page', 'es' => 'Cuerpo <strong>página</strong> consultas' }.to_json %>
   slug: 'consultation-faq'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -17,6 +19,7 @@ consultation_faq:
 privacy:
   title_translations: <%= {'en' => 'Privacy', 'es' => 'Privacidad' }.to_json %>
   body_translations: <%= {'en' => 'These are the privacy terms', 'es' => 'Privacidad' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the privacy terms', 'es' => 'Privacidad' }.to_json %>
   slug: 'privacy'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -25,6 +28,7 @@ privacy:
 cookies:
   title_translations: <%= {'en' => 'Cookies' }.to_json %>
   body_translations: <%= {'en' => 'These are the cookies terms' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the cookies terms' }.to_json %>
   slug: 'cookies'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
@@ -32,6 +36,7 @@ cookies:
 about:
   title_translations: <%= {'en' => 'About' }.to_json %>
   body_translations: <%= {'en' => 'About santander' }.to_json %>
+  body_source_translations: <%= {'en' => 'About santander' }.to_json %>
   slug: 'about'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: santander
@@ -39,6 +44,7 @@ about:
 themes:
   title_translations: <%= {'en' => 'Themes in the site' }.to_json %>
   body_translations: <%= {'en' => 'These are the themes' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the themes' }.to_json %>
   slug: 'themes'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -47,6 +53,7 @@ themes:
 themes_draft:
   title_translations: <%= {'en' => 'Themes draft' }.to_json %>
   body_translations: <%= {'en' => 'These are the themes (draft)' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the themes (draft)' }.to_json %>
   slug: 'themes-draft'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
@@ -55,6 +62,7 @@ themes_draft:
 notice_1:
   title_translations: <%= {'en' => 'Notice 1 title' }.to_json %>
   body_translations: <%= {'en' => 'Notice 1 body' }.to_json %>
+  body_source_translations: <%= {'en' => 'Notice 1 body' }.to_json %>
   slug: 'notice-1'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -63,6 +71,7 @@ notice_1:
 notice_2:
   title_translations: <%= {'en' => 'Notice 2 title' }.to_json %>
   body_translations: <%= {'en' => 'Notice 2 body' }.to_json %>
+  body_source_translations: <%= {'en' => 'Notice 2 body' }.to_json %>
   slug: 'notice-2'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -79,8 +88,18 @@ about_site:
 
 about_participation:
   title_translations: <%= {'en' => 'About participation' }.to_json %>
-  body_translations: <%= {'en' => 'Sobre participación' }.to_json %>
+  body_translations: <%= {"en" => "<p>About participation description\r\n {% list_children_pages about-participation %}</p>\r\n", "es" => ""}.to_json %>
+  body_source_translations: <%= {"en" => "About participation description\r\n {% list_children_pages about-participation %}", "es" => ""}.to_json %>
   slug: 'about-participation'
+  visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
+  site: madrid
+  collection: site_pages
+
+about_participation_details:
+  title_translations: <%= {'en' => 'About participation details' }.to_json %>
+  body_translations: <%= {'en' => 'Detalles sobre participación' }.to_json %>
+  body_source_translations: <%= {'en' => 'Detalles sobre participación' }.to_json %>
+  slug: 'about-participation-details'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_pages
@@ -88,6 +107,7 @@ about_participation:
 generic_site_page:
   title_translations: <%= {'en' => 'Generic page' }.to_json %>
   body_translations: <%= {'en' => 'Generic page' }.to_json %>
+  body_source_translations: <%= {'en' => 'Generic page' }.to_json %>
   slug: 'generic-page'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -95,8 +115,8 @@ generic_site_page:
 how_to_participate:
   title_translations: <%= {'en' => 'How to participate' }.to_json %>
   body_translations: <%= {'en' => 'How to participate' }.to_json %>
+  body_source_translations: <%= {'en' => 'How to participate' }.to_json %>
   slug: 'how-to-participate'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: participation_pages
-

--- a/test/fixtures/gobierto_cms/section_items.yml
+++ b/test/fixtures/gobierto_cms/section_items.yml
@@ -5,7 +5,14 @@ participation_items:
   section: participation
   level: 0
 
-satander_navigation_budgets_item:
+participation_items_child:
+  item: about_participation_details (GobiertoCms::Page)
+  position: 0
+  parent_id: nil
+  section: participation
+  level: 0
+
+santander_navigation_budgets_item:
   item_id: "GobiertoBudgets"
   item_type: "GobiertoModule"
   position: 0
@@ -13,7 +20,7 @@ satander_navigation_budgets_item:
   section: global_navigation_santander
   level: 0
 
-satander_navigation_people_item:
+santander_navigation_people_item:
   item_id: "GobiertoPeople"
   item_type: "GobiertoModule"
   position: 1
@@ -21,7 +28,7 @@ satander_navigation_people_item:
   section: global_navigation_santander
   level: 0
 
-satander_navigation_section_item:
+santander_navigation_section_item:
   item: cms_pages_santander (GobiertoCms::Section)
   position: 2
   parent_id: nil

--- a/test/fixtures/gobierto_common/collection_items.yml
+++ b/test/fixtures/gobierto_common/collection_items.yml
@@ -86,6 +86,20 @@ how_to_participate_participation_pages:
   item_type: 'GobiertoCms::Page'
   container: madrid (Site)
 
+# about_participation
+about_participation_on_site:
+  collection: site_pages
+  item: about_participation
+  item_type: 'GobiertoCms::Page'
+  container: madrid (Site)
+
+# about_participation_details
+about_participation_details_on_site:
+  collection: site_pages
+  item: about_participation_details
+  item_type: 'GobiertoCms::Page'
+  container: madrid (Site)
+
 # site news
 site_news_1_on_site:
   collection: site_news

--- a/test/integration/gobierto_cms/visit_page_in_section_test.rb
+++ b/test/integration/gobierto_cms/visit_page_in_section_test.rb
@@ -33,7 +33,7 @@ module GobiertoCms
 
         within "article" do
           assert has_selector?("h1", text: cms_page.title)
-          assert has_content?(cms_page.body)
+          assert has_content?("About participation description")
         end
       end
     end

--- a/test/integration/gobierto_cms/visit_section_test.rb
+++ b/test/integration/gobierto_cms/visit_section_test.rb
@@ -18,11 +18,15 @@ module GobiertoCms
     end
 
     def section_pages
-      @section_pages ||= [gobierto_cms_pages(:about_participation)]
+      @section_pages ||= [gobierto_cms_pages(:about_participation), gobierto_cms_pages(:about_participation_details)]
     end
 
     def section_page
       section_pages.first
+    end
+
+    def section_page_child
+      section_pages.last
     end
 
     def test_visit_section
@@ -39,6 +43,26 @@ module GobiertoCms
 
         assert has_content?(section_page.title)
         assert has_content?(section.title)
+      end
+    end
+
+    def test_list_children_pages
+      with_current_site(site) do
+        section_child = GobiertoCms::SectionItem.find_by_item_id(section_page_child.id)
+        section_parent = GobiertoCms::SectionItem.find_by_item_id(section_page.id)
+        section_child.parent_id = section_parent.id
+        section_child.level += 1
+        section_child.save
+
+        visit @path
+
+        within "article" do
+          within "div.page_children" do
+            within "div.page_child" do
+              assert has_link?(section_page_child.title)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/286

## :v: What does this PR do?

Fixed the liquid tag for the generation of links to the child pages.

## :mag: How should this be manually tested?

Adding the tag in a page (with page-slug) with childrens.
`{% list_children_pages page-slug %}`

## :eyes: Screenshots

### Before this PR

Liquid Error

### After this PR

<img width="1440" alt="captura de pantalla 2018-03-09 a las 12 29 04" src="https://user-images.githubusercontent.com/69764/37205585-900a9f3c-2395-11e8-85e1-0c157fff3496.png">

## :shipit: Does this PR changes any configuration file?

No