### PR TITLE
Add admin preview token to contribution containers

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
@@ -48,7 +48,7 @@ module GobiertoAdmin
               edit_admin_participation_process_contribution_container_path(
                 process_id: @process.id,
                 id: @contribution_container_form.contribution_container.id), notice: t(".success_html",
-                                                                             link: gobierto_participation_contribution_container_preview_url(@contribution_container_form.contribution_container))
+                                                                             link: gobierto_participation_contribution_container_preview_url(@contribution_container_form.contribution_container, host: current_site.domain))
             )
           else
             render :edit
@@ -69,7 +69,7 @@ module GobiertoAdmin
               edit_admin_participation_process_contribution_container_path(
                 id: @contribution_container_form.contribution_container.id,
                 process_id: @process.id), notice: t(".success_html",
-                                          link: gobierto_participation_contribution_container_preview_url(@contribution_container_form.contribution_container))
+                                          link: gobierto_participation_contribution_container_preview_url(@contribution_container_form.contribution_container, host: current_site.domain))
             )
           else
             @contribution_container_visibility_levels = contribution_container_visibility_levels

--- a/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/process_contribution_containers_controller.rb
@@ -4,6 +4,9 @@ module GobiertoAdmin
   module GobiertoParticipation
     module Processes
       class ProcessContributionContainersController < Processes::BaseController
+
+        helper_method :gobierto_participation_contribution_container_preview_url
+
         def index
           @contribution_containers = find_process.contribution_containers
           @archived_contribution_containers = find_process.contribution_containers.only_archived
@@ -42,11 +45,10 @@ module GobiertoAdmin
             track_create_activity
 
             redirect_to(
-              edit_admin_participation_process_contribution_container_path(process_id: @process.id,
-                                                                           id: @contribution_container_form.contribution_container.id),
-              notice: t(".success_html", link: gobierto_participation_process_contribution_container_url(@contribution_container_form.contribution_container.slug,
-                                                                                                                 process_id: @process.slug,
-                                                                                                                 host: current_site.domain))
+              edit_admin_participation_process_contribution_container_path(
+                process_id: @process.id,
+                id: @contribution_container_form.contribution_container.id), notice: t(".success_html",
+                                                                             link: gobierto_participation_contribution_container_preview_url(@contribution_container_form.contribution_container))
             )
           else
             render :edit
@@ -64,11 +66,10 @@ module GobiertoAdmin
             track_update_activity
 
             redirect_to(
-              edit_admin_participation_process_contribution_container_path(id: @contribution_container_form.contribution_container.id,
-                                                                           process_id: @process.id),
-              notice: t(".success_html", link: gobierto_participation_process_contribution_container_url(@contribution_container_form.contribution_container.slug,
-                                                                                                                 process_id: @process.slug,
-                                                                                                                 host: current_site.domain))
+              edit_admin_participation_process_contribution_container_path(
+                id: @contribution_container_form.contribution_container.id,
+                process_id: @process.id), notice: t(".success_html",
+                                          link: gobierto_participation_contribution_container_preview_url(@contribution_container_form.contribution_container))
             )
           else
             @contribution_container_visibility_levels = contribution_container_visibility_levels
@@ -137,6 +138,16 @@ module GobiertoAdmin
 
         def find_process
           current_site.processes.find(params[:process_id])
+        end
+
+        def gobierto_participation_contribution_container_preview_url(contribution_container, options = {})
+          if contribution_container.draft?
+            options.merge!(preview_token: current_admin.preview_token)
+          end
+          gobierto_participation_process_contribution_container_url(contribution_container.process.slug,
+                                                                    contribution_container.slug,
+                                                                    options)
+
         end
       end
     end

--- a/app/controllers/gobierto_participation/processes/contribution_containers_controller.rb
+++ b/app/controllers/gobierto_participation/processes/contribution_containers_controller.rb
@@ -18,7 +18,7 @@ module GobiertoParticipation
       end
 
       def find_contribution_containers
-        current_process.contribution_containers.active
+        current_process.contribution_containers
       end
     end
   end

--- a/test/integration/gobierto_admin/gobierto_participation/contribution_containers/create_contribution_container_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/contribution_containers/create_contribution_container_test.rb
@@ -75,6 +75,51 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_preview_draft_contribution_container_as_admin
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            click_on "Stages"
+
+            all("a", text: "Manage")[1].click
+
+            click_on "New"
+
+            within "form.new_contribution_container" do
+              fill_in "contribution_container_title_translations_en", with: "My contribution_container title"
+              fill_in "contribution_container_description_translations_en", with: "My contribution_container description"
+              fill_in "contribution_container_starts", with: "2017-01-01"
+              fill_in "contribution_container_ends", with: "2017-01-30"
+
+              click_link "ES"
+              fill_in "contribution_container_title_translations_es", with: "Mi contendedor de aportaciones"
+              fill_in "contribution_container_description_translations_es", with: "Descripción de mi contenedor de aportaciones"
+
+              within ".widget_save" do
+                choose "Draft"
+              end
+
+              click_button "Create"
+            end
+
+            within "div.flash-message.notice" do
+              preview_link = find("a", text: "View the container")
+
+              assert preview_link[:href].include?(admin.preview_token)
+
+              preview_link.click
+            end
+
+            contribution_container = ::GobiertoParticipation::ContributionContainer.last
+
+            assert_equal gobierto_participation_process_contribution_container_path(contribution_container.process.slug,
+                                                                                    contribution_container.slug), current_path
+            assert has_selector?("h2", text: contribution_container.title)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #1435 


## :v: What does this PR do?

Add preview token to contribution container when is created/updated.

Note that you can only access this token when you create/update (flash message) unlike other tables of other objects. We use the position where the view link usually is to view contributions.

## :mag: How should this be manually tested?

Create or update a contribution container

## :eyes: Screenshots

### Before this PR
Without preview token

### After this PR

<img width="1421" alt="captura de pantalla 2018-03-09 a las 22 52 41" src="https://user-images.githubusercontent.com/69764/37231770-bb794e28-23ec-11e8-9018-6e91053d24f7.png">

## :shipit: Does this PR changes any configuration file?

No