### PR TITLE
Limit budget lines data query

### DIFF
--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -79,7 +79,7 @@ module GobiertoBudgets
 
         result = []
         data.sort_by{|k,_| k }.each do |year, v|
-          if year <= Date.today.year
+          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last
             result.push({
               date: year.to_s,
               value: v,
@@ -137,7 +137,7 @@ module GobiertoBudgets
 
         result = []
         data.sort_by{|k,_| k }.each do |year, v|
-          if year <= Date.today.year
+          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last
             result.push({
               date: year.to_s,
               value: v,
@@ -194,7 +194,7 @@ module GobiertoBudgets
 
         result = []
         data.sort_by{|k,_| k }.each do |year, v|
-          if year <= Date.today.year
+          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last
             result.push({
               date: year.to_s,
               value: v,
@@ -241,7 +241,7 @@ module GobiertoBudgets
           if old_value = values[k -1]
             dif = delta_percentage(v, old_value)
           end
-          if k <= Date.today.year
+          if k <= GobiertoBudgets::SearchEngineConfiguration::Year.last
             result.push({date: k.to_s, value: v, dif: dif})
           elsif @include_next_year && v > 0
             result.push({date: k.to_s, value: v, dif: dif})


### PR DESCRIPTION
Closes #1456


## :v: What does this PR do?

This PR fixes budget lines when municipalities have data from this year but the global data hasn't been loaded yet.

## :mag: How should this be manually tested?

Check the screenshots!

## :eyes: Screenshots

### Before this PR

![pasted_image_at_2018_02_16_11_28_am](https://user-images.githubusercontent.com/17616/36303707-532b6c24-130d-11e8-8deb-c46b63e6fee4.png)

### After this PR

Municipality with 2018 data:

![screen shot 2018-03-12 at 10 25 53](https://user-images.githubusercontent.com/17616/37275539-c9cd1fa0-25df-11e8-9275-af804c7fdb4d.png)

Municipality without 2018 data:


![screen shot 2018-03-12 at 10 26 22](https://user-images.githubusercontent.com/17616/37275551-d590ed62-25df-11e8-9239-51368f157540.png)
