### PR TITLE
1448 upload files configuration

### DIFF
--- a/app/forms/concerns/gobierto_common/dynamic_content_form_helper.rb
+++ b/app/forms/concerns/gobierto_common/dynamic_content_form_helper.rb
@@ -77,7 +77,7 @@ module GobiertoCommon
         collection: person.model_name.collection,
         attribute_name: :attachment,
         file: attachment_file
-      ).call
+      ).upload!
     end
 
     def build_content_block_record_for(content_block)

--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -131,12 +131,12 @@ module GobiertoAdmin
     end
 
     def upload_file
-      FileUploadService.new(
+      GobiertoAdmin::FileUploadService.new(
         site: site,
         collection: file_attachment.model_name.collection,
         attribute_name: :file,
         file: file
-      ).call
+      ).upload!
     end
 
     def file_is_not_duplicated

--- a/app/forms/gobierto_admin/gobierto_participation/process_form.rb
+++ b/app/forms/gobierto_admin/gobierto_participation/process_form.rb
@@ -91,12 +91,12 @@ module GobiertoAdmin
         @header_image_url ||= begin
           return process.header_image_url unless header_image.present?
 
-          FileUploadService.new(
+          GobiertoAdmin::FileUploadService.new(
             site: site,
             collection: process.model_name.collection,
             attribute_name: :header_image,
             file: header_image
-          ).call
+          ).upload!
         end
       end
 

--- a/app/forms/gobierto_admin/gobierto_people/person_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_form.rb
@@ -81,12 +81,12 @@ module GobiertoAdmin
         @bio_url ||= begin
           return person.bio_url unless bio_file.present?
 
-          FileUploadService.new(
+          GobiertoAdmin::FileUploadService.new(
             site: site,
             collection: person.model_name.collection,
             attribute_name: :bio,
             file: bio_file
-          ).call
+          ).upload!
         end
       end
 
@@ -94,7 +94,7 @@ module GobiertoAdmin
         @avatar_url ||= begin
           return person.avatar_url unless avatar_file.present?
 
-          FileUploadService.new(
+          GobiertoAdmin::FileUploadService.new(
             site: site,
             collection: person.model_name.collection,
             attribute_name: :avatar,
@@ -103,7 +103,7 @@ module GobiertoAdmin
             y: logo_crop_y.to_f,
             w: logo_crop_w.to_f,
             h: logo_crop_h.to_f
-          ).call
+          ).upload!
         end
       end
 

--- a/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/person_statement_form.rb
@@ -67,13 +67,13 @@ module GobiertoAdmin
         @attachment_url ||= begin
           return person_statement.attachment_url unless attachment_file.present?
 
-          FileUploadService.new(
+          GobiertoAdmin::FileUploadService.new(
             site: person.site,
             collection: person_statement.model_name.collection,
             attribute_name: :attachment,
             file: attachment_file,
             content_disposition: "attachment"
-          ).call
+          ).upload!
         end
       end
 

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -143,12 +143,12 @@ module GobiertoAdmin
       @logo_url ||= begin
         return site.configuration.logo unless logo_file.present?
 
-        FileUploadService.new(
+        GobiertoAdmin::FileUploadService.new(
           site: site,
           collection: site.model_name.collection,
           attribute_name: :logo,
           file: logo_file
-        ).call
+        ).upload!
       end
     end
 

--- a/app/models/gobierto_budgets/data/annual.rb
+++ b/app/models/gobierto_budgets/data/annual.rb
@@ -24,7 +24,7 @@ module GobiertoBudgets
       end
 
       def get_url(format)
-        file = FileUploader::S3.new(file_name: filename(format))
+        file = GobiertoCommon::FileUploadService.new(file_name: filename(format))
         file.uploaded_file_exists? && file.call
       end
 
@@ -34,7 +34,7 @@ module GobiertoBudgets
         calculate_place_budget_lines
 
         FORMATS.each do |format_key, configuration|
-          file_urls << FileUploader::S3.new(
+          file_urls << GobiertoCommon::FileUploadService.new(
             file_name: filename(format_key),
             content: configuration[:serializer].call(@place_budget_lines),
             content_type: configuration[:content_type]

--- a/app/models/gobierto_budgets/data/bubbles.rb
+++ b/app/models/gobierto_budgets/data/bubbles.rb
@@ -19,12 +19,9 @@ module GobiertoBudgets
       attr_reader :place
 
       def upload_file
-        tmp_file = Tempfile.new
-        tmp_file.binmode
-        tmp_file.write(@file_content.to_json)
-        tmp_file.close
-        file = ActionDispatch::Http::UploadedFile.new(filename: "bubbles.json", tempfile: tmp_file)
-        ::FileUploader::S3.new(file: file, file_name: self.class.file_name_for(place)).upload!
+        GobiertoCommon::FileUploadService.new(content: @file_content.to_json,
+                                              file_name: self.class.file_name_for(place),
+                                              content_type: "application/json; charset=utf-8").upload!
       end
 
       def build_data_file

--- a/app/services/gobierto_admin/file_upload_service.rb
+++ b/app/services/gobierto_admin/file_upload_service.rb
@@ -1,30 +1,17 @@
-require "file_uploader"
+# frozen_string_literal: true
 
 module GobiertoAdmin
-  class FileUploadService
-    attr_reader :file, :site, :collection, :x, :y, :w, :h
+  class FileUploadService < ::GobiertoCommon::FileUploadService
+    attr_reader :x, :y, :w, :h
 
-    def initialize(site:, collection:, attribute_name:, file:, x: nil, y: nil, w: nil, h: nil, content_disposition: nil, add_suffix: true)
-      @adapter = APP_CONFIG['file_uploads_adapter'].presence.try(:to_sym) || :s3
-      @site = site
-      @collection = collection
-      @attribute_name = attribute_name
+    def initialize(site:, collection:, attribute_name:, file:, x: nil, y: nil, w: nil, h: nil, content_disposition: nil, content_type: nil, add_suffix: true)
       @file = crop_image(x, y, w, h, file)
-      @content_disposition = content_disposition
-      @add_suffix = add_suffix
-    end
-
-    delegate :call, to: :adapter
-
-    def adapter
-      if Rails.env.development?
-        return FileUploader::Local.new(file: file, file_name: file_name)
-      end
-
-      case @adapter
-      when :s3 then FileUploader::S3.new(file: file, file_name: file_name, content_disposition: @content_disposition)
-      when :filesystem then FileUploader::Local.new(file: file, file_name: file_name)
-      end
+      super(site: site,
+            collection: collection,
+            attribute_name: attribute_name,
+            content_disposition: content_disposition,
+            content_type: content_type,
+            add_suffix: add_suffix)
     end
 
     def crop_image(x, y, w, h, file)
@@ -72,28 +59,6 @@ module GobiertoAdmin
         file_from_url(image_response["secure_url"], file)
       else
         file
-      end
-    end
-
-    private
-
-    def file_name
-      @file_name ||= begin
-        [site_id, collection, attribute_name, file.original_filename].join("/")
-      end
-    end
-
-    protected
-
-    def site_id
-      site.present? ? "site-#{site.id}" : "site-unknown"
-    end
-
-    def attribute_name
-      if @add_suffix
-        "#{@attribute_name}-#{SecureRandom.uuid}"
-      else
-        @attribute_name
       end
     end
 

--- a/app/services/gobierto_common/file_upload_service.rb
+++ b/app/services/gobierto_common/file_upload_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "file_uploader"
+
+module GobiertoCommon
+  class FileUploadService
+    attr_reader :file, :site, :collection
+
+    def initialize(args={})
+      @adapter = APP_CONFIG['file_uploads_adapter'].presence.try(:to_sym) || :s3
+      @site = args[:site]
+      @collection = args[:collection]
+      @attribute_name = args[:attribute_name]
+      @file_name = args[:file_name]
+      @file ||= if args[:content].present?
+                @tmp_file = Tempfile.new
+                @tmp_file.binmode
+                @tmp_file.write(args[:content])
+                @tmp_file.close
+                ActionDispatch::Http::UploadedFile.new(filename: @file_name.split('/').last, tempfile: @tmp_file, original_filename: @file_name.split(''))
+              else
+                args[:file]
+              end
+      @content_disposition = args[:content_disposition]
+      @content_type = args[:content_type]
+      @add_suffix = args[:add_suffix] || true
+    end
+
+    delegate :call, :uploaded_file_exists?, :upload!, to: :adapter
+
+    def adapter
+      if Rails.env.development?
+        return FileUploader::Local.new(file: file, file_name: file_name)
+      end
+
+      case @adapter
+      when :s3 then FileUploader::S3.new(file: file, file_name: file_name, content_disposition: @content_disposition)
+      when :filesystem then FileUploader::Local.new(file: file, file_name: file_name)
+      end
+    end
+
+    private
+
+    def file_name
+      @file_name ||= begin
+        [site_id, collection, attr_name, file.original_filename].join("/")
+      end
+    end
+
+    protected
+
+    def site_id
+      site.present? ? "site-#{site.id}" : "site-unknown"
+    end
+
+    def attr_name
+      if @add_suffix
+        "#{@attribute_name}-#{SecureRandom.uuid}"
+      else
+        @attribute_name
+      end
+    end
+  end
+end

--- a/config/application.yml
+++ b/config/application.yml
@@ -67,7 +67,7 @@ default: &default
     endpoint: <%= ENV["POPULATE_DATA_ENDPOINT"] %>
   gobierto_observatory:
     year: 2015
-  file_uploads_adapter: s3
+  file_uploads_adapter: filesystem
   auth_modules:
     -
       name: null_strategy

--- a/lib/file_uploader/local.rb
+++ b/lib/file_uploader/local.rb
@@ -12,12 +12,24 @@ module FileUploader
     end
 
     def call
+      upload || file_uri
+    end
+
+    def upload
+      upload! if !uploaded_file_exists? && @file
+    end
+
+    def upload!
       FileUtils.mkdir_p(file_base_path) unless File.exist?(file_base_path)
       FileUtils.mv(file.tempfile.path, file_path)
       File.chmod(0o664, file_path)
       ObjectSpace.undefine_finalizer(file.tempfile)
 
       file_uri
+    end
+
+    def uploaded_file_exists?
+      File.exists?(file_path)
     end
 
     private

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -6,16 +6,8 @@ module FileUploader
   class S3
     attr_reader :file, :file_name
 
-    def initialize(file_name:, content: nil, file: nil, content_disposition: nil, content_type: nil, bucket_name: nil)
-      @file = if content.present?
-                @tmp_file = Tempfile.new
-                @tmp_file.binmode
-                @tmp_file.write(content)
-                @tmp_file.close
-                ActionDispatch::Http::UploadedFile.new(filename: @file_name, tempfile: @tmp_file)
-              else
-                file
-              end
+    def initialize(file_name:, file: nil, content_disposition: nil, content_type: nil, bucket_name: nil)
+      @file = file
       @file_name = file_name
       @bucket_name = bucket_name
       @content_disposition = content_disposition

--- a/test/forms/gobierto_admin/gobierto_attachments/file_attachment_form_tests/base_test.rb
+++ b/test/forms/gobierto_admin/gobierto_attachments/file_attachment_form_tests/base_test.rb
@@ -9,9 +9,15 @@ module GobiertoAdmin
 
         def setup
           super
-          ::FileUploader::S3.any_instance
-                            .stubs(:call)
-                            .returns('http://www.domain.com/logo-madrid.png')
+          [::FileUploader::S3, ::FileUploader::Local].each do |file_uploader|
+            file_uploader.any_instance
+              .stubs(:upload!)
+              .returns('http://www.domain.com/logo-madrid.png')
+            file_uploader.any_instance
+              .stubs(:call)
+              .returns('http://www.domain.com/logo-madrid.png')
+
+          end
         end
 
         def site

--- a/test/forms/gobierto_admin/gobierto_people/person_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_form_test.rb
@@ -40,6 +40,16 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def uploaded_file
+        @uploaded_file ||= begin
+                             tmp_file = Tempfile.new
+                             tmp_file.binmode
+                             tmp_file.write("Test content")
+                             ActionDispatch::Http::UploadedFile.new(tempfile: tmp_file,
+                                                                    original_filename: "file.pdf")
+                           end
+      end
+
       def test_save_with_valid_attributes
         assert valid_person_form.save
         assert valid_person_form.person.google_calendar_token.present?
@@ -74,7 +84,7 @@ module GobiertoAdmin
       end
 
       def test_content_block_records_are_assigned_after_site_id
-        person_params = { name: person.name, content_block_records_attributes: { "0" => { attachment_file: "file.pdf" } } }
+        person_params = { name: person.name, content_block_records_attributes: { "0" => { attachment_file: uploaded_file } } }
 
         ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/file.pdf")
 

--- a/test/forms/gobierto_admin/gobierto_people/person_statement_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_people/person_statement_form_test.rb
@@ -41,6 +41,16 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def uploaded_file
+        @uploaded_file ||= begin
+                             tmp_file = Tempfile.new
+                             tmp_file.binmode
+                             tmp_file.write("Test content")
+                             ActionDispatch::Http::UploadedFile.new(tempfile: tmp_file,
+                                                                    original_filename: "file.pdf")
+                           end
+      end
+
       def test_save_with_valid_attributes
         assert valid_person_statement_form.save
       end
@@ -64,7 +74,7 @@ module GobiertoAdmin
         person_statement_params = {
           title_translations: { I18n.locale => person_statement.title },
           published_on: person_statement.published_on,
-          content_block_records_attributes: { "0" => { attachment_file: "file.pdf" } }
+          content_block_records_attributes: { "0" => { attachment_file: uploaded_file } }
         }
 
         ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/file.pdf")

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -8,7 +8,7 @@ module GobiertoAdmin
     include FileUploaderHelpers
 
     def file_upload_service
-      @file_upload_service ||= FileUploadService.new(
+      @file_upload_service ||= GobiertoAdmin::FileUploadService.new(
         site: site,
         collection: :test_collection,
         attribute_name: :test_attribute,

--- a/test/services/gobierto_admin/file_upload_service_test.rb
+++ b/test/services/gobierto_admin/file_upload_service_test.rb
@@ -30,10 +30,12 @@ module GobiertoAdmin
     end
 
     def test_adapter
-      assert_kind_of FileUploader::S3, file_upload_service.adapter
-      assert_equal file, file_upload_service.adapter.file
-      assert_includes file_upload_service.adapter.file_name, "site-#{site.id}/test_collection/test_attribute"
-      assert_includes file_upload_service.adapter.file_name, file.original_filename
+      Object.stub_const(:APP_CONFIG, APP_CONFIG.dup.tap { |config| config["file_uploads_adapter"] = "s3" }) do
+        assert_kind_of FileUploader::S3, file_upload_service.adapter
+        assert_equal file, file_upload_service.adapter.file
+        assert_includes file_upload_service.adapter.file_name, "site-#{site.id}/test_collection/test_attribute"
+        assert_includes file_upload_service.adapter.file_name, file.original_filename
+      end
     end
 
     def test_adapter_in_development


### PR DESCRIPTION
Closes #1448


## :v: What does this PR do?
Uses the storage configuration in `config/application.yml`, which can be 's3' or 'filesystem' on all uploads the application makes. To do this:
* Some of the `FileUploadService` functionality has been extracted to a `GobiertoCommon::FileUploadService`. `GobiertoAdmin::FileUploadService` is now inherited from it.
* `GobiertoBudgets::Data::Bubbles` and `GobiertoBudgets::Data::Annual` store their data using `GobiertoCommon::FileUploadService` instead of using directly `FileUpload::S3`.

## :mag: How should this be manually tested?
Set in `config/application.yml` `file_uploads_adapter` as `filesystem`.
Run `./bin/rails gobierto_budgets:data:sites_annual` from terminal in the application path. The files generated are expected to be saved in filesystem. Also, in the application, the links to the files should be local in http://madrid.gobierto.test/datos

## :shipit: Does this PR changes any configuration file?
No
