### PR TITLE
Link data from invoices and add data submenu

### DIFF
--- a/app/views/gobierto_budgets/layouts/_navigation.sub.html.erb
+++ b/app/views/gobierto_budgets/layouts/_navigation.sub.html.erb
@@ -32,3 +32,6 @@
     <%= link_to t('gobierto_budgets.layouts.menu_subsections.providers'), gobierto_budgets_providers_path, class: class_if('active', controller_name == 'providers'), data: { turbolinks: false }  %>
   </div>
 <% end %>
+<div class="sub-nav-item">
+  <%= link_to t('gobierto_budgets.layouts.menu_subsections.data'), gobierto_exports_root_path, data: { turbolinks: false }  %>
+</div>

--- a/app/views/gobierto_budgets/providers/index.html.erb
+++ b/app/views/gobierto_budgets/providers/index.html.erb
@@ -154,6 +154,7 @@
       </div>
     </div>
 
+    <%= render "shared/download_open_data" %>
   </main>
 </div>
 

--- a/app/views/gobierto_people/people/_navigation.html.erb
+++ b/app/views/gobierto_people/people/_navigation.html.erb
@@ -42,9 +42,4 @@
   </div>
 <% end %>
 
-<div class="download_open_data">
-
-  <i class="fa fa-table"></i>
-  <%= link_to t(".exports"), gobierto_exports_root_url %>
-
-</div>
+<%= render "shared/download_open_data" %>

--- a/app/views/shared/_download_open_data.html.erb
+++ b/app/views/shared/_download_open_data.html.erb
@@ -1,0 +1,4 @@
+<div class="download_open_data">
+  <i class="fa fa-table"></i>
+  <%= link_to t(".exports"), gobierto_exports_root_url %>
+</div>

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -501,6 +501,7 @@ ca:
         budgets: Pressupostos
       menu_subsections:
         budget: Pressupost
+        data: Dades
         elaboration: Elaboració
         execution: Execució
         guide: Guia

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -479,6 +479,7 @@ en:
         budgets: Budgets
       menu_subsections:
         budget: Budget
+        data: Data
         elaboration: Elaboration
         execution: Execution
         guide: Guide

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -493,6 +493,7 @@ es:
         budgets: Presupuestos
       menu_subsections:
         budget: Presupuesto
+        data: Datos
         elaboration: Elaboración
         execution: Ejecución
         guide: Guía

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -47,7 +47,6 @@ ca:
         agenda: Agenda
         bio: Biografia i CV
         blog: Blog
-        exports: Descarrega les dades en format reutilitzable
         gifts: Obsequis i regals
         statements: Béns i activitats
         trips: Viatges

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -46,7 +46,6 @@ en:
         agenda: Agenda
         bio: Biography and CV
         blog: Blog
-        exports: Download data in a reusable format
         gifts: Gifts
         statements: Goods and Activities
         trips: Trips

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -47,7 +47,6 @@ es:
         agenda: Agenda
         bio: Biografía y CV
         blog: Blog
-        exports: Descarga los datos en formato reutilizable
         gifts: Obsequios y regalos
         statements: Bienes y Actividades
         trips: Viajes

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -116,6 +116,8 @@ ca:
       scopes_scope_created: Àmbit creat
       scopes_scope_updated: Àmbit actualitzat
   shared:
+    download_open_data:
+      exports: Descarrega les dades en format reutilitzable
     poll_question:
       multiple_choice_msg: Pots triar diverses opcions
     poll_teaser:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -110,6 +110,8 @@ en:
       scopes_scope_created: Scope created
       scopes_scope_updated: Scope updated
   shared:
+    download_open_data:
+      exports: Download data in a reusable format
     poll_question:
       multiple_choice_msg: You can choose several options
     poll_teaser:

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -116,6 +116,8 @@ es:
       scopes_scope_created: Ámbito creado
       scopes_scope_updated: Ámbito actualizado
   shared:
+    download_open_data:
+      exports: Descarga los datos en formato reutilizable
     poll_question:
       multiple_choice_msg: Puedes elegir varias opciones
     poll_teaser:

--- a/test/integration/gobierto_budgets/home_page_test.rb
+++ b/test/integration/gobierto_budgets/home_page_test.rb
@@ -25,6 +25,20 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_menu_subsections
+    with_current_site(site) do
+      visit @path
+
+      within "nav.sub-nav" do
+        assert has_link? "Budgets"
+        assert has_link? "Execution"
+        assert has_link? "Guide"
+        assert has_link? "Receipt"
+        assert has_link? "Data"
+      end
+    end
+  end
+
   def test_metric_boxes
     with_current_site(site) do
       visit @path


### PR DESCRIPTION
Closes #319


## :v: What does this PR do?

- Add data link in submenu
- Add export in /presupuestos/proveedores-facturas. I put it in a partial on shared.

## :mag: How should this be manually tested?

/presupuestos/proveedores-facturas

## :eyes: Screenshots

### Before this PR

No

### After this PR

![captura de pantalla 2018-03-15 a las 18 34 04](https://user-images.githubusercontent.com/69764/37480435-8a610c44-287f-11e8-9431-45ab6a774c46.png)

![captura de pantalla 2018-03-15 a las 18 34 18](https://user-images.githubusercontent.com/69764/37480442-8cca09d6-287f-11e8-94b9-32c7a8f08109.png)


## :shipit: Does this PR changes any configuration file?

No