### PR TITLE
Capture calendar exception

### DIFF
--- a/app/services/gobierto_people/remote_calendars.rb
+++ b/app/services/gobierto_people/remote_calendars.rb
@@ -15,7 +15,7 @@ module GobiertoPeople
         begin
           calendar_integration.new(container).sync!
           Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: '127.0.0.1',  subject: container, site_id: site.id })
-        rescue Exception => e
+        rescue StandardError => e
           Rollbar.error(e)
         end
       end

--- a/app/services/gobierto_people/remote_calendars.rb
+++ b/app/services/gobierto_people/remote_calendars.rb
@@ -12,8 +12,12 @@ module GobiertoPeople
 
         I18n.locale = site.configuration.default_locale
 
-        calendar_integration.new(container).sync!
-        Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: '127.0.0.1',  subject: container, site_id: site.id })
+        begin
+          calendar_integration.new(container).sync!
+          Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: '127.0.0.1',  subject: container, site_id: site.id })
+        rescue Exception => e
+          Rollbar.error(e)
+        end
       end
     end
 


### PR DESCRIPTION
Closes #1524 

## :v: What does this PR do?

This PR ensures that a failure synching a calendar won't stop the sync and it'll continue with the rest of calendars.

## :mag: How should this be manually tested?

Run it in production, and check all the calendars update activity.

## :eyes: Screenshots

Not here