### PR TITLE
Markup for indicators update date

### DIFF
--- a/app/views/gobierto_indicators/indicators/gci.html.erb
+++ b/app/views/gobierto_indicators/indicators/gci.html.erb
@@ -21,7 +21,7 @@
           <%= t('.gci_description') %>
         </p>
 
-        <p>
+        <p class="indicators-update-date">
           <%= t("gobierto_indicators.indicators.shared.latest_update_html", date: l(@indicator_updated_at, format: :long)) %>
         </p>
       </div>

--- a/app/views/gobierto_indicators/indicators/ip.html.erb
+++ b/app/views/gobierto_indicators/indicators/ip.html.erb
@@ -21,7 +21,7 @@
           <%= t('.ip_description') %>
         </p>
 
-        <p>
+        <p class="indicators-update-date">
           <%= t("gobierto_indicators.indicators.shared.latest_update_html", date: l(@indicator_updated_at, format: :long)) %>
         </p>
       </div>

--- a/app/views/gobierto_indicators/indicators/ita.html.erb
+++ b/app/views/gobierto_indicators/indicators/ita.html.erb
@@ -21,7 +21,7 @@
           <%= t('.ita_description') %>
         </p>
 
-        <p>
+        <p class="indicators-update-date">
           <%= t("gobierto_indicators.indicators.shared.latest_update_html", date: l(@indicator_updated_at, format: :long)) %>
         </p>
       </div>


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

Adds a class in the HTML for the `<p>` that contains update date, so we can hide it with CSS if we don't want to show it. 