### PR TITLE
Backclick scope limited

### DIFF
--- a/app/views/gobierto_indicators/indicators/_template.html.erb
+++ b/app/views/gobierto_indicators/indicators/_template.html.erb
@@ -93,8 +93,8 @@
 
 <!-- item view wrap template -->
 <script type="text/x-template" id="item-view-wrap-template">
-  <li @click="unselect" class="item item-lvl-1">
-    <div class="item-title">
+  <li class="item item-lvl-1">
+    <div class="item-title" @click="unselect">
       <div class="item-toggle p_h_r_1">
         <div class="toggle-container">
           <i class="fa fa-caret-left"></i>


### PR DESCRIPTION
Closes #1526 

## :v: What does this PR do?
Limit the indicator's detail click back functionality to the title/subtitle, instead of the full component


