### PR TITLE
Add description to gci indicators detail

### DIFF
--- a/app/views/gobierto_indicators/indicators/_template.html.erb
+++ b/app/views/gobierto_indicators/indicators/_template.html.erb
@@ -39,6 +39,7 @@
       <div class="item-id p_h_r_1">{{ model.id }}</div>
       <div class="item-text">
         <span>{{ model.attributes.title }}</span>
+        <p v-if="model.attributes.description">{{ model.attributes.description }}</p>
       </div>
       <div class="item-check" v-if="type == 'boolean'">
         <div class="row">

--- a/test/integration/gobierto_indicators/indicators/indicator_show_test.rb
+++ b/test/integration/gobierto_indicators/indicators/indicator_show_test.rb
@@ -78,6 +78,8 @@ module GobiertoIndicators
           end
 
           assert has_content? "Nombre total de llars"
+          assert has_content? "El nombre total d'habitatges amb persones empadronades,
+                               tant en règim de lloguer com en propietat."
           assert has_content? "16366"
           assert has_content? "Calculation"
           assert has_content? "Suma total d'habitatges amb persones empadronades"


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/298

- [ ] Waiting for customer validation (staging)

## :v: What does this PR do?

<p> is added with the description in the indicator detail.

## :mag: How should this be manually tested?

/indicadores/gci/2017 In the detail of an indicator

## :eyes: Screenshots

### Before this PR

Without description

### After this PR

![captura de pantalla 2018-03-22 a las 15 19 35](https://user-images.githubusercontent.com/69764/37777249-5a390a22-2de7-11e8-8e9b-bf163672baac.png)


## :shipit: Does this PR changes any configuration file?

- [ ] Pending: Execute bin/deploy.sh to upload the changes of Sant Feliu indicators to production