### PR TITLE
Fix pages links when included in sections

### DIFF
--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -3,6 +3,7 @@ module GobiertoAdmin
     include SessionHelper
     include SiteSessionHelper
     include LayoutPolicyHelper
+    include ::GobiertoCms::PageHelper
 
     skip_before_action :authenticate_user_in_site
     before_action :authenticate_admin!, :set_admin_site
@@ -61,11 +62,7 @@ module GobiertoAdmin
 
     def gobierto_cms_page_preview_path(page, options = {})
       options.merge!(preview_token: current_admin.preview_token) unless page.active?
-      if page.collection.item_type == "GobiertoCms::Page"
-        gobierto_cms_page_path(page.slug, options)
-      elsif page.collection.item_type == "GobiertoCms::News"
-        gobierto_cms_news_path(page.slug, options)
-      end
+      gobierto_cms_page_or_news_path(page, options)
     end
 
   end

--- a/app/controllers/gobierto_admin/gobierto_plans/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/base_controller.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
         if plan.draft?
           options.merge!(preview_token: current_admin.preview_token)
         end
-        gobierto_plans_url(plan.plan_type.slug, plan.year, options)
+        gobierto_plans_plan_url(plan.plan_type.slug, plan.year, options)
       end
     end
   end

--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -13,7 +13,7 @@ module GobiertoPlans
       load_years
       @year = @years.first
 
-      redirect_to gobierto_plans_path(slug: @plan_type.slug, year: @year)
+      redirect_to gobierto_plans_plan_path(slug: @plan_type.slug, year: @year)
     end
 
     def show
@@ -74,7 +74,7 @@ module GobiertoPlans
 
     def load_year
       if params[:year].nil?
-        redirect_to gobierto_plans_path(slug: @plans.find_by!(year: @years.first).slug, year: @years.first)
+        redirect_to gobierto_plans_plan_path(slug: @plans.find_by!(year: @years.first).slug, year: @years.first)
       else
         @year = params[:year].to_i
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,12 +100,4 @@ module ApplicationHelper
       end
     end
   end
-
-  def gobierto_cms_page_or_news_path(page, options = {})
-    if page.collection.item_type == "GobiertoCms::Page"
-      gobierto_cms_page_path(page.slug, options)
-    elsif page.collection.item_type == "GobiertoCms::News"
-      gobierto_cms_news_path(page.slug, options)
-    end
-  end
 end

--- a/app/helpers/gobierto_cms/page_helper.rb
+++ b/app/helpers/gobierto_cms/page_helper.rb
@@ -14,5 +14,18 @@ module GobiertoCms
       html << "</ul>"
       html.join.html_safe
     end
+
+    def gobierto_cms_page_or_news_path(page, options = {})
+      url_helpers = Rails.application.routes.url_helpers
+      if page.collection.item_type == "GobiertoCms::Page"
+        if page.section
+          url_helpers.gobierto_cms_section_item_path(page.section.slug, page.slug, options)
+        else
+          url_helpers.gobierto_cms_page_path(page.slug, options)
+        end
+      elsif page.collection.item_type == "GobiertoCms::News"
+        url_helpers.gobierto_cms_news_path(page.slug, options)
+      end
+    end
   end
 end

--- a/app/helpers/gobierto_participation/process_helper.rb
+++ b/app/helpers/gobierto_participation/process_helper.rb
@@ -6,7 +6,7 @@ module GobiertoParticipation
       case stage.stage_type
         when "information", "results"
           if stage.process_stage_page.present?
-            gobierto_cms_page_path(stage.process_stage_page.page.slug, process_id: stage.process.slug)
+            gobierto_cms_page_or_news_path(stage.process_stage_page.page, process_id: stage.process.slug)
           end
         when "agenda"
           gobierto_participation_process_events_path(process_id: stage.process.slug)

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -101,7 +101,11 @@ module GobiertoCms
 
     def resource_path
       if collection.item_type == "GobiertoCms::Page"
-        url_helpers.gobierto_cms_page_url({ id: slug }.merge(host: site.domain))
+        if section
+          url_helpers.gobierto_cms_section_item_url({slug_section: section.slug, id: slug}.merge(host: site.domain))
+        else
+          url_helpers.gobierto_cms_page_url({ id: slug }.merge(host: site.domain))
+        end
       elsif collection.item_type == "GobiertoCms::News"
         url_helpers.gobierto_cms_news_url({ id: slug }.merge(host: site.domain))
       end

--- a/app/models/gobierto_plans/plan_type.rb
+++ b/app/models/gobierto_plans/plan_type.rb
@@ -21,8 +21,8 @@ module GobiertoPlans
       [name]
     end
 
-    def recent_plan_date
-      plans.published.pluck(:year).sort.reverse!.first
+    def self.site_plant_types(site)
+      site.plans.includes(:plan_type).published.group_by(&:plan_type).keys
     end
   end
 end

--- a/app/views/gobierto_budgets/layouts/_navigation.sub.html.erb
+++ b/app/views/gobierto_budgets/layouts/_navigation.sub.html.erb
@@ -1,39 +1,37 @@
-<% cache(["layouts/gobierto_budgets/navigation_sub", current_site, I18n.locale]) do %>
-  <% if budgets_elaboration_active? %>
-    <div class="sub-nav-item<%= class_if(' active', controller_name == 'budgets_elaboration') %>">
-      <% content_for_if(:current_submodule_link, controller_name == 'budgets_elaboration') do %>
-        <%= link_to t('gobierto_budgets.layouts.menu_subsections.elaboration'), gobierto_budgets_budgets_elaboration_path, data: { turbolinks: false }  %>
-      <% end %>
-    </div>
-  <% end %>
-  <div class="sub-nav-item<%= class_if(' active', (controller_name == 'budgets' && action_name == 'index') || controller_name == 'budget_lines') %>">
-    <% content_for_if(:current_submodule_link, (controller_name == 'budgets' && action_name == 'index') || controller_name == 'budget_lines') do %>
-      <%= link_to t('gobierto_budgets.layouts.application.budgets'), gobierto_budgets_budgets_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), data: { turbolinks: false } %>
+<% if budgets_elaboration_active? %>
+  <div class="sub-nav-item<%= class_if(' active', controller_name == 'budgets_elaboration') %>">
+    <% content_for_if(:current_submodule_link, controller_name == 'budgets_elaboration') do %>
+      <%= link_to t('gobierto_budgets.layouts.menu_subsections.elaboration'), gobierto_budgets_budgets_elaboration_path, data: { turbolinks: false }  %>
     <% end %>
-  </div>
-  <div class="sub-nav-item<%= class_if(' active', controller_name == 'budgets_execution') %>">
-    <% content_for_if(:current_submodule_link, controller_name == 'budgets_execution') do %>
-      <%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), data: { turbolinks: false } %>
-    <% end %>
-  </div>
-  <div class="sub-nav-item<%= class_if(' active', controller_name == 'budgets' && action_name == 'guide') %>">
-    <% content_for_if(:current_submodule_link, controller_name == 'budgets' && action_name == 'guide') do %>
-      <%= link_to t('gobierto_budgets.layouts.menu_subsections.guide'), gobierto_budgets_budgets_guide_path, data: { turbolinks: false } %>
-    <% end %>
-  </div>
-  <% if budgets_receipt_active? %>
-    <div class="sub-nav-item<%= class_if(' active', controller_name == 'receipts') %>">
-      <% content_for_if(:current_submodule_link, controller_name == 'receipts') do %>
-        <%= link_to t('gobierto_budgets.layouts.menu_subsections.receipt'), gobierto_budgets_receipt_path, class: class_if('active', controller_name == 'receipts'), data: { turbolinks: false }  %>
-      <% end %>
-    </div>
-  <% end %>
-  <% if budgets_providers_active? %>
-    <div class="sub-nav-item<%= class_if(' active', controller_name == 'providers') %>">
-      <%= link_to t('gobierto_budgets.layouts.menu_subsections.providers'), gobierto_budgets_providers_path, class: class_if('active', controller_name == 'providers'), data: { turbolinks: false }  %>
-    </div>
-  <% end %>
-  <div class="sub-nav-item">
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.data'), gobierto_exports_root_path, data: { turbolinks: false }  %>
   </div>
 <% end %>
+<div class="sub-nav-item<%= class_if(' active', (controller_name == 'budgets' && action_name == 'index') || controller_name == 'budget_lines') %>">
+  <% content_for_if(:current_submodule_link, (controller_name == 'budgets' && action_name == 'index') || controller_name == 'budget_lines') do %>
+    <%= link_to t('gobierto_budgets.layouts.application.budgets'), gobierto_budgets_budgets_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), data: { turbolinks: false } %>
+  <% end %>
+</div>
+<div class="sub-nav-item<%= class_if(' active', controller_name == 'budgets_execution') %>">
+  <% content_for_if(:current_submodule_link, controller_name == 'budgets_execution') do %>
+    <%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last), data: { turbolinks: false } %>
+  <% end %>
+</div>
+<div class="sub-nav-item<%= class_if(' active', controller_name == 'budgets' && action_name == 'guide') %>">
+  <% content_for_if(:current_submodule_link, controller_name == 'budgets' && action_name == 'guide') do %>
+    <%= link_to t('gobierto_budgets.layouts.menu_subsections.guide'), gobierto_budgets_budgets_guide_path, data: { turbolinks: false } %>
+  <% end %>
+</div>
+<% if budgets_receipt_active? %>
+  <div class="sub-nav-item<%= class_if(' active', controller_name == 'receipts') %>">
+    <% content_for_if(:current_submodule_link, controller_name == 'receipts') do %>
+      <%= link_to t('gobierto_budgets.layouts.menu_subsections.receipt'), gobierto_budgets_receipt_path, class: class_if('active', controller_name == 'receipts'), data: { turbolinks: false }  %>
+    <% end %>
+  </div>
+<% end %>
+<% if budgets_providers_active? %>
+  <div class="sub-nav-item<%= class_if(' active', controller_name == 'providers') %>">
+    <%= link_to t('gobierto_budgets.layouts.menu_subsections.providers'), gobierto_budgets_providers_path, class: class_if('active', controller_name == 'providers'), data: { turbolinks: false }  %>
+  </div>
+<% end %>
+<div class="sub-nav-item">
+  <%= link_to t('gobierto_budgets.layouts.menu_subsections.data'), gobierto_exports_root_path, data: { turbolinks: false }  %>
+</div>

--- a/app/views/gobierto_cms/shared/_pages_side_navigation.html.erb
+++ b/app/views/gobierto_cms/shared/_pages_side_navigation.html.erb
@@ -6,7 +6,7 @@
       <li><%= link_to @collection.title, gobierto_cms_pages_path(@collection.slug) %></a>
         <ul>
           <% @pages.each do |page| %>
-            <li><%= link_to page.title, gobierto_cms_page_path(page.slug) %></li>
+            <li><%= link_to page.title, gobierto_cms_page_or_news_path(page) %></li>
           <% end %>
         </ul>
       </li>

--- a/app/views/gobierto_plans/layouts/_navigation.sub.html.erb
+++ b/app/views/gobierto_plans/layouts/_navigation.sub.html.erb
@@ -1,7 +1,5 @@
-<% current_site.plan_types.each do |plan_type| %>
+<% GobiertoPlans::PlanType.site_plant_types(current_site).each do |plan_type| %>
   <div class="sub-nav-item <%= class_if(' active', plan_type.slug == params[:slug] ) %>">
-    <% if plan_type.plans.published.any? %>
-      <%= link_to plan_type.name, gobierto_plans_path(slug: plan_type.slug, year: plan_type.recent_plan_date) %>
-    <% end %>
+    <%= link_to plan_type.name, gobierto_plans_plans_path(slug: plan_type.slug) %>
   </div>
 <% end %>

--- a/app/views/gobierto_plans/plan_types/show.html.erb
+++ b/app/views/gobierto_plans/plan_types/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:current_submodule_link) do %>
-  <%= link_to title(@plan.title), gobierto_plans_path(slug: @plan.plan_type.slug, year: '') %>
+  <%= link_to title(@plan.title), gobierto_plans_plans_path(slug: @plan.plan_type.slug) %>
 <% end %>
 
 <% if @plan.css.present? %>
@@ -15,7 +15,7 @@
       <div class="pure-u-1 pure-u-md-12-24">
         <div class="inline_header">
           <h2 class="with_description p_h_r_1"><%= @plan.title %></h2>
-          <%= render partial: 'layouts/year_breadcrumb', locals: {path_calculation_method: :gobierto_plans_path} %>
+          <%= render partial: 'layouts/year_breadcrumb', locals: {path_calculation_method: :gobierto_plans_plan_path} %>
         </div>
 
         <p v-if="!selected">

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,8 @@ module Gobierto
       "#{config.root}/lib/validators",
       "#{config.root}/lib/constraints",
       "#{config.root}/lib/errors",
-      "#{config.root}/lib/ibm_notes"
+      "#{config.root}/lib/ibm_notes",
+      "#{config.root}/lib/liquid",
     ]
     config.autoload_paths += required_paths
     config.eager_load_paths += required_paths

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,7 +319,8 @@ Rails.application.routes.draw do
   namespace :gobierto_plans, path: "planes" do
     constraints GobiertoSiteConstraint.new do
       get "/" => "plan_types#index", as: :root
-      get ":slug/:year" => "plan_types#show"
+      get ":slug" => "plan_types#show", as: :plans
+      get ":slug/:year" => "plan_types#show", as: :plan
     end
   end
 

--- a/lib/liquid/gobierto_cms/tags/list_children_pages.rb
+++ b/lib/liquid/gobierto_cms/tags/list_children_pages.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ListChildrenPages < Liquid::Tag
+  include GobiertoCms::PageHelper
+
   def initialize(tag_name, params, tokens)
     super
 
@@ -24,15 +26,6 @@ class ListChildrenPages < Liquid::Tag
     end
   rescue ActiveRecord::RecordNotFound
     return ""
-  end
-
-  def gobierto_cms_page_or_news_path(page, options = {})
-    url_helpers = Rails.application.routes.url_helpers
-    if page.collection.item_type == "GobiertoCms::Page"
-      url_helpers.gobierto_cms_page_path(page.slug, options)
-    elsif page.collection.item_type == "GobiertoCms::News"
-      url_helpers.gobierto_cms_news_path(page.slug, options)
-    end
   end
 
   def children_pages(nodes, level)

--- a/test/integration/gobierto_admin/gobierto_cms/create_section_item_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/create_section_item_test.rb
@@ -23,7 +23,7 @@ module GobiertoAdmin
       end
 
       def collection
-        @collection ||= gobierto_common_collections(:news)
+        @collection ||= gobierto_common_collections(:site_pages)
       end
 
       def section
@@ -37,7 +37,7 @@ module GobiertoAdmin
               visit @path
 
               within "tr#collection-item-#{collection.id}" do
-                click_link "News"
+                click_link "Site pages"
               end
 
               click_link "New"
@@ -52,6 +52,7 @@ module GobiertoAdmin
               click_button "Create"
 
               assert has_message?("Page created successfully")
+              assert has_link?("View the page", href: "/s/participacion/new-page-with-section?preview_token=nick-preview-token")
               assert has_field?("page_slug", with: "new-page-with-section")
 
               assert_equal(

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -6,7 +6,7 @@ module GobiertoPlans
   class PlanShowTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = gobierto_plans_path(slug: plan_type.slug, year: plan.year)
+      @path = gobierto_plans_plan_path(slug: plan_type.slug, year: plan.year)
     end
 
     def site

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -122,6 +122,7 @@ class ActionDispatch::IntegrationTest
   self.use_transactional_tests = true
 
   def setup
+    Rails.cache.clear
     $redis.flushdb
     Capybara.current_driver = Capybara.default_driver
   end


### PR DESCRIPTION
Closes #1542 
Closes #1541 

## :v: What does this PR do?

This PR fixes a bug in the generation of pages urls. If a page belongs to a section the URL will be the section's url.

It has been refactored too to use a unique helper to implement this logic.

Extra ball: remove some unnecessary queries in the layout.

## :mag: How should this be manually tested?

1. Edit a page that belongs to a section. The link to preview the page after saving it should link to the section. URL: http://getafe.gobify.net/admin/cms/pages/16/edit?collection_id=43

2. Liquid helper should link to the section url of the page properly. URL: http://getafe.gobify.net/s/portal-de-transparencia/informacion-del-portal
