### PR TITLE
Fix default locale when only one locale is selected

### DIFF
--- a/app/views/gobierto_admin/shared/_form_locale_switchers.html.erb
+++ b/app/views/gobierto_admin/shared/_form_locale_switchers.html.erb
@@ -8,4 +8,6 @@
       </a>
     <% end %>
   </div>
+<% else %>
+  <div <%= %Q{data-loaded-locale="#{current_site.configuration.default_locale}"}.html_safe %>></div>
 <% end %>


### PR DESCRIPTION
Closes #1540 

## :v: What does this PR do?

This PR fixes a bug in the locale selector component when the admin locale is not available in the list of site configured locales.

## :mag: How should this be manually tested?

Go to http://demo.gobify.net/admin/people/people/46/edit and you shoul see the bio field.

## :eyes: Screenshots

### After this PR

![screen shot 2018-03-27 at 08 50 43](https://user-images.githubusercontent.com/17616/37951220-f375caec-319b-11e8-958d-3240f613bc2d.png)
