### PR TITLE
Liquid tag to list collection items

### DIFF
--- a/app/decorators/gobierto_cms/page_decorator.rb
+++ b/app/decorators/gobierto_cms/page_decorator.rb
@@ -1,5 +1,7 @@
 module GobiertoCms
   class PageDecorator < BaseDecorator
+    include ActionView::Helpers::TextHelper
+
     def initialize(page, context = nil, item_type = nil)
       @object = page
       @context = context || page.collection.container_type
@@ -24,6 +26,10 @@ module GobiertoCms
         return attachment.url if attachment.content_type.start_with?("image/")
       end
       nil
+    end
+
+    def summary(length = 100)
+      truncate(strip_tags(body), length: length)
     end
 
     private

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -2,10 +2,4 @@
 
 Liquid::Template.error_mode = :lax
 
-require "liquid/gobierto_cms/tags/page_url"
-require "liquid/gobierto_cms/tags/page_title"
-require "liquid/gobierto_cms/tags/list_children_pages"
-require "liquid/gobierto_common/filters/image_filter"
-require "liquid/gobierto_common/filters/liquid_i18n"
-require "liquid/gobierto_common/tags/render_partial"
-require "liquid/gobierto_participation/tags/show_poll"
+Dir["#{Rails.root.join("lib/liquid")}/**/*.rb"].each {|file| require file }

--- a/docs/liquid-templates.md
+++ b/docs/liquid-templates.md
@@ -61,6 +61,62 @@ In the context of a CMS section, it renders the children pages of the given page
 </div>
 ```
 
+## list_items_from
+
+It renders the items of a collection.
+
+- Arguments:
+  - `collection_slug`: the slug of the collection
+  - `date`: include the date of the page. Default: true
+  - `intro_text`: include the page intro text. Default: true
+  - `limit`: number of items. Default: 4
+  - `order`: order of items. Values: `ASC` or `DESC`. Default: DESC.
+
+- Usage: `{% list_items_from collection_slug | date: true, intro_text: true, limit: 4, order: DESC %}`
+
+- Returns:
+
+```
+<div class="list_items_from_collection">
+  <%= link_to 'collection_item' do %>
+    <div class="collection_item">
+      <img src="http://pam.esplugues.cat/wp-content/uploads/2016/02/Gener15-10885-420x237.jpeg">
+      <span class="date">26 feb 16</span>
+      <h2>Esplugues aprova el Pla d’Actuació Municipal amb un ampli consens</h2>
+      <p class="description">Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. </p>
+    </div>
+  <% end %>
+
+  <%= link_to 'collection_item' do %>
+    <div class="collection_item">
+      <img src="http://pam.esplugues.cat/wp-content/uploads/2016/02/IMG_0505-420x237.jpeg">
+      <span class="date">26 feb 16</span>
+      <h2>Bon govern i transpàrencia, principal demanda de la ciutadania al procés participatiu del Pla d’Actuació Municipal 2016-2019</h2>
+      <p class="description">Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. </p>
+    </div>
+  <% end %>
+
+  <%= link_to 'collection_item' do %>
+    <div class="collection_item">
+      <img src="http://pam.esplugues.cat/wp-content/uploads/2015/11/image2.jpg">
+      <span class="date">26 feb 16</span>
+      <h2>Finalitza el període d’aportacions ciutadanes al Pla d’Actuació Municipal 2016-2019</h2>
+      <p class="description">Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. </p>
+    </div>
+  <% end %>
+
+  <%= link_to 'collection_item' do %>
+    <div class="collection_item">
+      <img src="http://pam.esplugues.cat/wp-content/uploads/2015/11/image1.jpg">
+      <span class="date">26 feb 16</span>
+      <h2>Continua obert el període d’aportacions ciutadanes al Pla d’Actuació Municipal 2016-2019, que s’obre al personal de l’Ajuntament</h2>
+      <p class="description">Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. Intro text if configured. </p>
+    </div>
+  <% end %>
+</div>
+```
+
+
 ## page_title
 
 Renders the title of a page (an instance of`GobiertoCms::Page`)

--- a/lib/liquid/gobierto_cms/tags/list_items_from.rb
+++ b/lib/liquid/gobierto_cms/tags/list_items_from.rb
@@ -33,7 +33,6 @@ class ListItemsFrom < Liquid::Tag
     html = [ %Q{<div class="list_items_from_collection">} ]
     pages.each do |page|
       page = GobiertoCms::PageDecorator.new(page)
-      html << %Q{<div class="page_child">}
       collection_item_text = [ %Q{<div class="collection_item">} ]
       if page.main_image
         collection_item_text << %Q{ <img src="#{page.main_image}"> }
@@ -47,7 +46,6 @@ class ListItemsFrom < Liquid::Tag
       end
       collection_item_text << "</div>"
       html << helpers.link_to(collection_item_text.join.html_safe, gobierto_cms_page_or_news_path(page))
-      html << "</div>"
     end
     html << "</div>"
     html.join.html_safe

--- a/lib/liquid/gobierto_cms/tags/list_items_from.rb
+++ b/lib/liquid/gobierto_cms/tags/list_items_from.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class ListItemsFrom < Liquid::Tag
+  include GobiertoCms::PageHelper
+
+  def initialize(tag_name, params, tokens)
+    super
+
+    @options = { date: true, intro_text: true, limit: 4, order: "DESC" }
+    split_params = params.split("|")
+    @collection_slug = split_params.first.strip
+
+    if split_params.length > 1
+      parsed_options = Hash[split_params.last.split(",").map{|e| e.split(":").map(&:strip) }].symbolize_keys
+      parsed_options[:date] = parsed_options[:date] == "true" if parsed_options.has_key?(:date)
+      parsed_options[:intro_text] = parsed_options[:intro_text] == "true" if parsed_options.has_key?(:intro_text)
+      parsed_options[:limit] = parsed_options[:limit].to_i if parsed_options.has_key?(:limit)
+      @options.merge!(parsed_options)
+    end
+  end
+
+  def render(context)
+    current_site = context.environments.first["current_site"]
+    pages = fetch_pages(current_site)
+
+    return "" if pages.empty?
+    render_pages(pages)
+  rescue ActiveRecord::RecordNotFound
+    return ""
+  end
+
+  def render_pages(pages)
+    html = [ %Q{<div class="list_items_from_collection">} ]
+    pages.each do |page|
+      page = GobiertoCms::PageDecorator.new(page)
+      html << %Q{<div class="page_child">}
+      collection_item_text = [ %Q{<div class="collection_item">} ]
+      if page.main_image
+        collection_item_text << %Q{ <img src="#{page.main_image}"> }
+      end
+      if @options[:date]
+        collection_item_text << %Q{ <span class="date">#{I18n.l(page.updated_at, format: "%d %b %y")}</span> }
+      end
+      collection_item_text << %Q{ <h2>#{page.title}</h2> }
+      if @options[:intro_text]
+        collection_item_text << %Q{ <p class="description">#{page.summary}</p> }
+      end
+      collection_item_text << "</div>"
+      html << helpers.link_to(collection_item_text.join.html_safe, gobierto_cms_page_or_news_path(page))
+      html << "</div>"
+    end
+    html << "</div>"
+    html.join.html_safe
+  end
+
+  private
+
+  def fetch_pages(current_site)
+    collection = current_site.collections.find_by!(slug: @collection_slug)
+    current_site.pages.where(id: collection.pages_in_collection).active.limit(@options[:limit]).order("id #{@options[:order]}")
+  end
+
+  def helpers
+    ActionController::Base.helpers
+  end
+end
+
+Liquid::Template.register_tag("list_items_from", ListItemsFrom)

--- a/test/decorators/gobierto_cms/page_decorator_test.rb
+++ b/test/decorators/gobierto_cms/page_decorator_test.rb
@@ -28,5 +28,9 @@ module GobiertoCms
       assert_equal "gobierto_cms/pages/templates/page", site_page_decorated.template
       assert_equal "gobierto_participation/processes/pages/templates/news", themes_page_decorated.template
     end
+
+    def test_summary
+      assert_equal "This is the body of the page", site_page_decorated.summary
+    end
   end
 end


### PR DESCRIPTION
Closes #1551 

## :v: What does this PR do?

This PR adds a new liquid tag named `list_items_from`. This is the signature:

```
{% list_items_from site-pages | date: true, intro_text: true, limit: 2, order: DESC %}
```

## :mag: How should this be manually tested?

You can check it in the home page of http://getafe.gobify.net/

Note:

if the page contains an attachment of type image, there's a helper that renders the featured image. We can use it until #1552 is implemented.

## :eyes: Screenshots

### Before this PR

🙅‍♂️ 

### After this PR

![screen shot 2018-03-28 at 12 24 07](https://user-images.githubusercontent.com/17616/38023558-ee736972-3282-11e8-8bed-6e46507fd796.png)
