### PR TITLE
#1216: Add download_open_data link in gobierto budgets

### DIFF
--- a/app/views/gobierto_budgets/budget_lines/index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/index.html.erb
@@ -9,4 +9,6 @@
 <div class="column">
 	<%= render partial: 'gobierto_budgets/budgets/year_breadcrumb', locals: {path_calculation_method: :gobierto_budgets_budgets_path} %>
   <%= render partial: 'gobierto_budgets/budget_lines/explorer' %>
+
+  <%= render "shared/download_open_data" %>
 </div>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -331,4 +331,6 @@
   <% if budget_lines_feedback_active? %>
     <%= render 'gobierto_budgets/shared/enough_information' %>
   <% end %>
+
+  <%= render "shared/download_open_data" %>
 </div>

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -91,4 +91,5 @@
 
   <%= render partial: 'gobierto_budgets/budget_lines/explorer' %>
 
+  <%= render "shared/download_open_data" %>
 </div>


### PR DESCRIPTION
Closes #1216


## :v: What does this PR do?
* Adds a "Download data..." link at bottom of budgets, budget_lines and budgets_elaboration index pages above explore the detail box.

## :mag: How should this be manually tested?
Visit:
* http://santfeliu.gobify.net/presupuestos/resumen/2017
* http://santfeliu.gobify.net/presupuestos/partidas/2017/economic/I
* http://santfeliu.gobify.net/presupuestos/elaboracion

## :eyes: Screenshots

### Before this PR
<img width="1173" alt="screen shot 2018-04-03 at 15 38 06" src="https://user-images.githubusercontent.com/446459/38253820-f1d5aec0-3757-11e8-9915-14aa36e8f613.png">

### After this PR
<img width="1155" alt="screen shot 2018-04-03 at 15 37 35" src="https://user-images.githubusercontent.com/446459/38253830-f773ba0c-3757-11e8-8790-bdab43fb1715.png">

## :shipit: Does this PR changes any configuration file?

No