### PR TITLE
Refactor plans URLs

### DIFF
--- a/app/views/gobierto_plans/layouts/_navigation.sub.html.erb
+++ b/app/views/gobierto_plans/layouts/_navigation.sub.html.erb
@@ -1,5 +1,5 @@
 <% GobiertoPlans::PlanType.site_plant_types(current_site).each do |plan_type| %>
   <div class="sub-nav-item <%= class_if(' active', plan_type.slug == params[:slug] ) %>">
-    <%= link_to plan_type.name, gobierto_plans_plans_path(slug: plan_type.slug) %>
+    <%= link_to plan_type.name, gobierto_plans_plan_path(slug: plan_type.slug) %>
   </div>
 <% end %>

--- a/app/views/gobierto_plans/plan_types/show.html.erb
+++ b/app/views/gobierto_plans/plan_types/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:current_submodule_link) do %>
-  <%= link_to title(@plan.title), gobierto_plans_plans_path(slug: @plan.plan_type.slug) %>
+  <%= link_to title(@plan.title), gobierto_plans_plan_path(slug: @plan.plan_type.slug) %>
 <% end %>
 
 <% if @plan.css.present? %>

--- a/app/views/layouts/_year_breadcrumb.html.erb
+++ b/app/views/layouts/_year_breadcrumb.html.erb
@@ -1,13 +1,11 @@
-<div class="breadcrumb year_only">
-  <div class="bread_hover">
-    <div class="bread_links">
-      <%= link_to @year, url_for(current_parameters_with_year(@year)), id: @year, 'aria-haspopup' => 'true', 'aria-label' => 'Escoge el año de los datos', 'aria-owns' => 'popup-year', 'aria-controls' => 'popup-year', 'aria-expanded' => 'false' %>
-      <% if @years.size > 1 %>
+<% if @years.size > 1 %>
+  <div class="breadcrumb year_only">
+    <div class="bread_hover">
+      <div class="bread_links">
+        <%= link_to @year, url_for(current_parameters_with_year(@year)), id: @year, 'aria-haspopup' => 'true', 'aria-label' => 'Escoge el año de los datos', 'aria-owns' => 'popup-year', 'aria-controls' => 'popup-year', 'aria-expanded' => 'false' %>
         <i class="fa fa-sort-down"></i>
-      <% end %>
-    </div>
+      </div>
 
-    <% if @years.size > 1 %>
       <div id="popup-year" class="line_browser clearfix" role="group">
         <div class="bread_links clearfix">
           <%= link_to @year, url_for(current_parameters_with_year(@year)) %>
@@ -19,13 +17,13 @@
             <% @years.each do |year| %>
               <tr role="presentation" >
                 <td data-code="<%= year %>">
-                  <%= link_to year, url_for(current_parameters_with_year(year)) %>
+                <%= link_to year, url_for(current_parameters_with_year(year)) %>
                 </td>
               </tr>
             <% end %>
           </table>
         </div>
       </div>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,8 +320,7 @@ Rails.application.routes.draw do
   namespace :gobierto_plans, path: "planes" do
     constraints GobiertoSiteConstraint.new do
       get "/" => "plan_types#index", as: :root
-      get ":slug" => "plan_types#show", as: :plans
-      get ":slug/:year" => "plan_types#show", as: :plan
+      get ":slug(/:year)" => "plan_types#show", as: :plan
     end
   end
 

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -43,8 +43,6 @@ module GobiertoPlans
         with_current_site(site) do
           visit @path
 
-          assert has_content? "2012"
-
           assert has_content? "Strategic Plan introduction"
 
           assert has_content? "#{axes.size} axes"


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR simplifies plans URLs to avoid errors when the year is not provided.

It also removes the year selector if there's only one year.

## :mag: How should this be manually tested?

The plan preview link in the admin shouldn't generate an invalid URL.