### PR TITLE
1320 export invoices data

### DIFF
--- a/app/models/gobierto_budgets/data/providers.rb
+++ b/app/models/gobierto_budgets/data/providers.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module GobiertoBudgets
+  module Data
+    class Providers
+      class UnsupportedFormat < StandardError; end
+
+      FORMATS = {
+        json: { deserializer: ->(content) { JSON.parse(content) },
+                invalid: ->(data) { data.blank? || (data.is_a?(Hash) && data.keys.include?("error")) },
+                content_type: "application/json; charset=utf-8" },
+        csv:  { deserializer: ->(content) { CSV.parse(content) },
+                invalid: ->(data) { data.blank? || data[0].include?("error_code") },
+                content_type: "text/csv; charset=utf-8" }
+      }.freeze
+
+      attr_accessor :site, :year
+
+      def initialize(options = {})
+        @year = options[:year]
+        @site = options[:site]
+        @data = {}
+      end
+
+      def any_data?
+        FORMATS.any? do |format, configuration|
+          format_data(format) && !configuration[:invalid].call(configuration[:deserializer].call(format_data(format)))
+        end
+      end
+
+      def get_url(format)
+        file = GobiertoCommon::FileUploadService.new(file_name: filename(format))
+        file.uploaded_file_exists? && file.call
+      end
+
+      def any_file?
+        FORMATS.any? do |format, _|
+          get_url(format)
+        end
+      end
+
+      def generate_files
+        file_urls = []
+        return file_urls unless any_data?
+
+        FORMATS.each do |format_key, configuration|
+          file_urls << GobiertoCommon::FileUploadService.new(
+            file_name: filename(format_key),
+            content: format_data(format_key),
+            content_type: configuration[:content_type]
+          ).upload!
+        end
+        file_urls
+      end
+
+      protected
+
+      def place
+        site.place
+      end
+
+      def filename(format)
+        raise UnsupportedFormat unless FORMATS.keys.include?(format.to_sym)
+        ["gobierto_budgets", place.id, "data", "providers", "#{ year }.#{ format }"].join("/")
+      end
+
+      def format_data(format)
+        @data[format] ||= request_response(format)
+      end
+
+      private
+
+      def token
+        @token ||= site.configuration.populate_data_api_token
+      end
+
+      def endpoint
+        @endpoint ||= APP_CONFIG["populate_data"]["endpoint"]
+      end
+
+      def date_range
+        @date_range ||= "#{ year }0101-#{ year }1231"
+      end
+
+      def format_uri(format)
+        URI("#{ endpoint }/datasets/ds-facturas-municipio.#{ format }?filter_by_location_id=#{ site.place.id }&date_date_range=#{ date_range }&sort_asc_by=date")
+      end
+
+      def request_response(format)
+        uri = format_uri(format)
+
+        res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          req = Net::HTTP::Get.new uri
+          req["authorization"] = "Bearer #{ token }"
+          req["Origin"] = site.domain
+          http.request req
+        end
+
+        return nil unless res.is_a? Net::HTTPSuccess
+        res.body
+      end
+    end
+  end
+end

--- a/app/views/gobierto_budgets/exports/_index.html.erb
+++ b/app/views/gobierto_budgets/exports/_index.html.erb
@@ -1,13 +1,13 @@
 <div class="pure-g data_block" id="section-people">
 
   <div class="pure-u-1 pure-u-md-7-24">
-    <h2><%= t("gobierto_budgets.exports.title") %></h2>
+    <h2><%= t("gobierto_budgets.exports.budget_lines_title") %></h2>
     <p></p>
   </div>
 
   <div class="pure-u-1 pure-u-md-17-24 main_content">
     <div class="data_block subblock">
-      <p><%= t("gobierto_budgets.exports.description") %></p>
+      <p><%= t("gobierto_budgets.exports.budget_lines_description") %></p>
       <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
         <% data = GobiertoBudgets::Data::Annual.new(site: current_site, year: year) %>
         <% if data.any_data? %>
@@ -23,3 +23,31 @@
     </div>
   </div>
 </div>
+
+<% if budgets_providers_active? %>
+  <div class="pure-g data_block" id="section-people">
+
+    <div class="pure-u-1 pure-u-md-7-24">
+      <h2><%= t("gobierto_budgets.exports.invoices_title") %></h2>
+      <p></p>
+    </div>
+
+    <div class="pure-u-1 pure-u-md-17-24 main_content">
+      <div class="data_block subblock">
+        <p><%= t("gobierto_budgets.exports.invoices_description") %></p>
+        <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
+          <% data = GobiertoBudgets::Data::Providers.new(site: current_site, year: year) %>
+          <% if data.any_file? %>
+            <div class="data_subitem">
+              <h3> <%= year %> </h3>
+              <% GobiertoBudgets::Data::Annual::FORMATS.keys.each do |format| %>
+                <% url = data.get_url(format) %>
+                <%= link_to(format.to_s.upcase, url, target: '_blank', class: 'button small', role: 'button') if url %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -465,8 +465,10 @@ ca:
     events:
       gobierto_budgets_budgets_updated: Pressuposts actualitzats
     exports:
-      description: Compara despeses i ingressos any per any
-      title: Partides del pressupost
+      budget_lines_description: Compara despeses i ingressos any per any
+      budget_lines_title: Partides del pressupost
+      invoices_description: Dades per any
+      invoices_title: Proveïdors i Factures
     featured_budget_lines:
       gobierto_site_template:
         how_much_place_in: Quant es gasta %{place} en...

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -446,8 +446,10 @@ en:
     events:
       gobierto_budgets_budgets_updated: Budgets updated
     exports:
-      description: Compare income and expenses year by year
-      title: Budget lines
+      budget_lines_description: Compare income and expenses year by year
+      budget_lines_title: Budget lines
+      invoices_description: Data per year
+      invoices_title: Providers and Invoices
     featured_budget_lines:
       gobierto_site_template:
         how_much_place_in: How much does %{place} expend on...

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -458,8 +458,10 @@ es:
     events:
       gobierto_budgets_budgets_updated: Presupuestos actualizados
     exports:
-      description: Compara gastos e ingresos año por año
-      title: Partidas presupuestarias
+      budget_lines_description: Compara gastos e ingresos año por año
+      budget_lines_title: Partidas presupuestarias
+      invoices_description: Datos por año
+      invoices_title: Proveedores y Facturas
     featured_budget_lines:
       gobierto_site_template:
         how_much_place_in: "¿Cuánto se gasta %{place} en..."

--- a/lib/tasks/gobierto_budgets/data/annual.rake
+++ b/lib/tasks/gobierto_budgets/data/annual.rake
@@ -4,18 +4,27 @@ namespace :gobierto_budgets do
   namespace :data do
     desc "Generate annual budgets data files for all sites"
     task sites_annual: :environment do
+      generate_site_annual_files_for(GobiertoBudgets::Data::Annual)
+    end
+
+    desc "Generate providers and invoices annual files for all sites"
+    task sites_annual_providers: :environment do
+      generate_site_annual_files_for(GobiertoBudgets::Data::Providers)
+    end
+
+    def generate_site_annual_files_for(data_model)
       Site.all.each do |site|
         place = site.place
         next if place.nil?
         file_urls = []
         GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
-          file_urls += GobiertoBudgets::Data::Annual.new(site: site, year: year).generate_files
+          file_urls += data_model.new(site: site, year: year).generate_files
         end
 
-        puts "\n- Data calculated for site #{site.domain} and place #{place.name} - #{place.id}: " +
-          (file_urls.any? ? "#{file_urls.count} files uploaded:" : "No files generated.")
+        puts "\n- Data calculated for site #{ site.domain } and place #{ place.name } - #{ place.id }: " +
+          (file_urls.any? ? "#{ file_urls.count } files uploaded:" : "No files generated.")
         file_urls.each do |file_url|
-          puts "\t+ #{file_url}"
+          puts "\t+ #{ file_url }"
         end
       end
     end


### PR DESCRIPTION
Closes #1320


## :v: What does this PR do?
* Adds a class to generate and upload csv and json files containing invoices data by year.
* Adds a task to generate this data for all sites and each year.
* Include links to the created files of invoices in public data page if the invoices feature is enabled.

## :mag: How should this be manually tested?
Execute from server the task to generate file: `./bin/rails gobierto_budgets:data:sites_annual_providers`

Visit http://mataro.gobify.net/datos

## :eyes: Screenshots

### Before this PR
<img width="1243" alt="screen shot 2018-04-04 at 17 21 11" src="https://user-images.githubusercontent.com/446459/38317183-bb0fd638-382c-11e8-9542-cc0cba315369.png">

### After this PR
<img width="1253" alt="screen shot 2018-04-04 at 17 51 37" src="https://user-images.githubusercontent.com/446459/38318946-e55518aa-3830-11e8-85e6-59dde464dd52.png">

## :shipit: Does this PR changes any configuration file?
No
