### PR TITLE
Moving styles to the stylesheet

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/visualizations/vis_lines_execution.js
+++ b/app/assets/javascripts/gobierto_budgets/visualizations/vis_lines_execution.js
@@ -210,9 +210,7 @@ var VisLinesExecution = Class.extend({
         .attr('dy', 12)
         .attr('dx', -10)
         .attr('text-anchor', 'end')
-        .style('font-size', function(d) { return d.level === 1 ? '1rem' : '0.875rem';})
-        .style('font-weight', function(d) { return d.level === 1 ? '600' : '400';})
-        .style('fill', function(d) { return d.level === 1 ? '#4A4A4A' : '#767168';})
+        .attr('class', function(d) { return d.level === 1 ? 'line-txt-group' : 'line-txt-detail';})
         .text(function(d) { return d['name_' + this.localeFallback] }.bind(this))
         .on('mousemove', function () {
           $(this).prev().css('stroke', 'black');

--- a/app/assets/stylesheets/comp-graph-vis_lines_table.scss
+++ b/app/assets/stylesheets/comp-graph-vis_lines_table.scss
@@ -67,3 +67,14 @@
 .le-country {
   background: $color_vis_country;
 }
+
+.line-txt-group {
+  font-size: 1rem;
+  font-weight: 600;
+  fill: #4A4A4A;
+}
+.line-txt-detail {
+  font-size: .875rem;
+  font-weight: 400;
+  fill: #767168;
+}

--- a/app/views/gobierto_budgets/budgets_execution/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_execution/index.html.erb
@@ -16,15 +16,16 @@
         <div class="inline_header">
           <h2 class="with_description p_h_r_0_5"><%= t('.title') %></h2>
           <%= render partial: 'gobierto_budgets/budgets/year_breadcrumb', locals: {path_calculation_method: :gobierto_budgets_budgets_path} %>
-
-          <p class="block_description">
-            <%= t('.description') %>.
-          </p>
-
-          <%= render('gobierto_budgets/shared/data_updated_at') %>
-
-          <p><%= link_to t('.budget_guide'), gobierto_budgets_budgets_guide_path %>.</p>
         </div>
+
+        <p class="block_description">
+          <%= t('.description') %>.
+        </p>
+
+        <%= render('gobierto_budgets/shared/data_updated_at') %>
+
+        <p><%= link_to t('.budget_guide'), gobierto_budgets_budgets_guide_path %>.</p>
+
       </div>
 
       <div class="pure-u-1 pure-u-md-1-2 metric_boxes metric_boxes_detailed">


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

Moves inline styles in budget execution D3 graph to the stylesheet, so styles can be overwritten.