### PR TITLE
Fix budget line descendants API

### DIFF
--- a/app/controllers/gobierto_budgets/budget_line_descendants_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_line_descendants_controller.rb
@@ -10,17 +10,16 @@ class GobiertoBudgets::BudgetLineDescendantsController < GobiertoBudgets::Applic
       conditions.merge!({level: 1})
     end
 
-    @budget_lines = []
-    budget_lines = GobiertoBudgets::BudgetLine.all(where: conditions)
+    @budget_lines = budget_lines = GobiertoBudgets::BudgetLine.all(where: conditions)
 
     if !request.format.json? && @parent_code && @parent_code.length >= 1
       while budget_lines.any?
+        @budget_lines.concat budget_lines
         children_budget_lines = budget_lines
         budget_lines = []
         children_budget_lines.each do |budget_line|
           budget_lines.concat GobiertoBudgets::BudgetLine.all(where: conditions.merge(parent_code: budget_line.code))
         end
-        @budget_lines.concat budget_lines
       end
     end
 

--- a/app/views/gobierto_budgets/budget_line_descendants/index.js.erb
+++ b/app/views/gobierto_budgets/budget_line_descendants/index.js.erb
@@ -7,7 +7,6 @@
 <% end %>
 
 <% @budget_lines.map(&:parent_code).uniq.each do |parent_code| %>
-  console.log('disabling ' + <%= parent_code %>);
   var $el = $('[data-budget-line="<%= parent_code %>"]');
   /* Collapses branch - Prevents resending the form when extended */
   $el.on('ajax:beforeSend', 'a', function(event, xhr, settings) {

--- a/test/controllers/gobierto_budgets/budget_line_descendants_controller_test.rb
+++ b/test/controllers/gobierto_budgets/budget_line_descendants_controller_test.rb
@@ -12,7 +12,7 @@ class GobiertoBudgets::BudgetLineDescendantsControllerTest < GobiertoControllerT
       get gobierto_budgets_budget_line_descendants_path(year: 2017, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::EconomicArea.area_name, parent_code: '1'), as: :json
       assert_response :success
       response_data = JSON.parse(response.body)
-      assert_equal 4, response_data.length
+      assert_equal 1, response_data.length
       assert_equal "Impuesto sobre la renta", response_data.first["name"]
     end
   end

--- a/test/controllers/gobierto_budgets/budget_line_descendants_controller_test.rb
+++ b/test/controllers/gobierto_budgets/budget_line_descendants_controller_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GobiertoBudgets::BudgetLineDescendantsControllerTest < GobiertoControllerTest
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_index
+    with_current_site(site) do
+      get gobierto_budgets_budget_line_descendants_path(year: 2017, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::EconomicArea.area_name, parent_code: '1'), as: :json
+      assert_response :success
+      response_data = JSON.parse(response.body)
+      assert_equal 4, response_data.length
+      assert_equal "Impuesto sobre la renta", response_data.first["name"]
+    end
+  end
+end


### PR DESCRIPTION
Closes #1571 
Closes [#302](/PopulateTools/issues/issues/302)

## :v: What does this PR do?

This PR fixes budget line descendants controller bug that avoided to expand items in the breadcrumb and in the lines explorer.

## :mag: How should this be manually tested?

1. Check the explorer can expand children
2. Check the breadcrumb expands children on hover

## :eyes: Screenshots

### Before this PR

Check in the issues

### After this PR

![screen shot 2018-04-09 at 09 55 10](https://user-images.githubusercontent.com/17616/38486062-33d386fc-3bdc-11e8-9963-8623f77d0e21.png)

![screen shot 2018-04-09 at 09 54 56](https://user-images.githubusercontent.com/17616/38486063-33fbfbdc-3bdc-11e8-9ddc-df2951a4ee13.png)
