### PR TITLE
1557 organization id elastic

### DIFF
--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -63,8 +63,8 @@ module GobiertoBudgets
       end
 
       def lines
-        @place = INE::Places::Place.find(params[:ine_code])
-        data_line = GobiertoBudgets::Data::Lines.new place: @place, year: params[:year], what: params[:what], kind: params[:kind],
+        @organization_id = params[:organization_id]
+        data_line = GobiertoBudgets::Data::Lines.new place: @place, organization_id: @organization_id, year: params[:year], what: params[:what], kind: params[:kind],
           code: params[:code], area: params[:area], include_next_year: params[:include_next_year],
           comparison: params[:comparison]
 
@@ -74,13 +74,13 @@ module GobiertoBudgets
       def budget_execution_deviation
         year = params[:year].to_i
         kind = params[:kind]
-        ine_code = params[:ine_code]
-        total_budgeted = GobiertoBudgets::BudgetTotal.budgeted_for(ine_code,year,kind)
-        total_executed = GobiertoBudgets::BudgetTotal.execution_for(ine_code,year,kind)
+        organization_id = params[:organization_id]
+        total_budgeted = GobiertoBudgets::BudgetTotal.budgeted_for(organization_id,year,kind)
+        total_executed = GobiertoBudgets::BudgetTotal.execution_for(organization_id,year,kind)
         deviation = total_executed - total_budgeted
         deviation_percentage = helpers.number_with_precision(delta_percentage(total_executed, total_budgeted), precision: 2)
         up_or_down = sign(total_executed, total_budgeted)
-        evolution = deviation_evolution(ine_code, kind)
+        evolution = deviation_evolution(organization_id, kind)
 
         heading = I18n.t("controllers.gobierto_budgets.api.data.budgets_execution_header", kind: kind_literal(kind), year: year)
         respond_to do |format|
@@ -103,10 +103,10 @@ module GobiertoBudgets
       def budget_execution_comparison
         year = params[:year].to_i
         kind = params[:kind]
-        ine_code = params[:ine_code]
+        organization_id = params[:organization_id]
         area = params[:area]
 
-        lines = GobiertoBudgets::Data::BudgetExecutionComparison.extract_lines(site: current_site, year: year, kind: kind, ine_code: ine_code, area: area)
+        lines = GobiertoBudgets::Data::BudgetExecutionComparison.extract_lines(site: current_site, year: year, kind: kind, organization_id: organization_id, area: area)
         site_stats = GobiertoBudgets::SiteStats.new site: current_site, year: year
         last_update = site_stats.budgets_data_updated_at
 
@@ -122,8 +122,8 @@ module GobiertoBudgets
 
       private
 
-      def get_debt(year, ine_code)
-        id = "#{ine_code}/#{year}"
+      def get_debt(year, organization_id)
+        id = "#{organization_id}/#{year}"
 
         begin
           value = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::Data.index,
@@ -134,19 +134,19 @@ module GobiertoBudgets
       end
 
       def budget_data(year, field, ranking = true)
-        ine_code = params[:ine_code].to_i
+        organization_id = params[:organization_id]
 
         opts = {year: year, code: @code, kind: @kind, area_name: @area, variable: field}
         results, total_elements = GobiertoBudgets::BudgetLine.for_ranking(opts)
 
         if ranking
-          position = GobiertoBudgets::BudgetLine.place_position_in_ranking(opts.merge(ine_code: ine_code))
+          position = GobiertoBudgets::BudgetLine.place_position_in_ranking(opts.merge(organization_id: organization_id))
         else
           total_elements = 0
           position = 0
         end
 
-        value = results.select {|r| r['ine_code'] == ine_code }.first.try(:[],field)
+        value = results.select {|r| r['organization_id'] == organization_id }.first.try(:[],field)
 
         return {
           value: value,
@@ -156,7 +156,7 @@ module GobiertoBudgets
       end
 
       def budget_data_executed(year, field)
-        id = "#{params[:ine_code]}/#{year}/#{@code}/#{@kind}"
+        id = "#{params[:organization_id]}/#{year}/#{@code}/#{@kind}"
 
         begin
           value = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, type: @area, id: id
@@ -191,7 +191,7 @@ module GobiertoBudgets
           _source: false
         }
 
-        id = "#{params[:ine_code]}/#{year}/#{GobiertoBudgets::BudgetLine::EXPENSE}"
+        id = "#{params[:organization_id]}/#{year}/#{GobiertoBudgets::BudgetLine::EXPENSE}"
 
         if ranking
           response = GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_forecast, type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, body: query
@@ -217,7 +217,7 @@ module GobiertoBudgets
       end
 
       def total_budget_data_executed(year, field)
-        id = "#{params[:ine_code]}/#{year}/#{GobiertoBudgets::BudgetLine::EXPENSE}"
+        id = "#{params[:organization_id]}/#{year}/#{GobiertoBudgets::BudgetLine::EXPENSE}"
 
         begin
           value = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_executed, type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: id
@@ -247,9 +247,9 @@ module GobiertoBudgets
         final_message
       end
 
-      def deviation_evolution(ine_code, kind)
-        response_budgeted = GobiertoBudgets::BudgetTotal.budget_evolution_for(ine_code, GobiertoBudgets::BudgetTotal::BUDGETED, kind)
-        response_executed = GobiertoBudgets::BudgetTotal.budget_evolution_for(ine_code, GobiertoBudgets::BudgetTotal::EXECUTED, kind)
+      def deviation_evolution(organization_id, kind)
+        response_budgeted = GobiertoBudgets::BudgetTotal.budget_evolution_for(organization_id, GobiertoBudgets::BudgetTotal::BUDGETED, kind)
+        response_executed = GobiertoBudgets::BudgetTotal.budget_evolution_for(organization_id, GobiertoBudgets::BudgetTotal::EXECUTED, kind)
 
         response_budgeted.map do |budgeted_result|
           year = budgeted_result['year']

--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -63,8 +63,8 @@ module GobiertoBudgets
       end
 
       def lines
-        @organization_id = params[:organization_id]
-        data_line = GobiertoBudgets::Data::Lines.new place: @place, organization_id: @organization_id, year: params[:year], what: params[:what], kind: params[:kind],
+        data_line = GobiertoBudgets::Data::Lines.new place: current_site.place, organization_id: current_site.organization_id,
+          organization_name: current_site.organization_name, year: params[:year], what: params[:what], kind: params[:kind],
           code: params[:code], area: params[:area], include_next_year: params[:include_next_year],
           comparison: params[:comparison]
 

--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -6,7 +6,7 @@ module GobiertoBudgets
 
       @kind = GobiertoBudgets::BudgetLine::EXPENSE
       results = GobiertoBudgets::BudgetLine.search({
-          kind: @kind, year: @year, ine_code: current_site.organization_id,
+          kind: @kind, year: @year, organization_id: current_site.organization_id,
           type: @area_name, range_hash: {
             level: {ge: 3},
             amount_per_inhabitant: { gt: 0 }

--- a/app/controllers/gobierto_budgets/receipts_controller.rb
+++ b/app/controllers/gobierto_budgets/receipts_controller.rb
@@ -5,8 +5,8 @@ class GobiertoBudgets::ReceiptsController < GobiertoBudgets::ApplicationControll
   def show
     year = GobiertoBudgets::SearchEngineConfiguration::Year.last
     @area = GobiertoBudgets::FunctionalArea.area_name
-    @parents = GobiertoBudgets::BudgetLine.all(where: { site: current_site, place: current_site.place, level: 1, year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: @area })
-    @interesting_expenses = GobiertoBudgets::BudgetLine.all(where: { site: current_site, place: current_site.place, level: 2, year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: @area })
+    @parents = GobiertoBudgets::BudgetLine.all(where: { site: current_site, level: 1, year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: @area })
+    @interesting_expenses = GobiertoBudgets::BudgetLine.all(where: { site: current_site, level: 2, year: year, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: @area })
   end
 
   private

--- a/app/controllers/gobierto_budgets/search_controller.rb
+++ b/app/controllers/gobierto_budgets/search_controller.rb
@@ -67,7 +67,7 @@ module GobiertoBudgets
             filter: {
               bool: {
                 must: [
-                  {term: { ine_code: organization_id }},
+                  {term: { organization_id: organization_id }},
                   {term: { kind: kind}},
                   {term: { year: year }},
                 ]

--- a/app/helpers/gobierto_budgets/application_helper.rb
+++ b/app/helpers/gobierto_budgets/application_helper.rb
@@ -3,6 +3,7 @@ module GobiertoBudgets
 
     def external_comparison_link
       municipalities = budgets_comparison_compare_municipalities.map{ |place_id| INE::Places::Place.find(place_id) } + [current_site.place]
+      municipalities.compact!
       year = @year || GobiertoBudgets::SearchEngineConfiguration::Year.last
 
       budget_line_path = if params[:id]

--- a/app/jobs/gobierto_budgets/generate_annual_lines_job.rb
+++ b/app/jobs/gobierto_budgets/generate_annual_lines_job.rb
@@ -3,7 +3,7 @@ class GobiertoBudgets::GenerateAnnualLinesJob < ActiveJob::Base
 
   def perform(*sites)
     sites.each do |site|
-      if site.place
+      if site.organization_id.present?
         GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
           data = GobiertoBudgets::Data::Annual.new(site: site, year: year)
           data.generate_files if data.any_data?

--- a/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_algolia_helpers.rb
@@ -30,7 +30,7 @@ module GobiertoBudgets
     included do
 
       def algolia_id
-        "#{index}/#{area.area_name}/#{ine_code}/#{year}/#{code}/#{kind}"
+        "#{index}/#{area.area_name}/#{organization_id}/#{year}/#{code}/#{kind}"
       end
 
       def algolia_as_json
@@ -39,7 +39,7 @@ module GobiertoBudgets
           index: index,
           type: area.area_name,
           site_id: site.id,
-          ine_code: ine_code,
+          organization_id: organization_id,
           year: year,
           code: code,
           kind: kind,

--- a/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
@@ -17,7 +17,7 @@ module GobiertoBudgets
           {term: { code: conditions[:code] }},
           {missing: { field: 'functional_code'}},
           {missing: { field: 'custom_code'}},
-          {term: { ine_code: conditions[:site].organization_id }}
+          {term: { organization_id: conditions[:site].organization_id }}
         ]
 
         query = {
@@ -64,7 +64,7 @@ module GobiertoBudgets
           {term: { year: conditions[:year] }},
           {term: { code: conditions[:functional_code] }},
           {exists: { field: 'functional_code'}},
-          {term: { ine_code: conditions[:site].organization_id }}
+          {term: { organization_id: conditions[:site].organization_id }}
         ]
 
         query = {
@@ -107,7 +107,7 @@ module GobiertoBudgets
 
         terms = [
           {term: { kind: conditions[:kind] }},
-          {term: { ine_code: conditions[:site].organization_id }}
+          {term: { organization_id: conditions[:site].organization_id }}
         ]
 
         terms.push({term: { year: conditions[:year] }}) if conditions[:year]
@@ -190,7 +190,7 @@ module GobiertoBudgets
         terms = [{term: { kind: options[:kind] }},
                 {term: { year: options[:year] }}]
 
-        terms << {term: { ine_code: options[:ine_code] }} if options[:ine_code].present?
+        terms << {term: { organization_id: options[:organization_id] }} if options[:organization_id].present?
         terms << {term: { parent_code: options[:parent_code] }} if options[:parent_code].present?
         terms << {term: { level: options[:level] }} if options[:level].present?
         terms << {term: { code: options[:code] }} if options[:code].present?
@@ -237,7 +237,7 @@ module GobiertoBudgets
       end
 
       def place_position_in_ranking(options)
-        id = %w{ine_code year code kind}.map {|f| options[f.to_sym]}.join('/')
+        id = %w{organization_id year code kind}.map {|f| options[f.to_sym]}.join('/')
 
         response = budget_line_query(options.merge(to_rank: true))
         buckets = response['hits']['hits'].map{|h| h['_id']}
@@ -264,8 +264,8 @@ module GobiertoBudgets
           reduced_filter = {population: population_filter}
           reduced_filter.merge!(aarr: aarr_filter) if aarr_filter
           results,total_elements = Population.for_ranking(options[:year], 0, nil, reduced_filter)
-          ine_codes = results.map{|p| p['ine_code']}
-          terms << [{terms: { ine_code: ine_codes }}] if ine_codes.any?
+          organization_ids = results.map{|p| p['organization_id']}
+          terms << [{terms: { organization_id: organization_id }}] if organization_ids.any?
         end
 
         if (total_filter && (total_filter[:from].to_i > BudgetTotal::TOTAL_FILTER_MIN || total_filter[:to].to_i < BudgetTotal::TOTAL_FILTER_MAX))
@@ -314,7 +314,7 @@ module GobiertoBudgets
       end
 
       def compare(options)
-        terms = [{terms: { ine_code: options[:ine_codes] }},
+        terms = [{terms: { organization_id: options[:organization_ids] }},
                  {term: { level: options[:level] }},
                  {term: { kind: options[:kind] }},
                  {term: { year: options[:year] }}]
@@ -325,7 +325,7 @@ module GobiertoBudgets
         query = {
           sort: [
             { code: { order: 'asc' } },
-            { ine_code: { order: 'asc' }}
+            { organization_id: { order: 'asc' }}
           ],
           query: {
             filtered: {
@@ -346,14 +346,14 @@ module GobiertoBudgets
       def has_children?(options)
         options.symbolize_keys!
         conditions = { parent_code: options[:code], type: options[:area] }
-        conditions.merge! options.slice(:ine_code,:kind,:year)
+        conditions.merge! options.slice(:organization_id,:kind,:year)
 
         return search(conditions)['hits'].length > 0
       end
 
       def top_differences(options)
         terms = [{term: { kind: options[:kind] }}, {term: { year: options[:year] }}, {term: { level: 3 }}]
-        terms << {term: { ine_code: options[:ine_code] }} if options[:ine_code].present?
+        terms << {term: { organization_id: options[:organization_id] }} if options[:organization_id].present?
         terms << {term: { code: options[:code] }} if options[:code].present?
 
         query = {
@@ -406,7 +406,7 @@ module GobiertoBudgets
         areas   = (conditions[:area] ? [conditions[:area]] : BudgetArea.all_areas)
 
         terms = []
-        terms << { term: { ine_code: conditions[:site].organization_id } } if conditions[:site]
+        terms << { term: { organization_id: conditions[:site].organization_id } } if conditions[:site]
         terms << { term: { kind: conditions[:kind] } } if conditions[:kind]
         terms << { term: { year: conditions[:year] } } if conditions[:year]
 
@@ -449,7 +449,7 @@ module GobiertoBudgets
 
       def elasticsearch_as_json
         {
-          ine_code: ine_code,
+          organization_id: organization_id,
           province_id: province_id,
           autonomy_id: autonomy_id,
           year: year,

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -20,6 +20,7 @@ module GobiertoBudgets
       :area,
       :kind,
       :code,
+      :organization_id,
       :ine_code,
       :province_id,
       :autonomy_id,
@@ -51,12 +52,12 @@ module GobiertoBudgets
       end
     end
 
-    def self.get_population(ine_code, year)
-      population = execute_get_population_query(ine_code, year)
+    def self.get_population(organization_id, year)
+      population = execute_get_population_query(organization_id, year)
 
       if population.nil?
-        previous_year_population = execute_get_population_query(ine_code, year - 1)
-        next_year_population = execute_get_population_query(ine_code, year + 1)
+        previous_year_population = execute_get_population_query(organization_id, year - 1)
+        next_year_population = execute_get_population_query(organization_id, year + 1)
 
         population = if previous_year_population && next_year_population
                        (previous_year_population + next_year_population) / 2
@@ -68,11 +69,11 @@ module GobiertoBudgets
       population
     end
 
-    def self.execute_get_population_query(ine_code, census_year)
+    def self.execute_get_population_query(organization_id, census_year)
       result = GobiertoBudgets::SearchEngine.client.get(
         index: GobiertoBudgets::SearchEngineConfiguration::Data.index,
         type: GobiertoBudgets::SearchEngineConfiguration::Data.type_population,
-        id: "#{ ine_code }/#{ census_year }"
+        id: "#{ organization_id }/#{ census_year }"
       )
       result["_source"]["value"]
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
@@ -90,8 +91,8 @@ module GobiertoBudgets
       @amount = params[:amount].round(2)
 
       place = site.place
-      @ine_code = site.organization_id
-      @id = "#{ ine_code }/#{ year }/#{ code }/#{ kind }"
+      @organization_id = site.organization_id
+      @id = "#{ organization_id }/#{ year }/#{ code }/#{ kind }"
       @category = Category.find_by(site: site, area_name: area.area_name, kind: kind, code: code)
       @name = get_name
       @description = get_description
@@ -103,7 +104,7 @@ module GobiertoBudgets
     end
 
     def population
-      @population ||= self.class.get_population(ine_code, year)
+      @population ||= self.class.get_population(organization_id, year)
     end
 
     # TODO: remove?

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -92,12 +92,13 @@ module GobiertoBudgets
 
       place = site.place
       @organization_id = site.organization_id
+      @ine_code = place ? place.id.to_i : nil
       @id = "#{ organization_id }/#{ year }/#{ code }/#{ kind }"
       @category = Category.find_by(site: site, area_name: area.area_name, kind: kind, code: code)
       @name = get_name
       @description = get_description
-      @province_id = place.province_id.to_i
-      @autonomy_id = place.province.autonomous_region_id.to_i
+      @province_id = place ? place.province_id.to_i : nil
+      @autonomy_id = place ? place.province.autonomous_region_id.to_i : nil
       @level = self.class.get_level(code)
       @parent_code = self.class.get_parent_code(code)
       @amount_per_inhabitant = (amount / population).round(2)

--- a/app/models/gobierto_budgets/budget_line_stats.rb
+++ b/app/models/gobierto_budgets/budget_line_stats.rb
@@ -114,7 +114,8 @@ module GobiertoBudgets
     end
 
     def mean_province_query(year, attribute)
-      filters = [{ term: { province_id: @place.province_id } }]
+      filters = []
+      filters.push(term: { province_id: @site.place.province_id }) if @site.place.present?
       filters.push(term: { code: @code })
       filters.push(term: { kind: @kind })
       filters.push(term: { year: year })

--- a/app/models/gobierto_budgets/budget_line_stats.rb
+++ b/app/models/gobierto_budgets/budget_line_stats.rb
@@ -4,7 +4,7 @@ module GobiertoBudgets
   class BudgetLineStats
     def initialize(options)
       @site = options.fetch :site
-      @place = @site.place
+      @organization_id = @site.organization_id
       @budget_line = options.fetch :budget_line
       @kind = @budget_line.kind
       @area_name = @budget_line.area_name
@@ -83,7 +83,7 @@ module GobiertoBudgets
 
     def budget_line_planned_query(year, attribute)
       year ||= @year
-      result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: @area_name, id: [@place.id, year, @code, @kind].join("/")
+      result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: @area_name, id: [@organization_id, year, @code, @kind].join("/")
       result["_source"][attribute]
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
@@ -91,7 +91,7 @@ module GobiertoBudgets
 
     def budget_line_planned_updated_query(year, attribute)
       year ||= @year
-      result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast_updated, type: @area_name, id: [@place.id, year, @code, @kind].join("/")
+      result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast_updated, type: @area_name, id: [@organization_id, year, @code, @kind].join("/")
       result["_source"][attribute]
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
@@ -99,7 +99,7 @@ module GobiertoBudgets
 
     def budget_line_executed_query(year, attribute)
       year ||= @year
-      result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, type: @area_name, id: [@place.id, year, @code, @kind].join("/")
+      result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed, type: @area_name, id: [@organization_id, year, @code, @kind].join("/")
       result["_source"][attribute]
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil
@@ -107,7 +107,7 @@ module GobiertoBudgets
 
     def total_budget_planned_query(year, attribute)
       result = GobiertoBudgets::SearchEngine.client.get index: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.index_forecast,
-                                                        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@place.id, year, @kind].join("/")
+                                                        type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: [@organization_id, year, @kind].join("/")
       result["_source"][attribute].to_f
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       nil

--- a/app/models/gobierto_budgets/budget_total_calculator.rb
+++ b/app/models/gobierto_budgets/budget_total_calculator.rb
@@ -5,6 +5,15 @@ module GobiertoBudgets
     def initialize(site, year)
       @site = site
       @year = year
+      @place_attributes = if (place = @site.place?)
+                            { ine_code: place.id.to_i,
+                              province_id: place.province.id.to_i,
+                              autonomy_id: place.province.autonomous_region.id.to_i }
+                          else
+                            { ine_code: nil,
+                              province_id: nil,
+                              autonomy_id: nil }
+                          end
     end
 
     def calculate!
@@ -16,29 +25,29 @@ module GobiertoBudgets
 
     private
 
-    attr_reader :site, :year
+    attr_reader :site, :year, :place_attributes
 
     def import_total_budget(year, index, kind)
-      place = site.place
+      organization_id = site.organization_id
 
-      total_budget, total_budget_per_inhabitant = get_data(index, place, year, kind)
+      total_budget, total_budget_per_inhabitant = get_data(index, organization_id, year, kind)
       if total_budget == 0.0 && kind == GobiertoBudgets::BudgetLine::EXPENSE
-        total_budget, total_budget_per_inhabitant = get_data(index, place, year, kind, GobiertoBudgets::EconomicArea.area_name)
+        total_budget, total_budget_per_inhabitant = get_data(index, organization_id, year, kind, GobiertoBudgets::EconomicArea.area_name)
       end
 
-      data = {
-        ine_code: place.id.to_i, province_id: place.province.id.to_i,
-        autonomy_id: place.province.autonomous_region.id.to_i, year: year,
+      data = place_attributes.merge({
+        organization_id: organization_id,
+        year: year,
         kind: kind,
         total_budget: total_budget,
         total_budget_per_inhabitant: total_budget_per_inhabitant
-      }
+      })
 
-      id = [place.id, year, kind].join("/")
+      id = [organization_id, year, kind].join("/")
       GobiertoBudgets::SearchEngine.client.index index: index, type: GobiertoBudgets::SearchEngineConfiguration::TotalBudget.type, id: id, body: data
     end
 
-    def get_data(index, place, year, kind, type = nil)
+    def get_data(index, organization_id, year, kind, type = nil)
       query = {
         query: {
           filtered: {
@@ -48,7 +57,7 @@ module GobiertoBudgets
             filter: {
               bool: {
                 must: [
-                  { term: { ine_code: place.id } },
+                  { term: { organization_id: organization_id } },
                   { term: { level: 1 } },
                   { term: { kind: kind } },
                   { term: { year: year } },

--- a/app/models/gobierto_budgets/budget_total_calculator.rb
+++ b/app/models/gobierto_budgets/budget_total_calculator.rb
@@ -5,7 +5,7 @@ module GobiertoBudgets
     def initialize(site, year)
       @site = site
       @year = year
-      @place_attributes = if (place = @site.place?)
+      @place_attributes = if (place = @site.place)
                             { ine_code: place.id.to_i,
                               province_id: place.province.id.to_i,
                               autonomy_id: place.province.autonomous_region.id.to_i }

--- a/app/models/gobierto_budgets/data/annual.rb
+++ b/app/models/gobierto_budgets/data/annual.rb
@@ -31,12 +31,12 @@ module GobiertoBudgets
       def generate_files
         file_urls = []
         return file_urls unless any_data?
-        calculate_place_budget_lines
+        calculate_organization_budget_lines
 
         FORMATS.each do |format_key, configuration|
           file_urls << GobiertoCommon::FileUploadService.new(
             file_name: filename(format_key),
-            content: configuration[:serializer].call(@place_budget_lines),
+            content: configuration[:serializer].call(@organization_budget_lines),
             content_type: configuration[:content_type]
           ).upload!
         end
@@ -45,37 +45,32 @@ module GobiertoBudgets
 
       protected
 
-      def place
-        site.place
-      end
-
       def filename(format)
         raise UnsupportedFormat unless FORMATS.keys.include?(format.to_sym)
-        ["gobierto_budgets", place.id, "data", "annual", "#{ year }.#{ format }"].join("/")
+        ["gobierto_budgets", site.organization_id, "data", "annual", "#{ year }.#{ format }"].join("/")
       end
 
-      def calculate_place_budget_lines
+      def calculate_organization_budget_lines
         presenter = GobiertoBudgets::BudgetLineExportPresenter
         indexes = presenter::INDEX_KEYS
 
-        @place_budget_lines = []
+        @organization_budget_lines = []
         GobiertoBudgets::BudgetLine.all_kinds. each do |kind|
           GobiertoBudgets::BudgetArea.all_areas.each do |area|
             indexes.each_key do |index|
               next unless area.available_kinds.include?(kind)
               index_budget_lines = GobiertoBudgets::BudgetLine.all(where: { year: year,
                                                                             site: site,
-                                                                            place: place,
                                                                             area_name: area.area_name,
                                                                             kind: kind,
                                                                             index: index },
                                                                    include: [:index, :updated_at],
                                                                    presenter: presenter)
               index_budget_lines.each do |line|
-                if (idx = @place_budget_lines.index { |global_line| global_line.id == line.id })
-                  @place_budget_lines[idx].merge!(line)
+                if (idx = @organization_budget_lines.index { |global_line| global_line.id == line.id })
+                  @organization_budget_lines[idx].merge!(line)
                 else
-                  @place_budget_lines << line
+                  @organization_budget_lines << line
                 end
               end
             end

--- a/app/models/gobierto_budgets/data/budget_execution_comparison.rb
+++ b/app/models/gobierto_budgets/data/budget_execution_comparison.rb
@@ -13,16 +13,15 @@ module GobiertoBudgets
         @year = options[:year]
         @kind = options[:kind]
         @area = options[:area]
-        @place = @site.place
       end
 
-      attr_reader :site, :year, :kind, :area, :place
+      attr_reader :site, :year, :kind, :area
 
       def calculate_lines
-        base_conditions = { site: site, place: place, kind: kind, area_name: area, level: 1, year: year }
+        base_conditions = { site: site, kind: kind, area_name: area, level: 1, year: year }
         lines_level_1 = calculate_lines_with_conditions(base_conditions)
 
-        base_conditions = { site: site, place: place, kind: kind, area_name: area, level: 2, year: year }
+        base_conditions = { site: site, kind: kind, area_name: area, level: 2, year: year }
         lines_level_2 = calculate_lines_with_conditions(base_conditions)
 
         lines_level_1 + lines_level_2

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -85,13 +85,12 @@ module GobiertoBudgets
 
         result = []
         data.sort_by { |k, _| k }.each do |year, v|
-          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last(force_default_last_year)
-            result.push(
-              date: year.to_s,
-              value: v,
-              dif: data[year - 1] ? delta_percentage(v, data[year - 1]) : 0
-            )
-          end
+          next if year > GobiertoBudgets::SearchEngineConfiguration::Year.last(force_default_last_year)
+          result.push(
+            date: year.to_s,
+            value: v,
+            dif: data[year - 1] ? delta_percentage(v, data[year - 1]) : 0
+          )
         end
 
         result.reverse

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -11,6 +11,8 @@ module GobiertoBudgets
         @kind = options[:kind] || GobiertoBudgets::BudgetLine::EXPENSE
         @code = options[:code]
         @area = options[:area]
+        @organization_name = options[:organization_name] || @place.try(:name)
+        @organization_id = options[:organization_id] || @place.try(:id)
         @include_next_year = options[:include_next_year] == "true"
         if @code
           @variable = @what == "total_budget" ? "amount" : "amount_per_inhabitant"
@@ -35,13 +37,17 @@ module GobiertoBudgets
 
       private
 
-      def mean_province
-        filters = [{ term: { province_id: @place.province_id } }]
+      def mean_filtered_by(conditions={})
+        options = conditions.extract!(:options)
+        force_default_last_year = options[:force_default_last_year] || true
+
+        filters = conditions.map do |condition, _|
+          { term: conditions.slice(condition) }
+        end
+        filters.push(term: { kind: @kind })
+        filters.push(term: { code: @code }) if @code
         filters.push(missing: { field: "functional_code" })
         filters.push(missing: { field: "custom_code" })
-        filters.push(term: { kind: @kind })
-
-        filters.push(term: { code: @code }) if @code
 
         query = {
           query: {
@@ -79,7 +85,7 @@ module GobiertoBudgets
 
         result = []
         data.sort_by { |k, _| k }.each do |year, v|
-          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last(true)
+          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last(force_default_last_year)
             result.push(
               date: year.to_s,
               value: v,
@@ -89,126 +95,28 @@ module GobiertoBudgets
         end
 
         result.reverse
+      end
+
+      def mean_province
+        @place ? mean_filtered_by(province_id: @place.province_id) : []
       end
 
       def mean_autonomy
-        filters = [{ term: { autonomy_id: @place.province.autonomous_region.id } }]
-        filters.push(missing: { field: "functional_code" })
-        filters.push(missing: { field: "custom_code" })
-        filters.push(term: { kind: @kind })
-
-        filters.push(term: { code: @code }) if @code
-
-        query = {
-          query: {
-            filtered: {
-              filter: {
-                bool: {
-                  must: filters
-                }
-              }
-            }
-          },
-          size: 10_000,
-          "aggs": {
-            "#{@variable}_per_year": {
-              "terms": {
-                "field": "year",
-                size: 10_000
-              },
-              "aggs": {
-                "budget_sum": {
-                  "sum": {
-                    "field": @variable.to_s
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        response = SearchEngine.client.search index: index, type: type, body: query
-        data = {}
-        response["aggregations"]["#{ @variable }_per_year"]["buckets"].each do |r|
-          data[r["key"]] = (r["budget_sum"]["value"].to_f / r["doc_count"].to_f).round(2)
-        end
-
-        result = []
-        data.sort_by { |k, _| k }.each do |year, v|
-          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last(true)
-            result.push(
-              date: year.to_s,
-              value: v,
-              dif: data[year - 1] ? delta_percentage(v, data[year - 1]) : 0
-            )
-          end
-        end
-
-        result.reverse
+        @place ? mean_filtered_by(autonomy_id: @place.province.autonomous_region.id) : []
       end
 
       def mean_national
-        filters = []
-        filters.push(term: { kind: @kind })
-        filters.push(term: { code: @code }) if @code
-        filters.push(missing: { field: "functional_code" })
-        filters.push(missing: { field: "custom_code" })
-
-        query = {
-          query: {
-            filtered: {
-              filter: {
-                bool: {
-                  must: filters
-                }
-              }
-            }
-          },
-          size: 10_000,
-          "aggs": {
-            "#{@variable}_per_year": {
-              "terms": {
-                "field": "year",
-                size: 10_000
-              },
-              "aggs": {
-                "budget_sum": {
-                  "sum": {
-                    "field": @variable.to_s
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        response = SearchEngine.client.search index: index, type: type, body: query
-        data = {}
-        response["aggregations"]["#{ @variable }_per_year"]["buckets"].each do |r|
-          data[r["key"]] = (r["budget_sum"]["value"].to_f / r["doc_count"].to_f).round(2)
-        end
-
-        result = []
-        data.sort_by { |k, _| k }.each do |year, v|
-          if year <= GobiertoBudgets::SearchEngineConfiguration::Year.last
-            result.push(
-              date: year.to_s,
-              value: v,
-              dif: data[year - 1] ? delta_percentage(v, data[year - 1]) : 0
-            )
-          end
-        end
-
-        result.reverse
+        mean_filtered_by(options: { force_default_last_year: false })
       end
 
-      def place_values(place = nil)
-        place = @place unless place.present?
-        filters = [{ term: { ine_code: place.id } }]
+      def values_filtered_by(conditions)
+        filters = conditions.map do |condition, _|
+          { term: conditions.slice(condition) }
+        end
+
         filters.push(missing: { field: "functional_code" })
         filters.push(missing: { field: "custom_code" })
         filters.push(term: { kind: @kind })
-
         filters.push(term: { code: @code }) if @code
 
         query = {
@@ -244,11 +152,21 @@ module GobiertoBudgets
         result
       end
 
+      def place_values(place = nil)
+        place = @place unless place.present?
+
+        place ? values_filtered_by(ine_code: place.id) : []
+      end
+
+      def organization_values
+        values_filtered_by(organization_id: @organization_id)
+      end
+
       def budget_values
         if @comparison
           place_value = [{
-            name: @place.name,
-            "values": place_values
+            name: @organization_name,
+            "values": organization_values
           }]
           @comparison.map do |place_id|
             if place = INE::Places::Place.find(place_id)
@@ -270,8 +188,8 @@ module GobiertoBudgets
               "values": mean_national
             },
             {
-              name: @place.name,
-              "values": place_values
+              name: @organization_name,
+              "values": organization_values
             }
           ]
         end

--- a/app/models/gobierto_budgets/data/treemap.rb
+++ b/app/models/gobierto_budgets/data/treemap.rb
@@ -14,7 +14,7 @@ module GobiertoBudgets
 
       def generate_json
         options = [
-          { term: { ine_code: @organization_id } },
+          { term: { organization_id: @organization_id } },
           { term: { kind: @kind } },
           { term: { year: @year } }
         ]

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -187,8 +187,8 @@ module GobiertoBudgets
     end
 
     def main_budget_lines_summary
-      main_budget_lines_forecast = BudgetLine.all(where: { kind: BudgetLine::EXPENSE, level: 1, place: @place, year: @year, area_name: EconomicArea.area_name })
-      main_budget_lines_execution = BudgetLine.all(where: { kind: BudgetLine::EXPENSE, level: 1, place: @place, year: @year, area_name: EconomicArea.area_name, index: SearchEngineConfiguration::BudgetLine.index_executed })
+      main_budget_lines_forecast = BudgetLine.all(where: { kind: BudgetLine::EXPENSE, level: 1, site: @site, year: @year, area_name: EconomicArea.area_name })
+      main_budget_lines_execution = BudgetLine.all(where: { kind: BudgetLine::EXPENSE, level: 1, site: @site, year: @year, area_name: EconomicArea.area_name, index: SearchEngineConfiguration::BudgetLine.index_executed })
 
       main_budget_lines_summary = {}
 

--- a/app/models/gobierto_budgets/top_budget_line.rb
+++ b/app/models/gobierto_budgets/top_budget_line.rb
@@ -17,7 +17,7 @@ module GobiertoBudgets
         { term: { kind: @conditions[:kind] } },
         { term: { year: @conditions[:year] } },
         { term: { level: 3 } },
-        { term: { ine_code: @conditions[:site].organization_id } }
+        { term: { organization_id: @conditions[:site].organization_id } }
       ]
 
       query = {

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -3,7 +3,7 @@ module GobiertoBudgets
 
     def self.load(id, site)
       return nil if id.nil?
-      ine_code, year, code, kind, area_name = id.split('/')
+      organization_id, year, code, kind, area_name = id.split('/')
       area = case area_name
              when EconomicArea.area_name
                EconomicArea
@@ -12,7 +12,7 @@ module GobiertoBudgets
              when CustomArea.area_name
                CustomArea
              end
-      self.new(ine_code: ine_code, year: year, code: code, kind: kind, area: area, site: site)
+      self.new(organization_id: organization_id, year: year, code: code, kind: kind, area: area, site: site)
     end
 
     def initialize(attributes)
@@ -20,7 +20,7 @@ module GobiertoBudgets
     end
 
     def id
-      (@attributes.values_at(:ine_code, :year, :code, :kind) + [@attributes[:area].area_name]).join('/')
+      (@attributes.values_at(:organization_id, :year, :code, :kind) + [@attributes[:area].area_name]).join('/')
     end
 
     def category
@@ -54,7 +54,7 @@ module GobiertoBudgets
     end
 
     def percentage_of_total
-      total_amount = total || GobiertoBudgets::BudgetTotal.for(@attributes[:ine_code], @attributes[:year])
+      total_amount = total || GobiertoBudgets::BudgetTotal.for(@attributes[:organization_id], @attributes[:year])
       ((amount.to_f / total_amount.to_f)*100).round(2)
     end
 

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -3,7 +3,7 @@ module GobiertoBudgets
 
     def self.load(id, site)
       return nil if id.nil?
-      organization_id, year, code, kind, area_name = id.split('/')
+      organization_id, year, code, kind, area_name = id.split("/")
       area = case area_name
              when EconomicArea.area_name
                EconomicArea
@@ -20,7 +20,7 @@ module GobiertoBudgets
     end
 
     def id
-      (@attributes.values_at(:organization_id, :year, :code, :kind) + [@attributes[:area].area_name]).join('/')
+      (@attributes.values_at(:organization_id, :year, :code, :kind) + [@attributes[:area].area_name]).join("/")
     end
 
     def category

--- a/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
@@ -1,6 +1,6 @@
 <tr data-budget-line="<%= budget_line.code %>">
   <td>
-    <% if GobiertoBudgets::BudgetLine.has_children?({code: budget_line.code, level: budget_line.level, area: area_name, year: year, ine_code: current_site.organization_id, kind: kind}) %>
+    <% if GobiertoBudgets::BudgetLine.has_children?({code: budget_line.code, level: budget_line.level, area: area_name, year: year, organization_id: current_site.organization_id, kind: kind}) %>
       <%= link_to '<i class="fa fa-plus-square-o"></i>'.html_safe, gobierto_budgets_budget_line_descendants_path(year, area_name, kind, parent_code: budget_line.code), remote: true, 'aria-label' => 'Plus' %>
     <% else %>
       <i class="fa fa-plus-square-o invisible"></i>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -287,8 +287,8 @@
 
       <div class="pure-u-1 pure-u-md-1-2">
         <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
-          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: current_site.organization_id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
-          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: current_site.organization_id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
+          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
+          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
         </div>
       </div>
     </div>
@@ -317,8 +317,8 @@
 
       <div class="pure-u-1 pure-u-md-1-2">
         <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
-          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_path(comparison: budgets_comparison_compare_municipalities, ine_code: current_site.organization_id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
-          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_path(comparison: budgets_comparison_compare_municipalities, ine_code: current_site.organization_id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
+          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_path(comparison: budgets_comparison_compare_municipalities, organization_id: current_site.organization_id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
+          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_path(comparison: budgets_comparison_compare_municipalities, organization_id: current_site.organization_id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
         </div>
       </div>
     </div>

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -80,8 +80,8 @@
 
     <div class="pure-u-1">
       <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
-        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: current_site.organization_id, year: @year, what: 'per_person', include_next_year: true, format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
-        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(ine_code: current_site.organization_id, year: @year, what: 'total_budget', include_next_year: true, format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
+        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'per_person', include_next_year: true, format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
+        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'total_budget', include_next_year: true, format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
 
         </div>
     </div>

--- a/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
+++ b/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
@@ -10,19 +10,19 @@
 
   <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
                              data-widget-type="per_person"
-                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_per_inhabitant_path(ine_code: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_per_inhabitant_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
                              title="<%= t('.per_person') %>">
   </div>
 
   <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
                              data-widget-type="budget"
-                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(ine_code: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
                              title="<%= t('.total') %>">
   </div>
 
   <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template-small"
                              data-widget-type="budget"
-                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(ine_code: current_site.organization_id, year: (@year - 1), kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(organization_id: current_site.organization_id, year: (@year - 1), kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
                              title="<%= t('.last_year') %>">
   </div>
 </div>

--- a/app/views/gobierto_budgets/indicators/index.html.erb
+++ b/app/views/gobierto_budgets/indicators/index.html.erb
@@ -9,7 +9,7 @@
           </div>
 
           <p>
-            <%= t("gobierto_budgets.indicators_intro", place: @site.place.name) %>
+            <%= t("gobierto_budgets.indicators_intro", place: @site.organization_name) %>
           </p>
 
           <%= render('gobierto_budgets/shared/data_updated_at') %>

--- a/app/views/gobierto_observatory/observatory/_card_comparison.html.erb
+++ b/app/views/gobierto_observatory/observatory/_card_comparison.html.erb
@@ -12,8 +12,8 @@
       	</a>
       </div>
       <div class="widget_body widget_comparison">
-        <div class="widget_figure first"><span class="figure figure-first"></span> <span><%= t("gobierto_observatory.cards.#{card_class}.figure_first", {place: @site.place.name, province: @site.place.province.name}) %></span></div>
-        <div class="widget_figure second"><span class="figure figure-second"></span> <span><%= t("gobierto_observatory.cards.#{card_class}.figure_second", {place: @site.place.name , province: @site.place.province.name}) %></span></div>
+        <div class="widget_figure first"><span class="figure figure-first"></span> <span><%= t("gobierto_observatory.cards.#{ card_class }.figure_first", { place: @site.organization_name }) %></span></div>
+        <div class="widget_figure second"><span class="figure figure-second"></span> <span><%= t("gobierto_observatory.cards.#{ card_class }.figure_second", { place: @site.organization_name }) %></span></div>
         <span class="pull-right widget_pct"></span>
       </div>
 

--- a/app/views/gobierto_observatory/observatory/index.html.erb
+++ b/app/views/gobierto_observatory/observatory/index.html.erb
@@ -1,7 +1,7 @@
 <div class="intro_section clearfix column">
 	<div class="pure-g">
 		<div class="pure-u-1 pure-u-md-2-5">
-      <p class="intro_desc"><%= t("gobierto_observatory.intro", place: @site.place.name) %></p>
+      <p class="intro_desc"><%= t("gobierto_observatory.intro", place: @site.organization_name) %></p>
 		</div>
 		<div class="pure-u-1 pure-u-md-3-5">
 			<%= image_tag('illustrations/integra.jpg', class: 'img-fluid side_50 pb1') %>

--- a/config/locales/gobierto_observatory/views/ca.yml
+++ b/config/locales/gobierto_observatory/views/ca.yml
@@ -66,7 +66,7 @@ ca:
         third_column: Disponible
         title: Renda municipal
       income_overview:
-        figure_first: "%{province}"
+        figure_first: "%{place}"
         figure_second: Espanya
         title: Renda bruta
       investment_by_inhabitant:

--- a/config/locales/gobierto_observatory/views/en.yml
+++ b/config/locales/gobierto_observatory/views/en.yml
@@ -66,7 +66,7 @@ en:
         third_column: Net
         title: Municipality income
       income_overview:
-        figure_first: "%{province}"
+        figure_first: "%{place}"
         figure_second: Spain
         title: Gross income
       investment_by_inhabitant:

--- a/config/locales/gobierto_observatory/views/es.yml
+++ b/config/locales/gobierto_observatory/views/es.yml
@@ -66,7 +66,7 @@ es:
         third_column: Disponible
         title: Renta municipal
       income_overview:
-        figure_first: "%{province}"
+        figure_first: "%{place}"
         figure_second: España
         title: Renta bruta
       investment_by_inhabitant:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,12 +299,12 @@ Rails.application.routes.draw do
       namespace :api do
         get "/categories" => "categories#index"
         get "/categories/:area/:kind" => "categories#index"
-        get "/data/widget/budget/:ine_code/:year/:code/:area/:kind" => "data#budget", as: :data_budget
-        get "/data/widget/budget_per_inhabitant/:ine_code/:year/:code/:area/:kind" => "data#budget_per_inhabitant", as: :data_budget_per_inhabitant
-        get "/data/lines/:ine_code/:year/:what" => "data#lines", as: :data_lines
-        get "/data/lines/budget_line/:ine_code/:year/:what/:kind/:code/:area" => "data#lines", as: :data_lines_budget_line
-        get "/data/widget/budget_execution_deviation/:ine_code/:year/:kind" => "data#budget_execution_deviation", as: :data_budget_execution_deviation
-        get "/data/widget/budget_execution_comparison/:ine_code/:year/:kind/:area" => "data#budget_execution_comparison", as: :data_budget_execution_comparison
+        get "/data/widget/budget/:organization_id/:year/:code/:area/:kind" => "data#budget", as: :data_budget
+        get "/data/widget/budget_per_inhabitant/:organization_id/:year/:code/:area/:kind" => "data#budget_per_inhabitant", as: :data_budget_per_inhabitant
+        get "/data/lines/:organization_id/:year/:what" => "data#lines", as: :data_lines
+        get "/data/lines/budget_line/:organization_id/:year/:what/:kind/:code/:area" => "data#lines", as: :data_lines_budget_line
+        get "/data/widget/budget_execution_deviation/:organization_id/:year/:kind" => "data#budget_execution_deviation", as: :data_budget_execution_deviation
+        get "/data/widget/budget_execution_comparison/:organization_id/:year/:kind/:area" => "data#budget_execution_comparison", as: :data_budget_execution_comparison
       end
     end
   end

--- a/lib/tasks/gobierto_budgets/algolia_indices.rake
+++ b/lib/tasks/gobierto_budgets/algolia_indices.rake
@@ -7,6 +7,7 @@ namespace :gobierto_budgets do
       site = Site.find_by!(domain: args[:site_domain])
       year = args[:year].to_i
       ine_code = site.place.id
+      organization_id = site.organization_id
 
       puts "== Reindexing records for site #{site.domain}=="
 
@@ -21,7 +22,7 @@ namespace :gobierto_budgets do
           forecast_hits = request_budget_lines_from_elasticsearch(
             GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
             area,
-            ine_code,
+            organization_id,
             year
           )
 
@@ -48,14 +49,14 @@ namespace :gobierto_budgets do
       )
     end
 
-    def request_budget_lines_from_elasticsearch(index, area, ine_code, year)
+    def request_budget_lines_from_elasticsearch(index, area, organization_id, year)
       query = {
         query: {
           filtered: {
             filter: {
               bool: {
                 must: [
-                  { term: { ine_code: ine_code } },
+                  { term: { organization_id: organization_id } },
                   { term: { year: year } }
                 ]
               }

--- a/lib/tasks/gobierto_budgets/data/annual.rake
+++ b/lib/tasks/gobierto_budgets/data/annual.rake
@@ -14,14 +14,15 @@ namespace :gobierto_budgets do
 
     def generate_site_annual_files_for(data_model)
       Site.all.each do |site|
-        place = site.place
-        next if place.nil?
+        organization_id = site.organization_id
+        organization_name = site.organization_name || site.place.try(name)
+        next if organization_id.nil?
         file_urls = []
         GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
           file_urls += data_model.new(site: site, year: year).generate_files
         end
 
-        puts "\n- Data calculated for site #{ site.domain } and place #{ place.name } - #{ place.id }: " +
+        puts "\n- Data calculated for site #{ site.domain } and organization #{ organization_name } - #{ organization_id }: " +
           (file_urls.any? ? "#{ file_urls.count } files uploaded:" : "No files generated.")
         file_urls.each do |file_url|
           puts "\t+ #{ file_url }"

--- a/lib/tasks/gobierto_budgets/fixtures.rake
+++ b/lib/tasks/gobierto_budgets/fixtures.rake
@@ -12,29 +12,30 @@ namespace :gobierto_budgets do
       create_all_budgets_mapping
 
       import_categories
-      place = INE::Places::Place.find_by_slug("madrid")
-      (GobiertoBudgets::SearchEngineConfiguration::Year.last - 1..GobiertoBudgets::SearchEngineConfiguration::Year.last).each do |year|
-        import_gobierto_budgets_for_place(place, year)
-        import_gobierto_budgets_data_for_place(place, year)
-      end
 
-      place = INE::Places::Place.find_by_slug("santander")
-      (GobiertoBudgets::SearchEngineConfiguration::Year.last - 1..GobiertoBudgets::SearchEngineConfiguration::Year.last).each do |year|
-        import_gobierto_budgets_for_place(place, year)
-        import_gobierto_budgets_data_for_place(place, year)
+      organizations = [INE::Places::Place.find_by_slug("madrid"), INE::Places::Place.find_by_slug("santander"), "wadus"]
+      organizations.each do |organization|
+        (GobiertoBudgets::SearchEngineConfiguration::Year.last - 1..GobiertoBudgets::SearchEngineConfiguration::Year.last).each do |year|
+          import_gobierto_budgets_for_organization(organization, year)
+          import_gobierto_budgets_data_for_organization(organization, year)
+        end
       end
     end
 
-    def import_gobierto_budgets_data_for_place(place, year)
+    def import_gobierto_budgets_data_for_organization(organization, year)
+      place, organization_id = resolve_place_and_organization_id(organization)
+
       index = GobiertoBudgets::SearchEngineConfiguration::Data.index
-      data_for_place = [GobiertoBudgets::SearchEngineConfiguration::Data.type_population, GobiertoBudgets::SearchEngineConfiguration::Data.type_debt].map do |type|
+      data_for_organization = [GobiertoBudgets::SearchEngineConfiguration::Data.type_population, GobiertoBudgets::SearchEngineConfiguration::Data.type_debt].map do |type|
         {
           index: {
             _index: index,
-            _id: [place.id, year].join("/"),
+            _id: [organization_id, year].join("/"),
             _type: type,
             data: {
-              ine_code: place.id, province_id: place.province_id,
+              organization_id: organization_id,
+              ine_code: place.id.to_i,
+              province_id: place.province_id,
               autonomy_id: place.province.autonomous_region_id,
               year: year, value: rand(1_000_000)
             }
@@ -42,29 +43,36 @@ namespace :gobierto_budgets do
         }
       end
 
-      GobiertoBudgets::SearchEngine.client.bulk(body: data_for_place)
+      GobiertoBudgets::SearchEngine.client.bulk(body: data_for_organization)
     end
 
-    def import_gobierto_budgets_for_place(place, year)
-      puts "== Importing budgets for place #{place.name} in #{year} =="
+    def import_gobierto_budgets_for_organization(organization, year)
+      place, organization_id = resolve_place_and_organization_id(organization)
+
+      puts "== Importing budgets for organization #{ place.blank? ? organization_id : "Place: #{ place.name }" } in #{ year } =="
       base_data = {
-        ine_code: place.id.to_i, province_id: place.province.id.to_i,
-        autonomy_id: place.province.autonomous_region.id.to_i, year: year,
+        organization_id: organization_id,
+        ine_code: place.id.to_i,
+        province_id: place.province.id.to_i,
+        autonomy_id: place.province.autonomous_region.id.to_i,
+        year: year,
         population: rand(1_000_000)
       }
 
-      budgets_for_place = [GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed].map do |index|
+      budgets = [GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed].map do |index|
         categories_fixtures do |category|
-          next if category["ine_code"] && (category["ine_code"] != place.id.to_i)
+          next if category["organization_id"] && (category["organization_id"] != organization_id)
 
           category["kind"] = category["kind"] == "income" ? "I" : "G"
           {
             index: {
               _index: index,
-              _id: [place.id, year, category["code"], category["kind"]].join("/"),
+              _id: [organization_id, year, category["code"], category["kind"]].join("/"),
               _type: category["area"],
-              data: base_data.merge(amount: rand(1_000_000), code: category["code"],
-                                    level: category["level"], kind: category["kind"],
+              data: base_data.merge(amount: rand(1_000_000),
+                                    code: category["code"],
+                                    level: category["level"],
+                                    kind: category["kind"],
                                     amount_per_inhabitant: (rand(1_000) / 2.0).round(2),
                                     parent_code: category["parent_code"])
             }
@@ -79,15 +87,11 @@ namespace :gobierto_budgets do
           {
             index: {
               _index: index,
-              _id: [place.id, year, category["kind"]].join("/"),
+              _id: [organization_id, year, category["kind"]].join("/"),
               _type: type,
-              data: {
-                ine_code: place.id.to_i, province_id: place.province.id.to_i,
-                autonomy_id: place.province.autonomous_region.id.to_i, year: year,
-                kind: category["kind"],
-                total_budget: rand(1_000_000),
-                total_budget_per_inhabitant: rand(1_000_000)
-              }
+              data: base_data.except(:population).merge(kind: category["kind"],
+                                                        total_budget: rand(1_000_000),
+                                                        total_budget_per_inhabitant: rand(1_000_000))
             }
           }
         end
@@ -95,17 +99,19 @@ namespace :gobierto_budgets do
 
       economic_budget_lines_for_functional = []
       categories_fixtures do |category|
-        next if category["ine_code"] && (category["ine_code"] != place.id.to_i)
+        next if category["organization_id"] && (category["organization_id"] != organization_id)
         next if category["area_name"] != "economic" && category["kind"] == "income"
 
         index = GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast
         category["kind"] = category["kind"] == "income" ? "I" : "G"
         economic_budget_lines_for_functional.push(index: {
                                                     _index: index,
-                                                    _id: [place.id, year, "#{category["code"]}-1-f}", category["kind"]].join("/"),
+                                                    _id: [organization_id, year, "#{ category["code"] }-1-f}", category["kind"]].join("/"),
                                                     _type: category["area"],
-                                                    data: base_data.merge(amount: rand(1_000_000), code: category["code"],
-                                                                          level: category["level"], kind: category["kind"],
+                                                    data: base_data.merge(amount: rand(1_000_000),
+                                                                          code: category["code"],
+                                                                          level: category["level"],
+                                                                          kind: category["kind"],
                                                                           amount_per_inhabitant: (rand(1_000) / 2.0).round(2),
                                                                           functional_code: 1,
                                                                           parent_code: category["parent_code"])
@@ -114,24 +120,26 @@ namespace :gobierto_budgets do
 
       economic_budget_lines_for_custom = []
       categories_fixtures do |category|
-        next if category["ine_code"] && (category["ine_code"] != place.id.to_i)
+        next if category["organization_id"] && (category["organization_id"] != organization_id)
         next if category["area_name"] != "economic" && category["kind"] == "income"
 
         index = GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast
         category["kind"] = "G"
         economic_budget_lines_for_functional.push(index: {
                                                     _index: index,
-                                                    _id: [place.id, year, "#{category["code"]}-1-c}", category["kind"]].join("/"),
+                                                    _id: [organization_id, year, "#{ category["code"] }-1-c}", category["kind"]].join("/"),
                                                     _type: category["area"],
-                                                    data: base_data.merge(amount: rand(1_000_000), code: category["code"],
-                                                                          level: category["level"], kind: category["kind"],
+                                                    data: base_data.merge(amount: rand(1_000_000),
+                                                                          code: category["code"],
+                                                                          level: category["level"],
+                                                                          kind: category["kind"],
                                                                           amount_per_inhabitant: (rand(1_000) / 2.0).round(2),
                                                                           custom_code: 1,
                                                                           parent_code: category["parent_code"])
                                                   })
       end
 
-      GobiertoBudgets::SearchEngine.client.bulk(body: budgets_for_place + total_budgets + economic_budget_lines_for_functional + economic_budget_lines_for_custom)
+      GobiertoBudgets::SearchEngine.client.bulk(body: budgets + total_budgets + economic_budget_lines_for_functional + economic_budget_lines_for_custom)
     end
 
     def categories_fixtures
@@ -165,7 +173,7 @@ namespace :gobierto_budgets do
         {
           index: {
             _index: GobiertoBudgets::SearchEngineConfiguration::BudgetCategories.index,
-            _id: category.slice("ine_code", "area", "code", "kind").values.join("/"),
+            _id: category.slice("organization_id", "area", "code", "kind").values.join("/"),
             _type: GobiertoBudgets::SearchEngineConfiguration::BudgetCategories.type,
             data: category
           }
@@ -197,6 +205,7 @@ namespace :gobierto_budgets do
       GobiertoBudgets::SearchEngine.client.indices.put_mapping index: index, type: type, body: {
         type.to_sym => {
           properties: {
+            organization_id:       { type: "string", index: "not_analyzed" },
             ine_code:              { type: "integer", index: "not_analyzed" },
             year:                  { type: "integer", index: "not_analyzed" },
             amount:                { type: "double", index: "not_analyzed" },
@@ -222,9 +231,10 @@ namespace :gobierto_budgets do
       GobiertoBudgets::SearchEngine.client.indices.put_mapping index: index, type: type, body: {
         type.to_sym => {
           properties: {
-            ine_code:       { type: "integer", index: "not_analyzed" },
-            kind:           { type: "string", index: "not_analyzed" }, # income I / expense G
-            code:           { type: "string", index: "not_analyzed" },
+            organization_id: { type: "string", index: "not_analyzed" },
+            ine_code:        { type: "integer", index: "not_analyzed" },
+            kind:            { type: "string", index: "not_analyzed" }, # income I / expense G
+            code:            { type: "string", index: "not_analyzed" },
             values: {
               properties: {
                 date:       { type: "string", index: "not_analyzed" },
@@ -245,6 +255,7 @@ namespace :gobierto_budgets do
       GobiertoBudgets::SearchEngine.client.indices.put_mapping index: index, type: type, body: {
         type.to_sym => {
           properties: {
+            organization_id:             { type: "string", index: "not_analyzed" },
             ine_code:                    { type: "integer", index: "not_analyzed" },
             province_id:                 { type: "integer", index: "not_analyzed" },
             autonomy_id:                 { type: "integer", index: "not_analyzed" },
@@ -261,20 +272,57 @@ namespace :gobierto_budgets do
       index = GobiertoBudgets::SearchEngineConfiguration::Data.index
       [GobiertoBudgets::SearchEngineConfiguration::Data.type_population, GobiertoBudgets::SearchEngineConfiguration::Data.type_debt].each do |type|
         m = GobiertoBudgets::SearchEngine.client.indices.get_mapping index: index, type: type
-        return unless m.empty?
+        next unless m.empty?
 
         puts "== Creating data mapping =="
         GobiertoBudgets::SearchEngine.client.indices.put_mapping index: index, type: type, body: {
           type.to_sym => {
             properties: {
-              ine_code:    { type: "integer", index: "not_analyzed" },
-              province_id: { type: "integer", index: "not_analyzed" },
-              autonomy_id: { type: "integer", index: "not_analyzed" },
-              year:        { type: "integer", index: "not_analyzed" },
-              value:       { type: "double", index: "not_analyzed" }
+              organization_id: { type: "string", index: "not_analyzed" },
+              ine_code:        { type: "integer", index: "not_analyzed" },
+              province_id:     { type: "integer", index: "not_analyzed" },
+              autonomy_id:     { type: "integer", index: "not_analyzed" },
+              year:            { type: "integer", index: "not_analyzed" },
+              value:           { type: "double", index: "not_analyzed" }
             }
           }
         }
+      end
+    end
+
+    def resolve_place_and_organization_id(organization)
+      if organization.is_a? INE::Places::Place
+        [organization, organization.id]
+      else
+        [NullObjectPlace.new, organization]
+      end
+    end
+
+    class NullObjectPlace
+      [:a, :s, :f, :i].each do |type|
+        define_method :"to_#{type}" do
+          nil
+        end
+      end
+
+      def tap
+        self
+      end
+
+      def nil?
+        true
+      end
+
+      def present?
+        false
+      end
+
+      def empty?
+        true
+      end
+
+      def method_missing(*)
+        self
       end
     end
   end

--- a/test/fixtures/gobierto_budgets/categories.yml
+++ b/test/fixtures/gobierto_budgets/categories.yml
@@ -12,6 +12,20 @@ economic_1_g:
     'en' => 'Personal expenses are... (custom, translated)'
   }.to_json %>
 
+economic_1_g_organization:
+  site: organization_wadus
+  area_name: economic
+  code: '1'
+  kind: <%= GobiertoBudgets::BudgetLine::EXPENSE %>
+  custom_name_translations: <%= {
+    'es' => 'Gastos de personal (custom, translated)',
+    'en' => 'Personal expenses (custom, translated)'
+  }.to_json %>
+  custom_description_translations: <%= {
+    'es' => 'Los gastos de personal son... (custom, translated)',
+    'en' => 'Personal expenses are... (custom, translated)'
+  }.to_json %>
+
 economic_1_i:
   site: madrid
   area_name: economic

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -129,3 +129,11 @@ gobierto_budgets_settings_madrid:
     }
   ]}
 }.to_json %>
+
+gobierto_budgets_settings_organization_wadus:
+  site: organization_wadus
+  module_name: "GobiertoBudgets"
+  settings: <%= {
+    "budgets_receipt_enabled": true,
+    "budgets_receipt_configuration": {}
+}.to_json %>

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -21,7 +21,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   end
 
   def test_budget_line_information
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       assert has_content?("Personal expenses (custom, translated)")
@@ -30,7 +30,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   end
 
   def test_metric_boxes
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       assert has_css?(".metric_box h3", text: "Expense plan. / inh.")
@@ -43,7 +43,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   end
 
   def test_invalid_budget_line_url
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit gobierto_budgets_budget_line_path("1", last_year, GobiertoBudgets::EconomicArea.area_name, "foo")
 
       assert_equal 400, status_code

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -8,8 +8,12 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
     @path = gobierto_budgets_budget_line_path("1", last_year, GobiertoBudgets::EconomicArea.area_name, GobiertoBudgets::BudgetLine::EXPENSE)
   end
 
-  def site
-    @site ||= sites(:madrid)
+  def placed_site
+    @placed_site ||= sites(:madrid)
+  end
+
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
   end
 
   def last_year
@@ -17,7 +21,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   end
 
   def test_budget_line_information
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       assert has_content?("Personal expenses (custom, translated)")
@@ -26,7 +30,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   end
 
   def test_metric_boxes
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       assert has_css?(".metric_box h3", text: "Expense plan. / inh.")
@@ -39,7 +43,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   end
 
   def test_invalid_budget_line_url
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit gobierto_budgets_budget_line_path("1", last_year, GobiertoBudgets::EconomicArea.area_name, "foo")
 
       assert_equal 400, status_code

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -21,7 +21,7 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
   end
 
   def test_execution_information
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       assert has_content?("Budget execution")

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -8,8 +8,12 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
     @path = gobierto_budgets_budgets_execution_path(last_year)
   end
 
-  def site
-    @site ||= sites(:madrid)
+  def placed_site
+    @placed_site ||= sites(:madrid)
+  end
+
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
   end
 
   def last_year
@@ -17,7 +21,7 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
   end
 
   def test_execution_information
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       assert has_content?("Budget execution")

--- a/test/integration/gobierto_budgets/guide_test.rb
+++ b/test/integration/gobierto_budgets/guide_test.rb
@@ -21,7 +21,7 @@ class GobiertoBudgets::GuideTest < ActionDispatch::IntegrationTest
   end
 
   def test_greeting
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       assert has_content?("How a municipal budget works")

--- a/test/integration/gobierto_budgets/guide_test.rb
+++ b/test/integration/gobierto_budgets/guide_test.rb
@@ -8,8 +8,12 @@ class GobiertoBudgets::GuideTest < ActionDispatch::IntegrationTest
     @path = gobierto_budgets_budgets_guide_path
   end
 
-  def site
-    @site ||= sites(:madrid)
+  def placed_site
+    @placed_site ||= sites(:madrid)
+  end
+
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
   end
 
   def last_year
@@ -17,7 +21,7 @@ class GobiertoBudgets::GuideTest < ActionDispatch::IntegrationTest
   end
 
   def test_greeting
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       assert has_content?("How a municipal budget works")

--- a/test/integration/gobierto_budgets/home_page_test.rb
+++ b/test/integration/gobierto_budgets/home_page_test.rb
@@ -8,8 +8,12 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
     @path = gobierto_budgets_root_path(last_year)
   end
 
-  def site
-    @site ||= sites(:madrid)
+  def placed_site
+    @placed_site ||= sites(:madrid)
+  end
+
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
   end
 
   def last_year
@@ -17,7 +21,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_greeting
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       assert has_content?("Budgets")
@@ -26,7 +30,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_menu_subsections
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       within "nav.sub-nav" do
@@ -40,7 +44,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_metric_boxes
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit @path
 
       assert has_css?(".metric_box h3", text: "Expenses per inhabitant")

--- a/test/integration/gobierto_budgets/home_page_test.rb
+++ b/test/integration/gobierto_budgets/home_page_test.rb
@@ -21,7 +21,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_greeting
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       assert has_content?("Budgets")
@@ -30,7 +30,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_menu_subsections
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       within "nav.sub-nav" do
@@ -44,7 +44,7 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_metric_boxes
-    with_each_current_site(placed_site, organization_site) do |site|
+    with_each_current_site(placed_site, organization_site) do
       visit @path
 
       assert has_css?(".metric_box h3", text: "Expenses per inhabitant")

--- a/test/integration/gobierto_budgets/indicators_test.rb
+++ b/test/integration/gobierto_budgets/indicators_test.rb
@@ -3,15 +3,19 @@
 require "test_helper"
 
 class GobiertoBudgets::IndicatorsTest < ActionDispatch::IntegrationTest
-  def site
-    @site ||= sites(:madrid)
+  def placed_site
+    @placed_site ||= sites(:madrid)
+  end
+
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
   end
 
   def test_greeting
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit gobierto_budgets_indicators_path
 
-      assert has_content?("Understand the budgets of Madrid
+      assert has_content?("Understand the budgets of #{ site.organization_name }
                            through its main figures: gross savings, per capita
                            investment or investment financing.")
     end

--- a/test/integration/gobierto_budgets/receipt_test.rb
+++ b/test/integration/gobierto_budgets/receipt_test.rb
@@ -3,15 +3,19 @@
 require "test_helper"
 
 class GobiertoBudgets::ReceiptTest < ActionDispatch::IntegrationTest
-  def site
-    @site ||= sites(:madrid)
+  def placed_site
+    @placed_site ||= sites(:madrid)
+  end
+
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
   end
 
   def test_greeting
-    with_current_site(site) do
+    with_each_current_site(placed_site, organization_site) do |site|
       visit gobierto_budgets_receipt_path
 
-      assert has_content?("Your contribution to Ayuntamiento de Madrid")
+      assert has_content?("Your contribution to #{site.name}")
     end
   end
 end

--- a/test/integration/gobierto_budgets/receipt_test.rb
+++ b/test/integration/gobierto_budgets/receipt_test.rb
@@ -15,7 +15,7 @@ class GobiertoBudgets::ReceiptTest < ActionDispatch::IntegrationTest
     with_each_current_site(placed_site, organization_site) do |site|
       visit gobierto_budgets_receipt_path
 
-      assert has_content?("Your contribution to #{site.name}")
+      assert has_content?("Your contribution to #{ site.name }")
     end
   end
 end

--- a/test/models/gobierto_budgets/budget_line_test.rb
+++ b/test/models/gobierto_budgets/budget_line_test.rb
@@ -107,7 +107,7 @@ module GobiertoBudgets
         index: "index_forecast",
         type: "economic",
         site_id: site.id,
-        ine_code: budget_line.ine_code,
+        organization_id: budget_line.organization_id,
         year: budget_line.year,
         code: budget_line.code,
         kind: budget_line.kind,

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -19,6 +19,10 @@ class SiteTest < ActiveSupport::TestCase
     @site ||= sites(:madrid)
   end
 
+  def organization_site
+    @organization_site ||= sites(:organization_wadus)
+  end
+
   def draft_site
     @draft_site ||= sites(:santander)
   end
@@ -52,8 +56,7 @@ class SiteTest < ActiveSupport::TestCase
   end
 
   def test_place_when_organization_not_municipality
-    site.organization_id = "XXXX"
-    assert_nil site.place
+    assert_nil organization_site.place
   end
 
   def test_find_by_allowed_domain

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -14,6 +14,14 @@ module SiteSessionHelpers
     end
   end
 
+  def with_each_current_site(*sites)
+    sites.each do |site|
+      with_current_site(site) do
+        yield(site)
+      end
+    end
+  end
+
   def with_current_site_with_host(site)
     with_current_site(site) do
       with_site_host(site) do


### PR DESCRIPTION
Related with #1557

## :v: What does this PR do?
* In elasticsearch gobierto budgets fixtures:
  * Adds to data in elasticsearch entries an `organization_id` field, containing the value of the site.
  * Changes the `_id` attributes using `organization_id` instead of an `ine_code` of a place.
  * Maintains the `ine_code`, `province_id` and `autonomy_id` fields and fills them if the organization is related with a municipality.
  * Creates data for an `organization_id` not related with a municipality.
* In tests:
  * On all integration tests checks the assertions with a site with `organization_id` unrelated with a municipality
* In the rest of the code:
  * Replaces all references to `ine_code` or `site.place.id` with `organization_id` in elastic searches except for specific searches related with municipality of a site.


## :mag: How should this be manually tested?
Update a site from admin and set an `organization_id` with related budgets data, like `wadus`.

* Explore the budgets page. All should work except some comparisons with province and autonomy, since the organization hasn't a related municipality.
* Go to data/  page and download the budgets data in csv and json formats.

## :shipit: Does this PR changes any configuration file?

No