### PR TITLE
Force JSON url to have a format parameter

### DIFF
--- a/app/assets/javascripts/gobierto_plans/app/controllers/plan_types_controller.js
+++ b/app/assets/javascripts/gobierto_plans/app/controllers/plan_types_controller.js
@@ -176,7 +176,7 @@ this.GobiertoPlans.PlanTypesController = (function() {
         },
         methods: {
           getJson: function() {
-            $.getJSON(window.location.href, function(json) {
+            $.getJSON(window.location.href, {format: 'json'}, function(json) {
               // Tree with categories and the leaves (nodes)
               var data = json["plan_tree"];
               // Nodes can have variable attributes and these are their keys


### PR DESCRIPTION
Closes #1578 


## :v: What does this PR do?

This PR adds a format attribute to the JSON to avoid the browser cache both urls as if they were different.

## :mag: How should this be manually tested?

1. Go to the plan
2. Visit another link
3. Click back button

