### PR TITLE
1554 - Add published_on to GobiertoCms::Page

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -8,7 +8,7 @@ module GobiertoAdmin
       def index
         @sections = current_site.sections
         @collections = current_site.collections.by_item_type(["GobiertoCms::Page", "GobiertoCms::News"])
-        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).sort_by_updated_at.limit(10)
+        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).sort_by_published_on.limit(10)
       end
 
       def new
@@ -118,6 +118,7 @@ module GobiertoAdmin
           :slug,
           :section,
           :parent,
+          :published_on,
           title_translations: [*I18n.available_locales],
           body_translations:  [*I18n.available_locales],
           body_source_translations:  [*I18n.available_locales]

--- a/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
@@ -21,11 +21,11 @@ module GobiertoAdmin
 
       def show
         @section = find_section
-        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).active.sort_by_updated_at.uniq
+        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).active.sort_by_published_on.uniq
       end
 
       def pages
-        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).active.sort_by_updated_at.search(params[:query]).uniq
+        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).active.sort_by_published_on.search(params[:query]).uniq
 
         respond_to do |format|
           format.js { render layout: false }

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -17,6 +17,7 @@ module GobiertoAdmin
         :slug,
         :attachment_ids,
         :section,
+        :published_on,
         :parent
       )
 
@@ -51,6 +52,16 @@ module GobiertoAdmin
 
       def visibility_level
         @visibility_level ||= "draft"
+      end
+
+      def published_on
+        @published_on ||= Time.zone.now
+
+        if @published_on.respond_to?(:strftime)
+          @published_on.strftime("%Y-%m-%d %H:%M")
+        else
+          @published_on
+        end
       end
 
       private
@@ -98,6 +109,7 @@ module GobiertoAdmin
           page_attributes.body_source_translations = body_source_translations
           page_attributes.slug = slug
           page_attributes.visibility_level = visibility_level
+          page_attributes.published_on = published_on
           if page.new_record? && attachment_ids.present?
             if attachment_ids.is_a?(String)
               page_attributes.attachment_ids = attachment_ids.split(",")

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -39,12 +39,12 @@ module GobiertoCms
 
     enum visibility_level: { draft: 0, active: 1 }
 
-    validates :site, :title, :body, presence: true
+    validates :site, :title, :body, :published_on, presence: true
     validates :slug, uniqueness: { scope: :site }
 
     scope :inverse_sorted, -> { order(id: :asc) }
     scope :sorted, -> { order(id: :desc) }
-    scope :sort_by_updated_at, -> { order(updated_at: :desc) }
+    scope :sort_by_published_on, -> { order(published_on: :desc) }
 
     def section
       GobiertoCms::SectionItem.find_by(item: self).try(:section)

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -31,6 +31,21 @@
         <%= f.label :slug %>
         <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
       </div>
+
+      <div class="form_item input_text">
+        <%= f.label :published_on %>
+        <%= f.text_field :published_on, data: {
+            "language": I18n.locale,
+            "timepicker": true,
+            "date-format": "yyyy-mm-dd",
+            "time-format": "hh:ii",
+            "startDate": format_time(f, :published_on, 2)
+          },
+          class: "air-datepicker",
+          readonly: !Rails.env.test?
+        %>
+      </div>
+
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
@@ -23,7 +23,7 @@
             <% end %>
           </h2>
           <div class="date">
-            <%= l(page.updated_at, format: :short) %>
+            <%= l(page.published_on, format: :short) %>
           </div>
         </div>
       <% end %>

--- a/app/views/gobierto_admin/gobierto_cms/sections/_pages_filter.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/sections/_pages_filter.html.erb
@@ -8,7 +8,7 @@
             <span class="secondary"><%= page.collection.title %></span>
           <% end %>
         </h2>
-        <div class="date"><%= time_ago_in_words(page.updated_at) %></div>
+        <div class="date"><%= time_ago_in_words(page.published_on) %></div>
       </div>
     <% end %>
   <% end %>

--- a/app/views/gobierto_admin/gobierto_common/collections/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/collections/index.html.erb
@@ -24,7 +24,7 @@
             <% end %>
           </h2>
           <div class="date">
-            <%= l(page.created_at, format: :short) %>
+            <%= l(page.published_on, format: :short) %>
           </div>
         </div>
       <% end %>

--- a/app/views/gobierto_admin/gobierto_common/collections/show/_pages.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/collections/show/_pages.html.erb
@@ -4,6 +4,7 @@
     <th><%= GobiertoCms::Page.human_attribute_name(:title) %></th>
     <th><%= t('.created_at') %></th>
     <th><%= t('.updated_at') %></th>
+    <th><%= t('.published_on') %></th>
     <th><%= t('.public') %></th>
     <th></th>
     <th></th>
@@ -16,6 +17,7 @@
         <td><%= link_to page.title, edit_admin_cms_page_path(page.id, collection_id: @collection.id) %></td>
         <td><%= time_ago_in_words(page.created_at) %></td>
         <td><%= time_ago_in_words(page.updated_at) %></td>
+        <td><%= time_ago_in_words(page.published_on) %></td>
         <td class="visibility_level">
           <% if page.draft? %>
             <i class="fa fa-lock"></i>
@@ -54,6 +56,7 @@
         <th><%= GobiertoCms::Page.human_attribute_name(:title) %></th>
         <th><%= t('.created_at') %></th>
         <th><%= t('.updated_at') %></th>
+        <th><%= t('.published_on') %></th>
         <th><%= t('.public') %></th>
         <th></th>
         <th></th>
@@ -66,6 +69,7 @@
             <td><%= page.title %></td>
             <td><%= time_ago_in_words(page.created_at) %></td>
             <td><%= time_ago_in_words(page.updated_at) %></td>
+            <td><%= time_ago_in_words(page.published_on) %></td>
             <td class="visibility_level">
               <%= t(".visibility_level.archived") %>
             </td>

--- a/app/views/gobierto_cms/pages/templates/_news.html.erb
+++ b/app/views/gobierto_cms/pages/templates/_news.html.erb
@@ -31,7 +31,7 @@
 
             <div class="note">
               <time>
-                <%= l(@page.updated_at, format: :long) %>
+                <%= l(@page.published_on, format: :long) %>
               </time>
             </div>
           </article>

--- a/app/views/gobierto_participation/processes/_place_news.html.erb
+++ b/app/views/gobierto_participation/processes/_place_news.html.erb
@@ -1,6 +1,6 @@
 <div class="place_news-item place-item pure-g">
   <div class="badge pure-u-1-3 pure-u-md-5-24">
-    <strong><%= l(page.created_at, format: '%e %b').upcase %></strong>
+    <strong><%= l(page.published_on, format: '%e %b').upcase %></strong>
   </div>
 
   <div class="pure-u-1 pure-u-md-19-24 news-content">

--- a/app/views/gobierto_participation/shared/pages/_information.html.erb
+++ b/app/views/gobierto_participation/shared/pages/_information.html.erb
@@ -26,12 +26,12 @@
       <h1><%= page.title %></h1>
       <div class='meta'>
         <time>
-          <%= l(page.updated_at, format: :long) %>
+          <%= l(page.published_on, format: :long) %>
         </time>
       </div>
       <%= raw page.body %>
       <div class='note'>
-        <%= t('gobierto_participation.shared.published_at', date: l(page.updated_at, format: :long), site: current_site.name) %>
+        <%= t('gobierto_participation.shared.published_at', date: l(page.published_on, format: :long), site: current_site.name) %>
       </div>
     </article>
   </div>

--- a/app/views/gobierto_participation/shared/pages/_page.html.erb
+++ b/app/views/gobierto_participation/shared/pages/_page.html.erb
@@ -28,12 +28,12 @@
       <h1><%= page.title %></h1>
       <div class='meta'>
         <time>
-          <%= l(page.updated_at, format: :long) %>
+          <%= l(page.published_on, format: :long) %>
         </time>
       </div>
       <%= raw page.body %>
       <div class='note'>
-        <%= t('gobierto_participation.shared.published_at', date: l(page.updated_at, format: :long), site: current_site.name) %>
+        <%= t('gobierto_participation.shared.published_at', date: l(page.published_on, format: :long), site: current_site.name) %>
       </div>
     </article>
   </div>

--- a/app/views/gobierto_participation/shared/pages/_page_teaser.html.erb
+++ b/app/views/gobierto_participation/shared/pages/_page_teaser.html.erb
@@ -4,7 +4,7 @@
   </h3>
 
   <div class="meta">
-    <time><%= time_ago_in_words(page.created_at) %></time>
+    <time><%= time_ago_in_words(page.published_on) %></time>
   </div>
 
   <% if page.main_image %>

--- a/config/locales/gobierto_admin/gobierto_cms/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/models/ca.yml
@@ -4,6 +4,7 @@ ca:
     attributes:
       gobierto_admin/gobierto_cms/page_form:
         body: Contingut
+        published_on: Data de publicació
         slug: URL
         title: Títol
       gobierto_admin/gobierto_cms/section_form:

--- a/config/locales/gobierto_admin/gobierto_cms/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/models/en.yml
@@ -4,6 +4,7 @@ en:
     attributes:
       gobierto_admin/gobierto_cms/page_form:
         body: Body
+        published_on: Publication date
         slug: URL
         title: Title
       gobierto_admin/gobierto_cms/section_form:

--- a/config/locales/gobierto_admin/gobierto_cms/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/models/es.yml
@@ -4,6 +4,7 @@ es:
     attributes:
       gobierto_admin/gobierto_cms/page_form:
         body: Contenido
+        published_on: Fecha de publicación
         slug: URL
         title: Título
       gobierto_admin/gobierto_cms/section_form:

--- a/config/locales/gobierto_admin/gobierto_common/collections/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/collections/views/ca.yml
@@ -31,6 +31,7 @@ ca:
           pages:
             created_at: Creada
             public: Pública
+            published_on: Publicada
             updated_at: Actualitzada
             view: Veure pàgina
             visibility_level:

--- a/config/locales/gobierto_admin/gobierto_common/collections/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/collections/views/en.yml
@@ -31,6 +31,7 @@ en:
           pages:
             created_at: Created at
             public: Public
+            published_on: Published on
             updated_at: Updated at
             view: View page
             visibility_level:

--- a/config/locales/gobierto_admin/gobierto_common/collections/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/collections/views/es.yml
@@ -31,6 +31,7 @@ es:
           pages:
             created_at: Creada
             public: Estado
+            published_on: Publicada
             updated_at: Actualizada
             view: Ver página
             visibility_level:

--- a/db/migrate/20180409145531_add_published_at_to_gobierto_cms_page.rb
+++ b/db/migrate/20180409145531_add_published_at_to_gobierto_cms_page.rb
@@ -1,0 +1,17 @@
+class AddPublishedAtToGobiertoCmsPage < ActiveRecord::Migration[5.2]
+
+  def up
+    add_column :gcms_pages, :published_on, :datetime
+
+    GobiertoCms::Page.all.each do |page|
+      page.update_attributes!(published_on: page.created_at)
+    end
+
+    change_column :gcms_pages, :published_on, :datetime, null: false
+  end
+
+  def down
+    remove_column :gcms_pages, :published_on
+  end
+
+end

--- a/db/migrate/20180409145531_add_published_at_to_gobierto_cms_page.rb
+++ b/db/migrate/20180409145531_add_published_at_to_gobierto_cms_page.rb
@@ -3,7 +3,7 @@ class AddPublishedAtToGobiertoCmsPage < ActiveRecord::Migration[5.2]
   def up
     add_column :gcms_pages, :published_on, :datetime
 
-    GobiertoCms::Page.all.each do |page|
+    GobiertoCms::Page.unscoped.each do |page|
       page.update_attributes!(published_on: page.created_at)
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_26_065211) do
+ActiveRecord::Schema.define(version: 2018_04_09_145531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -350,6 +350,7 @@ ActiveRecord::Schema.define(version: 2018_03_26_065211) do
     t.integer "collection_id"
     t.jsonb "body_source_translations"
     t.datetime "archived_at"
+    t.datetime "published_on", null: false
     t.index ["archived_at"], name: "index_gcms_pages_on_archived_at"
     t.index ["body_source_translations"], name: "index_gcms_pages_on_body_source_translations", using: :gin
     t.index ["body_translations"], name: "index_gcms_pages_on_body_translations", using: :gin

--- a/lib/liquid/gobierto_cms/tags/list_items_from.rb
+++ b/lib/liquid/gobierto_cms/tags/list_items_from.rb
@@ -55,7 +55,7 @@ class ListItemsFrom < Liquid::Tag
 
   def fetch_pages(current_site)
     collection = current_site.collections.find_by!(slug: @collection_slug)
-    current_site.pages.where(id: collection.pages_in_collection).active.limit(@options[:limit]).order("updated_at #{@options[:order]}")
+    current_site.pages.where(id: collection.pages_in_collection).active.limit(@options[:limit]).order("published_on #{@options[:order]}")
   end
 
   def helpers

--- a/lib/liquid/gobierto_cms/tags/list_items_from.rb
+++ b/lib/liquid/gobierto_cms/tags/list_items_from.rb
@@ -38,7 +38,7 @@ class ListItemsFrom < Liquid::Tag
         collection_item_text << %Q{ <img src="#{page.main_image}"> }
       end
       if @options[:date]
-        collection_item_text << %Q{ <span class="date">#{I18n.l(page.updated_at, format: "%d %b %y")}</span> }
+        collection_item_text << %Q{ <span class="date">#{I18n.l(page.published_on, format: "%d %b %y")}</span> }
       end
       collection_item_text << %Q{ <h2>#{page.title}</h2> }
       if @options[:intro_text]

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -6,6 +6,7 @@ site_news_1:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_news
+  published_on: <%= Date.current %>
 
 consultation_faq:
   title_translations: <%= { 'en' => 'Consultation page FAQ', 'es' => 'FAQ consultas' }.to_json %>
@@ -15,6 +16,7 @@ consultation_faq:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_pages
+  published_on: <%= Date.current %>
 
 privacy:
   title_translations: <%= {'en' => 'Privacy', 'es' => 'Privacidad' }.to_json %>
@@ -24,6 +26,7 @@ privacy:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_pages
+  published_on: <%= Date.current %>
 
 cookies:
   title_translations: <%= {'en' => 'Cookies' }.to_json %>
@@ -32,6 +35,7 @@ cookies:
   slug: 'cookies'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
+  published_on: <%= Date.current %>
 
 about:
   title_translations: <%= {'en' => 'About' }.to_json %>
@@ -40,6 +44,7 @@ about:
   slug: 'about'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: santander
+  published_on: <%= Date.current %>
 
 themes:
   title_translations: <%= {'en' => 'Themes in the site' }.to_json %>
@@ -49,6 +54,7 @@ themes:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: news
+  published_on: <%= Date.current %>
 
 themes_draft:
   title_translations: <%= {'en' => 'Themes draft' }.to_json %>
@@ -58,6 +64,7 @@ themes_draft:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
   collection: news
+  published_on: <%= Date.current %>
 
 notice_1:
   title_translations: <%= {'en' => 'Notice 1 title' }.to_json %>
@@ -67,6 +74,7 @@ notice_1:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: gender_violence_process_news
+  published_on: <%= Date.current %>
 
 notice_2:
   title_translations: <%= {'en' => 'Notice 2 title' }.to_json %>
@@ -76,6 +84,7 @@ notice_2:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: gender_violence_process_news
+  published_on: <%= Date.current %>
 
 about_site:
   title_translations: <%= { 'es' => 'Sobre el sitio', 'en' => 'About site' }.to_json %>
@@ -85,6 +94,7 @@ about_site:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_pages
+  published_on: <%= Date.current %>
 
 about_participation:
   title_translations: <%= {'en' => 'About participation' }.to_json %>
@@ -94,6 +104,7 @@ about_participation:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_pages
+  published_on: <%= Date.current %>
 
 about_participation_details:
   title_translations: <%= {'en' => 'About participation details' }.to_json %>
@@ -103,6 +114,7 @@ about_participation_details:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: site_pages
+  published_on: <%= Date.current %>
 
 generic_site_page:
   title_translations: <%= {'en' => 'Generic page' }.to_json %>
@@ -111,6 +123,7 @@ generic_site_page:
   slug: 'generic-page'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
+  published_on: <%= Date.current %>
 
 how_to_participate:
   title_translations: <%= {'en' => 'How to participate' }.to_json %>
@@ -120,3 +133,4 @@ how_to_participate:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   collection: participation_pages
+  published_on: <%= Date.current %>

--- a/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
@@ -5,15 +5,21 @@ require "test_helper"
 module GobiertoAdmin
   module GobiertoCms
     class PageFormTest < ActiveSupport::TestCase
-      def valid_page_form
-        @valid_page_form ||= PageForm.new(
+
+      def valid_page_form_attributes
+        @valid_page_form_attributes ||= {
           site_id: site.id,
           title_translations: { I18n.locale => page.title },
           body_translations: { I18n.locale => page.body },
           slug: "page-form-slug",
           collection_id: collection.id,
+          published_on: Time.zone.parse('30-12-1994 2:00'),
           visibility_level: page.visibility_level
-        )
+        }
+      end
+
+      def valid_page_form
+        @valid_page_form ||= PageForm.new(valid_page_form_attributes)
       end
 
       def invalid_page_form
@@ -22,7 +28,8 @@ module GobiertoAdmin
           title_translations: nil,
           body_translations: nil,
           slug: nil,
-          visibility_level: nil
+          visibility_level: nil,
+          published_on: nil
         )
       end
 
@@ -40,6 +47,17 @@ module GobiertoAdmin
 
       def test_save_with_valid_attributes
         assert valid_page_form.save
+
+        page = valid_page_form.page.reload
+
+        assert_equal Time.zone.parse('30-12-1994 2:00'), page.published_on
+      end
+
+      def test_assigns_default_published_date
+        page_form = PageForm.new(valid_page_form_attributes.except(:published_on))
+
+        assert page_form.save
+        assert page_form.page.published_on.present?
       end
 
       def test_error_messages_with_invalid_attributes

--- a/test/integration/gobierto_admin/gobierto_cms/create_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/create_page_test.rb
@@ -62,6 +62,7 @@ module GobiertoAdmin
               fill_in "page_title_translations_en", with: "My page"
               find("#page_body_translations_en", visible: false).set("The content of the page")
               fill_in "page_slug", with: "new-page"
+              fill_in "page_published_on", with: "2017-01-01 00:00"
 
               click_link "ES"
               fill_in "page_title_translations_es", with: "Mi página"
@@ -71,6 +72,7 @@ module GobiertoAdmin
 
               assert has_message?("Page created successfully")
               assert has_field?("page_slug", with: "new-page")
+              assert has_field?("page_published_on", with: "2017-01-01 00:00")
 
               assert_equal(
                 "The content of the page",

--- a/test/integration/gobierto_admin/gobierto_cms/create_section_item_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/create_section_item_test.rb
@@ -45,6 +45,7 @@ module GobiertoAdmin
               fill_in "page_title_translations_en", with: "My page with section"
               find("#page_body_translations_en", visible: false).set("The content of the page")
               fill_in "page_slug", with: "new-page-with-section"
+              fill_in "page_published_on", with: "2017-01-01 00:00"
 
               find("#permission_1", visible: false).trigger("click")
               find("select#page_section").find("option[value='#{section.id}']").select_option

--- a/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
@@ -41,11 +41,14 @@ module GobiertoAdmin
 
               fill_in "page_title_translations_en", with: "Themes updated"
               fill_in "page_slug", with: "themes-updated"
+              fill_in "page_published_on", with: "2017-01-01 00:00"
 
               click_button "Update"
 
               assert has_message?("Page updated successfully")
+
               assert has_field?("page_slug", with: "themes-updated")
+              assert has_field?("page_published_on", with: "2017-01-01 00:00")
 
               assert_equal(
                 "These are the themes",

--- a/test/integration/gobierto_admin/gobierto_participation/processes/process_pages_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/process_pages_test.rb
@@ -48,6 +48,7 @@ module GobiertoAdmin
 
               fill_in "page_title_translations_en", with: "News Title"
               find("#page_body_translations_en", visible: false).set("The content of the page")
+              fill_in "page_published_on", with: "2017-01-01"
 
               click_button "Create"
 


### PR DESCRIPTION
Closes #1554 

## :v: What does this PR do?

* Adds an additional field `published_on` to `GobiertoCms::Page`.
* Migrates existing pages to have this value set, since it's compulsory.

## :mag: How should this be manually tested?

* Create / modify the publication dates of pages in this collection http://getafe.gobify.net/admin/collections/244
* Check the order appears correctly in http://getafe.gobify.net/

## :shipit: Does this PR changes any configuration file?

No
