### PR TITLE
Rescue from AR not found with 404 error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from ActionController::UnknownFormat, with: :render_404
 

--- a/app/controllers/gobierto_cms/application_controller.rb
+++ b/app/controllers/gobierto_cms/application_controller.rb
@@ -22,6 +22,8 @@ module GobiertoCms
     protected
 
     def set_current_module
+      return if @collection.nil?
+
       if params[:process_id]
         @current_module = "gobierto_participation"
       else

--- a/app/controllers/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_cms/pages_controller.rb
@@ -33,6 +33,7 @@ module GobiertoCms
     def find_page
       page = pages_scope.find_by!(slug: params[:id])
       @collection = page.collection
+      raise ActiveRecord::RecordNotFound if @collection.nil?
       GobiertoCms::PageDecorator.new(page, @current_process.class.name || @collection.container_type, @collection.item_type)
     end
 
@@ -45,7 +46,9 @@ module GobiertoCms
     end
 
     def load_collection_pages
-      @pages = current_site.pages.where(id: @collection.pages_in_collection).active
+      if @collection
+        @pages = current_site.pages.where(id: @collection.pages_in_collection).active
+      end
     end
 
     def check_collection_type

--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -19,6 +19,7 @@ class MetaWelcomeController < ApplicationController
       else
         page = item
       end
+      render_404 and return if page.nil?
 
       if @section ||= page.section
         @section_item = ::GobiertoCms::SectionItem.find_by!(item: page, section: @section)

--- a/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budget_consultations/consultation_preview_test.rb
@@ -71,12 +71,8 @@ module GobiertoBudgetConsultations
 
     def test_preview_draft_page_if_not_admin
       with_current_site(site) do
-        assert_raises ActiveRecord::RecordNotFound do
-          visit gobierto_budget_consultations_consultation_path(draft_consultation)
-        end
-
-        # assert_response :not_found
-        assert has_no_selector?("h2", text: draft_consultation.title)
+        visit gobierto_budget_consultations_consultation_path(draft_consultation)
+        assert_equal 404, page.status_code
       end
     end
   end

--- a/test/integration/gobierto_admin/gobierto_calendars/event_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_preview_test.rb
@@ -122,19 +122,8 @@ module GobiertoAdmin
 
       def test_preview_pending_event_if_not_admin
         with_current_site(site) do
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_event_path(person.slug, pending_event.slug)
-          end
-
-          assert has_no_selector?("h2", text: pending_event.title)
-
-          person.draft!
-
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_event_path(person.slug, pending_event.slug)
-          end
-
-          assert has_no_selector?("h2", text: pending_event.title)
+          visit gobierto_people_person_event_path(person.slug, pending_event.slug)
+          assert_equal 404, page.status_code
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_cms/page_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/page_preview_test.rb
@@ -82,11 +82,8 @@ module GobiertoAdmin
 
       def test_preview_draft_page_if_not_admin
         with_current_site(site) do
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_cms_news_path(draft_page.slug)
-          end
-
-          assert has_no_selector?("h1", text: draft_page.title)
+          visit gobierto_cms_news_path(draft_page.slug)
+          assert_equal 404, page.status_code
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_post_preview_test.rb
@@ -122,19 +122,8 @@ module GobiertoAdmin
 
       def test_preview_draft_post_if_not_admin
         with_current_site(site) do
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
-          end
-
-          assert has_no_selector?("h1", text: draft_post.title)
-
-          draft_post.person.draft!
-
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
-          end
-
-          assert has_no_selector?("h1", text: draft_post.title)
+          visit gobierto_people_person_post_path(draft_post.person.slug, draft_post.slug)
+          assert_equal 404, page.status_code
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_people/person_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_preview_test.rb
@@ -75,12 +75,8 @@ module GobiertoAdmin
 
       def test_preview_draft_page_if_not_admin
         with_current_site(site) do
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_path(draft_person.slug)
-          end
-
-          # assert_response :not_found
-          assert has_no_selector?("h2", text: draft_person.name)
+          visit gobierto_people_person_path(draft_person.slug)
+          assert_equal 404, page.status_code
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_statement_preview_test.rb
@@ -122,19 +122,8 @@ module GobiertoAdmin
 
       def test_preview_draft_statement_if_not_admin
         with_current_site(site) do
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
-          end
-
-          assert has_no_selector?("h3", text: draft_statement.title)
-
-          draft_statement.person.draft!
-
-          assert_raises ActiveRecord::RecordNotFound do
-            visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
-          end
-
-          assert has_no_selector?("h3", text: draft_statement.title)
+          visit gobierto_people_person_statement_path(draft_statement.person.slug, draft_statement.slug)
+          assert_equal 404, page.status_code
         end
       end
     end

--- a/test/integration/gobierto_budget_consultations/consultation_show_test.rb
+++ b/test/integration/gobierto_budget_consultations/consultation_show_test.rb
@@ -71,11 +71,8 @@ module GobiertoBudgetConsultations
       consultation.draft!
 
       with_signed_in_user(user) do
-        assert_raises(ActiveRecord::RecordNotFound) do
-          visit @path
-        end
-
-        assert has_no_link?("Do you want to opinate?")
+        visit @path
+        assert_equal 404, page.status_code
       end
     end
 


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This was a misconfiguration in the application. AR not found error was captured with a 404 error page, but a Rollbar was emitted. This PR avoids the Rollbar.

## :mag: How should this be manually tested?

Load a resource in draft:

- check the app returns the 404 page
- check no rollbar has been emitted