### PR TITLE
Deal properly with abbreviation in catalan

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -111,4 +111,17 @@ module ApplicationHelper
       end
     end
   end
+
+  def whom(entity_name)
+    if I18n.locale == :ca
+      if /\A[aeiou]/i =~ entity_name
+        " l'#{entity_name}"
+      else
+        # TODO: define a setting with the genre of the entity
+        "la #{entity_name}"
+      end
+    else
+      " " + entity_name
+    end
+  end
 end

--- a/app/views/gobierto_budgets/receipts/show.html.erb
+++ b/app/views/gobierto_budgets/receipts/show.html.erb
@@ -2,7 +2,7 @@
   <div id="taxes_receipt" class="block">
     <div class="pure-g header_block_inline m_b_1">
       <div class="pure-u-1 pure-u-md-12-24">
-        <h2 class="with_description"><%= t('.title', site_name: current_site.name) %></h2>
+        <h2 class="with_description"><%= t('.title', site_name: whom(current_site.name)) %></h2>
         <p><%= t('.description') %></p>
       </div>
 
@@ -59,7 +59,7 @@
               </div>
             </div>
             <div class="pure-g">
-              <div class="pure-u-1 pure-u-md-14-24 pure-u-xl-15-24"><h3><%= t('.your_contribution', site_name: current_site.name) %></h3></div>
+              <div class="pure-u-1 pure-u-md-14-24 pure-u-xl-15-24"><h3><%= t('.your_contribution', site_name: whom(current_site.name)) %></h3></div>
               <div class="pure-u-1 pure-u-md-10-24 pure-u-xl-9-24 receipt_calc">
                 <div class="bg" v-for="(year, i) in categories">
                   <small>{{ getYear(i) }}</small>

--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -1,6 +1,6 @@
 <menu class="filter_boxed">
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
-    <ul role="tablist" aria-label="<%= t('.organigram', name: @site.name) %>">
+    <ul role="tablist" aria-label="<%= t('.organigram', name: whom(@site.name)) %>">
       <% if @present_groups['government'] %>
         <li role="presentation" class="<%= class_if('active', controller_name == 'government_party_people' || controller_name == 'welcome') %>">
           <%= link_to t("gobierto_people.people_filter.parties.government"), gobierto_people_government_party_people_path, tab_attributes(controller_name == 'government_party_people' || controller_name == 'welcome').merge('aria-controls' => 'people-list') %>
@@ -30,7 +30,7 @@
 
     <% if @political_group %>
       <div>
-        <ul role="tablist" aria-label="<%= t('.political_groups', name: @site.name) %>">
+        <ul role="tablist" aria-label="<%= t('.political_groups', name: whom(@site.name)) %>">
           <% @political_groups.each do |political_group| %>
             <li role="presentation" class="<%= class_if('active', @political_group == political_group) %>">
               <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group.slug), tab_attributes(@political_group == political_group).merge('aria-controls' => 'people-list').merge('aria-controls' => 'people-list') %>

--- a/app/views/gobierto_people/people/index.html.erb
+++ b/app/views/gobierto_people/people/index.html.erb
@@ -7,7 +7,7 @@
 <div class="column">
 
   <div class="block">
-    <h2 ><%= title t(".title", site_name: current_site.name) %></h2>
+    <h2><%= title t(".title", site_name: whom(current_site.name)) %></h2>
   </div>
 
   <%= render "gobierto_people/people/people_filter"  %>

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :disable_turbolinks_hook do %>
-    <meta name="turbolinks-cache-control" content="no-cache">
+  <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
 <%= render "gobierto_people/people/content_for_breadcrumb" %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -7,7 +7,7 @@
 <div class="column">
 
   <div class="block">
-    <h2 data-share-text><%= title t(".title", site_name: current_site.name) %></h2>
+    <h2 data-share-text><%= title t(".title", site_name: whom(current_site.name)) %></h2>
   </div>
 
   <%= render "gobierto_people/person_events/person_events_filter" %>

--- a/app/views/gobierto_people/welcome/index.html.erb
+++ b/app/views/gobierto_people/welcome/index.html.erb
@@ -28,7 +28,7 @@
 
         <div class="people-summary person-list item-list">
           <div class="block">
-            <h2><%= t(".people_summary.title", site_name: current_site.name) %></h2>
+            <h2><%= t(".people_summary.title", site_name: whom(current_site.name)) %></h2>
           </div>
 
           <%= render "gobierto_people/welcome/people_filter" %>

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -593,8 +593,8 @@ ca:
         pick_to_calculate: Selecciona per calcular
         share: Comparteix-ho
         share_text: Comprova com és la teva aportació al pressupost de d'
-        title: Quina es la teva contribució al pressupost de l'%{site_name}?
-        your_contribution: La teva contribució als pressupostos de l'%{site_name}
+        title: Quina es la teva contribució al pressupost de %{site_name}?
+        your_contribution: La teva contribució als pressupostos de %{site_name}
     shared:
       data_updated_at:
         last_update: Última actualització


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR deals properly posession abbreviations in catalan.

The helper is developed only for catalan, although could be used in Spanish too.

## :mag: How should this be manually tested?

Instead of "ORGANIGRAMA DE AJUNTAMENT D'ESPLUGUES DE LLOBREGAT" it should say "Organigrama de l'Ajuntament d'Esplugues de Llobregat"

http://esplugues.gobify.net/cargos-y-agendas
