### PR TITLE
308 - Strip HTML comments from imported events

### DIFF
--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -22,7 +22,7 @@ module GobiertoPeople
       end
 
       def show
-        @event = find_event
+        @event = ::GobiertoCalendars::EventDecorator.new(find_event)
         if valid_preview_token? && !manage_event?
           redirect_to(
             gobierto_people_person_path(@event.collection.container.slug),

--- a/app/decorators/gobierto_calendars/event_decorator.rb
+++ b/app/decorators/gobierto_calendars/event_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoCalendars
+  class EventDecorator < BaseDecorator
+
+    include ActionView::Helpers::TextHelper
+
+    def initialize(event)
+      @object = event
+    end
+
+    def formatted_html_description
+      simple_format description.gsub(/<!--(.*?)-->/, '')
+    end
+
+  end
+end

--- a/app/views/gobierto_people/people/person_events/show.html.erb
+++ b/app/views/gobierto_people/people/person_events/show.html.erb
@@ -37,7 +37,7 @@
 
         <div class="event-description">
           <% if @event.synchronized? %>
-            <%= simple_format @event.description %>
+            <%= @event.formatted_html_description %>
           <% else %>
             <%= raw @event.description %>
           <% end %>

--- a/test/decorators/gobierto_calendars/event_decorator_test.rb
+++ b/test/decorators/gobierto_calendars/event_decorator_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module GobiertoCalendars
+  class EventDecoratorTest < ActiveSupport::TestCase
+
+    def event
+      @event ||= gobierto_calendars_events(:richard_published)
+    end
+
+    def test_formatted_html_description
+      description = '<script>alert(1);</script><!-- C1 -->Content<!-- C2 -->More content<!-- C3 -->'
+      event.update(description: description)
+      decorator = EventDecorator.new(event)
+      expected_output = '<p>alert(1);ContentMore content</p>'
+
+      assert_equal expected_output, decorator.formatted_html_description
+    end
+
+  end
+end


### PR DESCRIPTION
Closes #308

## :v: What does this PR do?

Strips HTML comments from imported events

## :mag: How should this be manually tested?

Can't test in staging because of the SSL problem with Microsoft Exchange, but you can test in local assigning to a existing (synchronized) event the "buggy" description:

```ruby
event.update(description: "<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n<meta name=\"Generator\" content=\"Microsoft Exchange Server\">\n<!-- converted from rtf -->\n<style><!-- .EmailQuote { margin-left: 1pt; padding-left: 4pt; border-left: #800000 2px solid; } --></style>\n</head>\n<body>\n<font face=\"Calibri, sans-serif\" size=\"2\">\n<div>&nbsp;</div>\n<div>&nbsp;</div>\n</font>\n</body>\n</html>\n")
```
