### PR TITLE
Fix decorator with nil values

### DIFF
--- a/app/decorators/gobierto_calendars/event_decorator.rb
+++ b/app/decorators/gobierto_calendars/event_decorator.rb
@@ -10,6 +10,7 @@ module GobiertoCalendars
     end
 
     def formatted_html_description
+      return "" if description.blank?
       simple_format description.gsub(/<!--(.*?)-->/, '')
     end
 

--- a/test/decorators/gobierto_calendars/event_decorator_test.rb
+++ b/test/decorators/gobierto_calendars/event_decorator_test.rb
@@ -16,6 +16,10 @@ module GobiertoCalendars
       expected_output = '<p>alert(1);ContentMore content</p>'
 
       assert_equal expected_output, decorator.formatted_html_description
+
+      event.description_translations = { "ca" => nil, "es" => nil, "en" => nil }
+      decorator = EventDecorator.new(event)
+      assert_equal "", decorator.formatted_html_description
     end
 
   end


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR fixes the presenter when event description is nil.
