### PR TITLE
1597 duplicated descendant lines

### DIFF
--- a/app/views/gobierto_budgets/budget_line_descendants/index.js.erb
+++ b/app/views/gobierto_budgets/budget_line_descendants/index.js.erb
@@ -1,12 +1,12 @@
 <% @budget_lines.group_by{ |b| b.parent_code.to_s.length }.each do |length, budget_lines| %>
-  <% budget_lines.uniq.group_by{ |b| b.parent_code }.each do |parent_code, budget_lines_children| %>
+  <% budget_lines.group_by{ |b| b.parent_code }.each do |parent_code, budget_lines_children| %>
     var $el = $('[data-budget-line="<%= parent_code %>"]');
     $el.after('<%=j render partial: 'gobierto_budgets/budget_line_descendants/nested_budget_line', locals: { budget_lines: budget_lines_children, kind: @kind, area_name: @area_name, year: @year } %>');
     $('[data-budget-line="<%= parent_code %>"] td').find('.fa').toggleClass('fa-plus-square-o fa-minus-square-o');
   <% end %>
 <% end %>
 
-<% @budget_lines.map(&:parent_code).uniq.each do |parent_code| %>
+<% @budget_lines.map(&:parent_code).each do |parent_code| %>
   var $el = $('[data-budget-line="<%= parent_code %>"]');
   /* Collapses branch - Prevents resending the form when extended */
   $el.on('ajax:beforeSend', 'a', function(event, xhr, settings) {

--- a/test/controllers/gobierto_budgets/budget_line_descendants_controller_test.rb
+++ b/test/controllers/gobierto_budgets/budget_line_descendants_controller_test.rb
@@ -7,13 +7,21 @@ class GobiertoBudgets::BudgetLineDescendantsControllerTest < GobiertoControllerT
     @site ||= sites(:madrid)
   end
 
-  def test_index
+  def test_index_json
     with_current_site(site) do
       get gobierto_budgets_budget_line_descendants_path(year: 2017, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::EconomicArea.area_name, parent_code: '1'), as: :json
       assert_response :success
       response_data = JSON.parse(response.body)
       assert_equal 1, response_data.length
       assert_equal "Impuesto sobre la renta", response_data.first["name"]
+    end
+  end
+
+  def test_index_js
+    with_current_site(site) do
+      get gobierto_budgets_budget_line_descendants_path(year: 2017, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::EconomicArea.area_name, parent_code: '2'), xhr: true#  as: :js
+      assert_response :success
+      assert_equal 2, response.body.scan(/(?=Impuesto sobre el Valor Añadido)/).count
     end
   end
 end


### PR DESCRIPTION
Closes #1597


## :v: What does this PR do?
Fixes a bug  on budget lines index expanding descendant lines of a root line. It avoids duplicated lines

## :mag: How should this be manually tested?
Visit budgets index of a site http://madrid.gobify.net/presupuestos/resumen/2017 and click on a budget line with descendants

## :eyes: Screenshots

### Before this PR
<img width="712" alt="screen shot 2018-04-16 at 12 50 52" src="https://user-images.githubusercontent.com/446459/38807400-b6066216-417c-11e8-8bbc-4ae5956887b4.png">

### After this PR
<img width="773" alt="screen shot 2018-04-16 at 13 51 35" src="https://user-images.githubusercontent.com/446459/38807565-524a6578-417d-11e8-82de-b014f3d272d8.png">


## :shipit: Does this PR changes any configuration file?

No