### PR TITLE
1592 nil population budgets stats

### DIFF
--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -13,9 +13,10 @@ module GobiertoBudgets
           }
       })['hits']
 
-      @code = results.sample['code'] if results.any?
-
-      if @code.present?
+      if results.any?
+        random_item = results.sample
+        @code = random_item['code']
+        @population = random_item['population']
         render pick_template, layout: false
       else
         head :ok

--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -18,7 +18,7 @@ module GobiertoBudgets
       if @code.present?
         render pick_template, layout: false
       else
-        render head: :success
+        head :ok
       end
     end
 

--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -8,8 +8,8 @@ module GobiertoBudgets
       results = GobiertoBudgets::BudgetLine.search({
           kind: @kind, year: @year, organization_id: current_site.organization_id,
           type: @area_name, range_hash: {
-            level: {ge: 3},
-            amount_per_inhabitant: { gt: 0 }
+            level: { ge: 3 },
+            amount: { gt: 0 }
           }
       })['hits']
 

--- a/app/helpers/gobierto_budgets/application_helper.rb
+++ b/app/helpers/gobierto_budgets/application_helper.rb
@@ -130,9 +130,7 @@ module GobiertoBudgets
     end
 
     def bubbles_data_path(site)
-      path = GobiertoBudgets::Data::Bubbles.file_name_for(site.organization_id)
-
-      "https://#{ENV['S3_BUCKET_NAME']}.s3-eu-west-1.amazonaws.com/#{path}"
+      GobiertoBudgets::Data::Bubbles.new(current_site).file_url
     end
 
     def budget_line_breadcrumb(budget_line, year, kind)

--- a/app/importers/gobierto_budgets/json_parser.rb
+++ b/app/importers/gobierto_budgets/json_parser.rb
@@ -52,7 +52,7 @@ module GobiertoBudgets
           {
             index: {
               _index: index,
-              _id: [organization_id, year, codes[:code] + AREA_SUFFIXES[area], kind].join("/"),
+              _id: [organization_id, year, codes[:code], kind].join("/"),
               _type: area.area_name,
               data: base_data.merge(amount: amount.round(2),
                                     code: codes[:code],

--- a/app/importers/gobierto_budgets/json_parser.rb
+++ b/app/importers/gobierto_budgets/json_parser.rb
@@ -2,9 +2,9 @@
 
 module GobiertoBudgets
   class JsonParser
-    AREA_SUFFIXES = { EconomicArea => "",
-                      FunctionalArea =>  "-f",
-                      CustomArea => "-c" }.freeze
+    AREA_KEYS = { EconomicArea => { suffix: "", partition_field: nil },
+                  FunctionalArea =>  { suffix: "-f", partition_field: :functional_code },
+                  CustomArea => { suffix: "-c", partition_field: :custom_code } }.freeze
 
     attr_accessor :collection, :year, :kind, :site, :place, :population
 
@@ -26,26 +26,27 @@ module GobiertoBudgets
       site.organization_id
     end
 
-    def collect_amounts(area, level, index)
+    def collect_amounts(area, level, index, filter = nil)
       grouped_collection = @collection.group_by do |item|
         { code: item.code(area, level),
           parent_code: item.code(area, level - 1) }
       end
       grouped_collection.transform_values do |subcollection|
+        subcollection = subcollection.select { |item| filter.call(item) } if filter
         subcollection.sum { |item| item.amount(index) }
       end
     end
 
-    def budgets_for(area, index)
-      base_data = {
-        organization_id: organization_id,
+    def base_data
+      { organization_id: organization_id,
         ine_code: place.id.to_i,
         province_id: place.province.id.to_i,
         autonomy_id: place.province.autonomous_region.id.to_i,
         year: year,
-        population: population
-      }
+        population: population }
+    end
 
+    def budgets_for(area, index)
       (1..4).map do |level|
         collect_amounts(area, level, index).map do |codes, amount|
           next if amount.round(2) == 0.0
@@ -62,6 +63,33 @@ module GobiertoBudgets
                                     parent_code: codes[:parent_code])
             }
           }
+        end
+      end.flatten.compact
+    end
+
+    def economic_partitions_for(area, index)
+      return if AREA_KEYS[area][:partition_field].blank?
+
+      (1..4).map do |level|
+        collect_amounts(area, level, index).map do |area_codes, _|
+          partition_filter = ->(item) { item.code(area, level) == area_codes[:code] }
+          collect_amounts(EconomicArea, 1, index, partition_filter).map do |economic_codes, amount|
+            next if amount.round(2) == 0.0
+            {
+              index: {
+                _index: index,
+                _id: [organization_id, year, "#{ area_codes[:code] }-#{ economic_codes[:code] }#{ AREA_KEYS[area][:suffix] }", kind].join("/"),
+                _type: EconomicArea.area_name,
+                data: base_data.merge(amount: amount.round(2),
+                                      code: economic_codes[:code],
+                                      AREA_KEYS[area][:partition_field] => area_codes[:code],
+                                      level: 1,
+                                      kind: kind,
+                                      amount_per_inhabitant: population ? (amount / population).round(2) : nil,
+                                      parent_code: economic_codes[:parent_code])
+              }
+            }
+          end
         end
       end.flatten.compact
     end

--- a/app/javascript/budgets/modules/vis_bubbles.js
+++ b/app/javascript/budgets/modules/vis_bubbles.js
@@ -63,7 +63,7 @@ export var VisBubbles = Class.extend({
     if(this.locale === 'en') this.locale = 'es';
 
     this.maxAmount = d3.max(data, function (d) { return d.values[year] }.bind(this));
-    this.filtered = data.filter(function(d) { return d.budget_category === this.budget_category && d.values_per_inhabitant[year] > 1; }.bind(this));
+    this.filtered = data.filter(function(d) { return d.budget_category === this.budget_category; }.bind(this));
 
     this.radiusScale = d3.scaleSqrt()
       .range(this.isMobile ? [0, 80] : [0, 120])
@@ -84,19 +84,20 @@ export var VisBubbles = Class.extend({
           pct_diffs: d.pct_diff,
           id: d.id,
           values_per_inhabitant: d.values_per_inhabitant,
-          radius: this.radiusScale(d.values[year]),
+          radius: d.values[year] ? this.radiusScale(d.values[year]) : 0,
           value: d.values[year],
           name: d['level_2_' + this.locale],
           pct_diff: d.pct_diff[year],
           per_inhabitant: d.values_per_inhabitant[year],
           x: Math.random() * 600,
-          y: this.nodeScale(d.pct_diff[year]),
+          y: d.pct_diff[year] ? this.nodeScale(d.pct_diff[year]) : 0,
           year: year
         };
       }.bind(this))
     } else {
       this.nodes.forEach(function(d) {
         d.radius = this.radiusScale(d.values[year])
+        d.radius = d.values[year] ? this.radiusScale(d.values[year]) : 0
         d.value = d.values[year]
         d.pct_diff = d.pct_diffs[year]
         d.per_inhabitant = d.values_per_inhabitant[year]
@@ -182,10 +183,13 @@ export var VisBubbles = Class.extend({
     function getString(d) {
       return d > 0 ? I18n.t('gobierto_budgets.budgets.index.main_budget_levels_tooltip_up') : I18n.t('gobierto_budgets.budgets.index.main_budget_levels_tooltip_down');
     }
+    function perInhabitantTooltipStr(d) {
+      return d ? '<div class="clear_b">' + accounting.formatMoney(d, "€", 0, ".", ",") + ' ' + I18n.t('gobierto_budgets.budgets.index.main_budget_levels_per_inhabitant') + '</div>' : '';
+    }
 
     this.tooltip.html('<div class="line-name"><strong>' + d.name + '</strong></div> \
                        <div>' + accounting.formatMoney(d.value, "€", 0, ".", ",") + '</div> \
-                       <div class="clear_b">' + accounting.formatMoney(d.per_inhabitant, "€", 0, ".", ",") + ' ' + I18n.t('gobierto_budgets.budgets.index.main_budget_levels_per_inhabitant') + '</div> \
+                       ' + perInhabitantTooltipStr(d.per_inhabitant) + ' \
                        <div class="line-pct">' + getString(d.pct_diff) + ' ' + accounting.formatNumber(d.pct_diff, 1) + ' %</span> ' + I18n.t('gobierto_budgets.budgets.index.main_budget_levels_tooltip_article') + ' ' + (d.year - 1) + '</div>');
   },
   _mouseleft: function() {

--- a/app/javascript/budgets/modules/vis_treemap.js
+++ b/app/javascript/budgets/modules/vis_treemap.js
@@ -64,7 +64,13 @@ export var TreemapVis = Class.extend({
           }
         }.bind(this))
         .attr("title", function(d){
-          return "<strong>" + d.data.name + "</strong><br>" + accounting.formatMoney(d.data.budget, "€", 0, '.') + "<br>" + accounting.formatMoney(d.data.budget_per_inhabitant, "€", 0, ',') + " /" + I18n.t("gobierto_budgets.visualizations.inhabitant_short");
+          function totalBudgetTooltipStr(str) {
+            return "<br>" + accounting.formatMoney(str, "€", 0, '.');
+          }
+          function perInhabitantTooltipStr(str) {
+            return str ? "<br>" + accounting.formatMoney(str, "€", 0, ',') + " /" + I18n.t("gobierto_budgets.visualizations.inhabitant_short") : "";
+          }
+          return "<strong>" + d.data.name + "</strong>" + totalBudgetTooltipStr(d.data.budget) + perInhabitantTooltipStr(d.data.budget_per_inhabitant);
         }.bind(this))
         .attr("data-url", function(d){
           if(this.clickable){
@@ -77,12 +83,19 @@ export var TreemapVis = Class.extend({
         .style("height", function(d) { return (d.y1 - d.y0) + "px"; })
         .style("background", function(d) { return this.colorScale(d.data.code); }.bind(this))
         .html(function(d) {
+          function getBudgetAmount(d) {
+            if (d.data.budget_per_inhabitant) {
+              return accounting.formatMoney(d.data.budget_per_inhabitant, "€", 0) + "/" + I18n.t("gobierto_budgets.visualizations.inhabitant_short");
+            } else {
+              return accounting.formatMoney(d.data.budget, "€", 0);
+            }
+          }
           if(d.children) {
             return null;
           } else {
             // If the square is small, don't add the text
             if((d.x1 - d.x0) > 70 && (d.y1 - d.y0) > 90) {
-              return "<p><strong>" + d.data.name + "</strong></p><p>" + accounting.formatMoney(d.data.budget_per_inhabitant, "€", 0) + "/" + I18n.t("gobierto_budgets.visualizations.inhabitant_short") + "</p>";
+              return "<p><strong>" + d.data.name + "</strong></p><p>" + getBudgetAmount(d) + "</p>";
             }
           }
         })

--- a/app/models/gobierto_budgets/budget_total_calculator.rb
+++ b/app/models/gobierto_budgets/budget_total_calculator.rb
@@ -39,8 +39,8 @@ module GobiertoBudgets
         organization_id: organization_id,
         year: year,
         kind: kind,
-        total_budget: total_budget,
-        total_budget_per_inhabitant: total_budget_per_inhabitant
+        total_budget: total_budget.to_f,
+        total_budget_per_inhabitant: total_budget_per_inhabitant.to_f
       })
 
       id = [organization_id, year, kind].join("/")

--- a/app/models/gobierto_budgets/data/bubbles.rb
+++ b/app/models/gobierto_budgets/data/bubbles.rb
@@ -26,6 +26,11 @@ module GobiertoBudgets
                                               content_type: "application/json; charset=utf-8").upload!
       end
 
+      def file_url
+        file = GobiertoCommon::FileUploadService.new(file_name: self.class.file_name_for(site.organization_id))
+        file.uploaded_file_exists? && file.call
+      end
+
       def build_data_file
         base_conditions = { site: site, kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: GobiertoBudgets::FunctionalArea.area_name, level: 2 }
         expense_categories.each do |code, name|

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -175,14 +175,6 @@ module GobiertoBudgets
         else
           [
             {
-              "name": "mean_province",
-              "values": mean_province
-            },
-            {
-              "name": "mean_autonomy",
-              "values": mean_autonomy
-            },
-            {
               "name": "mean_national",
               "values": mean_national
             },
@@ -190,7 +182,20 @@ module GobiertoBudgets
               name: @organization_name,
               "values": organization_values
             }
-          ]
+          ].tap do |values|
+            unless place_values.blank?
+              values.unshift(
+                {
+                  "name": "mean_province",
+                  "values": mean_province
+                },
+                {
+                  "name": "mean_autonomy",
+                  "values": mean_autonomy
+                }
+              )
+            end
+          end
         end
       end
 

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -39,7 +39,7 @@ module GobiertoBudgets
 
       def mean_filtered_by(conditions={})
         options = conditions.extract!(:options)
-        force_default_last_year = options[:force_default_last_year] || true
+        force_default_last_year = options.has_key?(:force_default_last_year) ? options[:force_default_last_year] : true
 
         filters = conditions.map do |condition, _|
           { term: conditions.slice(condition) }

--- a/app/models/gobierto_budgets/data/providers.rb
+++ b/app/models/gobierto_budgets/data/providers.rb
@@ -55,13 +55,9 @@ module GobiertoBudgets
 
       protected
 
-      def place
-        site.place
-      end
-
       def filename(format)
         raise UnsupportedFormat unless FORMATS.keys.include?(format.to_sym)
-        ["gobierto_budgets", place.id, "data", "providers", "#{ year }.#{ format }"].join("/")
+        ["gobierto_budgets", site.organization_id, "data", "providers", "#{ year }.#{ format }"].join("/")
       end
 
       def format_data(format)
@@ -83,7 +79,7 @@ module GobiertoBudgets
       end
 
       def format_uri(format)
-        URI("#{ endpoint }/datasets/ds-facturas-municipio.#{ format }?filter_by_location_id=#{ site.place.id }&date_date_range=#{ date_range }&sort_asc_by=date")
+        URI("#{ endpoint }/datasets/ds-facturas-municipio.#{ format }?filter_by_location_id=#{ site.organization_id }&date_date_range=#{ date_range }&sort_asc_by=date")
       end
 
       def request_response(format)

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -147,7 +147,7 @@ module GobiertoBudgets
     def latest_available(variable, year = nil)
       year ||= @year
       value = {}
-      year.downto(2010).each do |y|
+      year.downto(SearchEngineConfiguration::Year.first).each do |y|
         if has_data?(variable, y)
           value = { value: send(variable, y), year: y }
           break

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -146,7 +146,7 @@ module GobiertoBudgets
 
     def latest_available(variable, year = nil)
       year ||= @year
-      value = []
+      value = {}
       year.downto(2010).each do |y|
         if has_data?(variable, y)
           value = { value: send(variable, y), year: y }

--- a/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
@@ -9,7 +9,7 @@
     <%= link_to budget_line.name, gobierto_budgets_budget_line_path(budget_line.to_param) %>
   </td>
   <td class="qty big_qty"><%= number_to_currency budget_line.amount, precision: 0 %></td>
-  <td class="qty"><%= number_to_currency budget_line.amount_per_inhabitant, precision: 0 %></td>
+  <%= content_tag :td, number_to_currency(budget_line.amount_per_inhabitant, precision: 0), class: "qty" if budget_line.amount_per_inhabitant %>
   <td class="qty"><%= number_with_precision(budget_line.percentage_of_total, precision: 2) + ' %' %></td>
   <td class="bar"><div class="bar" style="width:<%= budget_line.percentage_of_total %>%"></div></td>
 </tr>

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -72,7 +72,7 @@
       <tr>
         <th class="budget_line"><span><%= t('.budget_line') %></span></th>
         <th class="qty big_qty"><%= t('.amount') %></th>
-        <th class="qty"><%= t('.per_inhabitant') %></th>
+        <%= content_tag :th, t('.per_inhabitant'), class: "qty" if @site_stats.has_available_population_data? %>
         <th class="qty">%</th>
         <th class="qty bar"><span style="display:none" aria-hidden="true">WCAG 2.0 AA</span></th>
       </tr>
@@ -81,7 +81,7 @@
       <tr>
         <td class="budget_line"><strong>Total</strong></td>
         <td class="qty big_qty"><%= number_to_currency(kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget : @site_stats.total_budget, precision: 0) %></td>
-        <td class="qty big_qty"><%= number_to_currency(kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget_per_inhabitant : @site_stats.total_budget_per_inhabitant, precision: 2) %></td>
+        <%= content_tag :td, number_to_currency(kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget_per_inhabitant : @site_stats.total_budget_per_inhabitant, precision: 2), class: "qty big_qty" if @site_stats.has_available_population_data? %>
         <td class="qty"></td>
         <td class="bar"></td>
       </tr>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -67,17 +67,19 @@
 
     <div class="pure-g metric_boxes">
 
-      <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_per_inhabitant_tooltip') %>">
-        <div class="inner">
-          <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant') %></h3>
-          <div class="metric"><%= number_to_currency @budget_line_stats.amount_per_inhabitant, precision: 2 %></div>
-          <% if @budget_line_stats.amount_per_inhabitant_updated.present? %>
-            <div class="explanation">
-              <%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant_updated') %>: <%= number_to_currency(@budget_line_stats.amount_per_inhabitant_updated, precision: 2) %>
-            </div>
-          <% end %>
+      <% if @budget_line_stats.amount_per_inhabitant.present? %>
+        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_per_inhabitant_tooltip') %>">
+          <div class="inner">
+            <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant') %></h3>
+            <div class="metric"><%= number_to_currency @budget_line_stats.amount_per_inhabitant, precision: 2 %></div>
+            <% if @budget_line_stats.amount_per_inhabitant_updated.present? %>
+              <div class="explanation">
+                <%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant_updated') %>: <%= number_to_currency(@budget_line_stats.amount_per_inhabitant_updated, precision: 2) %>
+              </div>
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_tooltip') %>">
         <div class="inner">

--- a/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
+++ b/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
@@ -1,0 +1,52 @@
+<% show_widget ||= false %>
+<% data_args.merge!(format: "json") %>
+<% tabs = ["total_budget"].tap { |this| this.unshift("per_person") if @site_stats.has_available_population_data? } %>
+<% i18n_scope ||= "gobierto_budgets.budgets.index" %>
+
+<%= content_tag :div, id: wrapper_id, class: "pure-g", role: "tabpanel", "aria-controlledby": tabs.join(", "), data: {"vis-lines": ""} do -%>
+  <div class=" pure-u-1 pure-u-md-1-2 block" >
+    <h2><%= t(:at_a_glance, scope: i18n_scope) %></h2>
+
+    <%= content_tag :div, nil, id: chart_id %>
+  </div>
+
+  <div class="pure-u-1 pure-u-md-1-2 block">
+    <h2><%= t(:context, scope: i18n_scope) %></h2>
+
+    <%= content_tag :div, nil, id: tooltip_id %>
+    <div class="help">
+      <%= link_to t(:note_about_the_data, scope: i18n_scope), APP_CONFIG["gobierto_budgets"]["data_note_url"], target: "_blank", title: t(:note_about_the_data_title, scope: i18n_scope), class: "tipsit-n" %>
+    </div>
+
+    <% if show_widget %>
+      <%= render "gobierto_budgets/shared/compare" %>
+    <% end %>
+  </div>
+
+  <div class="pure-u-1 pure-u-md-1-2">
+    <div class="filter m_v_2" role="tablist" aria-label="<%= t(:visualize, scope: i18n_scope) %>">
+      <% if @site_stats.has_available_population_data? %>
+        <%= link_to t(:per_person, scope: i18n_scope), "#",
+          class: "active",
+          data: { "line-widget-series": line_widget_series,
+                  "line-widget-url": gobierto_budgets_api_data_lines_path(data_args.merge(what: "per_person")),
+                  "line-widget-type": "per_person" },
+          role: "tab",
+          tabindex: 0,
+          "aria-selected": "true",
+          id: "per_person",
+          "aria-controls": "lines_chart_wrapper" %>
+      <% end %>
+      <%= link_to t(:in_total, scope: i18n_scope), "#",
+        class: @site_stats.has_available_population_data? ? "" : "active",
+        data: { "line-widget-series": line_widget_series,
+                "line-widget-url": gobierto_budgets_api_data_lines_path(data_args.merge(what: "total_budget")),
+                "line-widget-type" => "total_budget" },
+        role: "tab",
+        tabindex:-1,
+        "aria-selected": !@site_stats.has_available_population_data?,
+        id: "total_budget",
+        "aria-controls": "lines_chart_wrapper" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -275,7 +275,7 @@
   </div>
 
 
-  <% if true || budgets_comparison_context_table_enabled %>
+  <% if budgets_comparison_context_table_enabled %>
     <div id="lines_chart_wrapper_separator" class="separator"></div>
     <%= render partial: "comparison_chart", locals: { wrapper_id: "lines_chart_wrapper",
                                                       chart_id: "lines_chart",

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -97,11 +97,15 @@
         <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip') %>">
           <div class="inner">
             <h3><%= t('.debt') %></h3>
-            <div class="metric"><%= format_currency @site_stats.latest_available(:debt, @year)[:value] %></div>
-            <% if @site_stats.latest_available(:debt, @year)[:year] != @year %>
-              <div class="explanation">
-                <%= t('.at_years_end', year: @site_stats.latest_available(:debt, @year)[:year])%>
-              </div>
+            <% if (debt = @site_stats.latest_available(:debt, @year)[:value]) %>
+              <div class="metric"><%= format_currency @site_stats.latest_available(:debt, @year)[:value] %></div>
+              <% if @site_stats.latest_available(:debt, @year)[:year] != @year %>
+                <div class="explanation">
+                  <%= t('.at_years_end', year: @site_stats.latest_available(:debt, @year)[:year])%>
+                </div>
+              <% end %>
+            <% else %>
+              <div class="metric"><span class="not_av"><%= t('.not_available_short') %></span></div>
             <% end %>
           </div>
         </div>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -38,12 +38,14 @@
     <% cache(["gobierto_budgets/metric_boxes", current_site, I18n.locale, @year]) do %>
       <div class="pure-g metric_boxes">
 
-        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.expenses_per_inhabitant_tooltip') %>">
-          <div class="inner">
-            <h3><%= t('.expenses_per_inhabitant') %></h3>
-            <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant %></div>
+        <% if @site_stats.has_available_population_data? %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.expenses_per_inhabitant_tooltip') %>">
+            <div class="inner">
+              <h3><%= t('.expenses_per_inhabitant') %></h3>
+              <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant %></div>
+            </div>
           </div>
-        </div>
+        <% end %>
 
         <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.total_expenses_tooltip') %>">
           <div class="inner">
@@ -78,17 +80,19 @@
           </div>
         </div>
 
-        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.inhabitants_tooltip') %>">
-          <div class="inner">
-            <h3><%= t('.inhabitants') %></h3>
-            <div class="metric"><%= number_with_precision @site_stats.latest_available(:population, @year)[:value], precision: 0, delimiter: '.' %></div>
-            <% if @site_stats.latest_available(:population, @year)[:year] != @year %>
-              <div class="explanation">
-                <%= t('.data_of_year', year: @site_stats.latest_available(:population, @year)[:year]) %>
-              </div>
-            <% end %>
+        <% if @site_stats.has_available_population_data? %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.inhabitants_tooltip') %>">
+            <div class="inner">
+              <h3><%= t('.inhabitants') %></h3>
+              <div class="metric"><%= number_with_precision @site_stats.latest_available(:population, @year)[:value], precision: 0, delimiter: '.' %></div>
+              <% if @site_stats.latest_available(:population, @year)[:year] != @year %>
+                <div class="explanation">
+                  <%= t('.data_of_year', year: @site_stats.latest_available(:population, @year)[:year]) %>
+                </div>
+              <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
 
         <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip') %>">
           <div class="inner">

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -270,62 +270,29 @@
   <div class="featured_b_l block m_v_3" data-featured-budget-line="<%= gobierto_budgets_featured_budget_line_path(@year, template: 'gobierto_site_template') %>">
   </div>
 
-  <div id="lines_chart_wrapper_separator" class="separator"></div>
 
-  <% if budgets_comparison_context_table_enabled %>
-    <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
-      <div class=" pure-u-1 pure-u-md-1-2 block" >
-        <h2><%= t('.at_a_glance') %></h2>
-
-        <div id="lines_chart"></div>
-      </div>
-
-      <div class="pure-u-1 pure-u-md-1-2 block">
-        <h2><%= t('.context') %></h2>
-
-        <div id="lines_tooltip"></div>
-        <div class="help">
-          <%= link_to t('.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], target: '_blank', title: t('.note_about_the_data_title'), class: 'tipsit-n' %>
-        </div>
-      </div>
-
-      <div class="pure-u-1 pure-u-md-1-2">
-        <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
-          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
-          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
-        </div>
-      </div>
-    </div>
+  <% if true || budgets_comparison_context_table_enabled %>
+    <div id="lines_chart_wrapper_separator" class="separator"></div>
+    <%= render partial: "comparison_chart", locals: { wrapper_id: "lines_chart_wrapper",
+                                                      chart_id: "lines_chart",
+                                                      tooltip_id: "lines_tooltip",
+                                                      line_widget_series: "means",
+                                                      show_widget: false,
+                                                      data_args: { organization_id: current_site.organization_id,
+                                                                   year: @year } } %>
   <% end %>
 
   <% if budgets_comparison_compare_municipalities.any? %>
-    <div id="lines_chart_comparison_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
-      <div class=" pure-u-1 pure-u-md-1-2 block" >
-        <h2><%= t('.at_a_glance') %></h2>
-
-        <div id="lines_chart_comparison"></div>
-      </div>
-
-      <div class="pure-u-1 pure-u-md-1-2 block">
-        <h2><%= t('.context') %></h2>
-
-        <div id="lines_tooltip_comparison"></div>
-        <div class="help">
-          <%= link_to t('.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], target: '_blank', title: t('.note_about_the_data_title'), class: 'tipsit-n' %>
-        </div>
-
-        <% if budgets_comparison_show_widget %>
-          <%= render 'gobierto_budgets/shared/compare' %>
-        <% end %>
-      </div>
-
-      <div class="pure-u-1 pure-u-md-1-2">
-        <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
-          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_path(comparison: budgets_comparison_compare_municipalities, organization_id: current_site.organization_id, year: @year, what: 'per_person', format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
-          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_path(comparison: budgets_comparison_compare_municipalities, organization_id: current_site.organization_id, year: @year, what: 'total_budget', format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
-        </div>
-      </div>
-    </div>
+    <div id="lines_chart_wrapper_separator" class="separator"></div>
+    <%= render partial: "comparison_chart", locals: { wrapper_id: "lines_chart_comparison_wrapper",
+                                                      chart_id: "lines_chart_comparison",
+                                                      tooltip_id: "lines_tooltip_comparison",
+                                                      line_widget_series: "comparison",
+                                                      show_widget: budgets_comparison_show_widget,
+                                                      data_args: { comparison: budgets_comparison_compare_municipalities,
+                                                                   organization_id: current_site.organization_id,
+                                                                   year: @year } }
+                                                                 %>
   <% end %>
 
   <div class="separator"></div>

--- a/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
+++ b/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
@@ -8,11 +8,13 @@
     <strong class="wadus"><%= link_to budget_line_denomination(@area_name, @code, @kind), gobierto_budgets_budget_line_path(@code.parameterize, @year, @area_name, @kind) %>?</strong>
   </div>
 
-  <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
-                             data-widget-type="per_person"
-                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_per_inhabitant_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
-                             title="<%= t('.per_person') %>">
-  </div>
+  <% if @population %>
+    <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
+                                        data-widget-type="per_person"
+                                        data-widget-data-url="<%= gobierto_budgets_api_data_budget_per_inhabitant_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                                        title="<%= t('.per_person') %>">
+    </div>
+  <% end %>
 
   <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
                              data-widget-type="budget"

--- a/test/integration/gobierto_budgets/home_page_test.rb
+++ b/test/integration/gobierto_budgets/home_page_test.rb
@@ -44,13 +44,21 @@ class GobiertoBudgets::HomePageTest < ActionDispatch::IntegrationTest
   end
 
   def test_metric_boxes
-    with_each_current_site(placed_site, organization_site) do
+    with_current_site(placed_site) do
       visit @path
 
       assert has_css?(".metric_box h3", text: "Expenses per inhabitant")
       assert has_css?(".metric_box h3", text: "Total expenses")
       assert has_css?(".metric_box h3", text: "Executed")
       assert has_css?(".metric_box h3", text: "Inhabitants")
+      assert has_css?(".metric_box h3", text: "Debt")
+      assert page.all(".metric_box .metric").all? { |e| e.text =~ /(\d+)|Not avail./ }
+    end
+    with_current_site(organization_site) do
+      visit @path
+
+      assert has_css?(".metric_box h3", text: "Total expenses")
+      assert has_css?(".metric_box h3", text: "Executed")
       assert has_css?(".metric_box h3", text: "Debt")
       assert page.all(".metric_box .metric").all? { |e| e.text =~ /(\d+)|Not avail./ }
     end


### PR DESCRIPTION
Related with #1592


## :v: What does this PR do?
Addapts the application to display properly budgets data when there is no population by:

* Hiding cards related with inhabitants
* Adapting bubbles and treemap graphs to show only totals
* Hiding per inhabitant tabs in charts
* Searching for featured lines not taking into account the population 
* Hiding per inhabitant column in lines explorer

Also fixes some bugs, including the export providers partial in data which was making use of site instead of organization_id

## :mag: How should this be manually tested?

Explore a site with an organization 

## :eyes: Screenshots

### Before this PR
<img width="236" alt="screen shot 2018-04-18 at 11 25 11" src="https://user-images.githubusercontent.com/446459/38923954-00ae857a-42fc-11e8-8d13-19b8346942f9.png">
<img width="480" alt="screen shot 2018-04-18 at 11 27 31" src="https://user-images.githubusercontent.com/446459/38923983-0ecc66c2-42fc-11e8-9b53-c9bf15271d94.png">
<img width="102" alt="screen shot 2018-04-18 at 11 27 23" src="https://user-images.githubusercontent.com/446459/38923966-07fc8412-42fc-11e8-8f2b-7c5155d88d30.png">
### After this PR

## :shipit: Does this PR changes any configuration file?
No
