### PR TITLE
1602 bubbles generation

### DIFF
--- a/app/models/gobierto_budgets/data/bubbles.rb
+++ b/app/models/gobierto_budgets/data/bubbles.rb
@@ -71,7 +71,7 @@ module GobiertoBudgets
         values_per_inhabitant = {}
         years = budget_lines.map(&:year).sort.reverse
         years.each_with_index do |year, _i|
-          if budget_line = budget_lines.detect { |b| b.year == year }
+          if (budget_line = budget_lines.detect { |b| b.year == year })
             values.store(year, budget_line.amount)
             values_per_inhabitant.store(year, budget_line.amount_per_inhabitant)
           else


### PR DESCRIPTION
Closes #1602


## :v: What does this PR do?
Fixes the differences in generation of bubbles depending of the used command. With this changes the `GobiertoBudgets::BudgetLinesImporter` model generates bubbles from existing data instead of existing translations in current locale.

The bubbles generation task uses `GobiertoBudgets::BudgetLinesImporter` which was taking the codes to create the bubbles from translations available in current `I18n.locale`. Creating each bubble, the model changes the locale setting it to `:es` and ending with `:ca`. So if we was generating the bubbles with `GobiertoBudgets::BudgetLinesImporter` without a previously locale set, the bubbles were generated with the translated lines on default locale `:es`. If we was generating the bubbles from the task, except for the first site, the other ones were calling `GobiertoBudgets::BudgetLinesImporter` with :ca: locale.

## :mag: How should this be manually tested?
execute the Rake task: `bin/rails gobierto_budgets:data:bubbles_sites` and use the GobiertoBudgets::BudgetLinesImporter from console and compare the results

## :eyes: Screenshots

### Before this PR
<img width="910" alt="screen shot 2018-04-20 at 17 08 14" src="https://user-images.githubusercontent.com/446459/39060395-8ab9dbcc-44c1-11e8-970a-49e76c1fd493.png">
<img width="1100" alt="screen shot 2018-04-20 at 17 10 04" src="https://user-images.githubusercontent.com/446459/39060396-8ad96bea-44c1-11e8-878e-eef9b3e329b0.png">

### After this PR
<img width="1116" alt="screen shot 2018-04-20 at 17 24 14" src="https://user-images.githubusercontent.com/446459/39060410-921752aa-44c1-11e8-82d0-91d34db9bb01.png">

## :shipit: Does this PR changes any configuration file?
No
