### PR TITLE
292 - Skip IBM Notes requests to recurrent event instances out of sync range

### DIFF
--- a/app/services/gobierto_people/calendar_service_helpers.rb
+++ b/app/services/gobierto_people/calendar_service_helpers.rb
@@ -4,7 +4,7 @@ module GobiertoPeople
     extend ActiveSupport::Concern
 
     def log_message(message)
-      Rails.logger.info("[SYNC-AGENDAS] #{message}")
+      Rails.logger.info("[SYNC-AGENDAS]#{integration_log_preffix} #{message}")
     end
 
     def log_synchronization_start(calendar_identifiers = {})
@@ -12,7 +12,7 @@ module GobiertoPeople
     end
 
     def log_synchronization_end(calendar_identifiers = {})
-      log_message("Synchronization of '#{calendar_identifiers}' has finished.")
+      log_message("Synchronization of #{calendar_identifiers} has finished.")
     end
 
     def log_available_calendars_count(calendars_size)

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -22,6 +22,10 @@ module GobiertoPeople
         @received_event_ids = []
       end
 
+      def integration_log_preffix
+        "[Google Calendar]"
+      end
+
       def sync!
         log_synchronization_start(person_id: person.id, person_name: person.name)
 

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -25,6 +25,10 @@ module GobiertoPeople
         end
       end
 
+      def integration_log_preffix
+        "[Microsoft Exchange]"
+      end
+
       def sync!
         log_synchronization_start(person_id: person.id, person_name: person.name)
 

--- a/lib/ibm_notes/api.rb
+++ b/lib/ibm_notes/api.rb
@@ -26,10 +26,10 @@ module IbmNotes
       response_page = get_response_page(params)
       begin
         if response_page.uri.path == URI.parse(params[:endpoint]).path
+          log_message "[GET #{params[:endpoint]}][HTTP #{response_page.code}]"
           if response_page.code.to_i == 200
             JSON.parse(response_page.body)
           else
-            Rails.logger.info "[IBM Notes GET #{params[:endpoint]}] ERROR response code = #{response_page.code}"
             raise IbmNotes::ServiceUnavailable
           end
         else
@@ -43,7 +43,7 @@ module IbmNotes
         end
       end
     rescue ::Mechanize::ResponseCodeError
-      Rails.logger.info "[IBM Notes GET #{params[:endpoint]} ] Mechanize response code error"
+      log_message "[GET #{params[:endpoint]}][Mechanize response code error]"
       return nil
     end
 
@@ -60,6 +60,10 @@ module IbmNotes
       agent.user_agent_alias = "Mac Safari"
       agent.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       agent
+    end
+
+    def self.log_message(message)
+      Rails.logger.info "[SYNC-AGENDAS][IBM Notes]#{message}"
     end
   end
 end


### PR DESCRIPTION
Closes [#292](https://github.com/PopulateTools/issues/issues/292)

## :v: What does this PR do?

Two of the people we have using IBM Notes configured had several recurrent events that expanded during a really log period (i.e. had lots of event instances).

The initial API request made to retrieve these people events was scoped on the sync range we have, but when retrieving the recurrent event instances we were not filtering anymore so we were doint *lots* of requests that took more than 40 minutes to finish for each person.

I've modified the code so we don't do HTTP request to event instances we already know are out of the sync range.