### PR TITLE
320 - Fix admin events filter

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
@@ -26,6 +26,8 @@ module GobiertoAdmin
           @events = @events.published
         when "past"
           @events = @events.past
+        else
+          @events = @events.upcoming
         end
 
         @events = @events.page(params[:events_page]).per(::GobiertoCalendars::Event::ADMIN_PAGE_SIZE)

--- a/app/presenters/gobierto_admin/gobierto_calendars/events_presenter.rb
+++ b/app/presenters/gobierto_admin/gobierto_calendars/events_presenter.rb
@@ -13,6 +13,10 @@ module GobiertoAdmin
         @events_count ||= events.count
       end
 
+      def upcoming_events_count
+        @upcoming_events_count ||= events.upcoming.count
+      end
+
       def pending_events_count
         @pending_events_count ||= events.pending.count
       end

--- a/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
@@ -3,9 +3,9 @@
 
     <div class="pure-u-1 pure-u-md-3-5 sub_filter">
       <ul>
-        <li class="all-events-filter active" data-scope="all">
-          <%= link_to t(".all_events"), admin_calendars_events_path(collection_id: collection), remote: true %>
-          (<%= @events_presenter.events_count %>)
+        <li class="upcoming-events-filter active" data-scope="upcoming">
+          <%= link_to t(".upcoming_events"), admin_calendars_events_path(collection_id: collection), remote: true %>
+          (<%= @events_presenter.upcoming_events_count %>)
         </li>
         <li class="pending-events-filter <%= class_if("warn", @events_presenter.pending_events_count > 0) %>" data-scope="pending">
           <%= link_to t(".pending_events"), admin_calendars_events_path(collection_id: collection, scope: :pending), remote: true %>
@@ -63,7 +63,7 @@
             <% end %>
           </td>
           <td>
-            <%= l(event.starts_at, format: :short) %>
+            <%= l(event.starts_at, format: :long) %>
           </td>
           <td>
             <% if event.first_location %>
@@ -128,7 +128,7 @@
                 <%= event.title %>
               </td>
               <td>
-                <%= l(event.starts_at, format: :short) %>
+                <%= l(event.starts_at, format: :long) %>
               </td>
               <td>
                 <% if event.first_location %>

--- a/app/views/gobierto_admin/gobierto_calendars/events/index.js.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/events/index.js.erb
@@ -3,7 +3,7 @@ $('[data-scope]').removeClass('active');
 <% if params[:scope] %>
   $('[data-scope="<%= params[:scope] %>"]').addClass('active');
 <% else %>
-  $('[data-scope="all"]').addClass('active');
+  $('[data-scope="upcoming"]').addClass('active');
 <% end %>
 
 <% if params[:events_page] %>

--- a/config/locales/gobierto_admin/gobierto_calendars/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/ca.yml
@@ -31,7 +31,6 @@ ca:
             pending: Pendent
             published: Publicat
         index:
-          all_events: Tots
           configuration: Configuració
           header:
             date: Data
@@ -42,6 +41,7 @@ ca:
           past_events: Esdeveniments passats
           pending_events: Pendents de moderar
           published_events: Esdeveniments publicats
+          upcoming_events: Pròxims
           view_event: Veure esdeveniment
           visibility_level:
             archived: Archivat

--- a/config/locales/gobierto_admin/gobierto_calendars/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/en.yml
@@ -31,7 +31,6 @@ en:
             pending: Pending
             published: Published
         index:
-          all_events: All
           configuration: Configuration
           header:
             date: Date
@@ -42,6 +41,7 @@ en:
           past_events: Past events
           pending_events: Moderation pending
           published_events: Published events
+          upcoming_events: Upcoming
           view_event: View event
           visibility_level:
             archived: Archived

--- a/config/locales/gobierto_admin/gobierto_calendars/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_calendars/views/es.yml
@@ -31,7 +31,6 @@ es:
             pending: Pendiente
             published: Publicado
         index:
-          all_events: Todos
           configuration: Configuración
           header:
             date: Fecha
@@ -42,6 +41,7 @@ es:
           past_events: Eventos pasados
           pending_events: Pendientes de moderar
           published_events: Eventos publicados
+          upcoming_events: Próximos
           view_event: Ver evento
           visibility_level:
             archived: Archivado

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -83,8 +83,8 @@ module GobiertoAdmin
 
               within ".sub_filter ul", match: :first do
                 assert has_selector?(
-                  ".all-events-filter",
-                  text: "All (#{person.events.count})"
+                  ".upcoming-events-filter",
+                  text: "Upcoming (#{person.events.upcoming.count})"
                 )
 
                 assert has_selector?(

--- a/test/integration/gobierto_admin/gobierto_calendars/event_preview_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_preview_test.rb
@@ -60,20 +60,19 @@ module GobiertoAdmin
       end
 
       def test_preview_active_person_pending_event
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            within "tr#person-event-item-#{pending_event.id}" do
-              preview_link = find("a", text: "View event")
+              click_link "Moderation pending"
 
-              assert preview_link[:href].include?(admin.preview_token)
+              within "tr#person-event-item-#{pending_event.id}" do
+                expected_preview_url = "#{gobierto_people_person_event_url(person.slug, pending_event.slug, host: site.domain)}?preview_token=#{admin.preview_token}"
 
-              preview_link.click
+                assert_equal expected_preview_url, find_link("View event")[:href]
+              end
             end
-
-            assert_equal gobierto_people_person_event_path(person.slug, pending_event.slug), current_path
-            assert has_selector?("h2", text: pending_event.title)
           end
         end
       end
@@ -81,20 +80,17 @@ module GobiertoAdmin
       def test_preview_draft_person_published_event
         person.draft!
 
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            within "tr#person-event-item-#{published_event.id}" do
-              preview_link = find("a", text: "View event")
+              within "tr#person-event-item-#{published_event.id}" do
+                expected_preview_url = "#{gobierto_people_person_event_url(person.slug, published_event.slug, host: site.domain)}?preview_token=#{admin.preview_token}"
 
-              assert preview_link[:href].include?(admin.preview_token)
-
-              preview_link.click
+                assert_equal expected_preview_url, find_link("View event")[:href]
+              end
             end
-
-            assert_equal gobierto_people_person_event_path(person.slug, published_event.slug), current_path
-            assert has_selector?("h2", text: published_event.title)
           end
         end
       end
@@ -102,20 +98,19 @@ module GobiertoAdmin
       def test_preview_draft_person_pending_event
         person.draft!
 
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            within "tr#person-event-item-#{pending_event.id}" do
-              preview_link = find("a", text: "View event")
+              click_link "Moderation pending"
 
-              assert preview_link[:href].include?(admin.preview_token)
+              within "tr#person-event-item-#{pending_event.id}" do
+                expected_preview_url = "#{gobierto_people_person_event_url(person.slug, pending_event.slug, host: site.domain)}?preview_token=#{admin.preview_token}"
 
-              preview_link.click
+                assert_equal expected_preview_url, find_link("View event")[:href]
+              end
             end
-
-            assert_equal gobierto_people_person_event_path(person.slug, pending_event.slug), current_path
-            assert has_selector?("h2", text: pending_event.title)
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_calendars/events_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/events_index_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 module GobiertoAdmin
   module GobiertoCalendars
     class EventsIndexTest < ActionDispatch::IntegrationTest
+
       def setup
         super
         @collection_path = admin_common_collection_path(collection)
@@ -26,6 +27,10 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def person_upcoming_events
+        @person_upcoming_events ||= person.events.upcoming
+      end
+
       def test_person_events_index
         with_javascript do
           with_signed_in_admin(admin) do
@@ -33,9 +38,9 @@ module GobiertoAdmin
               visit @collection_path
 
               within "table.person-events-list tbody" do
-                assert has_selector?("tr", count: person.events.count)
+                assert has_selector?("tr", count: person_upcoming_events.count)
 
-                person.events.each do |event|
+                person_upcoming_events.each do |event|
                   assert has_selector?("tr#person-event-item-#{event.id}")
                 end
               end
@@ -118,8 +123,8 @@ module GobiertoAdmin
 
               within ".sub_filter ul", match: :first do
                 assert has_selector?(
-                  ".all-events-filter",
-                  text: "All (#{person.events.count})"
+                  ".upcoming-events-filter",
+                  text: "Upcoming (#{person_upcoming_events.count})"
                 )
 
                 assert has_selector?(


### PR DESCRIPTION
Closes [#320](https://github.com/PopulateTools/issues/issues/320)

## :v: What does this PR do?

* Replaces the "All" events filter per "Upcoming"
* Changes event row date format to also display year

## How to test this

You can check it in http://esp*****s.gobify.net/admin/gobierto_calendars/events?collection_id=130