### PR TITLE
315 - Fix Algolia search in GobiertoCms

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::UnknownFormat, with: :render_404
 
   helper_method :helpers, :load_current_module_sub_sections, :current_site, :current_module,
-                :available_locales, :gobierto_calendars_event_preview_url
+                :current_module_class, :available_locales, :gobierto_calendars_event_preview_url
 
   before_action :set_current_site, :authenticate_user_in_site, :set_locale
 
@@ -45,6 +45,10 @@ class ApplicationController < ActionController::Base
     @current_module ||= if params[:controller].include?('/')
                           params[:controller].split('/').first
                         end
+  end
+
+  def current_module_class
+    @current_module_class ||= current_module&.camelize&.constantize
   end
 
   def set_current_site

--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -30,7 +30,7 @@ class MetaWelcomeController < ApplicationController
 
       @page = GobiertoCms::PageDecorator.new(page)
 
-      render "gobierto_cms/pages/show"
+      render "gobierto_cms/pages/show", layout: GobiertoCms::ApplicationController::DEFAULT_LAYOUT
     end
   end
 end

--- a/app/helpers/gobierto_helper.rb
+++ b/app/helpers/gobierto_helper.rb
@@ -33,7 +33,7 @@ module GobiertoHelper
   end
 
   def algolia_search_client
-    @algolia_search_client ||= GobiertoCommon::Search.new(current_site)
+    @algolia_search_client ||= GobiertoCommon::Search.new(current_site, current_module_class)
   end
 
   private

--- a/app/javascript/packs/cms.js
+++ b/app/javascript/packs/cms.js
@@ -1,0 +1,10 @@
+/* eslint no-console:0 */
+// This file is automatically compiled by Webpack, along with any other files
+// present in this directory. You're encouraged to place your actual application logic in
+// a relevant structure within app/javascript and only use these pack files to reference
+// that code so it'll be compiled.
+//
+// To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
+// layout file, like app/views/layouts/application.html.erb
+
+import 'shared'

--- a/app/javascript/participation/.eslintrc
+++ b/app/javascript/participation/.eslintrc
@@ -1,5 +1,5 @@
 {
   "globals": {
-    "GobiertoParticipation": true,
-  },
+    "GobiertoParticipation": true
+  }
 }

--- a/app/models/gobierto_common/search.rb
+++ b/app/models/gobierto_common/search.rb
@@ -1,7 +1,11 @@
 module GobiertoCommon
   class Search
-    def initialize(site)
+
+    attr_reader :site, :current_module_class
+
+    def initialize(site, current_module_class=nil)
       @site = site
+      @current_module_class = current_module_class || GobiertoCms
     end
 
     def search_in_indexes
@@ -12,12 +16,14 @@ module GobiertoCommon
       end.map(&add_quotes).join(',')
     end
 
-    attr_reader :site
-
     private
 
     def modules_to_search
-      @modules_to_search ||= (site.configuration.modules + site.configuration.default_modules).map(&:constantize)
+      @modules_to_search ||= begin
+        modules_classes = (site.configuration.modules + site.configuration.default_modules).map(&:constantize)
+        modules_classes.delete(current_module_class)
+        modules_classes.unshift(current_module_class) # make current module results appear first
+      end
     end
 
     def models_to_search

--- a/app/views/gobierto_cms/layouts/application.html.erb
+++ b/app/views/gobierto_cms/layouts/application.html.erb
@@ -1,1 +1,6 @@
+<% content_for :javascript_module_link do %>
+  <!-- load module javascript specifics -->
+  <%= javascript_pack_tag 'cms', 'data-turbolinks-track': true %>
+<% end %>
+
 <%= render template: 'layouts/application' %>


### PR DESCRIPTION
Closes [#315](https://github.com/PopulateTools/issues/issues/315)

## :v: What does this PR do?

* Includes the search Javascript code in `GobiertoCms` module
* Uses `GobiertoCms` layout when rendering a page from the `MetaWelcomeController`. I think I'm not breaking anything with:

https://github.com/PopulateTools/gobierto/blob/883b614407ab56d5d3333b0f8d5e5339066b9fba/app/controllers/meta_welcome_controller.rb#L33

but please check.

## :mag: How should this be manually tested?

Just go to http://getafe.gobify.net and check the search is working