### PR TITLE
1584 - Preserve query params in locale switcher links

### DIFF
--- a/app/views/layouts/_locale_selector.html.erb
+++ b/app/views/layouts/_locale_selector.html.erb
@@ -3,7 +3,7 @@
     <% if I18n.locale.to_s == locale.to_s %>
       <strong><%= t("locales.#{locale}_short") %></strong>
     <% else %>
-      <%= link_to t("locales.#{locale}_short"), {locale: locale}, data: { turbolinks: false } %>
+      <%= link_to t("locales.#{locale}_short"), request.query_parameters.merge(locale: locale), data: { turbolinks: false } %>
     <% end %>
   <% end %>
 <% end %>

--- a/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/update_page_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 module GobiertoAdmin
   module GobiertoCms
     class UpdatePageTest < ActionDispatch::IntegrationTest
+
       def setup
         super
         @path = admin_cms_pages_path
@@ -24,6 +25,10 @@ module GobiertoAdmin
 
       def collection
         @collection ||= gobierto_common_collections(:news)
+      end
+
+      def current_uri_query_params
+        URI.parse(current_url).query
       end
 
       def test_update_page
@@ -58,6 +63,22 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_update_page_and_switch_locale
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+
+            visit edit_admin_cms_page_path(cms_page, collection_id: collection.id)
+
+            assert_equal "collection_id=#{collection.id}", current_uri_query_params
+
+            within(".language_selector") { click_link "ES" }
+
+            assert_equal "collection_id=#{collection.id}&locale=es", current_uri_query_params
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Closes #1584 

## :mag: How should this be manually tested?

* Go to http://getafe.gobify.net/admin/cms/pages/117/edit?collection_id=244
* Switch the locale
* You shouldn't get a 404

