### PR TITLE
1630 - Propagate manual sync errors to UI

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -35,16 +35,30 @@ module GobiertoAdmin
       end
 
       def sync_calendars
+        browser_locale = I18n.locale
         I18n.locale = current_site.configuration.default_locale
 
-        @calendar_configuration_form = CalendarConfigurationForm.new(current_site: current_site, collection: @collection)
+        @calendar_configuration_form = CalendarConfigurationForm.new(
+          current_site: current_site,
+          collection: @collection
+        )
+
         if (calendar_integration = @calendar_configuration_form.calendar_integration_class).present?
           calendar_integration.new(@calendar_configuration_form.collection_container).sync!
           publish_calendar_sync_activity(@calendar_configuration_form)
+
+          I18n.locale = browser_locale
+
+          redirect_to(
+            edit_admin_calendars_configuration_path(@collection),
+            notice: t(".success")
+          )
         end
+      rescue ::GobiertoCalendars::CalendarIntegration::Error => e
+        I18n.locale = browser_locale
         redirect_to(
           edit_admin_calendars_configuration_path(@collection),
-          notice: t('.success')
+          alert: e.message
         )
       end
 

--- a/app/services/gobierto_calendars/calendar_integration/auth_error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/auth_error.rb
@@ -1,0 +1,11 @@
+module GobiertoCalendars
+  module CalendarIntegration
+    class AuthError < Error
+
+      def message
+        I18n.t "gobierto_calendars.calendar_integration.auth_error.message"
+      end
+
+    end
+  end
+end

--- a/app/services/gobierto_calendars/calendar_integration/auth_error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/auth_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCalendars
   module CalendarIntegration
     class AuthError < Error

--- a/app/services/gobierto_calendars/calendar_integration/error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/error.rb
@@ -1,0 +1,11 @@
+module GobiertoCalendars
+  module CalendarIntegration
+    class Error < StandardError
+
+      def message
+        I18n.t "gobierto_calendars.calendar_integration.error.message"
+      end
+
+    end
+  end
+end

--- a/app/services/gobierto_calendars/calendar_integration/error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCalendars
   module CalendarIntegration
     class Error < StandardError

--- a/app/services/gobierto_calendars/calendar_integration/timeout_error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/timeout_error.rb
@@ -1,0 +1,11 @@
+module GobiertoCalendars
+  module CalendarIntegration
+    class TimeoutError < Error
+
+      def message
+        I18n.t "gobierto_calendars.calendar_integration.timeout_error.message"
+      end
+
+    end
+  end
+end

--- a/app/services/gobierto_calendars/calendar_integration/timeout_error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/timeout_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCalendars
   module CalendarIntegration
     class TimeoutError < Error

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -56,10 +56,13 @@ module GobiertoPeople
         end
       rescue ::IbmNotes::InvalidCredentials
         log_message("Invalid credentials for site")
+        raise ::GobiertoCalendars::CalendarIntegration::AuthError
       rescue ::IbmNotes::ServiceUnavailable
         log_message("IBM Notes calendar API is down")
+        raise ::GobiertoCalendars::CalendarIntegration::TimeoutError
       rescue ::JSON::ParserError
         log_message("JSON parser error")
+        raise ::GobiertoCalendars::CalendarIntegration::Error
       ensure
         log_synchronization_end(person_id: person.id, person_name: person.name)
       end

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -8,7 +8,7 @@ module GobiertoPeople
 
       attr_reader :person, :site, :configuration
 
-      TARGET_CALENDAR_NAME = 'gobierto'
+      TARGET_CALENDAR_NAME = "gobierto"
 
       def initialize(person)
         @person = person
@@ -58,7 +58,7 @@ module GobiertoPeople
       def get_calendar_items
         root_folder = Exchanger::Folder.find(:calendar)
 
-        folder_exists!(folder: root_folder, folder_name: 'root')
+        folder_exists!(folder: root_folder, folder_name: "root")
 
         target_folder = root_folder.folders.find { |folder| folder.display_name == TARGET_CALENDAR_NAME }
 
@@ -130,13 +130,13 @@ module GobiertoPeople
       end
 
       def folder_exists!(params={})
-        if params[:folder].nil?
-          log_message("Can't find #{params[:folder_name]} calendar folder for #{person.name} (id: #{person.id}). Wrong username, password or endpoint?")
-          if params[:folder_name] == 'root'
-            raise ::GobiertoCalendars::CalendarIntegration::AuthError
-          else
-            raise ::GobiertoCalendars::CalendarIntegration::Error("No se encuentra el calendario #{params[:folder_name]}")
-          end
+        return if params[:folder].present?
+
+        log_message("Can't find #{params[:folder_name]} calendar folder for #{person.name} (id: #{person.id}). Wrong username, password or endpoint?")
+        if params[:folder_name] == "root"
+          raise ::GobiertoCalendars::CalendarIntegration::AuthError
+        else
+          raise ::GobiertoCalendars::CalendarIntegration::Error("No se encuentra el calendario #{params[:folder_name]}")
         end
       end
 

--- a/app/services/gobierto_people/remote_calendars.rb
+++ b/app/services/gobierto_people/remote_calendars.rb
@@ -15,6 +15,8 @@ module GobiertoPeople
         begin
           calendar_integration.new(container).sync!
           Publishers::AdminGobiertoCalendarsActivity.broadcast_event('calendars_synchronized', { ip: '127.0.0.1',  subject: container, site_id: site.id })
+        rescue GobiertoCalendars::CalendarIntegration::Error
+          # Rescue this errors because they're just meant to display error feedback in the UI
         rescue StandardError => e
           Rollbar.error(e)
         end

--- a/config/locales/gobierto_calendars/services/ca.yml
+++ b/config/locales/gobierto_calendars/services/ca.yml
@@ -1,0 +1,10 @@
+---
+ca:
+  gobierto_calendars:
+    calendar_integration:
+      auth_error:
+        message: Les credencials del calendari no són vàlides
+      error:
+        message: Hi ha hagut un problema sincronitzant el calendari
+      timeout_error:
+        message: El temps de connexió al servidor de calendaris ha expirat

--- a/config/locales/gobierto_calendars/services/en.yml
+++ b/config/locales/gobierto_calendars/services/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  gobierto_calendars:
+    calendar_integration:
+      auth_error:
+        message: Calendar credentials are not valid
+      error:
+        message: There has been a problem synchronizing the calendar
+      timeout_error:
+        message: The connection time to the calendar server has expired

--- a/config/locales/gobierto_calendars/services/es.yml
+++ b/config/locales/gobierto_calendars/services/es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  gobierto_calendars:
+    calendar_integration:
+      auth_error:
+        message: Las credenciales del calendario no son válidas
+      error:
+        message: Ha habido un problema sincronizando el calendario
+      timeout_error:
+        message: El tiempo de conexión al servidor de calendarios ha expirado

--- a/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_calendar_configuration_test.rb
@@ -297,6 +297,27 @@ module GobiertoAdmin
         end
       end
 
+      def test_sync_calendars_errors
+        configure_ibm_notes_calendar_integration(
+          collection: person.calendar,
+          data: ibm_notes_configuration
+        )
+
+        ::GobiertoPeople::IbmNotes::CalendarIntegration.any_instance
+                                                       .stubs(:sync!)
+                                                       .raises(::GobiertoCalendars::CalendarIntegration::Error)
+
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit edit_admin_calendars_configuration_path(person.calendar)
+
+            click_link "Sync now"
+
+            assert has_content? "There has been a problem synchronizing the calendar"
+          end
+        end
+      end
+
       def test_configure_new_google_calendar_integration
         with_javascript do
           with_signed_in_admin(admin) do

--- a/test/integration/gobierto_participation/processes/process_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_show_test.rb
@@ -175,7 +175,7 @@ module GobiertoParticipation
 
           assert has_content? "Interesting information"
 
-          process_duration_text = "#{gender_violence_process.starts.strftime("%e/%m/%y")} to #{gender_violence_process.ends.strftime("%-e/%m/%y")}"
+          process_duration_text = "#{gender_violence_process.starts.strftime("%-e/%m/%y")} to #{gender_violence_process.ends.strftime("%-e/%m/%y")}"
 
           assert has_content? process_duration_text
           assert has_content? "Women"

--- a/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
+++ b/test/services/gobierto_people/ibm_notes/calendar_integration_test.rb
@@ -439,6 +439,28 @@ module GobiertoPeople
         end
       end
 
+      def test_sync_with_errors
+        configure_ibm_notes_calendar_with_description
+
+        ::IbmNotes::Api.stubs(:get_person_events).raises(::IbmNotes::InvalidCredentials)
+
+        assert_raises ::GobiertoCalendars::CalendarIntegration::AuthError do
+          calendar_service.sync!
+        end
+
+        ::IbmNotes::Api.stubs(:get_person_events).raises(::IbmNotes::ServiceUnavailable)
+
+        assert_raises ::GobiertoCalendars::CalendarIntegration::TimeoutError do
+          calendar_service.sync!
+        end
+
+        ::IbmNotes::Api.stubs(:get_person_events).raises(::JSON::ParserError)
+
+        assert_raises ::GobiertoCalendars::CalendarIntegration::Error do
+          calendar_service.sync!
+        end
+      end
+
       def test_filter_events
         configure_ibm_notes_calendar_with_description
 

--- a/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
+++ b/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
@@ -283,6 +283,22 @@ module GobiertoPeople
         assert event.locations.empty?
       end
 
+      def test_sync_with_errors
+        configure_microsoft_exchange_calendar_with_description
+
+        ::Exchanger::Folder.stubs(:find).raises(::Addressable::URI::InvalidURIError)
+
+        assert_raises ::GobiertoCalendars::CalendarIntegration::AuthError do
+          calendar_service.sync!
+        end
+
+        ::Exchanger::Folder.stubs(:find).raises(::HTTPClient::ConnectTimeoutError)
+
+        assert_raises ::GobiertoCalendars::CalendarIntegration::TimeoutError do
+          calendar_service.sync!
+        end
+      end
+
       def test_filter_events
         configure_microsoft_exchange_calendar_with_description
 

--- a/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
+++ b/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
@@ -299,6 +299,27 @@ module GobiertoPeople
         end
       end
 
+      def test_sync_when_root_folder_does_not_exist
+        configure_microsoft_exchange_calendar_with_description
+
+        ::Exchanger::Folder.stubs(:find).returns(nil)
+
+        assert_raise ::GobiertoCalendars::CalendarIntegration::AuthError do
+          calendar_service.sync!
+        end
+      end
+
+      def test_sync_when_target_folder_does_not_exist
+        configure_microsoft_exchange_calendar_with_description
+
+        root_folder = mock
+        root_folder.stubs(:folders).returns([])
+
+        assert_raise ::GobiertoCalendars::CalendarIntegration::Error do
+          calendar_service.sync!
+        end
+      end
+
       def test_filter_events
         configure_microsoft_exchange_calendar_with_description
 

--- a/test/services/gobierto_people/remote_calendars_test.rb
+++ b/test/services/gobierto_people/remote_calendars_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/calendar_integration_helpers"
+
+module GobiertoPeople
+  class RemoteCalendarsTest < ActiveSupport::TestCase
+
+    include ::CalendarIntegrationHelpers
+
+    def person
+      @person ||= gobierto_people_people(:richard)
+    end
+
+    def ibm_notes_configuration
+      @ibm_notes_configuration ||= {
+        ibm_notes_usr: "ibm-notes-usr",
+        ibm_notes_pwd: "ibm-notes-pwd",
+        ibm_notes_url: "http://ibm-calendar/richard",
+        without_description: "0"
+      }
+    end
+
+    def microsoft_exchange_configuration
+      @microsoft_exchange_configuration ||= {
+        microsoft_exchange_usr: "microsoft-exchange-usr",
+        microsoft_exchange_pwd: "microsoft-exchange-pwd",
+        microsoft_exchange_url: "http://me-calendar/richard",
+        without_description: "0"
+      }
+    end
+
+    def ensure_rollbar_is_not_called
+      Rollbar.stubs(:error).raises(Minitest::Assertion)
+    end
+
+    def test_sync_with_invalid_configuration_credentials_does_not_propagate_ui_errors
+      clear_calendar_configurations
+
+      configure_ibm_notes_calendar_integration(
+        collection: person.calendar,
+        data: ibm_notes_configuration
+      )
+
+      ::IbmNotes::Api.stubs(:get_person_events).raises(::IbmNotes::InvalidCredentials)
+
+      ensure_rollbar_is_not_called
+      assert_nothing_raised do
+        GobiertoPeople::RemoteCalendars.sync
+      end
+
+      configure_microsoft_exchange_calendar_integration(
+        collection: person.calendar,
+        data: microsoft_exchange_configuration
+      )
+
+      ::Exchanger::Folder.stubs(:find).returns(nil)
+
+      ensure_rollbar_is_not_called
+      assert_nothing_raised do
+        GobiertoPeople::RemoteCalendars.sync
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Closes #1630 

## :v: What does this PR do?

Propagates most common errors during calendar synchronization (invalid credentials and timeouts) to UI, so the user knows about it instead of getting a "Successfully synced" message when that's not true.

## :mag: How should this be manually tested?

You can test in local or staging. I'd try to configure invalid IBM Notes and Microsoft Exchange calendars with a wrong password or username and click "sync".

You should get a warning in the flash alerting credentials are wrong. For tiemout-like errors the closest you can test in manually raise the exception modifying the code in local (but there are tests for this, so it's not that important).

I haven't done this for Google Calendar because the auth error will be given by ¿oauth? in the initial configuration step, not by Gobierto.

## :eyes: Screenshots

![image](https://user-images.githubusercontent.com/9287468/39620653-21f753be-4f8c-11e8-9ace-e5a33c25de7f.png)

## :shipit: Does this PR changes any configuration file?

No