### PR TITLE
Setup sidekiq dashboard & stats endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem "elasticsearch-extensions"
 
 # Background processing
 gem "sidekiq", "~> 5.1.0"
+gem "sidekiq-monitor-stats"
 
 # AWS SDK client
 gem "aws-sdk", "~> 2.6", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,8 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-monitor-stats (0.0.2)
+      sidekiq
     signet (0.8.1)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -540,6 +542,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   savon (~> 2.11.1)
   sidekiq (~> 5.1.0)
+  sidekiq-monitor-stats
   simple_calendar (~> 2.2)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   # The root page is kind of dynamic
   constraints GobiertoSiteConstraint.new do
@@ -408,5 +410,10 @@ Rails.application.routes.draw do
     constraints GobiertoSiteConstraint.new do
       get "/documento/:id" => 'attachment_documents#show', as: :document
     end
+  end
+
+  # Sidekiq admin console
+  constraints lambda {|request| SidekiqAuthConstraint.god_admin?(request) } do
+    mount Sidekiq::Web => "/admin/sidekiq", as: :sidekiq_console
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -413,7 +413,7 @@ Rails.application.routes.draw do
   end
 
   # Sidekiq admin console
-  constraints lambda {|request| SidekiqAuthConstraint.god_admin?(request) } do
+  constraints lambda {|request| SidekiqAuthConstraint.god_admin?(request) || SidekiqAuthConstraint.localhost?(request) } do
     mount Sidekiq::Web => "/admin/sidekiq", as: :sidekiq_console
   end
 end

--- a/lib/constraints/sidekiq_auth_constraint.rb
+++ b/lib/constraints/sidekiq_auth_constraint.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SidekiqAuthConstraint
+
+  def self.god_admin?(request)
+    admin_id = request.session[:admin_id]
+
+    return false unless admin_id
+
+    current_admin = GobiertoAdmin::Admin.find(admin_id)
+    current_admin.god?
+  end
+
+end

--- a/lib/constraints/sidekiq_auth_constraint.rb
+++ b/lib/constraints/sidekiq_auth_constraint.rb
@@ -11,4 +11,10 @@ class SidekiqAuthConstraint
     current_admin.god?
   end
 
+  def self.localhost?(request)
+    # Rails bug: this should return true instead
+    # https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/request.rb#L405
+    request.local? == 0
+  end
+
 end

--- a/test/integration/gobierto_admin/sidekiq_console_test.rb
+++ b/test/integration/gobierto_admin/sidekiq_console_test.rb
@@ -17,6 +17,12 @@ module GobiertoAdmin
       @site ||= sites(:madrid)
     end
 
+    def setup
+      super
+      # otherwise we're not running the code we want
+      SidekiqAuthConstraint.stubs(:localhost?).returns(false)
+    end
+
     def test_visit_sidekiq_console_as_god_admin
       with_signed_in_admin(god_admin) do
         visit sidekiq_console_path

--- a/test/integration/gobierto_admin/sidekiq_console_test.rb
+++ b/test/integration/gobierto_admin/sidekiq_console_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  class SidekiqConsoleTest < ActionDispatch::IntegrationTest
+
+    def regular_admin
+      @regular_admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def god_admin
+      @god_admin ||= gobierto_admin_admins(:natasha)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def test_visit_sidekiq_console_as_god_admin
+      with_signed_in_admin(god_admin) do
+        visit sidekiq_console_path
+
+        assert has_content?("Dashboard")
+      end
+    end
+
+    def test_visit_sidekiq_console_as_regular_admin
+      with_signed_in_admin(regular_admin) do
+        assert_raise ActionController::RoutingError do
+          visit sidekiq_console_path
+        end
+      end
+    end
+
+    def test_visit_sidekiq_console_as_annonymous
+      assert_raise ActionController::RoutingError do
+        visit sidekiq_console_path
+      end
+    end
+
+  end
+end

--- a/test/integration/gobierto_admin/sidekiq_monitor_stats_test.rb
+++ b/test/integration/gobierto_admin/sidekiq_monitor_stats_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  class SidekiqMonitorStatsTest < ActionDispatch::IntegrationTest
+
+    def sidekiq_monitor_stats_path
+      "#{sidekiq_console_path}/monitor-stats"
+    end
+
+    def test_visit_stats_from_localhost
+      ActionDispatch::Request.any_instance.stubs(:remote_addr).returns("127.0.0.1")
+
+      response_code = get(sidekiq_monitor_stats_path)
+
+      assert_equal 200, response_code
+    end
+
+    def test_visit_stats_from_external_host
+      ActionDispatch::Request.any_instance.stubs(:remote_addr).returns("1.2.3.4")
+
+      assert_raise ActionController::RoutingError do
+        get(sidekiq_monitor_stats_path)
+      end
+    end
+
+  end
+end

--- a/test/integration/gobierto_participation/processes/process_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_show_test.rb
@@ -175,7 +175,7 @@ module GobiertoParticipation
 
           assert has_content? "Interesting information"
 
-          process_duration_text = "#{gender_violence_process.starts.strftime("%e/%m/%y")} to #{gender_violence_process.ends.strftime("%-e/%m/%y")}"
+          process_duration_text = "#{gender_violence_process.starts.strftime("%-e/%m/%y")} to #{gender_violence_process.ends.strftime("%-e/%m/%y")}"
 
           assert has_content? process_duration_text
           assert has_content? "Women"

--- a/test/lib/constraints/sidekiq_auth_constraint_test.rb
+++ b/test/lib/constraints/sidekiq_auth_constraint_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SidekiqAuthConstraintTest < ActiveSupport::TestCase
+
+  def regular_admin
+    @regular_admin ||= gobierto_admin_admins(:tony)
+  end
+
+  def god_admin
+    @god_admin ||= gobierto_admin_admins(:natasha)
+  end
+
+  def anonnymous_request
+    request = mock
+    request.stubs(:session).returns({})
+    request
+  end
+
+  def regular_admin_request
+    request = mock
+    request.stubs(:session).returns({ admin_id: regular_admin.id })
+    request
+  end
+
+  def god_admin_request
+    request = mock
+    request.stubs(:session).returns({ admin_id: god_admin.id })
+    request
+  end
+
+  def test_god_admin?
+    refute SidekiqAuthConstraint.god_admin?(anonnymous_request)
+    refute SidekiqAuthConstraint.god_admin?(regular_admin_request)
+    assert SidekiqAuthConstraint.god_admin?(god_admin_request)
+  end
+
+end

--- a/test/lib/constraints/sidekiq_auth_constraint_test.rb
+++ b/test/lib/constraints/sidekiq_auth_constraint_test.rb
@@ -20,13 +20,13 @@ class SidekiqAuthConstraintTest < ActiveSupport::TestCase
 
   def regular_admin_request
     request = mock
-    request.stubs(:session).returns({ admin_id: regular_admin.id })
+    request.stubs(:session).returns(admin_id: regular_admin.id)
     request
   end
 
   def god_admin_request
     request = mock
-    request.stubs(:session).returns({ admin_id: god_admin.id })
+    request.stubs(:session).returns(admin_id: god_admin.id)
     request
   end
 


### PR DESCRIPTION
## What does this PR do?

* Enable Sidekiq web admin dashboard
* Enable an endpoint to retrieve sidekiq stats so they can be accessed by the sensu plugin

## How to test this:

If your are logged in as a **god** admin, these two URLs should be accessible (otherwise raise a 404):

* Staging sidekiq dashboard: http://madrid.gobify.net/admin/sidekiq
* Staging sidekiq status API: http://madrid.gobify.net/admin/sidekiq/monitor-stats