### PR TITLE
1660 refactor events form objects

### DIFF
--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -15,12 +15,14 @@ module GobiertoCalendars
       :description_source_translations,
       :starts_at,
       :ends_at,
-      :state,
       :notify,
-      :locations,
-      :attendees,
       :meta,
       :department_id
+    )
+    attr_writer(
+      :state,
+      :locations,
+      :attendees
     )
 
     delegate :persisted?, to: :event

--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -138,6 +138,8 @@ module GobiertoCalendars
         event_attributes.description_source_translations = description_source_translations
         event_attributes.starts_at = starts_at
         event_attributes.ends_at = ends_at
+        event_attributes.meta = meta
+        event_attributes.department_id = department_id
         event_attributes.locations = locations
         event_attributes.attendees = attendees
       end

--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+module GobiertoCalendars
+  class EventForm < BaseForm
+
+    prepend ::GobiertoCommon::Trackable
+
+    attr_accessor(
+      :id,
+      :external_id,
+      :site_id,
+      :person_id,
+      :title_translations,
+      :description_translations,
+      :description_source_translations,
+      :starts_at,
+      :ends_at,
+      :state,
+      :notify,
+      :locations,
+      :attendees,
+      :meta,
+      :department_id
+    )
+
+    delegate :persisted?, to: :event
+
+    validates :starts_at, :ends_at, :site, :collection, presence: true
+    validates :title_translations, translated_attribute_presence: true
+
+    trackable_on :event
+
+    notify_changed :state
+
+    def initialize(options = {})
+      options = options.to_h.with_indifferent_access
+      super options.except(*ignored_constructor_attributes)
+    end
+
+    def ignored_constructor_attributes
+      []
+    end
+
+    def destroy
+      unless event.new_record?
+        event.destroy
+      end
+    end
+
+    def save
+      save_event if valid?
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id)
+    end
+
+    def event
+      @event ||= event_class.find_by(id: id).presence || external_id && person.events.find_by(external_id: external_id).presence || build_event
+    end
+
+    def person
+      @person ||= site.people.find_by(id: person_id)
+    end
+
+    def collection
+      @collection ||= person.try(:events_collection)
+    end
+
+    def locations
+      @locations ||= []
+    end
+
+    def locations_attributes=(attributes)
+      @locations = []
+
+      attributes.each do |_, location_attributes|
+        next if location_attributes["_destroy"] == "1"
+        location = event_location_class.new(location_attributes.slice(:name, :address, :lat, :lng))
+        @locations.push(location) if location.valid?
+      end
+    end
+
+    def attendees
+      @attendees ||= event.attendees.presence || []
+      return @attendees if person.nil? || @attendees.map(&:person_id).include?(person.id)
+      @attendees.push(organizer)
+    end
+
+    def organizer
+      event.attendees.find_by(person_id: person.id).presence || event_attendee_class.new(person_id: person.id)
+    end
+
+    def state
+      @state ||= event.state
+    end
+
+    def notify?
+      notify && event.active? && person.present?
+    end
+
+    private
+
+    def build_event
+      event_class.new site_id: site_id
+    end
+
+    def event_class
+      ::GobiertoCalendars::Event
+    end
+
+    def event_location_class
+      ::GobiertoCalendars::EventLocation
+    end
+
+    def event_attendee_class
+      ::GobiertoCalendars::EventAttendee
+    end
+
+    def person_class
+      ::GobiertoPeople::Person
+    end
+
+    def collection_class
+      ::GobiertoCommon::Collection
+    end
+
+    def assign_event_attributes
+      @event = event.tap do |event_attributes|
+        event_attributes.external_id = external_id
+        event_attributes.collection = collection
+        event_attributes.site_id = site_id
+        event_attributes.state = state
+        event_attributes.title_translations = title_translations
+        event_attributes.description_translations = description_translations
+        event_attributes.description_source_translations = description_source_translations
+        event_attributes.starts_at = starts_at
+        event_attributes.ends_at = ends_at
+        event_attributes.locations = locations
+        event_attributes.attendees = attendees
+      end
+    end
+
+    def save_event
+      assign_event_attributes
+
+      if @event.valid?
+        run_callbacks(:save) do
+          @event.save
+        end
+
+        @event
+      else
+        promote_errors(@event.errors)
+
+        false
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_people/calendar_sync_event_form.rb
+++ b/app/forms/gobierto_people/calendar_sync_event_form.rb
@@ -32,8 +32,8 @@ module GobiertoPeople
       attributes.each do |_, location_attributes|
         next if location_attributes["_destroy"] == "1"
 
-        location = event.locations.detect{ |l| l.name == location_attributes[:name] } ||
-          event_location_class.new(name: location_attributes[:name])
+        location = event.locations.detect { |l| l.name == location_attributes[:name] } ||
+                   event_location_class.new(name: location_attributes[:name])
 
         @locations.push(location) if location.valid?
       end
@@ -43,7 +43,7 @@ module GobiertoPeople
       @attendees = []
 
       attendees_attributes.each do |attendee_attributes|
-        name  = attendee_attributes[:name]
+        name = attendee_attributes[:name]
         email = attendee_attributes[:email]
 
         attendee_person = attendee_attributes[:person] || site.people.find_by(email: email)
@@ -75,21 +75,21 @@ module GobiertoPeople
     private
 
     def event_in_sync_range_window
-      errors.add(:starts_at, 'is out of sync range') unless GobiertoCalendars.sync_range.cover?(starts_at)
+      errors.add(:starts_at, "is out of sync range") unless GobiertoCalendars.sync_range.cover?(starts_at)
     end
 
     def title_translations
       h = available_locales_to_hash
-      h.merge({site.configuration.default_locale => title})
+      h.merge(site.configuration.default_locale => title)
     end
 
     def description_translations
       h = available_locales_to_hash
-      h.merge({site.configuration.default_locale => description})
+      h.merge(site.configuration.default_locale => description)
     end
 
     def available_locales_to_hash
-      Hash[I18n.available_locales.map {|x| [x, nil]}]
+      Hash[I18n.available_locales.map { |x| [x, nil] }]
     end
 
     def save_event

--- a/app/forms/gobierto_people/calendar_sync_event_form.rb
+++ b/app/forms/gobierto_people/calendar_sync_event_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GobiertoPeople
-  class PersonEventForm < ::GobiertoCalendars::EventForm
+  class CalendarSyncEventForm < ::GobiertoCalendars::EventForm
 
     prepend ::GobiertoCommon::Trackable
 

--- a/app/forms/gobierto_people/person_event_form.rb
+++ b/app/forms/gobierto_people/person_event_form.rb
@@ -1,67 +1,29 @@
 # frozen_string_literal: true
 
 module GobiertoPeople
-  class PersonEventForm < BaseForm
+  class PersonEventForm < ::GobiertoCalendars::EventForm
 
     prepend ::GobiertoCommon::Trackable
 
     attr_accessor(
-      :external_id,
-      :site_id,
-      :person_id,
       :title,
-      :description,
-      :starts_at,
-      :ends_at,
-      :state,
-      :notify,
-      :locations,
-      :attendees
+      :description
     )
 
-    delegate :persisted?, to: :person_event
-
-    validates :external_id, :title, :starts_at, :ends_at, :site, :collection, presence: true
+    validates :external_id, :title, presence: true
     validate :event_in_sync_range_window
 
-    trackable_on :person_event
-
+    trackable_on :event
     notify_changed :state
 
     def initialize(options = {})
-        ordered_options = HashWithIndifferentAccess.new(site_id: options[:site_id], person_id: options[:person_id])
-        ordered_options.merge!(options)
-        super(ordered_options)
-      end
-
-    def destroy
-      unless person_event.new_record?
-        person_event.destroy
-      end
+      ordered_options = HashWithIndifferentAccess.new(site_id: options[:site_id], person_id: options[:person_id])
+      ordered_options.merge!(options)
+      super(ordered_options)
     end
 
     def save
-      save_person_event if valid?
-    end
-
-    def site
-      @site ||= Site.find_by(id: site_id)
-    end
-
-    def person_event
-      @person_event ||= person.events.find_by(external_id: external_id).presence || build_person_event
-    end
-
-    def person
-      @person ||= site.people.find_by(id: person_id)
-    end
-
-    def collection
-      @collection ||= person.try(:events_collection)
-    end
-
-    def locations
-      @locations ||= []
+      save_event if valid?
     end
 
     def locations_attributes=(attributes)
@@ -70,28 +32,11 @@ module GobiertoPeople
       attributes.each do |_, location_attributes|
         next if location_attributes["_destroy"] == "1"
 
-        location = person_event.locations.detect{ |l| l.name == location_attributes[:name] } ||
-          person_event_location_class.new(name: location_attributes[:name])
+        location = event.locations.detect{ |l| l.name == location_attributes[:name] } ||
+          event_location_class.new(name: location_attributes[:name])
 
         @locations.push(location) if location.valid?
       end
-    end
-
-    def attendees
-      @attendees ||= person_event.attendees.presence || []
-
-      return @attendees if person.nil?
-
-      if person_event.attendees.any?
-        unless organizer = person_event.attendees.find_by(person_id: person_id)
-          organizer = person_event_attendee_class.new(person_id: person_id)
-        end
-      else
-        organizer = person_event_attendee_class.new(person_id: person_id)
-      end
-      @attendees.push(organizer) unless @attendees.any?{ |a| a.person_id == organizer.person_id }
-
-      @attendees
     end
 
     def attendees=(attendees_attributes)
@@ -103,16 +48,16 @@ module GobiertoPeople
 
         attendee_person = attendee_attributes[:person] || site.people.find_by(email: email)
 
-        existing_attendee = person_event.attendees.detect do |a|
+        existing_attendee = event.attendees.detect do |a|
           (attendee_person.present? && a.person == attendee_person) || a.name == name
         end
 
         attendee = if existing_attendee
                      existing_attendee
                    elsif attendee_person.present?
-                     person_event_attendee_class.new(person: attendee_person)
+                     event_attendee_class.new(person: attendee_person)
                    else
-                     person_event_attendee_class.new(name: name)
+                     event_attendee_class.new(name: name)
                    end
 
         @attendees.push(attendee) if attendee.valid?
@@ -120,30 +65,14 @@ module GobiertoPeople
     end
 
     def state
-      @state ||= person_event.state || "published"
+      @state ||= event.state || "published"
     end
 
     def notify?
-      notify && person_event.active? && person.present?
+      notify && event.active? && person.present?
     end
 
     private
-
-    def build_person_event
-      event_class.new site_id: site_id
-    end
-
-    def event_class
-      ::GobiertoCalendars::Event
-    end
-
-    def person_event_location_class
-      ::GobiertoCalendars::EventLocation
-    end
-
-    def person_event_attendee_class
-      ::GobiertoCalendars::EventAttendee
-    end
 
     def event_in_sync_range_window
       errors.add(:starts_at, 'is out of sync range') unless GobiertoCalendars.sync_range.cover?(starts_at)
@@ -163,38 +92,26 @@ module GobiertoPeople
       Hash[I18n.available_locales.map {|x| [x, nil]}]
     end
 
-    def save_person_event
-      @person_event = person_event.tap do |person_event_attributes|
-        person_event_attributes.site_id = site_id
-        person_event_attributes.external_id = external_id
-        person_event_attributes.collection = collection
-        person_event_attributes.state = state
-        person_event_attributes.title_translations = title_translations
-        person_event_attributes.description_translations = description_translations
-        person_event_attributes.starts_at = starts_at
-        person_event_attributes.ends_at = ends_at
-        person_event_attributes.locations = locations
-        person_event_attributes.attendees = attendees
-      end
+    def save_event
+      assign_event_attributes
 
-      if @person_event.valid?
-        if @person_event.changes.any?
+      if @event.valid?
+        if @event.changes.any?
           if notify?
             run_callbacks(:save) do
-              @person_event.save
+              @event.save
             end
           else
-            @person_event.save
+            @event.save
           end
         end
 
-        @person_event
+        @event
       else
-        promote_errors(@person_event.errors)
+        promote_errors(@event.errors)
 
         false
       end
     end
-
   end
 end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -129,7 +129,7 @@ module GobiertoPeople
           event_params.merge!(locations_attributes: {"0" => {"_destroy" => "1" }})
         end
 
-        event_form = GobiertoPeople::PersonEventForm.new(event_params)
+        event_form = GobiertoPeople::CalendarSyncEventForm.new(event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
           log_destroy_rule

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -97,7 +97,7 @@ module GobiertoPeople
           notify: true
         }
 
-        event_form = GobiertoPeople::PersonEventForm.new(person_event_params)
+        event_form = GobiertoPeople::CalendarSyncEventForm.new(person_event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
           log_destroy_rule

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -104,7 +104,7 @@ module GobiertoPeople
           event_params.merge!(locations_attributes: { "0" => { "_destroy" => "1" } })
         end
 
-        event_form = GobiertoPeople::PersonEventForm.new(event_params)
+        event_form = GobiertoPeople::CalendarSyncEventForm.new(event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
           log_destroy_rule

--- a/test/forms/gobierto_people/calendar_sync_event_form_test.rb
+++ b/test/forms/gobierto_people/calendar_sync_event_form_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 require "support/event_helpers"
 
 module GobiertoPeople
-  class PersonEventFormTest < ActiveSupport::TestCase
+  class CalendarSyncEventFormTest < ActiveSupport::TestCase
 
     include ::EventHelpers
 
@@ -45,11 +45,11 @@ module GobiertoPeople
     end
 
     def valid_event_form
-      @valid_event_form ||= PersonEventForm.new(event_attributes)
+      @valid_event_form ||= CalendarSyncEventForm.new(event_attributes)
     end
 
     def invalid_event_form
-      @invalid_event_form ||= PersonEventForm.new(
+      @invalid_event_form ||= CalendarSyncEventForm.new(
         external_id: nil,
         site_id: site.id,
         person_id: nil,
@@ -80,8 +80,8 @@ module GobiertoPeople
       very_future_date = ::GobiertoCalendars.sync_range_end + 1.day
       very_old_date    = ::GobiertoCalendars.sync_range_start - 1.day
 
-      very_future_event = PersonEventForm.new(event_attributes.merge(starts_at: very_future_date))
-      very_old_event    = PersonEventForm.new(event_attributes.merge(starts_at: very_old_date))
+      very_future_event = CalendarSyncEventForm.new(event_attributes.merge(starts_at: very_future_date))
+      very_old_event    = CalendarSyncEventForm.new(event_attributes.merge(starts_at: very_old_date))
 
       refute very_future_event.save
       refute very_old_event.save
@@ -101,9 +101,9 @@ module GobiertoPeople
       event_3 = create_event(person: nelson,  title: 'Nelson event',  external_id: '123')
 
       # permutate order of all three events so test never passes by accident
-      event_3_form = PersonEventForm.new(site_id: site.id, person_id: nelson.id,  external_id: '123')
-      event_1_form = PersonEventForm.new(site_id: site.id, person_id: richard.id, external_id: '123')
-      event_2_form = PersonEventForm.new(site_id: site.id, person_id: tamara.id,  external_id: '123')
+      event_3_form = CalendarSyncEventForm.new(site_id: site.id, person_id: nelson.id,  external_id: '123')
+      event_1_form = CalendarSyncEventForm.new(site_id: site.id, person_id: richard.id, external_id: '123')
+      event_2_form = CalendarSyncEventForm.new(site_id: site.id, person_id: tamara.id,  external_id: '123')
 
       assert_equal 'Richard event', event_1_form.event.title
       assert_equal 'Tamara event',  event_2_form.event.title

--- a/test/forms/gobierto_people/calendar_sync_event_form_test.rb
+++ b/test/forms/gobierto_people/calendar_sync_event_form_test.rb
@@ -78,10 +78,10 @@ module GobiertoPeople
 
     def test_save_event_out_of_sync_range
       very_future_date = ::GobiertoCalendars.sync_range_end + 1.day
-      very_old_date    = ::GobiertoCalendars.sync_range_start - 1.day
+      very_old_date = ::GobiertoCalendars.sync_range_start - 1.day
 
       very_future_event = CalendarSyncEventForm.new(event_attributes.merge(starts_at: very_future_date))
-      very_old_event    = CalendarSyncEventForm.new(event_attributes.merge(starts_at: very_old_date))
+      very_old_event = CalendarSyncEventForm.new(event_attributes.merge(starts_at: very_old_date))
 
       refute very_future_event.save
       refute very_old_event.save
@@ -96,18 +96,18 @@ module GobiertoPeople
     end
 
     def test_scopes_event_search_on_person_when_external_id_collides
-      event_1 = create_event(person: richard, title: 'Richard event', external_id: '123')
-      event_2 = create_event(person: tamara,  title: 'Tamara event',  external_id: '123')
-      event_3 = create_event(person: nelson,  title: 'Nelson event',  external_id: '123')
+      event_1 = create_event(person: richard, title: "Richard event", external_id: "123")
+      event_2 = create_event(person: tamara, title: "Tamara event", external_id: "123")
+      event_3 = create_event(person: nelson, title: "Nelson event", external_id: "123")
 
       # permutate order of all three events so test never passes by accident
-      event_3_form = CalendarSyncEventForm.new(site_id: site.id, person_id: nelson.id,  external_id: '123')
-      event_1_form = CalendarSyncEventForm.new(site_id: site.id, person_id: richard.id, external_id: '123')
-      event_2_form = CalendarSyncEventForm.new(site_id: site.id, person_id: tamara.id,  external_id: '123')
+      event_3_form = CalendarSyncEventForm.new(site_id: site.id, person_id: nelson.id, external_id: "123")
+      event_1_form = CalendarSyncEventForm.new(site_id: site.id, person_id: richard.id, external_id: "123")
+      event_2_form = CalendarSyncEventForm.new(site_id: site.id, person_id: tamara.id, external_id: "123")
 
-      assert_equal 'Richard event', event_1_form.event.title
-      assert_equal 'Tamara event',  event_2_form.event.title
-      assert_equal 'Nelson event',  event_3_form.event.title
+      assert_equal "Richard event", event_1_form.event.title
+      assert_equal "Tamara event", event_2_form.event.title
+      assert_equal "Nelson event", event_3_form.event.title
     end
 
   end

--- a/test/forms/gobierto_people/person_event_form_test.rb
+++ b/test/forms/gobierto_people/person_event_form_test.rb
@@ -105,9 +105,9 @@ module GobiertoPeople
       event_1_form = PersonEventForm.new(site_id: site.id, person_id: richard.id, external_id: '123')
       event_2_form = PersonEventForm.new(site_id: site.id, person_id: tamara.id,  external_id: '123')
 
-      assert_equal 'Richard event', event_1_form.person_event.title
-      assert_equal 'Tamara event',  event_2_form.person_event.title
-      assert_equal 'Nelson event',  event_3_form.person_event.title
+      assert_equal 'Richard event', event_1_form.event.title
+      assert_equal 'Tamara event',  event_2_form.event.title
+      assert_equal 'Nelson event',  event_3_form.event.title
     end
 
   end


### PR DESCRIPTION
Closes #1660

## :v: What does this PR do?
* Extracts common code of `GobiertoAdmin::GobiertoCalendars::EventForm` and `GobiertoPeople::PersonEventForm` in a parent class `GobiertoCalendars::EventForm`
* Renames `GobiertoPeople::PersonEventForm` as `GobiertoPeople::CalendarSyncEventForm`
* Adds the assignment of department and meta attributes in the parent class

## :mag: How should this be manually tested?
Test the CRUD of events in http://madrid.gobify.net/admin/gobierto_calendars/events?collection_id=218 and sync calendar events http://madrid.gobify.net/admin/gobierto_calendars/configurations/141/edit

## :eyes: Screenshots

### Before this PR
🐴
### After this PR
🦄 
## :shipit: Does this PR changes any configuration file?
No