### PR TITLE
Fix issues with budget lines comparison graphs

### DIFF
--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -4,8 +4,9 @@ module GobiertoBudgets
       include GobiertoBudgets::ApplicationHelper
 
       caches_action :total_budget, :total_budget_execution, :population, :total_budget_per_inhabitant,
-                    :budget, :budget_execution, :budget_per_inhabitant, :budget_percentage_over_total, :debt,
-                    :lines
+                    :budget, :budget_execution, :budget_per_inhabitant, :budget_percentage_over_total, :debt3
+
+      caches_action :lines, cache_path: proc { |c| c.request.url }
 
       def budget
         @year = params[:year].to_i

--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -4,7 +4,7 @@ module GobiertoBudgets
       include GobiertoBudgets::ApplicationHelper
 
       caches_action :total_budget, :total_budget_execution, :population, :total_budget_per_inhabitant,
-                    :budget, :budget_execution, :budget_per_inhabitant, :budget_percentage_over_total, :debt3
+                    :budget, :budget_execution, :budget_per_inhabitant, :budget_percentage_over_total, :debt
 
       caches_action :lines, cache_path: proc { |c| c.request.url }
 

--- a/app/javascript/budgets/modules/vis_lineas_tabla.js
+++ b/app/javascript/budgets/modules/vis_lineas_tabla.js
@@ -93,6 +93,9 @@ export var VisLineasJ = Class.extend({
 
     // Chart dimensions
     this.containerWidth = parseInt(d3.select(this.container).style('width'), 10);
+    if (isNaN(this.containerWidth)) {
+      this.containerWidth = 0;
+    }
 
     if (d3.select(this.tableContainer).size() !== 0) {
       this.tableWidth = parseInt(d3.select(this.tableContainer).style('width'), 10);

--- a/app/javascript/shared/modules/tabs.js
+++ b/app/javascript/shared/modules/tabs.js
@@ -143,7 +143,7 @@ $(document).on('turbolinks:load', function() {
       setFocus = setFocus || true;
       // Deactivate all other tabs
 
-      var currentTabpanel = tab.closest('[role="tabpanel"]');
+      var currentTabpanel = $(tab).closest('[role="tabpanel"]');
 
       deactivateTabs(currentTabpanel);
 

--- a/app/javascript/shared/modules/tabs.js
+++ b/app/javascript/shared/modules/tabs.js
@@ -142,7 +142,10 @@ $(document).on('turbolinks:load', function() {
     function activateTab (tab, setFocus) {
       setFocus = setFocus || true;
       // Deactivate all other tabs
-      deactivateTabs();
+
+      var currentTabpanel = tab.closest('[role="tabpanel"]');
+
+      deactivateTabs(currentTabpanel);
 
       // Remove tabindex attribute
       tab.removeAttribute('tabindex');
@@ -167,14 +170,12 @@ $(document).on('turbolinks:load', function() {
     }
 
     // Deactivate all tabs and tab panels
-    function deactivateTabs () {
-      for (var t = 0; t < tabs.length; t++) {
-        tabs[t].setAttribute('tabindex', '-1');
-        tabs[t].setAttribute('aria-selected', 'false');
-      }
+    function deactivateTabs (currentTabpanel) {
+      var tabsInCurrentTabpanel = $(currentTabpanel).find('[role="tab"]');
 
-      for (var p = 0; p < panels.length; p++) {
-        panels[p].setAttribute('hidden', 'hidden');
+      for (var t = 0; t < tabsInCurrentTabpanel.length; t++) {
+        tabsInCurrentTabpanel[t].setAttribute('tabindex', '-1');
+        tabsInCurrentTabpanel[t].setAttribute('aria-selected', 'false');
       }
     }
 

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -153,8 +153,7 @@ module GobiertoBudgets
 
       def place_values(place = nil)
         place = @place unless place.present?
-
-        place ? values_filtered_by(ine_code: place.id) : []
+        place ? values_filtered_by(organization_id: place.id) : []
       end
 
       def organization_values
@@ -169,7 +168,10 @@ module GobiertoBudgets
           }]
           @comparison.map do |place_id|
             if place = INE::Places::Place.find(place_id)
-              { name: place.name, values: place_values(place) }
+              {
+                name: place.name,
+                values: place_values(place).reject { |item| item[:value].zero? }
+              }
             end
           end.compact + place_value
         else

--- a/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
+++ b/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
@@ -46,7 +46,7 @@
         tabindex:-1,
         "aria-selected": !@site_stats.has_available_population_data?,
         id: "total_budget",
-        "aria-controls": "lines_chart_wrapper" %>
+        "aria-controls": "lines_chart_comparison_wrapper" %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Closes [#342](https://github.com/PopulateTools/issues/issues/342)

## :v: What does this PR do?

* Fixes a cache bug that made both graphs return the same info
* Fixes bug in `tabs.js` code that disabled tabs in other panels.

## :mag: How should this be manually tested?

Go to the following pages, and try that the graphs tabs (and other tabs in the same page) behave as expected:

* http://mataro.gobify.net/presupuestos/resumen/2018
* http://mataro.gobify.net/presupuestos/partidas/13/2018/functional/G

## :shipit: Does this PR changes any configuration file?

No