### PR TITLE
Force GobiertoPeople dependency

### DIFF
--- a/app/controllers/concerns/submodules_helper.rb
+++ b/app/controllers/concerns/submodules_helper.rb
@@ -1,6 +1,8 @@
 module SubmodulesHelper
   extend ActiveSupport::Concern
 
+  require_dependency "gobierto_people"
+
   included do
     helper_method :active_submodules, :welcome_submodule_active?, :officials_submodule_active?,
                   :agendas_submodule_active?, :blogs_submodule_active?, :statements_submodule_active?,


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR forces to require GobiertoPeople before loading the submodules helper, which loads methods from that module.
