### PR TITLE
Interest groups associations

### DIFF
--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -17,7 +17,8 @@ module GobiertoCalendars
       :ends_at,
       :notify,
       :meta,
-      :department_id
+      :department_id,
+      :interest_group_id
     )
     attr_writer(
       :state,

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -35,6 +35,7 @@ module GobiertoCalendars
     belongs_to :site
     belongs_to :collection, class_name: "GobiertoCommon::Collection"
     belongs_to :department, class_name: "GobiertoPeople::Department"
+    belongs_to :interest_group, class_name: "GobiertoPeople::InterestGroup"
     has_many :locations, class_name: "EventLocation", dependent: :destroy
     has_many :attendees, class_name: "EventAttendee", dependent: :destroy
 

--- a/app/models/gobierto_people/interest_group.rb
+++ b/app/models/gobierto_people/interest_group.rb
@@ -8,6 +8,7 @@ module GobiertoPeople
     include GobiertoCommon::Metadatable
 
     belongs_to :site
+    has_many :events, class_name: "GobiertoCalendars::Event", dependent: :nullify
 
     scope :sorted, -> { order(name: :asc) }
 

--- a/db/migrate/20180601135249_add_interest_group_id_to_events.rb
+++ b/db/migrate/20180601135249_add_interest_group_id_to_events.rb
@@ -1,0 +1,5 @@
+class AddInterestGroupIdToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :gc_events, :interest_group, index: true
+  end
+end

--- a/db/migrate/20180601135249_add_interest_group_id_to_events.rb
+++ b/db/migrate/20180601135249_add_interest_group_id_to_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddInterestGroupIdToEvents < ActiveRecord::Migration[5.2]
   def change
     add_reference :gc_events, :interest_group, index: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_22_082718) do
+ActiveRecord::Schema.define(version: 2018_06_01_135249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -322,10 +322,12 @@ ActiveRecord::Schema.define(version: 2018_05_22_082718) do
     t.jsonb "description_source_translations"
     t.jsonb "meta"
     t.bigint "department_id"
+    t.bigint "interest_group_id"
     t.index ["archived_at"], name: "index_gc_events_on_archived_at"
     t.index ["department_id"], name: "index_gc_events_on_department_id"
     t.index ["description_source_translations"], name: "index_gc_events_on_description_source_translations", using: :gin
     t.index ["description_translations"], name: "index_gc_events_on_description_translations", using: :gin
+    t.index ["interest_group_id"], name: "index_gc_events_on_interest_group_id"
     t.index ["meta"], name: "index_gc_events_on_meta", using: :gin
     t.index ["site_id", "slug"], name: "index_gc_events_on_site_id_and_slug", unique: true
     t.index ["title_translations"], name: "index_gc_events_on_title_translations", using: :gin


### PR DESCRIPTION
## :v: What does this PR do?

Creates association between events and interest groups, adding an `interest_group_id` column to events table and defining the association in respective models

## :mag: How should this be manually tested?

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?
No