### PR TITLE
346 theme engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ yarn-debug.log*
 
 # I18njs
 app/javascript/i18n/translations.js
+
+# Gobierto Engines
+vendor/gobierto_engines/*
+!vendor/gobierto_engines/.keep

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -37,10 +37,18 @@
 @import "mixins";
 
 /*
- * Gobierto components
+ * Gobierto base and themes configuration
  *
  */
 @import "css-conf";
+<% Rails.application.config.engine_sass_config_overrides.each do |config| %>
+  @import "<%= config %>";
+<% end %>
+
+/*
+ * Gobierto components
+ *
+ */
 @import "comp-dropdown";
 @import "comp-breadcrumbs";
 @import "comp-flash_messages";
@@ -94,6 +102,9 @@
  *
  */
 @import "theme-participation";
+<% Rails.application.config.engine_sass_theme_dependencies.each do |dependency| %>
+  @import "<%= dependency %>";
+<% end %>
 
 /*
  * Print styles

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -45,3 +45,14 @@
   }
 }
 @include gutters;
+
+// flex alignment
+@mixin flex-align($horizontal: center, $vertical: center) {
+  display: flex;
+  justify-content: $horizontal;
+  align-items: $vertical;
+
+  > * {
+    margin: 0;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
     :algoliasearch_configured?
   )
 
-  before_action :set_current_site, :authenticate_user_in_site, :set_locale
+  before_action :set_current_site, :authenticate_user_in_site, :set_locale, :apply_engines_overrides
 
   def render_404
     render file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]
@@ -93,6 +93,16 @@ class ApplicationController < ActionController::Base
 
   def algoliasearch_configured?
     ::GobiertoCommon::Search.algoliasearch_configured?
+  end
+
+  def apply_engines_overrides
+    engine_overrides = current_site.engines_overrides
+    if engine_overrides.any?
+      puts "\n\n[DEBUG] Appending overrides directory\n\n"
+      prepend_view_path Rails.root.join("vendor/gobierto_engines/#{engine_overrides.first}/app/views")
+    else
+      puts "\n\n[DEBUG] No overrides to apply\n\n"
+    end
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,8 +96,8 @@ class ApplicationController < ActionController::Base
   end
 
   def apply_engines_overrides
-    engine_overrides = current_site.engines_overrides
-    if engine_overrides.any?
+    engine_overrides = current_site.try(:engines_overrides)
+    if engine_overrides.present?
       puts "\n\n[DEBUG] Appending overrides directory\n\n"
       engine_overrides.each do |engine|
         prepend_view_path Rails.root.join("vendor/gobierto_engines/#{ engine }/app/views")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,13 +97,9 @@ class ApplicationController < ActionController::Base
 
   def apply_engines_overrides
     engine_overrides = current_site.try(:engines_overrides)
-    if engine_overrides.present?
-      puts "\n\n[DEBUG] Appending overrides directory\n\n"
-      engine_overrides.each do |engine|
-        prepend_view_path Rails.root.join("vendor/gobierto_engines/#{ engine }/app/views")
-      end
-    else
-      puts "\n\n[DEBUG] No overrides to apply\n\n"
+    return if engine_overrides.blank?
+    engine_overrides.each do |engine|
+      prepend_view_path Rails.root.join("vendor/gobierto_engines/#{ engine }/app/views")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,7 +99,9 @@ class ApplicationController < ActionController::Base
     engine_overrides = current_site.engines_overrides
     if engine_overrides.any?
       puts "\n\n[DEBUG] Appending overrides directory\n\n"
-      prepend_view_path Rails.root.join("vendor/gobierto_engines/#{engine_overrides.first}/app/views")
+      engine_overrides.each do |engine|
+        prepend_view_path Rails.root.join("vendor/gobierto_engines/#{ engine }/app/views")
+      end
     else
       puts "\n\n[DEBUG] No overrides to apply\n\n"
     end

--- a/app/controllers/gobierto_admin/sites_controller.rb
+++ b/app/controllers/gobierto_admin/sites_controller.rb
@@ -174,6 +174,7 @@ module GobiertoAdmin
         :raw_configuration_variables,
         :home_page,
         :home_page_item_id,
+        :engine_overrides_param,
         site_modules: [],
         available_locales: [],
         title_translations: [*I18n.available_locales],

--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -42,6 +42,8 @@ module GobiertoAdmin
 
     attr_reader :logo_url
 
+    attr_writer :engine_overrides
+
     delegate :persisted?, to: :site
 
     validates :google_analytics_id,
@@ -81,6 +83,24 @@ module GobiertoAdmin
                       else
                         site.configuration.auth_modules
                       end
+    end
+
+    def engine_overrides_param=(engine_overrides)
+      if engine_overrides.is_a? String
+        engine_overrides = engine_overrides.split(/[;,\s]+/)
+      end
+      engine_overrides_base_path = Rails.root.join("vendor/gobierto_engines/")
+      @engine_overrides = engine_overrides.select do |engine|
+        Dir.exist?(File.join(engine_overrides_base_path, engine))
+      end
+    end
+
+    def engine_overrides
+      @engine_overrides ||= site.configuration.engine_overrides
+    end
+
+    def engine_overrides_param
+      @engine_overrides_param ||= engine_overrides.join(", ")
     end
 
     def head_markup
@@ -188,6 +208,7 @@ module GobiertoAdmin
         site_attributes.configuration.populate_data_api_token = populate_data_api_token
         site_attributes.configuration.raw_configuration_variables = raw_configuration_variables
         site_attributes.configuration.auth_modules = auth_modules
+        site_attributes.configuration.engine_overrides = engine_overrides
       end
 
       @organization_id_changed = @site.organization_id_changed?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -124,6 +124,10 @@ class Site < ApplicationRecord
     self.name
   end
 
+  def engines_overrides
+    ["gencat"]
+  end
+
   private
 
   def site_configuration_attributes

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -125,7 +125,7 @@ class Site < ApplicationRecord
   end
 
   def engines_overrides
-    ["gencat"]
+    configuration.engine_overrides
   end
 
   private

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -17,7 +17,8 @@ class SiteConfiguration
     :home_page,
     :home_page_item_id,
     :raw_configuration_variables,
-    :auth_modules
+    :auth_modules,
+    :engine_overrides
   ].freeze
 
   DEFAULT_LOGO_PATH = "sites/logo-default.png".freeze
@@ -54,6 +55,10 @@ class SiteConfiguration
 
   def auth_modules_data
     AUTH_MODULES.select { |mod| auth_modules.include?(mod.name) }
+  end
+
+  def engine_overrides
+    @engine_overrides || []
   end
 
   def logo_with_fallback

--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -188,6 +188,11 @@
         </div>
       <% end %>
 
+      <div class="form_item input_text">
+        <%= f.label :engine_overrides_param %>
+        <%= f.text_field(:engine_overrides_param) %>
+      </div>
+
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,9 @@ module Gobierto
       require_dependency config.root.join(*base_strategies_path).join(strategy, 'lib', 'initializer')
     end
 
+    config.engine_sass_config_overrides = []
+    config.engine_sass_theme_dependencies = []
+
     # Do not add wrapper .field_with_errors around form fields with validation errors
     config.action_view.field_error_proc = proc { |html_tag, _instance| html_tag }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,8 +61,18 @@ module Gobierto
       require_dependency config.root.join(*base_strategies_path).join(strategy, 'lib', 'initializer')
     end
 
+    # Engine Overrides
     config.engine_sass_config_overrides = []
     config.engine_sass_theme_dependencies = []
+
+    base_engines_path = %w(vendor gobierto_engines)
+    available_engines = Dir.chdir(config.root.join(*base_engines_path)) do
+      Dir.glob('*').select { |item| File.directory?(item) }
+    end
+
+    available_engines.each do |engine_dir|
+      require_dependency config.root.join(*base_engines_path).join(engine_dir, "lib", "initializer")
+    end
 
     # Do not add wrapper .field_with_errors around form fields with validation errors
     config.action_view.field_error_proc = proc { |html_tag, _instance| html_tag }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,9 +312,9 @@ ActiveRecord::Schema.define(version: 2018_05_22_082718) do
     t.integer "state", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_id"
     t.jsonb "title_translations"
     t.jsonb "description_translations"
-    t.string "external_id"
     t.integer "site_id", null: false
     t.string "slug", null: false
     t.integer "collection_id"


### PR DESCRIPTION
## :v: What does this PR do?
Adds support to include custom views and styles loaded from an external engine installed in `vendor/gobierto_engines/`.

* The engines there are expected to have a `lib/initializer.rb` file.
* From admin, in site configuration, the list of engines can be edited, listing the names of engine directories under `vendor/gobierto_engines/`

## :mag: How should this be manually tested?
install an engine under `vendor/gobierto_engines/` for example: `vendor/gobierto_engines/gobierto-custom-engine`
Go to admin and customize site setting engine overrides param as `gobierto-custom-engine`
<img width="728" alt="screen shot 2018-06-06 at 17 17 49" src="https://user-images.githubusercontent.com/446459/41048007-195d9a24-69ae-11e8-827d-75015221a9cb.png">

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?
No
