### PR TITLE
Fix year selector link in execution page

### DIFF
--- a/app/views/gobierto_budgets/budgets_execution/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_execution/index.html.erb
@@ -17,7 +17,7 @@
           <h2 class="with_description p_h_r_0_5"><%= t('.title') %></h2>
           <%= render partial: "gobierto_budgets/shared/year_breadcrumb", locals: {
                 selected_year: @year,
-                selected_year_path: gobierto_budgets_budgets_path(@year),
+                selected_year_path: gobierto_budgets_budgets_execution_path(@year),
                 available_years: available_years
               } %>
         </div>

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -44,4 +44,22 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  def test_year_breadcrumb_click
+    available_years = [2017, 2016]
+    GobiertoBudgets::SearchEngineConfiguration::Year.stubs(:with_data).with(
+      index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed
+    ).returns(available_years)
+
+    with_current_site(placed_site) do
+      visit gobierto_budgets_budgets_execution_path(available_years.first)
+
+      within "#popup-year" do
+        click_link available_years.first
+      end
+
+      refute_equal current_path, gobierto_budgets_budgets_execution_path(available_years.first)
+    end
+  end
+
 end


### PR DESCRIPTION
Closes an issue reported by DiBa.

## :v: What does this PR do?

Fixes the current year link in the execution page to keep the user in the execution page and not in the summary page.

## :mag: How should this be manually tested?

1. Click in the link
2. Check you are still in the execution section.
