### PR TITLE
362 - Interest groups API

### DIFF
--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApiBaseController < ApplicationController
+
+  respond_to :json
+
+  skip_before_action :verify_authenticity_token
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,8 +109,12 @@ class ApplicationController < ActionController::Base
     request.env['action_dispatch.remote_ip'].try(:calculate_ip) || request.remote_ip
   end
 
-  def raise_module_not_enabled
-    redirect_to(root_path) and return false
+  def raise_module_not_enabled(redirect = true)
+    if redirect
+      redirect_to(root_path) and return false
+    else
+      head :forbidden
+    end
   end
 
   def gobierto_calendars_event_preview_url(event, options = {})

--- a/app/controllers/concerns/gobierto_common/module_helper.rb
+++ b/app/controllers/concerns/gobierto_common/module_helper.rb
@@ -4,8 +4,8 @@ module GobiertoCommon
 
     private
 
-    def module_enabled!(site, module_namespace)
-      raise_module_not_enabled unless site.configuration.modules.include?(module_namespace.to_s)
+    def module_enabled!(site, module_namespace, redirect = true)
+      raise_module_not_enabled(redirect) unless site.configuration.modules.include?(module_namespace.to_s)
     end
 
     def module_allowed!(current_admin, module_namespace)

--- a/app/controllers/gobierto_people/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/base_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  module Api
+    module V1
+      class BaseController < ApiBaseController
+
+        before_action { module_enabled!(current_site, "GobiertoPeople", false) }
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
@@ -31,8 +31,7 @@ module GobiertoPeople
             :department_id,
             :person_id,
             :from_date,
-            :to_date,
-            :limit
+            :to_date
           ).to_h
         end
 

--- a/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  module Api
+    module V1
+      class InterestGroupsController < Api::V1::BaseController
+
+        def index
+          query = InterestGroupsQuery.new(
+            relation: current_site.interest_groups,
+            conditions: permitted_conditions,
+            limit: records_to_return
+          )
+
+          render(
+            json: query.results,
+            each_serializer: InterestGroupRowchartSerializer
+          )
+        end
+
+        private
+
+        def permitted_conditions
+          params.permit(
+            :department_id,
+            :person_id,
+            :from_date,
+            :to_date,
+            :limit
+          ).to_h
+        end
+
+        def records_to_return
+          params[:limit] || 10
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
@@ -20,8 +20,14 @@ module GobiertoPeople
 
         private
 
+        def parsed_parameters
+          params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
+          params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
+          params
+        end
+
         def permitted_conditions
-          params.permit(
+          parsed_parameters.permit(
             :department_id,
             :person_id,
             :from_date,

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -52,6 +52,7 @@ module GobiertoCalendars
     scope :sort_by_updated_at, -> { order(updated_at: :desc) }
     scope :inverse_sorted_by_id, -> { order(id: :asc) }
     scope :sorted_by_id, -> { order(id: :desc) }
+    scope :with_interest_group, -> { where.not(interest_group_id: nil) }
 
     scope :by_collection, ->(collection) do
       where(collection_id: collection.id)

--- a/app/models/gobierto_people/interest_group.rb
+++ b/app/models/gobierto_people/interest_group.rb
@@ -25,5 +25,9 @@ module GobiertoPeople
       [name]
     end
 
+    def events_count
+      events.count
+    end
+
   end
 end

--- a/app/models/gobierto_people/interest_group.rb
+++ b/app/models/gobierto_people/interest_group.rb
@@ -5,6 +5,7 @@ require_dependency "gobierto_people"
 module GobiertoPeople
   class InterestGroup < ApplicationRecord
 
+    include GobiertoCommon::Sluggable
     include GobiertoCommon::Metadatable
 
     belongs_to :site
@@ -15,6 +16,14 @@ module GobiertoPeople
     validates :name, presence: true
 
     metadata_attributes :status, :registry
+
+    def to_param
+      slug
+    end
+
+    def attributes_for_slug
+      [name]
+    end
 
   end
 end

--- a/app/models/gobierto_people/interest_group.rb
+++ b/app/models/gobierto_people/interest_group.rb
@@ -26,7 +26,7 @@ module GobiertoPeople
     end
 
     def events_count
-      events.count
+      attributes["events_count"] || events.count
     end
 
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -32,6 +32,7 @@ class Site < ApplicationRecord
   has_many :people, dependent: :destroy, class_name: "GobiertoPeople::Person"
   has_many :person_posts, through: :people, source: :posts, class_name: "GobiertoPeople::PersonPost"
   has_many :person_statements, through: :people, source: :statements, class_name: "GobiertoPeople::PersonStatement"
+  has_many :interest_groups, dependent: :destroy, class_name: "GobiertoPeople::InterestGroup"
 
   # GobiertoCalendars integration
   has_many :events, class_name: "GobiertoCalendars::Event", dependent: :destroy

--- a/app/queries/gobierto_people/interest_groups_query.rb
+++ b/app/queries/gobierto_people/interest_groups_query.rb
@@ -3,76 +3,54 @@
 module GobiertoPeople
   class InterestGroupsQuery
 
-    attr_reader :conditions, :limit, :relation
+    attr_reader :limit, :relation
 
     DEFAULT_LIMIT = 10
 
     def initialize(params = {})
-      @conditions = (params[:conditions] || {}).slice!(permitted_conditions)
-      parse_conditions!
+      @relation = (params[:relation] || model.all).joins(:events)
+      append_query_conditions(params[:conditions]) if params[:conditions]
       @limit = params[:limit] || DEFAULT_LIMIT
-      @relation = params[:relation] || model.all
     end
 
     def results
-      query_scope = conditions.any? ? relation.where(conditions) : relation
-
-      query_scope.joins(:events)
-                 .select("#{model.table_name}.*, COUNT(*) AS events_count")
-                 .group(:id)
-                 .order("events_count DESC")
-                 .limit(limit)
+      relation.select("#{model.table_name}.*, COUNT(*) AS events_count")
+              .group(:id)
+              .order("events_count DESC")
+              .limit(limit)
     end
 
     private
 
-    def permitted_conditions
-      [:department_id, :person_id]
-    end
-
-    def parse_conditions!
+    def append_query_conditions(conditions)
       if conditions[:department_id]
-        process_condition(
-          :department_id,
-          events_scope.where(department_id: conditions[:department_id])
-        )
+        append_condition(:department_id, conditions[:department_id])
       end
 
       if conditions[:person_id]
         person = ::GobiertoPeople::Person.find(conditions[:person_id])
-        process_condition(:person_id, person.events.with_interest_group)
+        append_condition(:collection_id, person.calendar.id)
       end
 
       if conditions[:from_date]
-        process_condition(
-          :from_date,
-          events_scope.where("starts_at >= ?", conditions[:from_date])
-        )
+        append_condition(:starts_at, conditions[:from_date], ">=")
       end
 
       if conditions[:to_date]
-        process_condition(
-          :to_date,
-          events_scope.where("ends_at <= ?", conditions[:to_date])
-        )
+        append_condition(:ends_at, conditions[:to_date], "<=")
       end
-    end
-
-    def events_scope
-      ::GobiertoCalendars::Event.with_interest_group
     end
 
     def model
       InterestGroup
     end
 
-    def process_condition(condition, interest_groups_scope)
-      conditions.delete(condition)
-      if conditions[:id]
-        conditions[:id] &= interest_groups_scope.pluck(:interest_group_id)
-      else
-        conditions[:id] = interest_groups_scope.pluck(:interest_group_id)
-      end
+    def events_table
+      ::GobiertoCalendars::Event.table_name
+    end
+
+    def append_condition(attribute_name, attribute_value, operator = "=")
+      @relation = relation.where("#{events_table}.#{attribute_name} #{operator} ?", attribute_value)
     end
 
   end

--- a/app/queries/gobierto_people/interest_groups_query.rb
+++ b/app/queries/gobierto_people/interest_groups_query.rb
@@ -69,7 +69,7 @@ module GobiertoPeople
     def process_condition(condition, interest_groups_scope)
       conditions.delete(condition)
       if conditions[:id]
-        conditions[:id] += interest_groups_scope.pluck(:interest_group_id)
+        conditions[:id] &= interest_groups_scope.pluck(:interest_group_id)
       else
         conditions[:id] = interest_groups_scope.pluck(:interest_group_id)
       end

--- a/app/queries/gobierto_people/interest_groups_query.rb
+++ b/app/queries/gobierto_people/interest_groups_query.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class InterestGroupsQuery
+
+    attr_reader :conditions, :limit, :relation
+
+    DEFAULT_LIMIT = 10
+
+    def initialize(params = {})
+      @conditions = (params[:conditions] || {}).slice!(permitted_conditions)
+      parse_conditions!
+      @limit = params[:limit] || DEFAULT_LIMIT
+      @relation = params[:relation] || model.all
+    end
+
+    def results
+      query_scope = conditions.any? ? relation.where(conditions) : relation
+
+      query_scope.joins(:events)
+                 .select("#{model.table_name}.*, COUNT(*) AS events_count")
+                 .group(:id)
+                 .order("events_count DESC")
+                 .limit(limit)
+    end
+
+    private
+
+    def permitted_conditions
+      [:department_id, :person_id]
+    end
+
+    def parse_conditions!
+      if conditions[:department_id]
+        process_condition(
+          :department_id,
+          events_scope.where(department_id: conditions[:department_id])
+        )
+      end
+
+      if conditions[:person_id]
+        person = ::GobiertoPeople::Person.find(conditions[:person_id])
+        process_condition(:person_id, person.events.with_interest_group)
+      end
+
+      if conditions[:from_date]
+        process_condition(
+          :from_date,
+          events_scope.where("starts_at >= ?", conditions[:from_date])
+        )
+      end
+
+      if conditions[:to_date]
+        process_condition(
+          :to_date,
+          events_scope.where("ends_at <= ?", conditions[:to_date])
+        )
+      end
+    end
+
+    def events_scope
+      ::GobiertoCalendars::Event.with_interest_group
+    end
+
+    def model
+      InterestGroup
+    end
+
+    def process_condition(condition, interest_groups_scope)
+      conditions.delete(condition)
+      if conditions[:id]
+        conditions[:id] += interest_groups_scope.pluck(:interest_group_id)
+      else
+        conditions[:id] = interest_groups_scope.pluck(:interest_group_id)
+      end
+    end
+
+  end
+end

--- a/app/serializers/gobierto_people/interest_group_rowchart_serializer.rb
+++ b/app/serializers/gobierto_people/interest_group_rowchart_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class InterestGroupRowchartSerializer < ActiveModel::Serializer
+
+    attributes :key, :value, :properties
+
+    def key
+      object.name
+    end
+
+    def value
+      object.events_count
+    end
+
+    def properties
+      {
+        url: url_helpers.gobierto_people_interest_group_url(
+          object,
+          host: object.site.domain
+        )
+      }
+    end
+
+    private
+
+    def url_helpers
+      Rails.application.routes.url_helpers
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,7 +256,7 @@ Rails.application.routes.draw do
       end
 
       # Interest groups
-      resources :interest_groups, only: :show
+      resources :interest_groups, only: :show, path: "grupos-de-interes"
 
       # People
       resources :people, only: [:show], path: "personas", param: :slug do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -255,6 +255,9 @@ Rails.application.routes.draw do
         resources :people, only: [:index], controller: "political_groups/people", path: "/"
       end
 
+      # Interest groups
+      resources :interest_groups, only: :show
+
       # People
       resources :people, only: [:show], path: "personas", param: :slug do
         resource :person_bio, only: [:show], controller: "people/person_bio", as: :bio, path: "biografia"
@@ -264,6 +267,13 @@ Rails.application.routes.draw do
           end
         end
         resource :google_calendar_calendars, only: [:edit, :update], controller: "people/google_calendar/calendars", as: :google_calendar_calendars
+      end
+
+      # API
+      namespace :api, path: "gobierto_people/api" do
+        namespace :v1 do
+          resources :interest_groups, only: :index
+        end
       end
     end
 

--- a/db/migrate/20180607153510_add_slug_to_interest_group.rb
+++ b/db/migrate/20180607153510_add_slug_to_interest_group.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSlugToInterestGroup < ActiveRecord::Migration[5.2]
+
+  def change
+    add_column :gp_interest_groups, :slug, :string
+  end
+
+end

--- a/db/migrate/20180607153921_generate_slugs_for_interest_groups.rb
+++ b/db/migrate/20180607153921_generate_slugs_for_interest_groups.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class GenerateSlugsForInterestGroups < ActiveRecord::Migration[5.2]
+
+  def up
+    ::GobiertoPeople::InterestGroup.all.each(&:save!)
+  end
+
+  def down
+    ::GobiertoPeople::InterestGroup.update_attribute(:slug, nil)
+  end
+
+end

--- a/db/migrate/20180607153940_add_contraints_to_interest_group_slug.rb
+++ b/db/migrate/20180607153940_add_contraints_to_interest_group_slug.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddContraintsToInterestGroupSlug < ActiveRecord::Migration[5.2]
+
+  def change
+    change_column :gp_interest_groups, :slug, :string, null: false
+    add_index :gp_interest_groups, [:site_id, :slug], unique: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_01_135249) do
+ActiveRecord::Schema.define(version: 2018_06_07_153940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -447,7 +447,9 @@ ActiveRecord::Schema.define(version: 2018_06_01_135249) do
     t.bigint "site_id", null: false
     t.string "name", null: false
     t.jsonb "meta"
+    t.string "slug", null: false
     t.index ["meta"], name: "index_gp_interest_groups_on_meta", using: :gin
+    t.index ["site_id", "slug"], name: "index_gp_interest_groups_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gp_interest_groups_on_site_id"
   end
 
@@ -459,8 +461,8 @@ ActiveRecord::Schema.define(version: 2018_06_01_135249) do
     t.date "end_date", null: false
     t.jsonb "meta"
     t.bigint "department_id"
-    t.jsonb "location"
     t.string "external_id"
+    t.jsonb "location"
     t.index ["department_id"], name: "index_gp_invitations_on_department_id"
     t.index ["location"], name: "index_gp_invitations_on_location", using: :gin
     t.index ["meta"], name: "index_gp_invitations_on_meta", using: :gin

--- a/test/fixtures/gobierto_calendars/event_attendees.yml
+++ b/test/fixtures/gobierto_calendars/event_attendees.yml
@@ -24,11 +24,15 @@ richard_richard_published_past:
   name:
   charge:
 
-richard_richard_culture_department_event:
-  event: richard_culture_department_event
+richard_richard_culture_department_event_google:
+  event: richard_culture_department_event_google
   person: richard
   name:
   charge:
+
+richard_richard_culture_department_event_accenture:
+  event: richard_culture_department_event_accenture
+  person: richard
 
 ## Tamara
 
@@ -44,11 +48,21 @@ tamara_tamara_published_past:
   name:
   charge:
 
-tamara_tamara_justice_department_event:
-  event: tamara_justice_department_event
+tamara_tamara_justice_department_event_without_interest_group:
+  event: tamara_justice_department_event_without_interest_group
   person: tamara
-  name:
-  charge:
+
+tamara_tamara_justice_department_event_coca_cola_recent:
+  event: tamara_justice_department_event_coca_cola_recent
+  person: tamara
+
+tamara_tamara_justice_department_event_pepsi_old:
+  event: tamara_justice_department_event_pepsi_old
+  person: tamara
+
+tamara_tamara_justice_department_event_pepsi_very_old:
+  event: tamara_justice_department_event_pepsi_very_old
+  person: tamara
 
 ## Nelson
 

--- a/test/fixtures/gobierto_calendars/events.yml
+++ b/test/fixtures/gobierto_calendars/events.yml
@@ -81,19 +81,42 @@ richard_published_past:
   ends_at: <%= 1.month.ago + 1.hour %>
   state: <%= GobiertoCalendars::Event.states["published"] %>
 
-richard_culture_department_event:
+richard_culture_department_event_google:
   site: madrid
   collection: richard_calendar
   department: culture_department
+  interest_group: google
   title_translations: <%= {
-    "en" => "Culture department event",
+    "en" => "Culture department event with Google",
   }.to_json %>
-  slug: <%= "#{1.month.from_now.strftime('%F')}-culture-department-event" %>
+  slug: <%= "#{1.month.from_now.strftime('%F')}-culture-department-event-google" %>
   description_translations: <%= {
-    "en" => "Culture department event description.",
+    "en" => "Culture department event with Google description.",
   }.to_json %>
   description_source_translations: <%= {
-    "en" => "Culture department event description.",
+    "en" => "Culture department event with Google description.",
+  }.to_json %>
+  starts_at: <%= 1.month.from_now %>
+  ends_at: <%= 1.month.from_now + 1.hour %>
+  state: <%= GobiertoCalendars::Event.states["published"] %>
+  meta: <%= {
+    "type" => "Lunch"
+  }.to_json %>
+
+richard_culture_department_event_accenture:
+  site: madrid
+  collection: richard_calendar
+  department: culture_department
+  interest_group: accenture
+  title_translations: <%= {
+    "en" => "Culture department event with Accenture",
+  }.to_json %>
+  slug: <%= "#{1.month.from_now.strftime('%F')}-culture-department-event-accenture" %>
+  description_translations: <%= {
+    "en" => "Culture department event with Accenture description.",
+  }.to_json %>
+  description_source_translations: <%= {
+    "en" => "Culture department event with Accenture description.",
   }.to_json %>
   starts_at: <%= 1.month.from_now %>
   ends_at: <%= 1.month.from_now + 1.hour %>
@@ -212,7 +235,7 @@ tamara_published_past:
   ends_at: <%= 15.days.ago + 1.hour %>
   state: <%= GobiertoCalendars::Event.states["published"] %>
 
-tamara_justice_department_event:
+tamara_justice_department_event_without_interest_group:
   site: madrid
   collection: tamara_calendar
   department: justice_department
@@ -232,6 +255,63 @@ tamara_justice_department_event:
   meta: <%= {
     "type" => "Interview"
   }.to_json %>
+
+tamara_justice_department_event_coca_cola_recent:
+  site: madrid
+  collection: tamara_calendar
+  department: justice_department
+  interest_group: coca_cola
+  title_translations: <%= {
+    "en" => "Justice department event with Coca Cola",
+  }.to_json %>
+  slug: <%= "#{1.month.from_now.strftime('%F')}-justice-department-event-coca-cola" %>
+  description_translations: <%= {
+    "en" => "Justice department event with Coca-Cola description.",
+  }.to_json %>
+  description_source_translations: <%= {
+    "en" => "Justice department event with Coca-Cola description.",
+  }.to_json %>
+  starts_at: <%= 1.month.ago %>
+  ends_at: <%= 1.month.ago + 1.hour %>
+  state: <%= GobiertoCalendars::Event.states["published"] %>
+
+tamara_justice_department_event_pepsi_old:
+  site: madrid
+  collection: tamara_calendar
+  department: justice_department
+  interest_group: pepsi
+  title_translations: <%= {
+    "en" => "Old justice department event with Pepsi",
+  }.to_json %>
+  slug: <%= "#{2.years.ago.strftime('%F')}-old-justice-department-event-pepsi" %>
+  description_translations: <%= {
+    "en" => "Old justice department event with Pepsi description.",
+  }.to_json %>
+  description_source_translations: <%= {
+    "en" => "Old justice department event with Pepsi description.",
+  }.to_json %>
+  starts_at: <%= 2.years.ago %>
+  ends_at: <%= 2.years.ago + 1.hour %>
+  state: <%= GobiertoCalendars::Event.states["published"] %>
+
+tamara_justice_department_event_pepsi_very_old:
+  site: madrid
+  collection: tamara_calendar
+  department: justice_department
+  interest_group: pepsi
+  title_translations: <%= {
+    "en" => "Very old justice department event with Pepsi",
+  }.to_json %>
+  slug: <%= "#{3.years.ago.strftime('%F')}-very-old-justice-department-event-pepsi" %>
+  description_translations: <%= {
+    "en" => "Very old justice department event with Pepsi description.",
+  }.to_json %>
+  description_source_translations: <%= {
+    "en" => "Very old justice department event with Pepsi description.",
+  }.to_json %>
+  starts_at: <%= 3.years.ago %>
+  ends_at: <%= 3.years.ago + 1.hour %>
+  state: <%= GobiertoCalendars::Event.states["published"] %>
 
 ## Gender Violence Process events
 

--- a/test/fixtures/gobierto_common/collection_items.yml
+++ b/test/fixtures/gobierto_common/collection_items.yml
@@ -315,6 +315,40 @@ richard_published_past_site:
   item: richard_published_past (GobiertoCalendars::Event)
   container: madrid (Site)
 
+# richard_culture_department_event_google
+
+richard_culture_department_event_google_person:
+  collection: richard_calendar
+  item: richard_culture_department_event_google (GobiertoCalendars::Event)
+  container: richard (GobiertoPeople::Person)
+
+richard_culture_department_event_google_people:
+  collection: richard_calendar
+  item: richard_culture_department_event_google (GobiertoCalendars::Event)
+  container_type: GobiertoPeople
+
+richard_culture_department_event_google_site:
+  collection: richard_calendar
+  item: richard_culture_department_event_google (GobiertoCalendars::Event)
+  container: madrid (Site)
+
+# richard_culture_department_event_accenture
+
+richard_culture_department_event_accenture_person:
+  collection: richard_calendar
+  item: richard_culture_department_event_accenture (GobiertoCalendars::Event)
+  container: richard (GobiertoPeople::Person)
+
+richard_culture_department_event_accenture_people:
+  collection: richard_calendar
+  item: richard_culture_department_event_accenture (GobiertoCalendars::Event)
+  container_type: GobiertoPeople
+
+richard_culture_department_event_accenture_site:
+  collection: richard_calendar
+  item: richard_culture_department_event_accenture (GobiertoCalendars::Event)
+  container: madrid (Site)
+
 # neil_published
 
 neil_published_person:
@@ -415,6 +449,74 @@ tamara_published_past_people:
 tamara_published_past_site:
   collection: tamara_calendar
   item: tamara_published_past (GobiertoCalendars::Event)
+  container: madrid (Site)
+
+# tamara_justice_department_event_without_interest_group
+
+tamara_justice_department_event_without_interest_group_person:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_without_interest_group (GobiertoCalendars::Event)
+  container: tamara (GobiertoPeople::Person)
+
+tamara_justice_department_event_without_interest_group_people:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_without_interest_group (GobiertoCalendars::Event)
+  container_type: GobiertoPeople
+
+tamara_justice_department_event_without_interest_group_site:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_without_interest_group (GobiertoCalendars::Event)
+  container: madrid (Site)
+
+# tamara_justice_department_event_without_interest_group
+
+tamara_justice_department_event_coca_cola_recent_person:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_coca_cola_recent (GobiertoCalendars::Event)
+  container: tamara (GobiertoPeople::Person)
+
+tamara_justice_department_event_coca_cola_recent_people:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_coca_cola_recent (GobiertoCalendars::Event)
+  container_type: GobiertoPeople
+
+tamara_justice_department_event_coca_cola_recent_site:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_coca_cola_recent (GobiertoCalendars::Event)
+  container: madrid (Site)
+
+# tamara_justice_department_event_pepsi_old
+
+tamara_justice_department_event_pepsi_old_person:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_pepsi_old (GobiertoCalendars::Event)
+  container: tamara (GobiertoPeople::Person)
+
+tamara_justice_department_event_pepsi_old_people:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_pepsi_old (GobiertoCalendars::Event)
+  container_type: GobiertoPeople
+
+tamara_justice_department_event_pepsi_old_site:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_pepsi_old (GobiertoCalendars::Event)
+  container: madrid (Site)
+
+# tamara_justice_department_event_pepsi_very_old
+
+tamara_justice_department_event_pepsi_very_old_person:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_pepsi_very_old (GobiertoCalendars::Event)
+  container: tamara (GobiertoPeople::Person)
+
+tamara_justice_department_event_pepsi_very_old_people:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_pepsi_very_old (GobiertoCalendars::Event)
+  container_type: GobiertoPeople
+
+tamara_justice_department_event_pepsi_very_old_site:
+  collection: tamara_calendar
+  item: tamara_justice_department_event_pepsi_very_old (GobiertoCalendars::Event)
   container: madrid (Site)
 
 # reading_club

--- a/test/fixtures/gobierto_people/interest_groups.yml
+++ b/test/fixtures/gobierto_people/interest_groups.yml
@@ -1,6 +1,7 @@
 google:
   site: madrid
   name: Google
+  slug: google
   meta: <%= {
     "status" => "Inscribed",
     "registry" => "Registry of Interest Groups of Madrid City Council"
@@ -9,6 +10,7 @@ google:
 coca_cola:
   site: madrid
   name: Coca Cola
+  slug: coca-cola
   meta: <%= {
     "status" => "In process"
   }.to_json %>
@@ -16,3 +18,4 @@ coca_cola:
 accenture:
   site: madrid
   name: Accenture
+  slug: accenture

--- a/test/fixtures/gobierto_people/interest_groups.yml
+++ b/test/fixtures/gobierto_people/interest_groups.yml
@@ -19,3 +19,8 @@ accenture:
   site: madrid
   name: Accenture
   slug: accenture
+
+pepsi:
+  site: madrid
+  name: Pepsi
+  slug: pepsi

--- a/test/integration/gobierto_people/api/v1/interest_groups_test.rb
+++ b/test/integration/gobierto_people/api/v1/interest_groups_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  module Api
+    module V1
+      class InterestGroupsTest < ActionDispatch::IntegrationTest
+
+        def madrid
+          @madrid ||= sites(:madrid)
+        end
+
+        def justice_department
+          @justice_department ||= gobierto_people_departments(:justice_department)
+        end
+
+        def pepsi
+          @pepsi ||= gobierto_people_interest_groups(:pepsi)
+        end
+
+        def tamara
+          @tamara ||= gobierto_people_people(:tamara)
+        end
+
+        def interest_group_attributes
+          %w(key value properties)
+        end
+
+        def interest_groups_with_events_count
+          ::GobiertoCalendars::Event.with_interest_group.pluck(:interest_group_id).uniq.size
+        end
+
+        def test_interest_groups_index_test
+          with_current_site(madrid) do
+
+            get gobierto_people_api_v1_interest_groups_path
+
+            assert_response :success
+
+            interest_groups = JSON.parse(response.body)
+
+            assert_equal interest_groups_with_events_count, interest_groups.size
+
+            assert array_match(interest_group_attributes, interest_groups.first.keys)
+          end
+        end
+
+        def test_interest_groups_index_with_filters_test
+          with_current_site(madrid) do
+
+            get(
+              gobierto_people_api_v1_interest_groups_path,
+              params: {
+                department_id: justice_department.id,
+                person_id: tamara.id
+              }
+            )
+
+            assert_response :success
+
+            interest_groups = JSON.parse(response.body)
+
+            assert_equal 2, interest_groups.size
+            assert_equal interest_groups.first["key"], pepsi.name
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_people/api/v1/interest_groups_test.rb
+++ b/test/integration/gobierto_people/api/v1/interest_groups_test.rb
@@ -7,6 +7,9 @@ module GobiertoPeople
     module V1
       class InterestGroupsTest < ActionDispatch::IntegrationTest
 
+        FAR_PAST = 10.years.ago.iso8601
+        FAR_FUTURE = 10.years.from_now.iso8601
+
         def madrid
           @madrid ||= sites(:madrid)
         end
@@ -53,7 +56,9 @@ module GobiertoPeople
               gobierto_people_api_v1_interest_groups_path,
               params: {
                 department_id: justice_department.id,
-                person_id: tamara.id
+                person_id: tamara.id,
+                from_date: FAR_PAST,
+                to_date: FAR_FUTURE
               }
             )
 

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -75,6 +75,8 @@ module GobiertoPeople
     end
 
     def test_person_events_index_pagination
+      government_member.events.destroy_all
+
       10.times do |i|
         create_event(person: government_member, starts_at: (Time.now.tomorrow + i.days).to_s, title: "Event #{i}")
       end

--- a/test/integration/gobierto_people/person_profile_test.rb
+++ b/test/integration/gobierto_people/person_profile_test.rb
@@ -38,10 +38,8 @@ module GobiertoPeople
         visit @path
 
         within ".upcoming-events" do
-          person.events.upcoming.each do |person_event|
-            assert has_link?(person_event.title)
-          end
-
+          assert has_link? "Future government event"
+          assert has_link? "Invited event"
           assert has_link?("View all")
         end
       end

--- a/test/integration/gobierto_people/welcome_index_test.rb
+++ b/test/integration/gobierto_people/welcome_index_test.rb
@@ -7,6 +7,8 @@ module GobiertoPeople
   class WelcomeIndexTest < ActionDispatch::IntegrationTest
     include NavigationItems
 
+    FAR_FUTURE = 10.years.from_now
+
     def setup
       super
       @path = gobierto_people_root_path
@@ -137,23 +139,24 @@ module GobiertoPeople
             assert has_no_link? executive_past_event.title
           end
 
-          click_link "Executive"
+          # simulate all events have passed
+          Timecop.freeze(FAR_FUTURE) do
+            click_link "Executive"
 
-          sleep 1
+            within ".people-summary" do
+              assert has_no_link? government_member.name
+              assert has_no_link? opposition_member.name
+              assert has_link? executive_member.name
+              assert has_link?("View all")
+            end
 
-          within ".people-summary" do
-            assert has_no_link? government_member.name
-            assert has_no_link? opposition_member.name
-            assert has_link? executive_member.name
-            assert has_link?("View all")
-          end
-
-          within ".events-summary" do
-            assert has_content? "There are no future events. Take a look at past ones"
-            assert has_no_link? government_event.title
-            assert has_no_link? government_past_event.title
-            assert has_no_link? opposition_event.title
-            assert has_link? executive_past_event.title
+            within ".events-summary" do
+              assert has_content? "There are no future events. Take a look at past ones"
+              assert has_no_link? government_event.title
+              assert has_no_link? government_past_event.title
+              assert has_no_link? opposition_event.title
+              assert has_link? executive_past_event.title
+            end
           end
 
           click_link "Opposition"
@@ -208,24 +211,24 @@ module GobiertoPeople
 
           click_link "Past events"
 
-          sleep 1
-
           within ".events-summary" do
             assert has_no_content? government_event.title
             assert has_content? government_past_event.title
             assert has_no_content? executive_past_event.title
           end
 
-          click_link "Executive"
+          # simulate all events have passed
+          Timecop.freeze(FAR_FUTURE) do
+            click_link "Executive"
 
-          sleep 1
-
-          within ".events-summary" do
-            assert has_content? "There are no future events. Take a look at past ones"
-            assert has_no_content? government_event.title
-            assert has_no_content? government_past_event.title
-            assert has_content? executive_past_event.title
+            within ".events-summary" do
+              assert has_content? "There are no future events. Take a look at past ones"
+              assert has_no_content? government_event.title
+              assert has_no_content? government_past_event.title
+              assert has_content? executive_past_event.title
+            end
           end
+
         end
       end
     end

--- a/test/models/gobierto_people/interest_group_test.rb
+++ b/test/models/gobierto_people/interest_group_test.rb
@@ -13,6 +13,17 @@ module GobiertoPeople
       @accenture ||= gobierto_people_interest_groups(:accenture)
     end
 
+    def pepsi
+      @pepsi ||= gobierto_people_interest_groups(:pepsi)
+    end
+
+    def pepsi_events
+      @pepsi_events ||= [
+        gobierto_calendars_events(:tamara_justice_department_event_pepsi_old),
+        gobierto_calendars_events(:tamara_justice_department_event_pepsi_very_old)
+      ]
+    end
+
     def test_status
       assert_equal "Inscribed", google.status
       assert_nil accenture.status
@@ -21,6 +32,19 @@ module GobiertoPeople
     def test_registry
       assert_equal "Registry of Interest Groups of Madrid City Council", google.registry
       assert_nil accenture.registry
+    end
+
+    def test_events_count
+      assert_equal pepsi_events.count, pepsi.events_count
+    end
+
+    def test_events_count_when_attribute_overriden_by_query
+      group = InterestGroup.where(id: pepsi.id)
+                           .select("id, name, 123 AS events_count")
+                           .first
+
+      assert_equal pepsi.name, group.name
+      assert_equal 123, group.events_count
     end
 
   end

--- a/test/queries/gobierto_people/interest_groups_query_test.rb
+++ b/test/queries/gobierto_people/interest_groups_query_test.rb
@@ -12,6 +12,7 @@ module GobiertoPeople
     alias justice_department_interest_group coca_cola
     alias tamara_interest_group coca_cola
     alias interest_group_with_recent_event coca_cola
+    alias tamara_interst_group_with_recent_event coca_cola
 
     def google
       @google ||= gobierto_people_interest_groups(:google)
@@ -23,6 +24,7 @@ module GobiertoPeople
       @pepsi ||= gobierto_people_interest_groups(:pepsi)
     end
     alias interest_group_with_old_event pepsi
+    alias tamara_interst_group_with_old_event pepsi
 
     def justice_department
       @justice_department ||= gobierto_people_departments(:justice_department)
@@ -66,10 +68,18 @@ module GobiertoPeople
       assert query.results.exclude?(interest_group_with_recent_event)
     end
 
+    def test_filter_by_multiple_conditions
+      query = InterestGroupsQuery.new(conditions: {
+        person_id: tamara.id,
+        from_date: 2.months.ago.iso8601
+      })
+
+      assert query.results.include?(tamara_interst_group_with_recent_event)
+      assert query.results.exclude?(tamara_interst_group_with_old_event)
+    end
+
     def test_limit
       query = InterestGroupsQuery.new(limit: 1)
-
-      query_results = query.results
 
       assert_equal 1, query.results.length
     end

--- a/test/queries/gobierto_people/interest_groups_query_test.rb
+++ b/test/queries/gobierto_people/interest_groups_query_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/event_helpers"
+
+module GobiertoPeople
+  class InterestGroupsQueryTest < ActiveSupport::TestCase
+
+    def coca_cola
+      @coca_cola ||= gobierto_people_interest_groups(:coca_cola)
+    end
+    alias justice_department_interest_group coca_cola
+    alias tamara_interest_group coca_cola
+    alias interest_group_with_recent_event coca_cola
+
+    def google
+      @google ||= gobierto_people_interest_groups(:google)
+    end
+    alias culture_department_interest_group google
+    alias richard_interest_group google
+
+    def pepsi
+      @pepsi ||= gobierto_people_interest_groups(:pepsi)
+    end
+    alias interest_group_with_old_event pepsi
+
+    def justice_department
+      @justice_department ||= gobierto_people_departments(:justice_department)
+    end
+
+    def tamara
+      @tamara ||= gobierto_people_people(:tamara)
+    end
+
+    def test_filter_by_department
+      query = InterestGroupsQuery.new(conditions: {
+        department_id: justice_department.id
+      })
+
+      assert query.results.include?(justice_department_interest_group)
+      assert query.results.exclude?(culture_department_interest_group)
+    end
+
+    def test_filter_by_person
+      query = InterestGroupsQuery.new(conditions: {
+        person_id: tamara.id
+      })
+
+      assert query.results.include?(tamara_interest_group)
+      assert query.results.exclude?(richard_interest_group)
+    end
+
+    def test_filter_by_date
+      query = InterestGroupsQuery.new(conditions: {
+        from_date: 2.months.ago
+      })
+
+      assert query.results.include?(interest_group_with_recent_event)
+      assert query.results.exclude?(interest_group_with_old_event)
+
+      query = InterestGroupsQuery.new(conditions: {
+        to_date: 1.year.ago
+      })
+
+      assert query.results.include?(interest_group_with_old_event)
+      assert query.results.exclude?(interest_group_with_recent_event)
+    end
+
+    def test_limit
+      query = InterestGroupsQuery.new(limit: 1)
+
+      query_results = query.results
+
+      assert_equal 1, query.results.length
+    end
+
+    def test_order
+      query = InterestGroupsQuery.new(conditions: {
+        person_id: tamara.id
+      })
+
+      # pepsi has 2 events, coca_cola has 1
+      assert_equal [pepsi, coca_cola], query.results
+    end
+
+  end
+end

--- a/test/serializers/gobierto_people/interest_group_rowchart_serializer_test.rb
+++ b/test/serializers/gobierto_people/interest_group_rowchart_serializer_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  class InterestGroupRowchartSerializerTest < ActiveSupport::TestCase
+
+    def madrid
+      @madrid ||= sites(:madrid)
+    end
+
+    def interest_group
+      @interest_group ||= gobierto_people_interest_groups(:google)
+    end
+
+    def interest_group_attributes
+      %w(key value properties)
+    end
+
+    def serializer
+      InterestGroupRowchartSerializer.new(interest_group)
+    end
+
+    def test_serialize
+      serializer_output = JSON.parse(serializer.to_json)
+
+      assert_equal "Google", serializer_output["key"]
+      assert_equal 1, serializer_output["value"]
+      assert_equal "http://#{madrid.domain}/interest_groups/#{interest_group.slug}", serializer_output["properties"]["url"]
+    end
+
+  end
+end

--- a/test/serializers/gobierto_people/interest_group_rowchart_serializer_test.rb
+++ b/test/serializers/gobierto_people/interest_group_rowchart_serializer_test.rb
@@ -26,7 +26,7 @@ module GobiertoPeople
 
       assert_equal "Google", serializer_output["key"]
       assert_equal 1, serializer_output["value"]
-      assert_equal "http://#{madrid.domain}/interest_groups/#{interest_group.slug}", serializer_output["properties"]["url"]
+      assert_equal "http://#{madrid.domain}/grupos-de-interes/#{interest_group.slug}", serializer_output["properties"]["url"]
     end
 
   end


### PR DESCRIPTION
Closes [#262](https://github.com/PopulateTools/issues/issues/362)

## :v: What does this PR do?

* Implements a JSON API endpoint for retrieving events count for each interest group
* Adds slug to `InterestGroup` model

## :mag: How should this be manually tested?

Sample queries for staging:

http://g****t.gobify.net/gobierto_people/api/v1/interest_groups
http://g****t.gobify.net/gobierto_people/api/v1/interest_groups?limit=100
http://g****t.gobify.net/gobierto_people/api/v1/interest_groups?department_id=53
http://g****t.gobify.net/gobierto_people/api/v1/interest_groups?person_id=905
http://g****t.gobify.net/gobierto_people/api/v1/interest_groups?from_date=30-11-2017&to_date=31-12-2017

## :shipit: Does this PR changes any configuration file?

No