### PR TITLE
361 departments api

### DIFF
--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  module Api
+    module V1
+      class DepartmentsController < Api::V1::BaseController
+
+        def index
+          query = DepartmentsQuery.new(
+            relation: GobiertoPeople::Department.where(site: current_site),
+            conditions: permitted_conditions,
+            limit: params[:limit]
+          )
+
+          render(
+            json: query.results,
+            each_serializer: RowchartItemSerializer
+          )
+        end
+
+        private
+
+        def parsed_parameters
+          params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
+          params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
+          params
+        end
+
+        def permitted_conditions
+          parsed_parameters.permit(
+            :interest_group_id,
+            :person_id,
+            :from_date,
+            :to_date
+          ).to_h
+        end
+
+      end
+    end
+  end
+end

--- a/app/models/gobierto_people/department.rb
+++ b/app/models/gobierto_people/department.rb
@@ -4,6 +4,8 @@ require_dependency "gobierto_people"
 
 module GobiertoPeople
   class Department < ApplicationRecord
+    include GobiertoCommon::Metadatable
+    include GobiertoCommon::UrlBuildable
 
     include GobiertoCommon::Sluggable
 

--- a/app/queries/gobierto_people/departments_query.rb
+++ b/app/queries/gobierto_people/departments_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class DepartmentsQuery < RowchartItemsQuery
+
+    private
+
+    def append_query_conditions(conditions)
+      if conditions[:interest_group_id]
+        append_condition(:interest_group_id, conditions[:interest_group_id])
+      end
+
+      if conditions[:person_id]
+        person = ::GobiertoPeople::Person.find(conditions[:person_id])
+        append_condition(:collection_id, person.calendar.id)
+      end
+
+      if conditions[:from_date]
+        append_condition(:starts_at, conditions[:from_date], ">=")
+      end
+
+      if conditions[:to_date]
+        append_condition(:ends_at, conditions[:to_date], "<=")
+      end
+    end
+
+    def model
+      Department
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,6 +279,7 @@ Rails.application.routes.draw do
       namespace :api, path: "gobierto_people/api" do
         namespace :v1 do
           resources :interest_groups, only: :index
+          resources :departments, only: :index
           resources :people, only: :index
         end
       end

--- a/test/integration/gobierto_people/api/v1/departments_test.rb
+++ b/test/integration/gobierto_people/api/v1/departments_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  module Api
+    module V1
+      class DepartmentsTest < ActionDispatch::IntegrationTest
+
+        FAR_PAST = 10.years.ago.iso8601
+        FAR_FUTURE = 10.years.from_now.iso8601
+
+        def madrid
+          @madrid ||= sites(:madrid)
+        end
+
+        def justice_department
+          @justice_department ||= gobierto_people_departments(:justice_department)
+        end
+
+        def coca_cola
+          @coca_cola ||= gobierto_people_interest_groups(:coca_cola)
+        end
+
+        def tamara
+          @tamara ||= gobierto_people_people(:tamara)
+        end
+
+        def attributes
+          %w(key value properties)
+        end
+
+        def departments_with_events_count
+          ::GobiertoCalendars::Event.select(:department_id).distinct.count
+        end
+
+        def test_departments_index_test
+          with_current_site(madrid) do
+
+            get gobierto_people_api_v1_departments_path
+
+            assert_response :success
+
+            departments = JSON.parse(response.body)
+
+            assert_equal departments_with_events_count, departments.size
+
+            assert array_match(attributes, departments.first.keys)
+          end
+        end
+
+        def test_departments_index_with_filters_test
+          with_current_site(madrid) do
+
+            get(
+              gobierto_people_api_v1_departments_path,
+              params: {
+                interest_group_id: coca_cola.id,
+                person_id: tamara.id,
+                from_date: FAR_PAST,
+                to_date: FAR_FUTURE
+              }
+            )
+
+            assert_response :success
+
+            departments = JSON.parse(response.body)
+
+            assert_equal 1, departments.size
+            assert_equal departments.first["key"], justice_department.name
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/queries/gobierto_people/departments_query_test.rb
+++ b/test/queries/gobierto_people/departments_query_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/event_helpers"
+
+module GobiertoPeople
+  class DepartmentsQueryTest < ActiveSupport::TestCase
+
+    def coca_cola
+      @coca_cola ||= gobierto_people_interest_groups(:coca_cola)
+    end
+
+    def justice_department
+      @justice_department ||= gobierto_people_departments(:justice_department)
+    end
+
+    def tamara
+      @tamara ||= gobierto_people_people(:tamara)
+    end
+
+    def test_filter_by_interest_group
+      query = DepartmentsQuery.new(conditions: { interest_group_id: coca_cola.id })
+
+      assert query.results.include?(justice_department)
+    end
+  end
+end


### PR DESCRIPTION
Closes #361


## :v: What does this PR do?
* Adds queries and endpoints to get number of events by department
* The results can be filtered by:
  * `interest_group_id`
  * `person_id`
  * `from_date`
  * `to_date`

## :mag: How should this be manually tested?
Visit `gobierto_people/api/v1/departments.json`

## :shipit: Does this PR changes any configuration file?

No