### PR TITLE
API additions

### DIFF
--- a/app/controllers/gobierto_people/api/v1/people_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/people_controller.rb
@@ -51,6 +51,7 @@ module GobiertoPeople
 
         def permitted_conditions
           parsed_parameters.permit(
+            :interest_group_id,
             :department_id,
             :from_date,
             :to_date

--- a/app/queries/gobierto_people/departments_query.rb
+++ b/app/queries/gobierto_people/departments_query.rb
@@ -3,6 +3,12 @@
 module GobiertoPeople
   class DepartmentsQuery < RowchartItemsQuery
 
+    def results_with_history
+      relation.select("#{ model.table_name }.*, to_char(#{ events_table }.starts_at, 'YYYY/MM') AS year_month, COUNT(*) AS custom_events_count")
+              .group("#{ model.table_name }.id, year_month")
+              .order("#{ model.table_name }.id ASC, year_month ASC")
+    end
+
     private
 
     def append_query_conditions(conditions)
@@ -27,6 +33,5 @@ module GobiertoPeople
     def model
       Department
     end
-
   end
 end

--- a/app/queries/gobierto_people/people_query.rb
+++ b/app/queries/gobierto_people/people_query.rb
@@ -10,6 +10,10 @@ module GobiertoPeople
         append_condition(:department_id, conditions[:department_id])
       end
 
+      if conditions[:interest_group_id]
+        append_condition(:interest_group_id, conditions[:interest_group_id])
+      end
+
       if conditions[:from_date]
         append_condition(:starts_at, conditions[:from_date], ">=")
       end

--- a/test/integration/gobierto_people/api/v1/people_index_test.rb
+++ b/test/integration/gobierto_people/api/v1/people_index_test.rb
@@ -21,6 +21,10 @@ module GobiertoPeople
           @justice_department ||= gobierto_people_departments(:justice_department)
         end
 
+        def coca_cola_group
+          @coca_cola_group ||= gobierto_people_interest_groups(:coca_cola)
+        end
+
         def tamara
           @tamara ||= gobierto_people_people(:tamara)
         end
@@ -36,6 +40,10 @@ module GobiertoPeople
         end
 
         def people_with_events_on_justice_department
+          [tamara]
+        end
+
+        def people_with_events_on_coca_cola_group
           [tamara]
         end
 
@@ -71,6 +79,23 @@ module GobiertoPeople
             people = JSON.parse(response.body)
 
             assert_equal people_with_events_on_justice_department.size, people.size
+            assert_equal people.first["key"], tamara.name
+          end
+        end
+
+        def test_people_index_with_interest_group_filter
+          with_current_site(madrid) do
+            get(
+              gobierto_people_api_v1_people_path,
+              params: {
+                interest_group_id: coca_cola_group.id
+              }
+            )
+            assert_response :success
+
+            people = JSON.parse(response.body)
+
+            assert_equal people_with_events_on_coca_cola_group.size, people.size
             assert_equal people.first["key"], tamara.name
           end
         end

--- a/test/queries/gobierto_people/people_query_test.rb
+++ b/test/queries/gobierto_people/people_query_test.rb
@@ -12,15 +12,21 @@ module GobiertoPeople
       @justice_department ||= gobierto_people_departments(:justice_department)
     end
 
+    def coca_cola_interest_group
+      @coca_cola_interest_group ||= gobierto_people_interest_groups(:coca_cola)
+    end
+
     def tamara
       @tamara ||= gobierto_people_people(:tamara)
     end
     alias person_with_justice_department_events tamara
+    alias person_with_coca_cola_events tamara
 
     def richard
       @richard ||= gobierto_people_people(:richard)
     end
     alias person_without_justice_department_events richard
+    alias person_without_coca_cola_events richard
 
     def site
       @site || sites(:madrid)
@@ -48,6 +54,16 @@ module GobiertoPeople
 
       assert query_results.include?(person_with_justice_department_events)
       assert query_results.exclude?(person_without_justice_department_events)
+    end
+
+    def test_filter_by_interest_group
+      query_results = PeopleQuery.new(
+        relation: site.people,
+        conditions: { interest_group_id: coca_cola_interest_group.id }
+      ).results
+
+      assert query_results.include?(person_with_coca_cola_events)
+      assert query_results.exclude?(person_without_coca_cola_events)
     end
 
     def test_filter_by_date


### PR DESCRIPTION
## :v: What does this PR do?
Adds an option to Departments API to get data grouped by department and date.

## :mag: How should this be manually tested?
Just try `/gobierto_people/api/v1/departments?include_history=true&limit=14`, for example

## :shipit: Does this PR changes any configuration file?
No