### PR TITLE
Minitest plugin to include gobierto engines

### DIFF
--- a/lib/minitest/gobierto_engines_tests_plugin.rb
+++ b/lib/minitest/gobierto_engines_tests_plugin.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Minitest
+  def self.plugin_gobierto_engines_tests_init(*)
+    if ::Rails::TestUnit::Runner.send(:extract_filters, ARGV).empty?
+      tests = Rake::FileList['vendor/gobierto_engines/**/*_test.rb']
+      tests.to_a.each { |path| require File.expand_path(path) }
+    end
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

This PR adss a minitest plugin that extends test paths to engine test paths.

## :mag: How should this be manually tested?

Add tests to `gobierto_engines/<engine>/test/` and check they are executed.