### PR TITLE
Add URLs to history api

### DIFF
--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -23,14 +23,29 @@ module GobiertoPeople
 
             records.each do |record|
               if (index = result_indexes[record.name])
-                result[index][:value] << { key: Time.zone.parse(record.year_month), value: record.custom_events_count }
+                result[index][:value] << {
+                  key: Time.zone.parse(record.year_month),
+                  value: record.custom_events_count,
+                  properties: {
+                    url: gobierto_people_department_path(record.slug, start_date: Time.zone.parse(record.year_month).to_date.to_s(:db), end_date: (Time.zone.parse(record.year_month).to_date + 1.month).to_s(:db))
+                  }
+                }
               else
                 result_indexes[record.name] = result.size
                 result << {
                   key: record.name,
                   value: [
-                    { key: Time.zone.parse(record.year_month), value: record.custom_events_count }
-                  ]
+                    {
+                      key: Time.zone.parse(record.year_month),
+                      value: record.custom_events_count,
+                      properties: {
+                        url: gobierto_people_department_path(record.slug, start_date: Time.zone.parse(record.year_month).to_date.to_s(:db), end_date: (Time.zone.parse(record.year_month).to_date + 1.month).to_s(:db))
+                      }
+                    }
+                  ],
+                  properties: {
+                    url: gobierto_people_department_path(record.slug)
+                  }
                 }
               end
             end
@@ -65,6 +80,13 @@ module GobiertoPeople
             :from_date,
             :to_date
           ).to_h
+        end
+
+        def date_range(year_month)
+          {
+            start_date: Time.zone.parse(year_month).to_date.to_s(:db),
+            end_date: (Time.zone.parse(year_month).to_date + 1.month).to_s(:db)
+          }
         end
 
       end

--- a/app/controllers/gobierto_people/api/v1/people_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/people_controller.rb
@@ -23,14 +23,25 @@ module GobiertoPeople
 
             records.each do |record|
               if (index = result_indexes[record.name])
-                result[index][:value] << { key: Time.zone.parse(record.year_month), value: record.custom_events_count }
+                result[index][:value] << {
+                  key: Time.zone.parse(record.year_month),
+                  value: record.custom_events_count,
+                  url: gobierto_people_person_past_events_path(record.slug, {page: false}.merge(date_range(record.year_month)))
+                }
               else
                 result_indexes[record.name] = result.size
                 result << {
                   key: record.name,
                   value: [
-                    { key: Time.zone.parse(record.year_month), value: record.custom_events_count }
-                  ]
+                    {
+                      key: Time.zone.parse(record.year_month),
+                      value: record.custom_events_count,
+                      url: gobierto_people_person_past_events_path(record.slug, {page: false}.merge(date_range(record.year_month)))
+                    }
+                  ],
+                  properties: {
+                    url: gobierto_people_person_past_events_path(record.slug, page: false)
+                  }
                 }
               end
             end
@@ -64,6 +75,13 @@ module GobiertoPeople
             :from_date,
             :to_date
           ).to_h
+        end
+
+        def date_range(year_month)
+          {
+            start_date: Time.zone.parse(year_month).to_date.to_s(:db),
+            end_date: (Time.zone.parse(year_month).to_date + 1.month).to_s(:db)
+          }
         end
 
       end

--- a/test/integration/gobierto_people/api/v1/people_index_test.rb
+++ b/test/integration/gobierto_people/api/v1/people_index_test.rb
@@ -122,7 +122,10 @@ module GobiertoPeople
 
             expected_tamara_data = {
               "key" => tamara.name,
-              "value" => [{ "key" => Time.zone.parse("2017/01"), "value" => 2 }]
+              "value" => [{ "key" => Time.zone.parse("2017/01"), "value" => 2, "url"=>"/agendas/tamara-devoux/eventos-pasados?end_date=2017-02-01&page=false&start_date=2017-01-01" }],
+              "properties" => {
+                "url" => "/agendas/tamara-devoux/eventos-pasados?page=false"
+              }
             }
 
             assert_equal expected_tamara_data, tamara_data


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR adds properties urls to punchcards API endpoints

## :mag: How should this be manually tested?

Check in `/gobierto_people/api/v1/people?include_history=true&amp;limit=14`
