### PR TITLE
345 date filters

### DIFF
--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoPeople
   module DatesRangeHelper
     extend ActiveSupport::Concern
@@ -19,7 +21,7 @@ module GobiertoPeople
     end
 
     def empty_date_range_param?
-      (params.keys & ["start_date", "end_date"]).empty?
+      (params.keys & %w(start_date end_date)).empty?
     end
 
     private
@@ -40,7 +42,7 @@ module GobiertoPeople
       date = if params[param].present?
                Time.zone.parse(params[param])
              else
-               use_default ? site_configuration_date_range[param] :nil
+               use_default ? site_configuration_date_range[param] : nil
              end
       session[param] = date
     rescue ArgumentError

--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -7,7 +7,11 @@ module GobiertoPeople
     RANGE_PARAM_NAMES = %w(start_date end_date).freeze
 
     included do
-      helper_method :dates_range?, :filter_start_date, :filter_end_date
+      helper_method :dates_range?, :filter_start_date, :filter_end_date, :date_range_params
+    end
+
+    def date_range_params
+      params.slice(:start_date, :end_date).permit(:start_date, :end_date)
     end
 
     def filter_start_date

--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -1,0 +1,50 @@
+module GobiertoPeople
+  module DatesRangeHelper
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :dates_range?, :filter_start_date, :filter_end_date
+    end
+
+    def filter_start_date
+      date_from_param_or_session(:start_date, empty_date_range_param?) if site_configuration_dates_range?
+    end
+
+    def filter_end_date
+      date_from_param_or_session(:end_date, empty_date_range_param?) if site_configuration_dates_range?
+    end
+
+    def site_configuration_dates_range?
+      site_configuration_date_range.values.compact.present?
+    end
+
+    def empty_date_range_param?
+      (params.keys & ["start_date", "end_date"]).empty?
+    end
+
+    private
+
+    def site_configuration_date_range
+      @site_configuration_date_range ||= { start_date: parse_date(current_site.configuration.configuration_variables["gobierto_people_default_filter_start_date"]),
+                                           end_date: parse_date(current_site.configuration.configuration_variables["gobierto_people_default_filter_end_date"]) }
+    end
+
+    def parse_date(date)
+      return unless date
+      Time.zone.parse(date)
+    rescue ArgumentError
+      nil
+    end
+
+    def date_from_param_or_session(param, use_default)
+      date = if params[param].present?
+               Time.zone.parse(params[param])
+             else
+               use_default ? site_configuration_date_range[param] :nil
+             end
+      session[param] = date
+    rescue ArgumentError
+      default_value
+    end
+  end
+end

--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -9,11 +9,11 @@ module GobiertoPeople
     end
 
     def filter_start_date
-      date_from_param_or_session(:start_date, empty_date_range_param?) if site_configuration_dates_range?
+      date_from_param_or_session(:start_date) if site_configuration_dates_range?
     end
 
     def filter_end_date
-      date_from_param_or_session(:end_date, empty_date_range_param?) if site_configuration_dates_range?
+      date_from_param_or_session(:end_date) if site_configuration_dates_range?
     end
 
     def site_configuration_dates_range?
@@ -38,13 +38,12 @@ module GobiertoPeople
       nil
     end
 
-    def date_from_param_or_session(param, use_default)
-      date = if params[param].present?
-               Time.zone.parse(params[param])
-             else
-               use_default ? site_configuration_date_range[param] : nil
-             end
-      session[param] = date
+    def date_from_param_or_session(param)
+      if params[param].present?
+        session[param] = Time.zone.parse(params[param])
+      else
+        session[param] ||= site_configuration_date_range[param]
+      end
     rescue ArgumentError
       default_value
     end

--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -56,9 +56,11 @@ module GobiertoPeople
         private
 
         def parsed_parameters
-          params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
-          params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
-          params
+          @parsed_parameters ||= begin
+                                   params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
+                                   params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
+                                   params
+                                 end
         end
 
         def permitted_conditions

--- a/app/controllers/gobierto_people/departments_controller.rb
+++ b/app/controllers/gobierto_people/departments_controller.rb
@@ -24,8 +24,8 @@ module GobiertoPeople
                                             start_date: filter_start_date,
                                             end_date: filter_end_date)
       @department_stats = {
-        total_people_with_attendances: people.relation.count,
-        unique_interest_groups: interest_groups.relation.select(:interest_group_id).distinct.count
+        total_people_with_attendances: people.count,
+        unique_interest_groups: interest_groups.select(:interest_group_id).distinct.count
       }
     end
 
@@ -38,7 +38,7 @@ module GobiertoPeople
     def site_events
       QueryWithEvents.new(source: current_site.events,
                           start_date: filter_start_date,
-                          end_date: filter_end_date).relation.events
+                          end_date: filter_end_date)
     end
 
     def site_departments

--- a/app/controllers/gobierto_people/departments_controller.rb
+++ b/app/controllers/gobierto_people/departments_controller.rb
@@ -9,7 +9,7 @@ module GobiertoPeople
 
     def index
       @departments_count = site_departments.count
-      @departments = site_departments.joins(:events).group(:id).order("count(#{ events_table }.id) DESC").limit(DEFAULT_LIMIT)
+      @departments = site_departments.joins(:events).group(:id).order(Arel.sql("count(#{ events_table }.id) DESC")).limit(DEFAULT_LIMIT)
       @total_events = site_events.with_department.count
       @total_people = site_events.with_department.select(:collection_id).distinct.count
     end

--- a/app/controllers/gobierto_people/departments_controller.rb
+++ b/app/controllers/gobierto_people/departments_controller.rb
@@ -16,11 +16,11 @@ module GobiertoPeople
 
     def show
       @department = site_departments.find_by_slug!(params[:id])
-      people = QueryWithEvents.new(relation: @department.people.with_event_attendances,
+      people = QueryWithEvents.new(source: @department.people.with_event_attendances,
                                    start_date: filter_start_date,
                                    end_date: filter_end_date)
 
-      interest_groups = QueryWithEvents.new(relation: @department.events.with_interest_group,
+      interest_groups = QueryWithEvents.new(source: @department.events,
                                             start_date: filter_start_date,
                                             end_date: filter_end_date)
       @department_stats = {
@@ -36,9 +36,9 @@ module GobiertoPeople
     protected
 
     def site_events
-      QueryWithEvents.new(relation: current_site.events,
+      QueryWithEvents.new(source: current_site.events,
                           start_date: filter_start_date,
-                          end_date: filter_end_date).relation
+                          end_date: filter_end_date).relation.events
     end
 
     def site_departments

--- a/app/controllers/gobierto_people/departments_controller.rb
+++ b/app/controllers/gobierto_people/departments_controller.rb
@@ -37,8 +37,8 @@ module GobiertoPeople
 
     def site_events
       QueryWithEvents.new(relation: current_site.events,
-                                   start_date: filter_start_date,
-                                   end_date: filter_end_date).relation
+                          start_date: filter_start_date,
+                          end_date: filter_end_date).relation
     end
 
     def site_departments

--- a/app/controllers/gobierto_people/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/interest_groups_controller.rb
@@ -15,7 +15,7 @@ module GobiertoPeople
 
     def show
       @interest_group = @site.interest_groups.find_by_slug!(params[:id])
-      events = QueryWithEvents.new(relation: @interest_group.events,
+      events = QueryWithEvents.new(source: @interest_group.events,
                                    start_date: filter_start_date,
                                    end_date: filter_end_date)
       @total_events = events.relation.count

--- a/app/controllers/gobierto_people/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/interest_groups_controller.rb
@@ -2,6 +2,8 @@
 
 module GobiertoPeople
   class InterestGroupsController < GobiertoPeople::ApplicationController
+    include DatesRangeHelper
+
     DEFAULT_LIMIT = 10
     before_action :check_active_submodules
 
@@ -13,8 +15,11 @@ module GobiertoPeople
 
     def show
       @interest_group = @site.interest_groups.find_by_slug!(params[:id])
-      @total_events = @interest_group.events.count
-      @total_people = @interest_group.events.select(:collection_id).distinct.count
+      events = QueryWithEvents.new(relation: @interest_group.events,
+                                   start_date: filter_start_date,
+                                   end_date: filter_end_date)
+      @total_events = events.relation.count
+      @total_people = events.relation.select(:collection_id).distinct.count
     end
 
     def check_active_submodules

--- a/app/controllers/gobierto_people/people/base_controller.rb
+++ b/app/controllers/gobierto_people/people/base_controller.rb
@@ -3,6 +3,7 @@ module GobiertoPeople
     class BaseController < GobiertoPeople::ApplicationController
 
       include PreviewTokenHelper
+      include DatesRangeHelper
 
       before_action :set_person
 

--- a/app/controllers/gobierto_people/people/gifts_controller.rb
+++ b/app/controllers/gobierto_people/people/gifts_controller.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
       before_action :check_active_submodules
 
       def index
-        @person_gifts = @person.received_gifts
+        @person_gifts = @person.received_gifts.between_dates(filter_start_date, filter_end_date)
       end
 
       def show

--- a/app/controllers/gobierto_people/people/invitations_controller.rb
+++ b/app/controllers/gobierto_people/people/invitations_controller.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
       before_action :check_active_submodules
 
       def index
-        @person_invitations = @person.invitations
+        @person_invitations = @person.invitations.between_dates(filter_start_date, filter_end_date)
       end
 
       def show

--- a/app/controllers/gobierto_people/people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/past_person_events_controller.rb
@@ -11,9 +11,13 @@ module GobiertoPeople
           @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         elsif params[:page] == "false"
           # permit non-pagination and avoid N+1 queries for custom engines
-          @events = @person.events.past.sorted_backwards.includes(:interest_group)
+          @events = QueryWithEvents.new(source: @person.events,
+                                        start_date: filter_start_date,
+                                        end_date: filter_end_date).past.sorted_backwards.includes(:interest_group)
         else
-          @events = @person.events.past.sorted_backwards.page params[:page]
+          @events = QueryWithEvents.new(source: @person.events,
+                                        start_date: filter_start_date,
+                                        end_date: filter_end_date).past.sorted_backwards.page params[:page]
         end
 
         respond_to do |format|

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -10,7 +10,9 @@ module GobiertoPeople
           @events = @person.attending_events.by_date(@filtering_date)
           @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         else
-          @events = @person.attending_events.upcoming.sorted.page params[:page]
+          @events = QueryWithEvents.new(source: @person.attending_events,
+                                        start_date: filter_start_date,
+                                        end_date: filter_end_date).upcoming.sorted.page params[:page]
         end
 
         respond_to do |format|

--- a/app/controllers/gobierto_people/people/trips_controller.rb
+++ b/app/controllers/gobierto_people/people/trips_controller.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
       before_action :check_active_submodules
 
       def index
-        @person_trips = CollectionDecorator.new(@person.trips, decorator: TripDecorator)
+        @person_trips = CollectionDecorator.new(@person.trips.between_dates(filter_start_date, filter_end_date), decorator: TripDecorator)
       end
 
       def show

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -48,10 +48,12 @@ module GobiertoPeople
       @latest_activity = ActivityCollectionDecorator.new(Activity.for_recipient(@person).limit(30).sorted.page(params[:page]))
 
       # custom engine
-      @last_events = @person.attending_events.with_interest_group.sorted_backwards.limit(LAST_ITEMS_SIZE)
-      @last_trips = @person.trips.sorted.limit(LAST_ITEMS_SIZE)
-      @last_invitations = @person.invitations.sorted.limit(LAST_ITEMS_SIZE)
-      @last_gifts = @person.received_gifts.sorted.limit(LAST_ITEMS_SIZE)
+      @last_events = QueryWithEvents.new(source: @person.attending_events.with_interest_group.sorted_backwards.limit(LAST_ITEMS_SIZE),
+                                         start_date: filter_start_date,
+                                         end_date: filter_end_date)
+      @last_trips = @person.trips.between_dates(filter_start_date, filter_end_date).sorted.limit(LAST_ITEMS_SIZE)
+      @last_invitations = @person.invitations.between_dates(filter_start_date, filter_end_date).sorted.limit(LAST_ITEMS_SIZE)
+      @last_gifts = @person.received_gifts.between_dates(filter_start_date, filter_end_date).sorted.limit(LAST_ITEMS_SIZE)
     end
 
     private

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -4,6 +4,7 @@ module GobiertoPeople
     include PoliticalGroupsHelper
     include PreviewTokenHelper
     include PeopleClassificationHelper
+    include DatesRangeHelper
 
     before_action :check_active_submodules, except: :show
 

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -4,6 +4,7 @@ module GobiertoPeople
   class WelcomeController < GobiertoPeople::ApplicationController
     include PoliticalGroupsHelper
     include PeopleClassificationHelper
+    include DatesRangeHelper
 
     before_action :check_active_submodules
 
@@ -44,10 +45,17 @@ module GobiertoPeople
     end
 
     def load_home_statistics
+      people = QueryWithEvents.new(relation: current_site.event_attendances,
+                                   start_date: filter_start_date,
+                                   end_date: filter_end_date,
+                                   not_null: [:department_id])
+      interest_groups = QueryWithEvents.new(relation: current_site.interest_groups,
+                                            start_date: filter_start_date,
+                                            end_date: filter_end_date)
       @home_statistics = {
-        total_events: current_site.event_attendances.count,
-        total_interest_groups: current_site.interest_groups.count,
-        total_people_with_attendances: current_site.event_attendances.select(:person_id).distinct.count
+        total_events: people.relation.count,
+        total_interest_groups: interest_groups.relation.count,
+        total_people_with_attendances: people.relation.select(:person_id).distinct.count
       }
     end
   end

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -17,8 +17,8 @@ module GobiertoPeople
       set_present_groups
 
       # TODO: this info is only needed for custom engine
-      @gifts = current_site.gifts.limit(4)
-      @invitations = current_site.invitations.limit(4)
+      @gifts = current_site.gifts.limit(4).between_dates(filter_start_date, filter_end_date)
+      @invitations = current_site.invitations.limit(4).between_dates(filter_start_date, filter_end_date)
       load_home_statistics
     end
 

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -53,9 +53,9 @@ module GobiertoPeople
                                             start_date: filter_start_date,
                                             end_date: filter_end_date)
       @home_statistics = {
-        total_events: people.relation.count,
-        total_interest_groups: interest_groups.relation.count,
-        total_people_with_attendances: people.relation.select(:person_id).distinct.count
+        total_events: people.count,
+        total_interest_groups: interest_groups.count,
+        total_people_with_attendances: people.select(:person_id).distinct.count
       }
     end
   end

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -45,11 +45,11 @@ module GobiertoPeople
     end
 
     def load_home_statistics
-      people = QueryWithEvents.new(relation: current_site.event_attendances,
+      people = QueryWithEvents.new(source: current_site.event_attendances,
                                    start_date: filter_start_date,
                                    end_date: filter_end_date,
                                    not_null: [:department_id])
-      interest_groups = QueryWithEvents.new(relation: current_site.interest_groups,
+      interest_groups = QueryWithEvents.new(source: current_site.interest_groups,
                                             start_date: filter_start_date,
                                             end_date: filter_end_date)
       @home_statistics = {

--- a/app/decorators/gobierto_people/person_decorator.rb
+++ b/app/decorators/gobierto_people/person_decorator.rb
@@ -72,12 +72,14 @@ module GobiertoPeople
       statements.active.any?
     end
 
-    def meetings_with_interest_groups
-      events.with_interest_group
+    def meetings_with_interest_groups(start_date: nil, end_date: nil)
+      QueryWithEvents.new(source: events.with_interest_group,
+                          start_date: start_date,
+                          end_date: end_date)
     end
 
-    def interest_groups_count
-      meetings_with_interest_groups.select(:interest_group_id).distinct.count
+    def interest_groups_count(start_date: nil, end_date: nil)
+      meetings_with_interest_groups(start_date: start_date, end_date: end_date).select(:interest_group_id).distinct.count
     end
 
     private

--- a/app/models/gobierto_people/gift.rb
+++ b/app/models/gobierto_people/gift.rb
@@ -12,7 +12,7 @@ module GobiertoPeople
     belongs_to :department
 
     scope :sorted, -> { order(date: :desc, name: :asc) }
-    scope :between_dates, ->(start_date, end_date) do
+    scope :between_dates, lambda { |start_date, end_date|
       if start_date && end_date
         where(date: start_date..end_date)
       elsif start_date
@@ -20,7 +20,7 @@ module GobiertoPeople
       elsif end_date
         where("date <= ?", end_date)
       end
-    end
+    }
 
     default_scope { sorted }
 

--- a/app/models/gobierto_people/gift.rb
+++ b/app/models/gobierto_people/gift.rb
@@ -12,6 +12,15 @@ module GobiertoPeople
     belongs_to :department
 
     scope :sorted, -> { order(date: :desc, name: :asc) }
+    scope :between_dates, ->(start_date, end_date) do
+      if start_date && end_date
+        where(date: start_date..end_date)
+      elsif start_date
+        where("date >= ?", start_date)
+      elsif end_date
+        where("date <= ?", end_date)
+      end
+    end
 
     default_scope { sorted }
 

--- a/app/models/gobierto_people/invitation.rb
+++ b/app/models/gobierto_people/invitation.rb
@@ -12,6 +12,15 @@ module GobiertoPeople
     belongs_to :department
 
     scope :sorted, -> { order(start_date: :desc, end_date: :asc, title: :asc) }
+    scope :between_dates, ->(start_date, end_date) do
+      if start_date && end_date
+        where("start_date >= ? AND end_date <= ?", start_date, end_date)
+      elsif start_date
+        where("start_date >= ?", start_date)
+      elsif end_date
+        where("end_date <= ?", end_date)
+      end
+    end
 
     default_scope { sorted }
 

--- a/app/models/gobierto_people/invitation.rb
+++ b/app/models/gobierto_people/invitation.rb
@@ -12,7 +12,7 @@ module GobiertoPeople
     belongs_to :department
 
     scope :sorted, -> { order(start_date: :desc, end_date: :asc, title: :asc) }
-    scope :between_dates, ->(start_date, end_date) do
+    scope :between_dates, lambda { |start_date, end_date|
       if start_date && end_date
         where("start_date >= ? AND end_date <= ?", start_date, end_date)
       elsif start_date
@@ -20,7 +20,7 @@ module GobiertoPeople
       elsif end_date
         where("end_date <= ?", end_date)
       end
-    end
+    }
 
     default_scope { sorted }
 

--- a/app/models/gobierto_people/trip.rb
+++ b/app/models/gobierto_people/trip.rb
@@ -12,6 +12,15 @@ module GobiertoPeople
     belongs_to :department
 
     scope :sorted, -> { order(start_date: :desc) }
+    scope :between_dates, lambda { |start_date, end_date|
+      if start_date && end_date
+        where("start_date >= ? AND end_date <= ?", start_date, end_date)
+      elsif start_date
+        where("start_date >= ?", start_date)
+      elsif end_date
+        where("end_date <= ?", end_date)
+      end
+    }
 
     validates :person, :title, :start_date, :end_date, presence: true
 

--- a/app/queries/gobierto_people/query_with_events.rb
+++ b/app/queries/gobierto_people/query_with_events.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class QueryWithEvents
+
+    class NotImplementedError < StandardError; end
+
+    attr_reader :relation
+
+    def initialize(params = {})
+      @relation = (params[:relation] || model.all)
+      @relation = relation.joins(events_association)
+      append_condition(:starts_at, params[:start_date], ">=") if params[:start_date]
+      append_condition(:ends_at, params[:end_date], "<=") if params[:end_date]
+      params[:not_null].each do |attr|
+        append_not_null_condition(attr)
+      end if params[:not_null]
+    end
+
+    def update_relation
+      @relation = yield(@relation)
+    end
+
+    private
+
+    def model
+      raise NotImplementedError, "Must override this method"
+    end
+
+    def events_association
+      @events_association ||= [:event, :events].find { |assoc| relation.reflect_on_association(assoc) }
+    end
+
+    def events_table
+      ::GobiertoCalendars::Event.table_name
+    end
+
+    def append_condition(attribute_name, attribute_value, operator = "=")
+      @relation = relation.where("#{events_table}.#{attribute_name} #{operator} ?", attribute_value)
+    end
+
+    def append_not_null_condition(attribute_name)
+      @relation = relation.where.not(events_table => { attribute_name => nil })
+    end
+  end
+end

--- a/app/queries/gobierto_people/query_with_events.rb
+++ b/app/queries/gobierto_people/query_with_events.rb
@@ -8,6 +8,10 @@ module GobiertoPeople
 
     attr_reader :relation
 
+    def method_missing(*args, &block)
+      relation.send(*args, &block)
+    end
+
     def initialize(params = {})
       @source = (params[:source] || model)
       add_events_relation

--- a/test/integration/gobierto_people/date_filters_test.rb
+++ b/test/integration/gobierto_people/date_filters_test.rb
@@ -75,7 +75,7 @@ module GobiertoPeople
       end
     end
 
-    def test_date_filter_is_mantained_without_date_params
+    def test_date_filter_is_not_mantained_without_date_params
       set_site_dates(site, start_date: FAR_PAST)
       with_current_site(site) do
         visit path_without_date_params
@@ -90,7 +90,7 @@ module GobiertoPeople
 
         visit path_without_date_params
         within ".container" do
-          assert has_content? "3 registered events"
+          assert has_content? "6 registered events"
         end
 
         visit path_with_start_and_end_dates(RECENT_PAST, NEAR_FUTURE)
@@ -100,32 +100,33 @@ module GobiertoPeople
 
         visit path_without_date_params
         within ".container" do
-          assert has_content? "0 registered events"
+          assert has_content? "6 registered events"
         end
       end
     end
 
-    def test_reset_date_filters
-      set_site_dates(site, start_date: RECENT_PAST)
+    def test_bad_date_params
+      set_site_dates(site, start_date: FAR_PAST)
       with_current_site(site) do
         visit path_without_date_params
         within ".container" do
+          assert has_content? "6 registered events"
+        end
+
+        visit path_with_start_and_end_dates("wadus", "wadus")
+        within ".container" do
+          assert has_content? "6 registered events"
+        end
+
+        visit path_with_start_and_end_dates(RECENT_PAST, "wadus")
+        within ".container" do
           assert has_content? "3 registered events"
         end
 
-        visit path_with_start_and_end_dates(RECENT_PAST, NEAR_FUTURE)
-        within ".container" do
-          assert has_content? "0 registered events"
-        end
-
+        visit path_with_start_date("wadus")
         visit path_without_date_params
         within ".container" do
-          assert has_content? "0 registered events"
-        end
-
-        visit path_with_start_and_end_dates(false, false)
-        within ".container" do
-          assert has_content? "3 registered events"
+          assert has_content? "6 registered events"
         end
       end
     end

--- a/test/integration/gobierto_people/date_filters_test.rb
+++ b/test/integration/gobierto_people/date_filters_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/gobierto_people/submodules_helper"
+
+module GobiertoPeople
+  class DateFiltersTest < ActionDispatch::IntegrationTest
+    include ::GobiertoPeople::SubmodulesHelper
+
+    FAR_PAST = 10.years.ago
+    RECENT_PAST = 1.day.ago
+    NEAR_FUTURE = 1.day.from_now
+    FAR_FUTURE = 10.years.from_now
+
+    def setup
+      enable_submodule(site, :departments)
+      super
+    end
+
+    def set_site_dates(site, start_date: nil, end_date: nil)
+      config_vars = {}
+      config_vars[:gobierto_people_default_filter_start_date] = start_date if start_date
+      config_vars[:gobierto_people_default_filter_end_date] = end_date if end_date
+      site.configuration.raw_configuration_variables = config_vars.to_json.tr(",", "\n")
+      site.save
+    end
+
+    def path_without_date_params
+      gobierto_people_departments_path
+    end
+
+    def path_with_start_date(date)
+      gobierto_people_departments_path(start_date: date)
+    end
+
+    def path_with_start_and_end_dates(start_date, end_date)
+      gobierto_people_departments_path(start_date: start_date, end_date: end_date)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def test_site_without_default_dates_configured
+      with_current_site(site) do
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "6 registered events"
+        end
+
+        visit path_with_start_and_end_dates(RECENT_PAST, NEAR_FUTURE)
+        within ".container" do
+          assert has_content? "6 registered events"
+        end
+      end
+    end
+
+    def test_site_with_default_dates_configured
+      set_site_dates(site, start_date: RECENT_PAST)
+      with_current_site(site) do
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "3 registered events"
+        end
+
+        visit path_with_start_date(FAR_PAST)
+        within ".container" do
+          assert has_content? "6 registered events"
+        end
+
+        visit path_with_start_and_end_dates(RECENT_PAST, NEAR_FUTURE)
+        within ".container" do
+          assert has_content? "0 registered events"
+        end
+      end
+    end
+
+    def test_date_filter_is_mantained_without_date_params
+      set_site_dates(site, start_date: FAR_PAST)
+      with_current_site(site) do
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "6 registered events"
+        end
+
+        visit path_with_start_and_end_dates(RECENT_PAST, FAR_FUTURE)
+        within ".container" do
+          assert has_content? "3 registered events"
+        end
+
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "3 registered events"
+        end
+
+        visit path_with_start_and_end_dates(RECENT_PAST, NEAR_FUTURE)
+        within ".container" do
+          assert has_content? "0 registered events"
+        end
+
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "0 registered events"
+        end
+      end
+    end
+
+    def test_reset_date_filters
+      set_site_dates(site, start_date: RECENT_PAST)
+      with_current_site(site) do
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "3 registered events"
+        end
+
+        visit path_with_start_and_end_dates(RECENT_PAST, NEAR_FUTURE)
+        within ".container" do
+          assert has_content? "0 registered events"
+        end
+
+        visit path_without_date_params
+        within ".container" do
+          assert has_content? "0 registered events"
+        end
+
+        visit path_with_start_and_end_dates(false, false)
+        within ".container" do
+          assert has_content? "3 registered events"
+        end
+      end
+    end
+  end
+end

--- a/test/queries/gobierto_people/query_with_events.rb
+++ b/test/queries/gobierto_people/query_with_events.rb
@@ -54,75 +54,75 @@ module GobiertoPeople
 
     def test_query
       query = QueryWithEvents.new(source: site_source)
-      assert_equal 21, query.relation.count
+      assert_equal 21, query.count
 
       query = QueryWithEvents.new(source: department_source)
-      assert_equal 4, query.relation.count
+      assert_equal 4, query.count
 
       query = QueryWithEvents.new(source: interest_group_source)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
 
       query = QueryWithEvents.new(source: person_source)
-      assert_equal 6, query.relation.count
+      assert_equal 6, query.count
 
       query = QueryWithEvents.new(source: site_interest_groups_source)
-      assert_equal 4, query.relation.count
+      assert_equal 4, query.count
 
       query = QueryWithEvents.new(source: site_departments_source)
-      assert_equal 2, query.relation.count
+      assert_equal 2, query.count
 
       query = QueryWithEvents.new(source: people_with_events_in_department_source)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
     end
 
     def test_query_with_start_date
       start_date = 1.day.ago
 
       query = QueryWithEvents.new(source: site_source, start_date: start_date)
-      assert_equal 11, query.relation.count
+      assert_equal 11, query.count
 
       query = QueryWithEvents.new(source: department_source, start_date: start_date)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
 
       query = QueryWithEvents.new(source: interest_group_source, start_date: start_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
 
       query = QueryWithEvents.new(source: person_source, start_date: start_date)
-      assert_equal 2, query.relation.count
+      assert_equal 2, query.count
 
       query = QueryWithEvents.new(source: site_interest_groups_source, start_date: start_date)
-      assert_equal 2, query.relation.count
+      assert_equal 2, query.count
 
       query = QueryWithEvents.new(source: site_departments_source, start_date: start_date)
-      assert_equal 2, query.relation.count
+      assert_equal 2, query.count
 
       query = QueryWithEvents.new(source: people_with_events_in_department_source, start_date: start_date)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
     end
 
     def test_query_with_end_date
       end_date = 1.day.ago
 
       query = QueryWithEvents.new(source: site_source, end_date: end_date)
-      assert_equal 9, query.relation.count
+      assert_equal 9, query.count
 
       query = QueryWithEvents.new(source: department_source, end_date: end_date)
-      assert_equal 3, query.relation.count
+      assert_equal 3, query.count
 
       query = QueryWithEvents.new(source: interest_group_source, end_date: end_date)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
 
       query = QueryWithEvents.new(source: person_source, end_date: end_date)
-      assert_equal 4, query.relation.count
+      assert_equal 4, query.count
 
       query = QueryWithEvents.new(source: site_interest_groups_source, end_date: end_date)
-      assert_equal 2, query.relation.count
+      assert_equal 2, query.count
 
       query = QueryWithEvents.new(source: site_departments_source, end_date: end_date)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
 
       query = QueryWithEvents.new(source: people_with_events_in_department_source, end_date: end_date)
-      assert_equal 1, query.relation.count
+      assert_equal 1, query.count
     end
 
     def test_query_with_start_and_end_dates
@@ -130,25 +130,25 @@ module GobiertoPeople
       end_date = 5.days.from_now
 
       query = QueryWithEvents.new(source: site_source, start_date: start_date, end_date: end_date)
-      assert_equal 4, query.relation.count
+      assert_equal 4, query.count
 
       query = QueryWithEvents.new(source: department_source, start_date: start_date, end_date: end_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
 
       query = QueryWithEvents.new(source: interest_group_source, start_date: start_date, end_date: end_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
 
       query = QueryWithEvents.new(source: person_source, start_date: start_date, end_date: end_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
 
       query = QueryWithEvents.new(source: site_interest_groups_source, start_date: start_date, end_date: end_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
 
       query = QueryWithEvents.new(source: site_departments_source, start_date: start_date, end_date: end_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
 
       query = QueryWithEvents.new(source: people_with_events_in_department_source, start_date: start_date, end_date: end_date)
-      assert_equal 0, query.relation.count
+      assert_equal 0, query.count
     end
   end
 end

--- a/test/queries/gobierto_people/query_with_events.rb
+++ b/test/queries/gobierto_people/query_with_events.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/event_helpers"
+
+module GobiertoPeople
+  class QueryWithEventsTest < ActiveSupport::TestCase
+
+    include ::EventHelpers
+
+    def justice_department
+      @justice_department ||= gobierto_people_departments(:justice_department)
+    end
+
+    def coca_cola_interest_group
+      @coca_cola_interest_group ||= gobierto_people_interest_groups(:coca_cola)
+    end
+
+    def tamara
+      @tamara ||= gobierto_people_people(:tamara)
+    end
+
+    def site
+      @site || sites(:madrid)
+    end
+
+    def site_source
+      site.events
+    end
+
+    def department_source
+      justice_department.events
+    end
+
+    def interest_group_source
+      coca_cola_interest_group.events
+    end
+
+    def person_source
+      tamara.attending_events
+    end
+
+    def site_interest_groups_source
+      site.interest_groups
+    end
+
+    def site_departments_source
+      site.departments
+    end
+
+    def people_with_events_in_department_source
+      justice_department.people.with_event_attendances
+    end
+
+    def test_query
+      query = QueryWithEvents.new(source: site_source)
+      assert_equal 21, query.relation.count
+
+      query = QueryWithEvents.new(source: department_source)
+      assert_equal 4, query.relation.count
+
+      query = QueryWithEvents.new(source: interest_group_source)
+      assert_equal 1, query.relation.count
+
+      query = QueryWithEvents.new(source: person_source)
+      assert_equal 6, query.relation.count
+
+      query = QueryWithEvents.new(source: site_interest_groups_source)
+      assert_equal 4, query.relation.count
+
+      query = QueryWithEvents.new(source: site_departments_source)
+      assert_equal 2, query.relation.count
+
+      query = QueryWithEvents.new(source: people_with_events_in_department_source)
+      assert_equal 1, query.relation.count
+    end
+
+    def test_query_with_start_date
+      start_date = 1.day.ago
+
+      query = QueryWithEvents.new(source: site_source, start_date: start_date)
+      assert_equal 11, query.relation.count
+
+      query = QueryWithEvents.new(source: department_source, start_date: start_date)
+      assert_equal 1, query.relation.count
+
+      query = QueryWithEvents.new(source: interest_group_source, start_date: start_date)
+      assert_equal 0, query.relation.count
+
+      query = QueryWithEvents.new(source: person_source, start_date: start_date)
+      assert_equal 2, query.relation.count
+
+      query = QueryWithEvents.new(source: site_interest_groups_source, start_date: start_date)
+      assert_equal 2, query.relation.count
+
+      query = QueryWithEvents.new(source: site_departments_source, start_date: start_date)
+      assert_equal 2, query.relation.count
+
+      query = QueryWithEvents.new(source: people_with_events_in_department_source, start_date: start_date)
+      assert_equal 1, query.relation.count
+    end
+
+    def test_query_with_end_date
+      end_date = 1.day.ago
+
+      query = QueryWithEvents.new(source: site_source, end_date: end_date)
+      assert_equal 9, query.relation.count
+
+      query = QueryWithEvents.new(source: department_source, end_date: end_date)
+      assert_equal 3, query.relation.count
+
+      query = QueryWithEvents.new(source: interest_group_source, end_date: end_date)
+      assert_equal 1, query.relation.count
+
+      query = QueryWithEvents.new(source: person_source, end_date: end_date)
+      assert_equal 4, query.relation.count
+
+      query = QueryWithEvents.new(source: site_interest_groups_source, end_date: end_date)
+      assert_equal 2, query.relation.count
+
+      query = QueryWithEvents.new(source: site_departments_source, end_date: end_date)
+      assert_equal 1, query.relation.count
+
+      query = QueryWithEvents.new(source: people_with_events_in_department_source, end_date: end_date)
+      assert_equal 1, query.relation.count
+    end
+
+    def test_query_with_start_and_end_dates
+      start_date = 5.days.ago
+      end_date = 5.days.from_now
+
+      query = QueryWithEvents.new(source: site_source, start_date: start_date, end_date: end_date)
+      assert_equal 4, query.relation.count
+
+      query = QueryWithEvents.new(source: department_source, start_date: start_date, end_date: end_date)
+      assert_equal 0, query.relation.count
+
+      query = QueryWithEvents.new(source: interest_group_source, start_date: start_date, end_date: end_date)
+      assert_equal 0, query.relation.count
+
+      query = QueryWithEvents.new(source: person_source, start_date: start_date, end_date: end_date)
+      assert_equal 0, query.relation.count
+
+      query = QueryWithEvents.new(source: site_interest_groups_source, start_date: start_date, end_date: end_date)
+      assert_equal 0, query.relation.count
+
+      query = QueryWithEvents.new(source: site_departments_source, start_date: start_date, end_date: end_date)
+      assert_equal 0, query.relation.count
+
+      query = QueryWithEvents.new(source: people_with_events_in_department_source, start_date: start_date, end_date: end_date)
+      assert_equal 0, query.relation.count
+    end
+  end
+end


### PR DESCRIPTION
Closes #345


## :v: What does this PR do?
Allows to set date ranges on gobierto_people to get data about events, gifts, invitations and trips restricted to that range.

This branch **can't be merged!** Some tests of gobierto_participation are unexpectedly failing, I'm working on it.

## :mag: How should this be manually tested?
Set at least one default range date for site in admin customize site form / other configuration variables section. The available date keys are `gobierto_people_default_start_date` and `gobierto_people_end_date`
<img width="312" alt="screen shot 2018-06-23 at 01 20 07" src="https://user-images.githubusercontent.com/446459/41802780-c2ab70ba-7683-11e8-8a21-4379ce3343fb.png">

Check some paths like:
* `/cargos-y-agendas?start_date=2018-06-10&end_date=2018-06-23`
* `/cargos-y-agendas?start_date=2018-06-10`
* `/cargos-y-agendas?end_date=2018-06-23`
* `/cargos-y-agendas`
The last path should use default range dates for site. If there isn't at least one default range date for site the arguments are ignored and the results won't be filtered by date.

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No