### PR TITLE
388 - Shorten department names for API

### DIFF
--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -24,27 +24,13 @@ module GobiertoPeople
             result_indexes = {}
 
             records.each do |record|
-              if (index = result_indexes[record.name])
-                result[index][:value] << {
-                  key: Time.zone.parse(record.year_month),
-                  value: record.custom_events_count,
-                  properties: {
-                    url: gobierto_people_department_path(record.slug, start_date: Time.zone.parse(record.year_month).to_date.to_s(:db), end_date: (Time.zone.parse(record.year_month).to_date + 1.month).to_s(:db))
-                  }
-                }
+              if (index = result_indexes[record.short_name])
+                result[index][:value] << record_value_item(record)
               else
-                result_indexes[record.name] = result.size
+                result_indexes[record.short_name] = result.size
                 result << {
-                  key: record.name,
-                  value: [
-                    {
-                      key: Time.zone.parse(record.year_month),
-                      value: record.custom_events_count,
-                      properties: {
-                        url: gobierto_people_department_path(record.slug, start_date: Time.zone.parse(record.year_month).to_date.to_s(:db), end_date: (Time.zone.parse(record.year_month).to_date + 1.month).to_s(:db))
-                      }
-                    }
-                  ],
+                  key: record.short_name,
+                  value: [record_value_item(record)],
                   properties: {
                     url: gobierto_people_department_path(record.slug)
                   }
@@ -88,10 +74,18 @@ module GobiertoPeople
           head :forbidden unless departments_submodule_active?
         end
 
-        def date_range(year_month)
+        def record_value_item(record)
+          year_month = Time.zone.parse(record.year_month)
           {
-            start_date: Time.zone.parse(year_month).to_date.to_s(:db),
-            end_date: (Time.zone.parse(year_month).to_date + 1.month).to_s(:db)
+            key: year_month,
+            value: record.custom_events_count,
+            properties: {
+              url: gobierto_people_department_path(
+                record.slug,
+                start_date: year_month.to_date.to_s(:db),
+                end_date: (year_month.to_date + 1.month).to_s(:db)
+              )
+            }
           }
         end
 

--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -63,7 +63,7 @@ module GobiertoPeople
             render json: result
           else
 
-            render json: top_departments, each_serializer: RowchartItemSerializer
+            render json: top_departments, each_serializer: DepartmentRowchartSerializer
           end
         end
 

--- a/app/models/gobierto_people/department.rb
+++ b/app/models/gobierto_people/department.rb
@@ -4,9 +4,9 @@ require_dependency "gobierto_people"
 
 module GobiertoPeople
   class Department < ApplicationRecord
+
     include GobiertoCommon::Metadatable
     include GobiertoCommon::UrlBuildable
-
     include GobiertoCommon::Sluggable
 
     belongs_to :site
@@ -18,6 +18,15 @@ module GobiertoPeople
     scope :sorted, -> { order(name: :asc) }
 
     validates :name, presence: true
+
+    SHORT_NAME_TRUNCATE_REGEX = Regexp.new([
+      "Departamento de ",
+      "Departamento ",
+      "Department of ",
+      "Departament de la ",
+      "Departament de ",
+      "Departament d'"
+    ].join("|")).freeze
 
     def to_param
       slug
@@ -37,5 +46,10 @@ module GobiertoPeople
           .where("gc_events.department_id = ?", id)
           .distinct
     end
+
+    def short_name
+      name.gsub(SHORT_NAME_TRUNCATE_REGEX, "")
+    end
+
   end
 end

--- a/app/serializers/gobierto_people/department_rowchart_serializer.rb
+++ b/app/serializers/gobierto_people/department_rowchart_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class DepartmentRowchartSerializer < RowchartItemSerializer
+
+    TRUNCATE_NAME_PATTERN = Regexp.new([
+      "Departamento de ",
+      "Departamento ",
+      "Department of ",
+      "Departament de la ",
+      "Departament de ",
+      "Departament d'"
+    ].join("|")).freeze
+
+    def key
+      object.name.gsub(TRUNCATE_NAME_PATTERN, "")
+    end
+
+  end
+end

--- a/app/serializers/gobierto_people/department_rowchart_serializer.rb
+++ b/app/serializers/gobierto_people/department_rowchart_serializer.rb
@@ -3,17 +3,8 @@
 module GobiertoPeople
   class DepartmentRowchartSerializer < RowchartItemSerializer
 
-    TRUNCATE_NAME_PATTERN = Regexp.new([
-      "Departamento de ",
-      "Departamento ",
-      "Department of ",
-      "Departament de la ",
-      "Departament de ",
-      "Departament d'"
-    ].join("|")).freeze
-
     def key
-      object.name.gsub(TRUNCATE_NAME_PATTERN, "")
+      object.short_name
     end
 
   end

--- a/test/integration/gobierto_people/api/v1/departments_test.rb
+++ b/test/integration/gobierto_people/api/v1/departments_test.rb
@@ -43,6 +43,8 @@ module GobiertoPeople
         end
 
         def test_departments_index_test
+          justice_department.update_attributes!(name: "Departament de la Presidència")
+
           with_current_site(madrid) do
 
             get gobierto_people_api_v1_departments_path
@@ -50,8 +52,11 @@ module GobiertoPeople
             assert_response :success
 
             departments = JSON.parse(response.body)
+            departments_names = departments.map { |d| d["key"] }
 
             assert_equal departments_with_events_count, departments.size
+            assert departments_names.include?("Presidència")
+            refute departments_names.include?("Departament de la Presidència")
 
             assert array_match(attributes, departments.first.keys)
           end

--- a/test/models/gobierto_people/department_test.rb
+++ b/test/models/gobierto_people/department_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  class DepartmentTest < ActiveSupport::TestCase
+
+    def department
+      @department ||= gobierto_people_departments(:culture_department)
+    end
+
+    def test_short_name
+      complete_names = [
+        "Departamento de Wadus",
+        "Department of Wadus",
+        "Departament de la Wadus",
+        "Departament de Wadus",
+        "Departament d'Wadus"
+      ]
+
+      complete_names.each do |name|
+        department.update_attributes!(name: name)
+        assert_equal "Wadus", department.short_name
+      end
+    end
+
+  end
+end

--- a/test/serializers/gobierto_people/department_rowchart_serializer_test.rb
+++ b/test/serializers/gobierto_people/department_rowchart_serializer_test.rb
@@ -10,19 +10,12 @@ module GobiertoPeople
     end
 
     def test_serialize
-      complete_names = [
-        "Departamento de Wadus",
-        "Department of Wadus",
-        "Departament de la Wadus",
-        "Departament de Wadus",
-        "Departament d'Wadus"
-      ]
+      department.update_attributes!(name: "Departament de la Presidència")
 
-      complete_names.each do |name|
-        department.update_attributes!(name: name)
-        serializer_output = JSON.parse(DepartmentRowchartSerializer.new(department).to_json)
-        assert_equal "Wadus", serializer_output["key"]
-      end
+      serializer = DepartmentRowchartSerializer.new(department)
+      serializer_output = JSON.parse(serializer.to_json)
+
+      assert_equal "Presidència", serializer_output["key"]
     end
 
   end

--- a/test/serializers/gobierto_people/department_rowchart_serializer_test.rb
+++ b/test/serializers/gobierto_people/department_rowchart_serializer_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  class DepartmentRowchartSerializerTest < ActiveSupport::TestCase
+
+    def department
+      @department ||= gobierto_people_departments(:culture_department)
+    end
+
+    def test_serialize
+      complete_names = [
+        "Departamento de Wadus",
+        "Department of Wadus",
+        "Departament de la Wadus",
+        "Departament de Wadus",
+        "Departament d'Wadus"
+      ]
+
+      complete_names.each do |name|
+        department.update_attributes!(name: name)
+        serializer_output = JSON.parse(DepartmentRowchartSerializer.new(department).to_json)
+        assert_equal "Wadus", serializer_output["key"]
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Closes [#388](https://github.com/PopulateTools/issues/issues/388)

## :v: What does this PR do?

Removes the department preffix from the name for the API listings.

## :mag: How should this be manually tested?

You can check in:

http://g*****.gobify.net/cargos-y-agendas
http://g*****.gobify.net/departamentos