### PR TITLE
Fix person events order

### DIFF
--- a/app/controllers/gobierto_people/people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/past_person_events_controller.rb
@@ -7,7 +7,8 @@ module GobiertoPeople
       def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
-          @events = @person.events.by_date(@filtering_date).sorted.page params[:page]
+          @events = @person.events.by_date(@filtering_date)
+          @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         elsif params[:page] == "false"
           # permit non-pagination and avoid N+1 queries for custom engines
           @events = @person.events.past.sorted_backwards.includes(:interest_group)

--- a/app/controllers/gobierto_people/people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/past_person_events_controller.rb
@@ -12,7 +12,7 @@ module GobiertoPeople
           # permit non-pagination and avoid N+1 queries for custom engines
           @events = @person.events.past.sorted_backwards.includes(:interest_group)
         else
-          @events = @person.events.past.sorted.page params[:page]
+          @events = @person.events.past.sorted_backwards.page params[:page]
         end
 
         respond_to do |format|

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -7,7 +7,8 @@ module GobiertoPeople
       def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
-          @events = @person.attending_events.by_date(@filtering_date).sorted.page params[:page]
+          @events = @person.attending_events.by_date(@filtering_date)
+          @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         else
           @events = @person.attending_events.upcoming.sorted.page params[:page]
         end

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -150,30 +150,43 @@ module GobiertoPeople
       end
 
       def test_filter_events_by_calendar_date_link
-        yesterday_event = gobierto_calendars_events(:nelson_yesterday_fixed)
-        tomorrow_event  = gobierto_calendars_events(:nelson_tomorrow_fixed)
+        richard.events.destroy_all
 
-        Timecop.freeze(Time.zone.parse('2014-04-15 6:00')) do
+        freeze_date = Time.zone.parse("2014-04-15 6:00")
+        yesterday = freeze_date - 1.day
+
+        yesterday_early_event = create_event(title: "Yesterday early event", starts_at: yesterday.change(hour: 7))
+        yesterday_late_event = create_event(title: "Yesterday late event", starts_at: yesterday.change(hour: 20))
+        tomorrow_event = create_event(title: "Tomorrow event", starts_at: freeze_date + 1.day)
+
+        midday_events = []
+        10.times do |index|
+          midday_events << create_event(title: "Yesterday midday event #{index}", starts_at: yesterday.change(hour: 14, min: index))
+        end
+
+        Timecop.freeze(freeze_date) do
           with_javascript do
             with_current_site(site) do
-              visit gobierto_people_person_events_path(nelson.slug)
-
-              click_button 'List'
-
-              within ".events-summary" do
-                assert has_no_content?(yesterday_event.title)
-                assert has_content?(tomorrow_event.title)
-              end
+              visit gobierto_people_person_events_path(richard.slug)
 
               within ".calendar-component" do
-                click_link yesterday_event.starts_at.day
+                click_link yesterday_early_event.starts_at.day
               end
 
-              assert has_content? "Displaying events of #{yesterday_event.starts_at.strftime("%b %d %Y")}"
+              assert has_content? "Displaying events of #{yesterday_early_event.starts_at.strftime("%b %d %Y")}"
+
+              click_link "View more"
+
+              sleep 2
 
               within ".events-summary" do
-                assert has_content?(yesterday_event.title)
                 assert has_no_content?(tomorrow_event.title)
+                assert ordered_elements page, [
+                  yesterday_late_event.title,
+                  midday_events.last.title,
+                  midday_events.first.title,
+                  yesterday_early_event.title
+                ]
               end
             end
           end

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -64,26 +64,30 @@ module GobiertoPeople
       end
 
       def test_events_summary_upcoming_and_past_filters
+        richard.events.destroy_all
+        far_past_event = create_event(title: "Richard far past event", starts_at: :far_past)
+        past_event = create_event(title: "Richard past event", starts_at: :past)
+        future_event = create_event(title: "Richard future event", starts_at: :future)
+        far_future_event = create_event(title: "Richard far future event", starts_at: :far_future)
+
         with_javascript do
           with_current_site(site) do
-
-            past_event = gobierto_calendars_events(:richard_published_past)
-            future_event = gobierto_calendars_events(:richard_published_just_attending)
-
             visit gobierto_people_person_events_path(richard.slug)
 
-            click_button 'List'
+            click_button "List"
 
             within ".events-summary" do
+              assert has_no_content?(far_past_event.title)
               assert has_no_content?(past_event.title)
-              assert has_content?(future_event.title)
+              assert ordered_elements(page, [future_event.title, far_future_event.title])
             end
 
             click_link "Past events"
 
             within ".events-summary" do
-              assert has_content?(past_event.title)
               assert has_no_content?(future_event.title)
+              assert has_no_content?(far_future_event.title)
+              assert ordered_elements(page, [past_event.title, far_past_event.title])
             end
           end
         end

--- a/test/support/event_helpers.rb
+++ b/test/support/event_helpers.rb
@@ -7,7 +7,7 @@ module EventHelpers
     far_past: 10.years.ago,
     future: 1.year.from_now,
     far_future: 10.years.from_now
-  }
+  }.freeze
 
   def create_event(options = {})
     person     = options[:person] || gobierto_people_people(:richard)
@@ -37,7 +37,7 @@ module EventHelpers
     starts_at_param = options[:starts_at]
     if starts_at_param && TIME_ALIASES[starts_at_param]
       TIME_ALIASES[starts_at_param]
-    elsif starts_at_param && starts_at_param.is_a?(String)
+    elsif starts_at_param&.is_a?(String)
       Time.zone.parse(starts_at_param)
     elsif starts_at_param
       starts_at_param
@@ -48,7 +48,7 @@ module EventHelpers
 
   def parse_end_date(options)
     ends_at_param = options[:ends_at]
-    if ends_at_param && ends_at_param.is_a?(String)
+    if ends_at_param&.is_a?(String)
       Time.zone.parse(ends_at_param)
     elsif ends_at_param
       ends_at_param

--- a/test/support/event_helpers.rb
+++ b/test/support/event_helpers.rb
@@ -2,6 +2,13 @@
 
 module EventHelpers
 
+  TIME_ALIASES = {
+    past: 1.year.ago,
+    far_past: 10.years.ago,
+    future: 1.year.from_now,
+    far_future: 10.years.from_now
+  }
+
   def create_event(options = {})
     person     = options[:person] || gobierto_people_people(:richard)
     collection = person.events_collection
@@ -28,7 +35,9 @@ module EventHelpers
 
   def parse_start_date(options)
     starts_at_param = options[:starts_at]
-    if starts_at_param && starts_at_param.is_a?(String)
+    if starts_at_param && TIME_ALIASES[starts_at_param]
+      TIME_ALIASES[starts_at_param]
+    elsif starts_at_param && starts_at_param.is_a?(String)
       Time.zone.parse(starts_at_param)
     elsif starts_at_param
       starts_at_param


### PR DESCRIPTION
## :v: What does this PR do?

* Fixes the order when returning past events.
* Improves test coverage

## :mag: How should this be manually tested?

In production the order is inverted for past events:

https://portalobert.esplugues.cat/agendas/sara-forgas-ubeda/eventos-pasados?list_view=true

In staging it's corrected:

http://esplugues.gobify.net/agendas/alberto-miedes-gcal/eventos-pasados?list_view=true

(try to click on the "View more" link also)