### PR TITLE
397 return paths with dates from api

### DIFF
--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -70,6 +70,10 @@ module GobiertoPeople
           ).to_h
         end
 
+        def date_range_params
+          parsed_parameters.slice(:from_date, :to_date).permit!.transform_keys{ |k| {"from_date" => "start_date", "to_date" => "end_date"}[k] }.transform_values{ |v| v&.strftime("%Y-%m-%d") }
+        end
+
         def check_active_submodules
           head :forbidden unless departments_submodule_active?
         end

--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -48,8 +48,7 @@ module GobiertoPeople
 
             render json: result
           else
-
-            render json: top_departments, each_serializer: DepartmentRowchartSerializer
+            render json: top_departments, each_serializer: DepartmentRowchartSerializer, date_range_query: date_range_params.to_query
           end
         end
 

--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -55,9 +55,11 @@ module GobiertoPeople
         private
 
         def parsed_parameters
-          params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
-          params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
-          params
+          @parsed_parameters ||= begin
+                                   params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
+                                   params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
+                                   params
+                                 end
         end
 
         def permitted_conditions

--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -32,7 +32,7 @@ module GobiertoPeople
                   key: record.short_name,
                   value: [record_value_item(record)],
                   properties: {
-                    url: gobierto_people_department_path(record.slug)
+                    url: gobierto_people_department_path(record.slug, date_range_params.merge(page: false))
                   }
                 }
               end

--- a/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
@@ -24,9 +24,11 @@ module GobiertoPeople
         private
 
         def parsed_parameters
-          params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
-          params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
-          params
+          @parsed_parameters ||= begin
+                                   params[:from_date] = Time.zone.parse(params[:from_date]) if params[:from_date]
+                                   params[:to_date] = Time.zone.parse(params[:to_date]) if params[:to_date]
+                                   params
+                                 end
         end
 
         def permitted_conditions

--- a/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
@@ -37,6 +37,10 @@ module GobiertoPeople
           ).to_h
         end
 
+        def date_range_params
+          parsed_parameters.slice(:from_date, :to_date).permit!.transform_keys{ |k| {"from_date" => "start_date", "to_date" => "end_date"}[k] }.transform_values{ |v| v&.strftime("%Y-%m-%d") }
+        end
+
         def check_active_submodules
           head :forbidden unless interest_groups_submodule_active?
         end

--- a/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/interest_groups_controller.rb
@@ -16,7 +16,8 @@ module GobiertoPeople
 
           render(
             json: query.results,
-            each_serializer: RowchartItemSerializer
+            each_serializer: RowchartItemSerializer,
+            date_range_query: date_range_params.to_query
           )
         end
 

--- a/app/controllers/gobierto_people/api/v1/people_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/people_controller.rb
@@ -48,7 +48,7 @@ module GobiertoPeople
 
             render json: result
           else
-            render json: top_people, each_serializer: RowchartItemSerializer
+            render json: top_people, each_serializer: RowchartItemSerializer, date_range_query: date_range_params.to_query
           end
         end
 

--- a/app/controllers/gobierto_people/api/v1/people_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/people_controller.rb
@@ -32,7 +32,7 @@ module GobiertoPeople
                   key: record.name,
                   value: [record_value_item(record)],
                   properties: {
-                    url: gobierto_people_person_past_events_url(record.slug, page: false)
+                    url: gobierto_people_person_past_events_url(record.slug, date_range_params.merge(page: false))
                   }
                 }
               end

--- a/app/controllers/gobierto_people/api/v1/people_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/people_controller.rb
@@ -69,6 +69,10 @@ module GobiertoPeople
           ).to_h
         end
 
+        def date_range_params
+          parsed_parameters.slice(:from_date, :to_date).permit!.transform_keys{ |k| {"from_date" => "start_date", "to_date" => "end_date"}[k] }.transform_values{ |v| v&.strftime("%Y-%m-%d") }
+        end
+
         def check_active_submodules
           head :forbidden unless agendas_submodule_active?
         end

--- a/app/serializers/gobierto_people/rowchart_item_serializer.rb
+++ b/app/serializers/gobierto_people/rowchart_item_serializer.rb
@@ -14,7 +14,11 @@ module GobiertoPeople
     end
 
     def properties
-      { url: object.to_url }
+      { url: "#{ object.to_url}#{ date_range_query }" }
+    end
+
+    def date_range_query
+      "?#{ instance_options[:date_range_query] }" if instance_options[:date_range_query].present?
     end
 
   end

--- a/test/integration/gobierto_people/api/v1/departments_test.rb
+++ b/test/integration/gobierto_people/api/v1/departments_test.rb
@@ -42,6 +42,10 @@ module GobiertoPeople
           ::GobiertoCalendars::Event.select(:department_id).distinct.count
         end
 
+        def short_date(date)
+          date[/^\d+-\d+-\d+/]
+        end
+
         def test_departments_index_test
           justice_department.update_attributes!(name: "Departament de la Presidència")
 
@@ -81,6 +85,7 @@ module GobiertoPeople
 
             assert_equal 1, departments.size
             assert_equal departments.first["key"], justice_department.name
+            assert_match "?end_date=#{ short_date(FAR_FUTURE) }&start_date=#{ short_date(FAR_PAST) }", departments.first["properties"]["url"]
           end
         end
 

--- a/test/integration/gobierto_people/api/v1/interest_groups_test.rb
+++ b/test/integration/gobierto_people/api/v1/interest_groups_test.rb
@@ -42,6 +42,10 @@ module GobiertoPeople
           super
         end
 
+        def short_date(date)
+          date[/^\d+-\d+-\d+/]
+        end
+
         def test_interest_groups_index_test
           with_current_site(madrid) do
 
@@ -76,6 +80,7 @@ module GobiertoPeople
 
             assert_equal 2, interest_groups.size
             assert_equal interest_groups.first["key"], pepsi.name
+            assert_match "?end_date=#{ short_date(FAR_FUTURE) }&start_date=#{ short_date(FAR_PAST) }", interest_groups.first["properties"]["url"]
           end
         end
 

--- a/test/integration/gobierto_people/api/v1/people_index_test.rb
+++ b/test/integration/gobierto_people/api/v1/people_index_test.rb
@@ -54,6 +54,10 @@ module GobiertoPeople
           [tamara]
         end
 
+        def short_date(date)
+          date[/^\d+-\d+-\d+/]
+        end
+
         def test_people_index_test
           with_current_site(madrid) do
 
@@ -87,6 +91,7 @@ module GobiertoPeople
 
             assert_equal people_with_events_on_justice_department.size, people.size
             assert_equal people.first["key"], tamara.name
+            assert_match "?end_date=#{ short_date(FAR_FUTURE) }&start_date=#{ short_date(FAR_PAST) }", people.first["properties"]["url"]
           end
         end
 


### PR DESCRIPTION
Closes #397

## :v: What does this PR do?

Adds a start_date and end date resolved from the initial request to url queries on url properties fields returned from API responses.

## :mag: How should this be manually tested?

Send a request to `/gobierto_people/api/v1/departments.json?from_date=2010-07-07` The response should include the `from_date` param as `start_date` for the departments in the url properties attribute

## :shipit: Does this PR changes any configuration file?
No