### PR TITLE
390 - Add Markdown/HTML support for Process body

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -121,7 +121,7 @@ module GobiertoAdmin
           :published_on,
           title_translations: [*I18n.available_locales],
           body_translations:  [*I18n.available_locales],
-          body_source_translations:  [*I18n.available_locales]
+          body_source_translations: [*I18n.available_locales]
         )
       end
 

--- a/app/controllers/gobierto_admin/gobierto_participation/processes_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes_controller.rb
@@ -124,7 +124,8 @@ module GobiertoAdmin
           :visibility_level,
           :has_duration,
           title_translations: [*I18n.available_locales],
-          body_translations:  [*I18n.available_locales]
+          body_translations:  [*I18n.available_locales],
+          body_source_translations: [*I18n.available_locales]
         )
       end
 

--- a/app/forms/gobierto_admin/gobierto_participation/process_form.rb
+++ b/app/forms/gobierto_admin/gobierto_participation/process_form.rb
@@ -9,6 +9,7 @@ module GobiertoAdmin
         :site_id,
         :title_translations,
         :body_translations,
+        :body_source_translations,
         :process_type,
         :starts,
         :ends,
@@ -149,6 +150,7 @@ module GobiertoAdmin
           process_attributes.site_id            = site_id
           process_attributes.title_translations = title_translations
           process_attributes.body_translations  = body_translations
+          process_attributes.body_source_translations = body_source_translations
           process_attributes.header_image_url   = header_image_url
           process_attributes.visibility_level   = visibility_level
           process_attributes.process_type       = process_type

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -21,7 +21,7 @@ module GobiertoParticipation
       add_attribute :resource_path, :class_name
     end
 
-    translates :title, :body, :information_text
+    translates :title, :body, :body_source, :information_text
 
     belongs_to :site
     belongs_to :issue

--- a/app/views/gobierto_admin/gobierto_participation/processes/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/processes/_form.html.erb
@@ -17,8 +17,20 @@
 
           <div class="form_item textarea" data-locale="<%= locale %>">
             <%= label_tag "process[body_translations][#{locale}]", f.object.class.human_attribute_name(:body) %>
-            <%= text_area_tag "process[body_translations][#{locale}]", f.object.body_translations && f.object.body_translations[locale], placeholder: t('.placeholders.body', locale: locale) %>
+            <%= text_area_tag(
+                  "process[body_source_translations][#{locale}]",
+                  f.object.body_source_translations && f.object.body_source_translations[locale],
+                  placeholder: t('.placeholders.body', locale: locale),
+                  data: { wysiwyg: true}
+                ) %>
           </div>
+
+          <%= hidden_field_tag(
+                "process[body_translations][#{locale}]",
+                f.object.body_translations && f.object.body_translations[locale],
+                id: "process_body_translations_#{locale}"
+              ) %>
+
         <% end %>
       </div>
 

--- a/app/views/gobierto_participation/processes/show.html.erb
+++ b/app/views/gobierto_participation/processes/show.html.erb
@@ -41,7 +41,7 @@
     <div class="pure-g">
       <div class="pure-u-1 pure-u-md-2-3">
         <h3 class="with_light_separator"><%= t(".about.#{current_process.process_type}") %></h3>
-        <p><%= current_process.body %></p>
+        <%== render_liquid(current_process.body) %>
 
         <% information_stage = current_process.stages.where(stage_type: 0).try(:first) %>
 

--- a/db/migrate/20180628143745_add_body_source_to_processes.rb
+++ b/db/migrate/20180628143745_add_body_source_to_processes.rb
@@ -1,0 +1,6 @@
+class AddBodySourceToProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :gpart_processes, :body_source_translations, :jsonb
+    add_index :gpart_processes, :body_source_translations, using: :gin
+  end
+end

--- a/db/migrate/20180628143928_copy_process_body_to_body_source.rb
+++ b/db/migrate/20180628143928_copy_process_body_to_body_source.rb
@@ -1,0 +1,8 @@
+class CopyProcessBodyToBodySource < ActiveRecord::Migration[5.2]
+  def change
+    ::GobiertoParticipation::Process.all.each do |process|
+      process.body_source_translations = process.body_translations
+      process.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_14_101232) do
+ActiveRecord::Schema.define(version: 2018_06_28_143928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -747,7 +747,9 @@ ActiveRecord::Schema.define(version: 2018_06_14_101232) do
     t.integer "issue_id"
     t.bigint "scope_id"
     t.datetime "archived_at"
+    t.jsonb "body_source_translations"
     t.index ["archived_at"], name: "index_gpart_processes_on_archived_at"
+    t.index ["body_source_translations"], name: "index_gpart_processes_on_body_source_translations", using: :gin
     t.index ["body_translations"], name: "index_gpart_processes_on_body_translations", using: :gin
     t.index ["site_id", "slug"], name: "index_gpart_processes_on_site_id_and_slug", unique: true
     t.index ["site_id"], name: "index_gpart_processes_on_site_id"

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -68,8 +68,8 @@ themes_draft:
 
 notice_1:
   title_translations: <%= {'en' => 'Notice 1 title' }.to_json %>
-  body_translations: <%= {'en' => 'Notice 1 body' }.to_json %>
-  body_source_translations: <%= {'en' => 'Notice 1 body' }.to_json %>
+  body_translations: <%= {'en' => 'Notice 1 <strong>body</strong>' }.to_json %>
+  body_source_translations: <%= {'en' => 'Notice 1 <strong>body</strong>' }.to_json %>
   slug: 'notice-1'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid

--- a/test/fixtures/gobierto_participation/processes.yml
+++ b/test/fixtures/gobierto_participation/processes.yml
@@ -4,6 +4,7 @@ green_city_group_active_empty:
   site: madrid
   title_translations: <%= { 'en' => 'Green city', 'es' => 'Ciudad verde' }.to_json %>
   body_translations: <%= { 'en' => 'Make Madrid a green city', 'es' => 'Hacer de Madrid una ciudad verde. Este grupo no tiene fases activas.' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Make Madrid a green city', 'es' => 'Hacer de Madrid una ciudad verde. Este grupo no tiene fases activas.' }.to_json %>
   slug: ciudad-verde
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
@@ -13,6 +14,7 @@ cultural_city_group_draft:
   site: madrid
   title_translations: <%= { 'en' => 'Cultural city', 'es' => 'Ciudad cultural' }.to_json %>
   body_translations: <%= { 'en' => 'Make Madrid a cultural city', 'es' => 'Hacer de Madrid una ciudad cultural' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Make Madrid a cultural city', 'es' => 'Hacer de Madrid una ciudad cultural' }.to_json %>
   slug: ciudad-cultural
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels["draft"] %>
@@ -22,6 +24,7 @@ public_debates_group_future:
   site: madrid
   title_translations: <%= { 'en' => 'Public Debates', 'es' => 'Debates Públicos' }.to_json %>
   body_translations: <%= { 'en' => 'Take part in these interesting debates', 'es' => 'Participa en estos interesantes debates' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Take part in these interesting debates', 'es' => 'Participa en estos interesantes debates' }.to_json %>
   slug: public-debates
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
@@ -33,6 +36,7 @@ dance_studio_group_ended:
   site: madrid
   title_translations: <%= { 'en' => 'Dance Studio', 'es' => 'Taller de danza' }.to_json %>
   body_translations: <%= { 'en' => '', 'es' => '' }.to_json %>
+  body_source_translations: <%= { 'en' => '', 'es' => '' }.to_json %>
   slug: dance-studio
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
@@ -51,6 +55,10 @@ bowling_group_very_active:
     'en' => 'French elders of 75+ years enjoying their time while playing lawn bowling. This group has lots of contributions and comments.',
     'es' => 'Señores franceses de más de 75 años jugando a la petanca para pasar sus ratos libres. Este grupo tiene muchas contribuciones y comentarios.'
   }.to_json %>
+  body_source_translations: <%= {
+    'en' => 'French elders of 75+ years enjoying their time while playing lawn bowling. This group has lots of contributions and comments.',
+    'es' => 'Señores franceses de más de 75 años jugando a la petanca para pasar sus ratos libres. Este grupo tiene muchas contribuciones y comentarios.'
+  }.to_json %>
   slug: grupo-de-petanca
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
@@ -62,7 +70,8 @@ bowling_group_very_active:
 sport_city_process:
   site: madrid
   title_translations: <%= { 'en' => 'Sport city', 'es' => 'Ciudad deportiva' }.to_json %>
-  body_translations: <%= { 'en' => 'Make Madrid a sport city', 'es' => 'Hacer de Madrid una ciudad deportiva' }.to_json %>
+  body_translations: <%= { 'en' => 'Make <strong>Madrid</strong> a sport city', 'es' => 'Hacer de <strong>Madrid</strong> una ciudad deportiva' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Make **Madrid** a sport city', 'es' => 'Hacer de **Madrid** una ciudad deportiva' }.to_json %>
   slug: ciudad-deportiva
   process_type: <%= GobiertoParticipation::Process.process_types[:process] %>
   visibility_level: <%= Site.visibility_levels["active"] %>
@@ -75,6 +84,7 @@ local_budgets_process:
   site: madrid
   title_translations: <%= { 'en' => 'Local budgets', 'es' => 'Presupuestos participativos' }.to_json %>
   body_translations: <%= { 'en' => 'Local budgets in Madrid', 'es' => 'Presupuestos participativos Madrid' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Local budgets in Madrid', 'es' => 'Presupuestos participativos Madrid' }.to_json %>
   slug: presupuestos-participativos
   process_type: <%= GobiertoParticipation::Process.process_types[:process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
@@ -89,6 +99,10 @@ gender_violence_process:
     'es' => 'Pacto social por el fin de la violencia contra la mujer'
   }.to_json %>
   body_translations: <%= {
+    'en' => '¿Qué tiene que ver la Violencia contra las mujeres contigo? ¿y con nuestra ciudad? Es un problema colectivo en el que está implicada toda la sociedad. Es necesario establecer redes de colaboración, cooperación y corresponsabilidad.',
+    'es' => '¿Qué tiene que ver la Violencia contra las mujeres contigo? ¿y con nuestra ciudad? Es un problema colectivo en el que está implicada toda la sociedad. Es necesario establecer redes de colaboración, cooperación y corresponsabilidad.'
+  }.to_json %>
+  body_source_translations: <%= {
     'en' => '¿Qué tiene que ver la Violencia contra las mujeres contigo? ¿y con nuestra ciudad? Es un problema colectivo en el que está implicada toda la sociedad. Es necesario establecer redes de colaboración, cooperación y corresponsabilidad.',
     'es' => '¿Qué tiene que ver la Violencia contra las mujeres contigo? ¿y con nuestra ciudad? Es un problema colectivo en el que está implicada toda la sociedad. Es necesario establecer redes de colaboración, cooperación y corresponsabilidad.'
   }.to_json %>
@@ -111,6 +125,10 @@ commission_for_carnival_festivities:
     'en' => 'Hail to the wine',
     'es' => 'Viva el vino'
   }.to_json %>
+  body_source_translations: <%= {
+    'en' => 'Hail to the wine',
+    'es' => 'Viva el vino'
+  }.to_json %>
   slug: comision-fiestas-carnaval
   process_type: <%= GobiertoParticipation::Process.process_types[:process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
@@ -123,6 +141,7 @@ center_scope_process:
   site: madrid
   title_translations: <%= { 'en' => 'Center process', 'es' => 'Proceso del centro' }.to_json %>
   body_translations: <%= { 'en' => 'Enjoy the center', 'es' => 'Disfruta del centro' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Enjoy the center', 'es' => 'Disfruta del centro' }.to_json %>
   slug: center
   process_type: <%= GobiertoParticipation::Process.process_types[:process] %>
   visibility_level: <%= Site.visibility_levels["active"] %>

--- a/test/integration/gobierto_admin/gobierto_participation/processes/create_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/create_process_test.rb
@@ -27,13 +27,12 @@ module GobiertoAdmin
               click_link "New"
 
               fill_in "process_title_translations_en", with: "New process title"
-              fill_in "process_body_translations_en", with: "New process body"
+              find("#process_body_translations_en", visible: false).set("New process body")
 
               click_link "ES"
 
               fill_in "process_title_translations_es", with: "Título del nuevo proceso"
-              fill_in "process_body_translations_es", with: "Descripción del nuevo proceso"
-              fill_in "process_body_translations_es", with: "Descripción del nuevo proceso"
+              find("#process_body_translations_es", visible: false).set("Descripción del nuevo proceso")
               fill_in "process_slug", with: ""
 
               select "Culture", from: "process_issue_id"


### PR DESCRIPTION
Closes [#390](https://github.com/PopulateTools/issues/issues/390)

## :v: What does this PR do?

* Adds markdown and HTML support for Process body

## :mag: How should this be manually tested?

You can edit a process body here:

http://al***as.gobify.net/admin/participation/processes/18/edit

And see the results here:

http://al***as.gobify.net/participacion/p/presupuestos-participativos-2018

## :shipit: Does this PR changes any configuration file?

No