### PR TITLE
1712 - Remove invalid reference to current_site

### DIFF
--- a/app/forms/gobierto_admin/gobierto_participation/process_stage_form.rb
+++ b/app/forms/gobierto_admin/gobierto_participation/process_stage_form.rb
@@ -40,7 +40,7 @@ module GobiertoAdmin
       end
 
       def process
-        @process ||= current_site.processes.find_by(id: process_id)
+        @process ||= ::GobiertoParticipation::Process.find_by(id: process_id)
       end
 
       def visibility_level

--- a/test/forms/gobierto_admin/gobierto_participation/process_stage_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_participation/process_stage_form_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoParticipation
+    class ProcessStageFormTest < ActiveSupport::TestCase
+
+      def process
+        @process ||= gobierto_participation_processes(:green_city_group_active_empty)
+      end
+
+      def test_initialize
+        form_object = ProcessStageForm.new(process_id: process.id)
+
+        assert_equal process, form_object.process
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Closes #1712 

## How to test this

Sending a PATCH to the URL in the Rollbar no longer produces an error:

https://rollbar.com/Populate/gobierto/items/1049/occurrences/45174026227/