### PR TITLE
399 person submodules redirect

### DIFF
--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
     RANGE_PARAM_NAMES = %w(start_date end_date).freeze
 
     included do
-      helper_method :dates_range?, :filter_start_date, :filter_end_date, :date_range_params, :all_start_date, :all_end_date
+      helper_method :site_configuration_dates_range?, :filter_start_date, :filter_end_date, :date_range_params, :all_start_date, :all_end_date
     end
 
     def date_range_params

--- a/app/models/gobierto_people.rb
+++ b/app/models/gobierto_people.rb
@@ -11,6 +11,10 @@ module GobiertoPeople
     %w(officials agendas blogs statements departments interest_groups trips gifts invitations)
   end
 
+  def self.custom_engine_resources
+    %w(events invitations gifts trips)
+  end
+
   def self.remote_calendar_integrations
     %w( ibm_notes google_calendar microsoft_exchange )
   end

--- a/test/controllers/gobierto_people/people_controller_test.rb
+++ b/test/controllers/gobierto_people/people_controller_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GobiertoPeople::PeopleeControllerTest < GobiertoControllerTest
+
+  def setup
+    %w(agendas gifts invitations trips).each do |submodule|
+      enable_submodule(site, submodule)
+    end
+    super
+  end
+
+  def site
+    @site_with_module_enabled ||= sites(:madrid)
+  end
+
+  def person
+    @person ||= gobierto_people_people(:richard)
+  end
+
+  def set_default_dates(options = {})
+    conf = site.configuration
+    conf.raw_configuration_variables = <<-YAML
+gobierto_people_default_filter_start_date: "#{options[:start_date]}"
+gobierto_people_default_filter_end_date: "#{options[:end_date]}"
+    YAML
+    site.save
+  end
+
+  def wide_date_range_params
+    @wide_date_range_params ||= { start_date: 10.years.ago.strftime("%Y-%m-%d"), end_date: 10.years.from_now.strftime("%Y-%m-%d") }
+  end
+
+  def test_redirect_without_default_dates
+    with_current_site(site) do
+      get gobierto_people_person_path(person.slug)
+      assert_response :success
+
+      person.events.destroy_all
+      person.received_gifts.destroy_all
+      person.invitations.destroy_all
+
+      get gobierto_people_person_path(person.slug)
+      assert_response :success
+
+      person.trips.destroy_all
+
+      get gobierto_people_person_path(person.slug)
+      assert_response :success
+    end
+  end
+
+  def test_redirect_with_default_dates
+    with_current_site(site) do
+      set_default_dates(wide_date_range_params)
+      get gobierto_people_person_path(person.slug)
+      assert_response :success
+
+      person.events.destroy_all
+
+      get gobierto_people_person_path(person.slug)
+      assert_response :success
+
+
+      person.events.destroy_all
+      person.invitations.destroy_all
+      person.trips.destroy_all
+
+      get gobierto_people_person_path(person.slug)
+      assert_response :redirect
+      assert_redirected_to(gobierto_people_person_gifts_path(@person.slug))
+
+      get gobierto_people_person_path(person.slug, start_date: "2012-01-01", end_date: "2019-01-01")
+      assert_response :redirect
+      assert_redirected_to(gobierto_people_person_gifts_path(@person.slug, start_date: "2012-01-01", end_date: "2019-01-01"))
+    end
+  end
+end


### PR DESCRIPTION
Related with #399


## :v: What does this PR do?
Redirects from person show controller to person events, gifts, invitations or trips when the person only have data of one type.

This redirect is only enabled when the site has defined a default date range for gobierto_people module and the redirection is determined based on the available resources for the current date filter. 

## :mag: How should this be manually tested?
Set a date range for site and visit the show page of a person. Play with start_date and end_date params to have only events, gifts, invitations or trips.

## :shipit: Does this PR changes any configuration file?
No