### PR TITLE
Enable budgets data to show 2018

### DIFF
--- a/app/models/gobierto_budgets/search_engine_configuration/year.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/year.rb
@@ -47,7 +47,7 @@ module GobiertoBudgets
       private_class_method :budgets_elaboration_disabled?
 
       def self.default
-        2017
+        2018
       end
       private_class_method :default
 


### PR DESCRIPTION
## :v: What does this PR do?

Enable budgets data to show 2018

## :mag: How should this be manually tested?

Visit any site with budgets module enabled and check that 2018 tab is avaiable.
