### PR TITLE
Fixes comparison API error

### DIFF
--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -138,6 +138,7 @@ module GobiertoBudgets
         response = SearchEngine.client.search index: index, type: type, body: query
         values = Hash[response["hits"]["hits"].map { |h| h["_source"] }.map { |h| [h["year"], h[@variable]] }]
         values.each do |k, v|
+          v = v.to_f
           dif = 0
           if old_value = values[k - 1]
             dif = delta_percentage(v, old_value)


### PR DESCRIPTION
Closes rollbar https://rollbar.com/Populate/gobierto/items/1073/

## :v: What does this PR do?

This PR forces a stored datum to be a float to be able to compare it with zero.

## :mag: How should this be manually tested?

This URL should work:

http://esplugues.gobify.net/presupuestos/api/data/lines/8077/2018/per_person.json?comparison[]=8211&comparison[]=8101&comparison[]=8073&comparison[]=8221&comparison[]=8169
