### PR TITLE
Enable budgets data to show 2018 (fix tests)

### DIFF
--- a/lib/tasks/gobierto_budgets/fixtures.rake
+++ b/lib/tasks/gobierto_budgets/fixtures.rake
@@ -129,7 +129,7 @@ namespace :gobierto_budgets do
         category["kind"] = "G"
         economic_budget_lines_for_functional.push(index: {
                                                     _index: index,
-                                                    _id: [organization_id, year, "#{ category["code"] }-1-c}", category["kind"]].join("/"),
+                                                    _id: [organization_id, year, "#{category["code"]}-1-c", category["kind"]].join("/"),
                                                     _type: category["area"],
                                                     data: base_data.merge(amount: rand(1_000_000),
                                                                           code: category["code"],

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -17,7 +17,7 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
   end
 
   def last_year
-    2016
+    2017
   end
 
   def test_execution_information
@@ -46,7 +46,7 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
   end
 
   def test_year_breadcrumb_click
-    available_years = [2016]
+    available_years = [2017]
     GobiertoBudgets::SearchEngineConfiguration::Year.stubs(:with_data).with(
       index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed
     ).returns(available_years)

--- a/test/models/gobierto_budgets/budget_line_test.rb
+++ b/test/models/gobierto_budgets/budget_line_test.rb
@@ -6,7 +6,7 @@ module GobiertoBudgets
   class BudgetLineTest < ActiveSupport::TestCase
     def setup
       super
-      budget_line.stubs(:population).returns(666)
+      GobiertoBudgets::BudgetLine.stubs(:get_population).returns(666)
     end
 
     def site

--- a/test/models/gobierto_budgets/search_engine_configuration/year_test.rb
+++ b/test/models/gobierto_budgets/search_engine_configuration/year_test.rb
@@ -21,14 +21,14 @@ module GobiertoBudgets
       end
 
       def test_last_year_when_no_data
-        assert_equal 2017, subject_class.last
+        assert_equal 2018, subject_class.last
       end
 
       def test_last_year_when_data_and_elaboration_enabled
         GobiertoBudgets::BudgetLine.stub(:any_data?, true) do
           site.gobierto_budgets_settings.settings["budgets_elaboration"] = true
           site.save!
-          assert_equal 2017, subject_class.last
+          assert_equal 2018, subject_class.last
         end
       end
 


### PR DESCRIPTION
Continues with #1744

## :v: What does this PR do?

This PR fixes some tests broken in #1744