### PR TITLE
389 submodules redirects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,9 +96,16 @@ class ApplicationController < ActionController::Base
     ::GobiertoCommon::Search.algoliasearch_configured?
   end
 
+  def engine_overrides
+    @engine_overrides ||= current_site.try(:engines_overrides)
+  end
+
+  def engine_overrides?
+    engine_overrides.present?
+  end
+
   def apply_engines_overrides
-    engine_overrides = current_site.try(:engines_overrides)
-    return if engine_overrides.blank?
+    return unless engine_overrides?
     engine_overrides.each do |engine|
       prepend_view_path Rails.root.join("vendor/gobierto_engines/#{ engine }/app/views")
     end

--- a/app/controllers/gobierto_people/person_gifts_controller.rb
+++ b/app/controllers/gobierto_people/person_gifts_controller.rb
@@ -1,5 +1,6 @@
 module GobiertoPeople
   class PersonGiftsController < GobiertoPeople::ApplicationController
+    include DatesRangeHelper
 
     before_action :check_active_submodules
 

--- a/app/controllers/gobierto_people/person_gifts_controller.rb
+++ b/app/controllers/gobierto_people/person_gifts_controller.rb
@@ -8,6 +8,8 @@ module GobiertoPeople
       redirect_to gifts_service_url and return if gifts_service_url.present?
 
       redirect_back(fallback_location: root_path, notice: t(".error")) unless engine_overrides?
+
+      @gifts = current_site.gifts.between_dates(filter_start_date, filter_end_date).order(date: :desc).limit(40)
     end
 
     private

--- a/app/controllers/gobierto_people/person_gifts_controller.rb
+++ b/app/controllers/gobierto_people/person_gifts_controller.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
     def index
       redirect_to gifts_service_url and return if gifts_service_url.present?
 
-      redirect_back(fallback_location: root_path, notice: t(".error"))
+      redirect_back(fallback_location: root_path, notice: t(".error")) unless engine_overrides?
     end
 
     private

--- a/app/controllers/gobierto_people/person_invitations_controller.rb
+++ b/app/controllers/gobierto_people/person_invitations_controller.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
     before_action :check_active_submodules
 
     def index
-      @invitations = current_site.invitations
+      @invitations = current_site.invitations.between_dates(filter_start_date, filter_end_date).order(start_date: :desc).limit(40)
     end
 
     private

--- a/app/controllers/gobierto_people/person_invitations_controller.rb
+++ b/app/controllers/gobierto_people/person_invitations_controller.rb
@@ -2,6 +2,7 @@
 
 module GobiertoPeople
   class PersonInvitationsController < GobiertoPeople::ApplicationController
+    include DatesRangeHelper
 
     before_action :check_active_submodules
 

--- a/app/controllers/gobierto_people/person_trips_controller.rb
+++ b/app/controllers/gobierto_people/person_trips_controller.rb
@@ -7,7 +7,7 @@ module GobiertoPeople
     def index
       redirect_to trips_service_url and return if trips_service_url.present?
 
-      redirect_back(fallback_location: root_path, notice: t(".error"))
+      redirect_back(fallback_location: root_path, notice: t(".error")) unless engine_overrides?
     end
 
     private

--- a/app/controllers/gobierto_people/person_trips_controller.rb
+++ b/app/controllers/gobierto_people/person_trips_controller.rb
@@ -8,6 +8,8 @@ module GobiertoPeople
       redirect_to trips_service_url and return if trips_service_url.present?
 
       redirect_back(fallback_location: root_path, notice: t(".error")) unless engine_overrides?
+
+      @trips = current_site.trips.between_dates(filter_start_date, filter_end_date).order(start_date: :desc).limit(40)
     end
 
     private

--- a/app/controllers/gobierto_people/person_trips_controller.rb
+++ b/app/controllers/gobierto_people/person_trips_controller.rb
@@ -1,5 +1,6 @@
 module GobiertoPeople
   class PersonTripsController < GobiertoPeople::ApplicationController
+    include DatesRangeHelper
 
     before_action :check_active_submodules
 

--- a/app/views/gobierto_people/person_gifts/index.html.erb
+++ b/app/views/gobierto_people/person_gifts/index.html.erb
@@ -1,0 +1,7 @@
+<h1><%= t("gobierto_people.people.navigation.gifts") %></h1>
+
+<ul>
+  <% @gifts.each do |gift| %>
+    <li><%= gift.name %></li>
+  <% end %>
+</ul>

--- a/app/views/gobierto_people/person_invitations/index.html.erb
+++ b/app/views/gobierto_people/person_invitations/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Invitations</h1>
+<h1><%= t("gobierto_people.people.navigation.invitations") %></h1>
 
 <ul>
   <% @invitations.each do |invitation| %>

--- a/app/views/gobierto_people/person_trips/index.html.erb
+++ b/app/views/gobierto_people/person_trips/index.html.erb
@@ -1,0 +1,7 @@
+<h1><%= t("gobierto_people.people.navigation.trips") %></h1>
+
+<ul>
+  <% @trips.each do |trip| %>
+    <li><%= trip.purpose %></li>
+  <% end %>
+</ul>

--- a/config/locales/gobierto_people/views/ca.yml
+++ b/config/locales/gobierto_people/views/ca.yml
@@ -70,6 +70,7 @@ ca:
         bio: Biografia i CV
         blog: Blog
         gifts: Obsequis i regals
+        invitations: Invitacions
         statements: Béns i activitats
         trips: Viatges
       people_filter:

--- a/config/locales/gobierto_people/views/en.yml
+++ b/config/locales/gobierto_people/views/en.yml
@@ -68,6 +68,7 @@ en:
         bio: Biography and CV
         blog: Blog
         gifts: Gifts
+        invitations: Invitations
         statements: Goods and Activities
         trips: Trips
       people_filter:

--- a/config/locales/gobierto_people/views/es.yml
+++ b/config/locales/gobierto_people/views/es.yml
@@ -71,6 +71,7 @@ es:
         bio: Biografía y CV
         blog: Blog
         gifts: Obsequios y regalos
+        invitations: Invitaciones
         statements: Bienes y Actividades
         trips: Viajes
       people_filter:


### PR DESCRIPTION
Closes [#389](https://github.com/PopulateTools/issues/issues/389)


## :v: What does this PR do?
* Avoids redirections to gobierto_people root path for gifts and trips index views if there if the site is configured to use an engine.
* Adds generic views for gifts, invitations and trips.
* Enables date range filters for gifts, invitations and trips controllers if there are default dates for site.

## :shipit: Does this PR changes any configuration file?
No
