### PR TITLE
Use department short_name when building auxiliary order array

### DIFF
--- a/app/controllers/gobierto_people/api/v1/departments_controller.rb
+++ b/app/controllers/gobierto_people/api/v1/departments_controller.rb
@@ -40,7 +40,7 @@ module GobiertoPeople
 
             # sort result according to department events count
             departments_order = Hash[
-              *top_departments.pluck(:name).each_with_index.collect do |department_name, index|
+              *top_departments.map(&:short_name).each_with_index.collect do |department_name, index|
                 [department_name, index]
               end.flatten
             ]

--- a/test/integration/gobierto_people/api/v1/departments_test.rb
+++ b/test/integration/gobierto_people/api/v1/departments_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/event_helpers"
 
 module GobiertoPeople
   module Api
@@ -9,6 +10,8 @@ module GobiertoPeople
 
         FAR_PAST = 10.years.ago.iso8601
         FAR_FUTURE = 10.years.from_now.iso8601
+
+        include ::EventHelpers
 
         def setup
           enable_submodule(madrid, :departments)
@@ -21,6 +24,10 @@ module GobiertoPeople
 
         def justice_department
           @justice_department ||= gobierto_people_departments(:justice_department)
+        end
+
+        def culture_department
+          @culture_department ||= gobierto_people_departments(:culture_department)
         end
 
         def coca_cola
@@ -83,6 +90,48 @@ module GobiertoPeople
             assert_equal 1, departments.size
             assert_equal departments.first["key"], justice_department.name
             assert_match "?end_date=#{ short_date(FAR_FUTURE) }&start_date=#{ short_date(FAR_PAST) }", departments.first["properties"]["url"]
+          end
+        end
+
+        def test_departments_index_test_with_events_history
+          ::GobiertoCalendars::Event.destroy_all
+          culture_department.update_attributes!(name: "Departament de Cultura")
+
+          create_event(person: tamara, starts_at: "15-01-2017", department: justice_department)
+          create_event(person: tamara, starts_at: "16-01-2017", department: culture_department)
+
+          with_current_site(madrid) do
+
+            get(
+              gobierto_people_api_v1_departments_path,
+              params: { include_history: true }
+            )
+
+            assert_response :success
+
+            departments = JSON.parse(response.body)
+
+            assert_equal [justice_department, culture_department].size, departments.size
+
+            justice_department_data = departments.detect { |item| item["key"] == justice_department.short_name }
+
+            expected_justice_department_data = {
+              "key" => justice_department.short_name,
+              "value" => [
+                {
+                  "key" => Time.zone.parse("2017/01"),
+                  "value" => 1,
+                  "properties" => {
+                    "url" => "/departamentos/justice-department?end_date=2017-02-01&start_date=2017-01-01"
+                  }
+                }
+              ],
+              "properties" => {
+                "url" => "/departamentos/justice-department?page=false"
+              }
+            }
+
+            assert_equal expected_justice_department_data, justice_department_data
           end
         end
 


### PR DESCRIPTION
Fixes https://rollbar.com/Populate/gobierto/items/1120/?item_page=0&#instances

## How to test this manually?

http://g*****.gobify.net/gobierto_people/api/v1/departments?from_date=2018-01-01%2000:00:00%20+0100&amp;include_history=true&amp;limit=14 no longer breaks