### PR TITLE
Run custom engines tests in same step as Gobierto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,11 @@ jobs:
       # Setup the database
       - run: bin/rails db:setup
 
+      # Install custom engines
+      - run: script/custom_engines_ci_setup
+
       # Run tests
       - run: script/test
-
-      # Run tests from custom engines
-      - run: script/custom_engines_ci_setup
-      - run: bin/rails test vendor/gobierto_engines/**/test
 
   staging-deploy:
     machine:

--- a/lib/minitest/gobierto_engines_tests_plugin.rb
+++ b/lib/minitest/gobierto_engines_tests_plugin.rb
@@ -3,7 +3,7 @@
 module Minitest
   def self.plugin_gobierto_engines_tests_init(*)
     if ::Rails::TestUnit::Runner.send(:extract_filters, ARGV).empty?
-      tests = Rake::FileList['vendor/gobierto_engines/**/*_test.rb']
+      tests = Rake::FileList["vendor/gobierto_engines/*/**/*_test.rb"]
       tests.to_a.each { |path| require File.expand_path(path) }
     end
   end


### PR DESCRIPTION
## :v: What does this PR do?

Modifies the CI configuration so custom engines tests are executed within the main test suite instead of in a separate step.

**EDIT**: tests passed in https://circleci.com/gh/PopulateTools/gobierto/7103

## :mag: How should this be manually tested?

In local you can put a `puts` statement in `::G*****::IntegrationTest#setup` and check tests are ran when doing `bin/rails test`

## :shipit: Does this PR changes any configuration file?

No