### PR TITLE
Providers issues in IE11

### DIFF
--- a/app/javascript/budgets/modules/invoices_controller.js
+++ b/app/javascript/budgets/modules/invoices_controller.js
@@ -5,7 +5,11 @@ window.GobiertoBudgets.InvoicesController = (function() {
 
   function InvoicesController() {}
 
+  // Global variables
+  var data, ndx, _r, _tabledata, _empty, _chartdata = {}, $tableHTML = {};
+
   InvoicesController.prototype.show = function() {
+    $tableHTML = $("#providers-table");
 
     let municipalityId = window.populateData.municipalityId;
     let maxYearUrl = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv?filter_by_location_id='+municipalityId+'&sort_desc_by=date&limit=1';
@@ -77,12 +81,6 @@ window.GobiertoBudgets.InvoicesController = (function() {
 
     getData('3m');
   };
-
-  // Global variables
-  var data, ndx, _r, _tabledata, _empty, _chartdata, $tableHTML = {};
-
-  // Markup object shorteners (after DOM rendered)
-  $().ready(() => $tableHTML = $("#providers-table"));
 
   function getData(filter) {
     var dateRange;

--- a/app/models/gobierto_budgets/search_engine_configuration/year.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/year.rb
@@ -29,12 +29,9 @@ module GobiertoBudgets
 
       def self.last_year_with_data
         current_year.downto(first) do |year|
-          next unless GobiertoBudgets::BudgetLine.any_data?(
-            site: current_site,
-            index: ::GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
-            year: year
-          )
-          return year if year == current_year && budgets_elaboration_disabled?
+          if GobiertoBudgets::BudgetLine.any_data?(site: current_site, index: ::GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, year: year)
+            return year
+          end
         end
 
         default

--- a/app/views/gobierto_budgets/providers/index.html.erb
+++ b/app/views/gobierto_budgets/providers/index.html.erb
@@ -167,6 +167,8 @@
 
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
-    window.GobiertoBudgets.invoices_controller.show();
+$(document).on('turbolinks:load', function() {
+  window.GobiertoBudgets.invoices_controller.show();
+});
   <% end %>
 <% end %>


### PR DESCRIPTION
Closes #395

## :v: What does this PR do?

This PR fixes how Javascript is setup for providers module to wait for the DOM to be ready. This was causing an issue in IE11 and sometimes in other browsers.

## :mag: How should this be manually tested?

- [ ] Test it in IE11 (done)
- [ ] Try to get a blank table when loading the page in other browsers
