### PR TITLE
Fix syntax bug in ME calendar integration

### DIFF
--- a/app/services/gobierto_calendars/calendar_integration/auth_error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/auth_error.rb
@@ -4,7 +4,9 @@ module GobiertoCalendars
   module CalendarIntegration
     class AuthError < Error
 
-      def message
+      private
+
+      def default_message
         I18n.t "gobierto_calendars.calendar_integration.auth_error.message"
       end
 

--- a/app/services/gobierto_calendars/calendar_integration/error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/error.rb
@@ -4,7 +4,13 @@ module GobiertoCalendars
   module CalendarIntegration
     class Error < StandardError
 
-      def message
+      def initialize(message = nil)
+        super(message || default_message)
+      end
+
+      private
+
+      def default_message
         I18n.t "gobierto_calendars.calendar_integration.error.message"
       end
 

--- a/app/services/gobierto_calendars/calendar_integration/timeout_error.rb
+++ b/app/services/gobierto_calendars/calendar_integration/timeout_error.rb
@@ -4,7 +4,9 @@ module GobiertoCalendars
   module CalendarIntegration
     class TimeoutError < Error
 
-      def message
+      private
+
+      def default_message
         I18n.t "gobierto_calendars.calendar_integration.timeout_error.message"
       end
 

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 module GobiertoPeople
   module MicrosoftExchange
     class CalendarIntegration
@@ -98,11 +98,11 @@ module GobiertoPeople
           person_id: person.id
         }
 
-        if event.location.present?
-          event_params.merge!(locations_attributes: { "0" => { name: event.location } })
-        else
-          event_params.merge!(locations_attributes: { "0" => { "_destroy" => "1" } })
-        end
+        event_params[:locations_attributes] = if event.location.present?
+                                                { "0" => { name: event.location } }
+                                              else
+                                                { "0" => { "_destroy" => "1" } }
+                                              end
 
         event_form = GobiertoPeople::CalendarSyncEventForm.new(event_params)
 
@@ -129,14 +129,15 @@ module GobiertoPeople
         end
       end
 
-      def folder_exists!(params={})
+      def folder_exists!(params = {})
         return if params[:folder].present?
 
         log_message("Can't find #{params[:folder_name]} calendar folder for #{person.name} (id: #{person.id}). Wrong username, password or endpoint?")
+
         if params[:folder_name] == "root"
           raise ::GobiertoCalendars::CalendarIntegration::AuthError
         else
-          raise ::GobiertoCalendars::CalendarIntegration::Error("No se encuentra el calendario #{params[:folder_name]}")
+          raise ::GobiertoCalendars::CalendarIntegration::Error, "No se encuentra el calendario #{params[:folder_name]}"
         end
       end
 

--- a/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
+++ b/test/services/gobierto_people/microsoft_exchange/calendar_integration_test.rb
@@ -315,6 +315,8 @@ module GobiertoPeople
         root_folder = mock
         root_folder.stubs(:folders).returns([])
 
+        ::Exchanger::Folder.stubs(:find).returns(root_folder)
+
         assert_raise ::GobiertoCalendars::CalendarIntegration::Error do
           calendar_service.sync!
         end


### PR DESCRIPTION
Fixes rollbar https://rollbar.com/Populate/gobierto/items/1139/occurrences/45947634357/

```ruby
raise ::GobiertoCalendars::CalendarIntegration::Error("No se encuentra el calendario #{params[:folder_name]}")
```

should have been:

```ruby
raise ::GobiertoCalendars::CalendarIntegration::Error, "No se encuentra el calendario #{params[:folder_name]}"
```

The test that checked for this had a bug and was executing instead a different `if` branch.