### PR TITLE
369 - Calculate default year for budgets comparison graph

### DIFF
--- a/app/javascript/budgets/modules/vis_lineas_tabla.js
+++ b/app/javascript/budgets/modules/vis_lineas_tabla.js
@@ -668,11 +668,14 @@ export var VisLineasJ = Class.extend({
  */
 function defaultYearForVerticalLine(data) {
   var yearsDataItems = {}
+  var measureType = Object.keys(data.budgets)[0];
 
-  data.budgets.per_person.forEach(function(x) { x.values.forEach(function(y) {
+  data.budgets[measureType].forEach(function(x) { x.values.forEach(function(y) {
     var year = y.date.getFullYear();
     yearsDataItems[year] = (yearsDataItems[year] === undefined ? 1 : yearsDataItems[year] + 1);
   }); });
+
+  if (yearsDataItems[data.year] > 1) return new Date(data.year, 0, 1);
 
   var yearsWithData = Object.keys(yearsDataItems).sort().reverse();
   var chosenYear = undefined;

--- a/app/javascript/budgets/modules/vis_lineas_tabla.js
+++ b/app/javascript/budgets/modules/vis_lineas_tabla.js
@@ -297,8 +297,10 @@ export var VisLineasJ = Class.extend({
         .attr('stroke', this.softGrey);
 
       // --> DRAW VERTICAL LINE
+      var defaultYear = defaultYearForVerticalLine(this.data);
+
       this.svgLines.selectAll('.v_line')
-            .data([this.dataYear])
+            .data([defaultYear])
             .enter()
           .append('line')
             .attr('class', 'v_line')
@@ -308,6 +310,9 @@ export var VisLineasJ = Class.extend({
             .attr('y2', this.height)
             .style('stroke', this.darkGrey);
 
+      // TODO: trigger the animation that updates the table in the right
+      // $("circle.x" + defaultYear.getFullYear()).trigger("mouseover");
+      // $("circle.x2015").trigger("mouseover");
 
       // --> DRAW THE LINES
       this.chart = this.svgLines.append('g')
@@ -504,6 +509,7 @@ export var VisLineasJ = Class.extend({
 
     var dataChartFiltered = this.dataChart.map(function(d) {
       return d.values.filter(function(v) {
+        // console.log("_mouseover was triggered!");
         return v.date.getFullYear() == selectedData.date.getFullYear();
       })[0];
     });
@@ -663,3 +669,27 @@ export var VisLineasJ = Class.extend({
   })()
 
 }); // End object
+
+/**
+ * Returns the most recent year that has data for at least two different municipalities.
+ */
+function defaultYearForVerticalLine(data) {
+  var yearsWithData = {}
+  var defaultYearForVerticalLine = undefined;
+  data.budgets.per_person[0].values.forEach(function(x) { yearsWithData[x.date] = 0 });
+  data.budgets.per_person.forEach(function(x) { x.values.forEach(function(y) { if (y.value) { yearsWithData[y.date] += 1 } }) });
+
+  for (var date in yearsWithData) {
+    if (yearsWithData[date] > 1) {
+      if (!defaultYearForVerticalLine || date > defaultYearForVerticalLine) {
+        defaultYearForVerticalLine = new Date(date);
+      }
+    }
+  }
+
+  if (!defaultYearForVerticalLine) {
+    defaultYearForVerticalLine = this.dataYear;
+  }
+
+  return defaultYearForVerticalLine;
+}

--- a/app/javascript/budgets/modules/vis_lineas_tabla.js
+++ b/app/javascript/budgets/modules/vis_lineas_tabla.js
@@ -297,7 +297,6 @@ export var VisLineasJ = Class.extend({
         .attr('stroke', this.softGrey);
 
       // --> DRAW VERTICAL LINE
-
       this.svgLines.selectAll('.v_line')
             .data([this.dataYear])
             .enter()
@@ -308,10 +307,6 @@ export var VisLineasJ = Class.extend({
             .attr('x2', function(d) { return this.xScale(d); }.bind(this))
             .attr('y2', this.height)
             .style('stroke', this.darkGrey);
-
-      // TODO: trigger the animation that updates the table in the right
-      // $("circle.x" + defaultYear.getFullYear()).trigger("mouseover");
-      // $("circle.x2015").trigger("mouseover");
 
       // --> DRAW THE LINES
       this.chart = this.svgLines.append('g')


### PR DESCRIPTION
Closes [#369](https://github.com/PopulateTools/issues/issues/369)

## :v: What does this PR do?

Selects by default the first year with data for at least two municipalities.

Pending:

- [x] Trigger the animation that updates the data in the right table
- [x] Update the same code in the comparator
- [x] Update the same code in gencat comparator

## :mag: How should this be manually tested?

In http://madrid.gobify.net/presupuestos/resumen/2018 you can see the year selected by default is 2015 instead of 2018.

In the comparators I haven't been able to check for this specific case, since all the municipalities I have searched have the budget amount set to *zero* when there's no data (this happens in production also https://presupuestos.gobierto.es/places/salcedillo/2018) - maybe we should review this because having zero budget and not having data for a certain year are different things.  But you can check after updating the code that nothing has broke in places like:

* http://g*****-presupuestos.gobify.net/places/mataro/2017
* http://presupuestos.gobify.net/places/mataro/2018
* http://g*****-presupuestos.gobify.net/budget_lines/mataro/2017/211/G/functional
* http://presupuestos.gobify.net/compare/salcedillo:mataro/2018/expense/functional

## Review video

https://www.youtube.com/watch?v=IeMVJrz4F_Y&feature=youtu.be

## New issues

https://github.com/PopulateTools/gobierto-comparador-presupuestos/issues/67

## :shipit: Does this PR changes any configuration file?

No