### PR TITLE
Preserve external_id when updating external events from the UI

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
@@ -70,9 +70,14 @@ module GobiertoAdmin
 
       def update
         @event = find_event
-        @event_form = EventForm.new(
-          event_params.merge(id: params[:id], admin_id: current_admin.id, site_id: current_site.id, collection_id: collection.id)
-        )
+
+        @event_form = EventForm.new(event_params.merge(
+          id: params[:id],
+          admin_id: current_admin.id,
+          site_id: current_site.id,
+          collection_id: collection.id,
+          external_id: @event.external_id
+        ))
 
         if @event_form.save
           redirect_to(

--- a/test/integration/gobierto_admin/gobierto_calendars/event_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/event_update_test.rb
@@ -18,6 +18,10 @@ module GobiertoAdmin
         @event ||= gobierto_calendars_events(:richard_published)
       end
 
+      def external_event
+        @external_event ||= gobierto_calendars_events(:richard_published_just_attending)
+      end
+
       def person
         @person ||= gobierto_people_people(:richard)
       end
@@ -127,6 +131,29 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_update_external_event
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit edit_admin_calendars_event_path(external_event, collection_id: collection)
+
+              within "form.edit_event" do
+                fill_in "event_title_translations_en", with: "Edited title"
+
+                click_button "Update"
+              end
+
+              assert has_message?("Event was successfully updated. See the event.")
+
+              external_event.reload
+
+              assert_equal "justattending", external_event.external_id
+            end
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Preserves the `external_id` attribute when updating person events from the UI.

### How to manually test this

Edit the first event in http://madrid.gobify.net/admin/gobierto_calendars/events?collection_id=29 (change the title to "Progress meeting... EDIT". Then sync manually and check the orginal title gets restored instead of duplicating the event.

