### PR TITLE
111 - Anonymize poll answers

### DIFF
--- a/app/models/concerns/gobierto_participation/poll_results_helpers.rb
+++ b/app/models/concerns/gobierto_participation/poll_results_helpers.rb
@@ -12,7 +12,7 @@ module GobiertoParticipation
       end
 
       def unique_answers_count
-        answers.select("DISTINCT user_id").count
+        answers.select("DISTINCT user_id_hmac").count
       end
 
       def men_participation_percentage
@@ -32,7 +32,9 @@ module GobiertoParticipation
       end
 
       def men_unique_answers_count
-        answers.joins(:user).select("DISTINCT user_id").where("users.gender = 0").count
+        Hash[answers.pluck(:user_id_hmac, :encrypted_meta).map do |answer|
+          [answer[0], SecretAttribute.decrypt(answer[1])[:gender]]
+        end].values.select(&:zero?).size
       end
 
       def women_unique_answers_count

--- a/app/models/gobierto_participation/poll.rb
+++ b/app/models/gobierto_participation/poll.rb
@@ -45,7 +45,7 @@ module GobiertoParticipation
     end
 
     def has_answers_from?(user)
-      answers.where(user: user).any?
+      answers.by_user(user).any?
     end
 
     def open?

--- a/app/models/gobierto_participation/poll_answer.rb
+++ b/app/models/gobierto_participation/poll_answer.rb
@@ -10,13 +10,13 @@ module GobiertoParticipation
     belongs_to :poll
     belongs_to :question, class_name: 'GobiertoParticipation::PollQuestion'
     belongs_to :answer_template, class_name: 'GobiertoParticipation::PollAnswerTemplate'
-    belongs_to :user
 
     scope :open_answers,  -> { where(answer_template: nil) }
     scope :fixed_answers, -> { where.not(answer_template: nil) }
+    scope :by_user, ->(user) { where(user_id_hmac: user.id_hmac) }
 
-    validates_uniqueness_of :user_id, scope: [:question_id], if: :open_answer?
-    validates_uniqueness_of :user_id, scope: [:question_id, :answer_template_id], if: :fixed_answer?
+    validates_uniqueness_of :user_id_hmac, scope: [:question_id], if: :open_answer?
+    validates_uniqueness_of :user_id_hmac, scope: [:question_id, :answer_template_id], if: :fixed_answer?
 
     validates_presence_of :text, if: :open_answer?
     validates_absence_of  :text,  if: :fixed_answer?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,14 @@ class User < ApplicationRecord
     @user_verifications[site] ||= census_verifications.find_by(site_id: site.id, user_id: self.id, verified: true)
     @user_verifications[site]
   end
+
+  def id_hmac
+    SecretAttribute.hmac(id)
+  end
+
+  def age
+    now = Time.now.utc.to_date
+    now.year - date_of_birth.year - ((now.month > date_of_birth.month || (now.month == date_of_birth.month && now.day >= date_of_birth.day)) ? 0 : 1)
+  end
+
 end

--- a/db/migrate/20180713102905_add_user_id_hmac_to_poll_answers.rb
+++ b/db/migrate/20180713102905_add_user_id_hmac_to_poll_answers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUserIdHmacToPollAnswers < ActiveRecord::Migration[5.2]
+
+  def change
+    add_column :gpart_poll_answers, :user_id_hmac, :string, null: true
+  end
+
+end

--- a/db/migrate/20180713103321_calculate_poll_answer_user_id_hmac.rb
+++ b/db/migrate/20180713103321_calculate_poll_answer_user_id_hmac.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CalculatePollAnswerUserIdHmac < ActiveRecord::Migration[5.2]
+
+  def up
+    ::GobiertoParticipation::PollAnswer.all.each do |poll_answer|
+      poll_answer.update_attribute(
+        :user_id_hmac,
+        SecretAttribute.hmac(poll_answer.user_id)
+      )
+    end
+  end
+
+  def down
+    ::GobiertoParticipation::PollAnswer.update_all(:user_id_hmac, nil)
+  end
+
+end

--- a/db/migrate/20180713103609_update_poll_answer_user_id_constraints.rb
+++ b/db/migrate/20180713103609_update_poll_answer_user_id_constraints.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class UpdatePollAnswerUserIdConstraints < ActiveRecord::Migration[5.2]
+
+  def up
+    change_column :gpart_poll_answers, :user_id_hmac, :string, null: false
+    remove_column :gpart_poll_answers, :user_id
+  end
+
+  def down
+    change_column :gpart_poll_answers, :user_id_hmac, :string, null: true
+    add_column :gpart_poll_answers, :user_id, :bigint
+
+    User.all.each do |user|
+      ::GobiertoParticipation::PollAnswer.by_user(user).each do |answer|
+        answer.update_attribute(:user_id, user.id)
+      end
+    end
+
+    change_column :gpart_poll_answers, :user_id, :bigint, null: false
+  end
+
+end

--- a/db/migrate/20180713151618_add_encrypted_meta_to_poll_answers.rb
+++ b/db/migrate/20180713151618_add_encrypted_meta_to_poll_answers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddEncryptedMetaToPollAnswers < ActiveRecord::Migration[5.2]
+
+  def change
+    add_column :gpart_poll_answers, :encrypted_meta, :text
+
+    add_index :gpart_poll_answers, [:question_id, :user_id_hmac, :answer_template_id], name: "unique_index_gpart_poll_answers_for_fixed_answer_questions", unique: true
+    add_index :gpart_poll_answers, [:user_id_hmac, :answer_template_id], name: "unique_index_gpart_poll_answers_for_open_answer_questions", unique: true
+    add_index :gpart_poll_answers, :user_id_hmac, name: "index_gpart_poll_answers_on_user_id_hmac"
+  end
+
+end

--- a/db/migrate/20180716092701_migrate_poll_answer_demographic_info.rb
+++ b/db/migrate/20180716092701_migrate_poll_answer_demographic_info.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class MigratePollAnswerDemographicInfo < ActiveRecord::Migration[5.2]
+
+  def poll_answer_class
+    ::GobiertoParticipation::PollAnswer
+  end
+
+  def up
+    poll_answer_class.reset_column_information
+
+    User.all.each do |user|
+      poll_answer_class.by_user(user).each do |answer|
+        answer.update_attribute(
+          :encrypted_meta,
+          SecretAttribute.encrypt(poll_answer_meta(user, answer))
+        )
+      end
+    end
+  end
+
+  def down
+    poll_answer_class.update_all(encrypted_meta: nil)
+  end
+
+  private
+
+  def poll_answer_meta(user, poll_answer)
+    custom_records_meta = Hash[user.custom_records.map(&:payload).map do |payload|
+      [payload.keys.first, payload.values.first]
+    end].symbolize_keys
+
+    {
+      gender: User.genders[user.gender],
+      birthdate: user.date_of_birth.iso8601,
+      age: age_on_date(user, poll_answer)
+    }.merge(custom_records_meta)
+  end
+
+  def age_on_date(user, poll_answer)
+    dob = user.date_of_birth
+    answer_date = poll_answer.created_at
+    answer_date.year - dob.year - ((answer_date.month > dob.month || (answer_date.month == dob.month && answer_date.day >= dob.day)) ? 0 : 1)
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_03_140608) do
+ActiveRecord::Schema.define(version: 2018_07_16_092701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -669,13 +669,14 @@ ActiveRecord::Schema.define(version: 2018_07_03_140608) do
     t.bigint "question_id", null: false
     t.integer "answer_template_id"
     t.text "text"
-    t.bigint "user_id", null: false
     t.datetime "created_at"
+    t.string "user_id_hmac", null: false
+    t.text "encrypted_meta"
     t.index ["poll_id"], name: "index_gpart_poll_answers_on_poll_id"
-    t.index ["question_id", "user_id", "answer_template_id"], name: "unique_index_gpart_poll_answers_for_fixed_answer_questions", unique: true
+    t.index ["question_id", "user_id_hmac", "answer_template_id"], name: "unique_index_gpart_poll_answers_for_fixed_answer_questions", unique: true
     t.index ["question_id"], name: "index_gpart_poll_answers_on_question_id"
-    t.index ["user_id", "answer_template_id"], name: "unique_index_gpart_poll_answers_for_open_answer_questions", unique: true
-    t.index ["user_id"], name: "index_gpart_poll_answers_on_user_id"
+    t.index ["user_id_hmac", "answer_template_id"], name: "unique_index_gpart_poll_answers_for_open_answer_questions", unique: true
+    t.index ["user_id_hmac"], name: "index_gpart_poll_answers_on_user_id_hmac"
   end
 
   create_table "gpart_poll_questions", force: :cascade do |t|

--- a/lib/secret_attribute.rb
+++ b/lib/secret_attribute.rb
@@ -4,6 +4,10 @@ require "digest/sha1"
 
 class SecretAttribute
 
+  def self.hmac(message, force_string = true)
+    OpenSSL::HMAC.hexdigest("SHA256", salt, force_string ? message.to_s : message)
+  end
+
   def self.digest(value)
     Digest::SHA1.hexdigest(value + salt)
   end

--- a/test/fixtures/gobierto_common/custom_user_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_user_field_records.yml
@@ -1,3 +1,5 @@
+## dennis
+
 dennis_custom_fields_district:
   user: dennis
   custom_user_field: madrid_custom_user_field_district
@@ -17,3 +19,10 @@ dennis_custom_fields_bio:
   user: dennis
   custom_user_field: madrid_custom_user_field_interests
   payload: <%= { "interests" => ["randomstring1", "randomstring2"]}.to_json %>
+
+## peter
+
+peter_custom_fields_district:
+  user: peter
+  custom_user_field: madrid_custom_user_field_district
+  payload: <%= { "district" => "Retiro" }.to_json %>

--- a/test/fixtures/gobierto_participation/poll_answers.yml
+++ b/test/fixtures/gobierto_participation/poll_answers.yml
@@ -5,28 +5,48 @@ dennis_ordinance_of_terraces_single_choice:
   question: ordinance_of_terraces_single_choice
   answer_template: ordinance_of_terraces_single_choice_answer_template_yes
   text:
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 dennis_ordinance_of_terraces_multiple_choice_0:
   poll: ordinance_of_terraces_published
   question: ordinance_of_terraces_multiple_choice
   answer_template: ordinance_of_terraces_multiple_choice_answer_template_schedules
   text:
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 dennis_ordinance_of_terraces_multiple_choice_1:
   poll: ordinance_of_terraces_published
   question: ordinance_of_terraces_multiple_choice
   answer_template: ordinance_of_terraces_multiple_choice_answer_template_taxes
   text:
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 dennis_ordinance_of_terraces_open:
   poll: ordinance_of_terraces_published
   question: ordinance_of_terraces_open
   answer_template:
   text: Es el vecino el que elige el alcalde y es el alcalde el que quiere que sean los vecinos el alcalde.
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 # noise_problems poll answers
 
@@ -35,53 +55,93 @@ dennis_noise_problems_single_choice:
   question: noise_problems_single_choice
   answer_template: noise_problems_single_choice_answer_template_yes
   text:
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 dennis_noise_problems_multiple_choice_0:
   poll: noise_problems_past
   question: noise_problems_multiple_choice
   answer_template: noise_problems_multiple_choice_answer_template_windows
   text:
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 dennis_noise_problems_multiple_choice_1:
   poll: noise_problems_past
   question: noise_problems_multiple_choice
   answer_template: noise_problems_multiple_choice_answer_template_fancy_headphones
   text:
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 dennis_noise_problems_open:
   poll: noise_problems_past
   question: noise_problems_open
   answer_template:
   text: Si me molestan mucho, pongo metal Serbio a todo volumen y los vecinos se acaban callando.
-  user: dennis
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:dennis) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 1,
+    birthdate: "1990-01-01",
+    age: 28
+  }) %>
 
 reed_noise_problems_single_choice:
   poll: noise_problems_past
   question: noise_problems_single_choice
   answer_template: noise_problems_single_choice_answer_template_yes
   text:
-  user: reed
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:reed) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 0,
+    birthdate: "1996-01-01",
+    age: 22
+  }) %>
 
 reed_noise_problems_multiple_choice_0:
   poll: noise_problems_past
   question: noise_problems_multiple_choice
   answer_template: noise_problems_multiple_choice_answer_template_windows
   text:
-  user: reed
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:reed) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 0,
+    birthdate: "1996-01-01",
+    age: 22
+  }) %>
 
 peter_noise_problems_single_choice:
   poll: noise_problems_past
   question: noise_problems_single_choice
   answer_template: noise_problems_single_choice_answer_template_yes
   text:
-  user: peter
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:peter) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 0,
+    birthdate: "1992-01-01",
+    age: 26
+  }) %>
 
 peter_noise_problems_multiple_choice_0:
   poll: noise_problems_past
   question: noise_problems_multiple_choice
   answer_template: noise_problems_multiple_choice_answer_template_windows
   text:
-  user: peter
+  user_id_hmac: <%= SecretAttribute.hmac ActiveRecord::FixtureSet.identify(:peter) %>
+  encrypted_meta: <%= SecretAttribute.encrypt({
+    gender: 0,
+    birthdate: "1992-01-01",
+    age: 26
+  }) %>

--- a/test/forms/gobierto_participation/poll_answer_form_test.rb
+++ b/test/forms/gobierto_participation/poll_answer_form_test.rb
@@ -84,6 +84,26 @@ module GobiertoParticipation
         refute incomplete_answers.valid?
       end
 
+      def test_save_demographic_info
+        poll_answer_form =  PollAnswerForm.new(poll_answers_params.merge(
+          user: user,
+          poll: poll
+        ))
+
+        poll_answer_form.save
+
+        answers = poll.answers.by_user(user)
+        meta_info = SecretAttribute.decrypt(answers.first.encrypted_meta)
+        expected_meta_info = {
+          gender: 0,
+          birthdate: user.date_of_birth.iso8601,
+          age: user.age,
+          district: "Retiro"
+        }
+
+        assert_equal expected_meta_info, meta_info
+      end
+
     end
   end
 end

--- a/test/integration/gobierto_participation/processes/poll_answers/poll_answers_create_test.rb
+++ b/test/integration/gobierto_participation/processes/poll_answers/poll_answers_create_test.rb
@@ -70,9 +70,9 @@ module GobiertoParticipation
 
             click_link 'x'
 
-            answers       = poll.answers.where(user: user)
+            answers = poll.answers.by_user(user)
             fixed_answers = answers.fixed_answers
-            open_answers  = answers.open_answers
+            open_answers = answers.open_answers
 
             assert_equal 3, fixed_answers.size
             assert_equal 1, open_answers.size

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -66,4 +66,14 @@ class UserTest < ActiveSupport::TestCase
   def test_valid
     assert user.valid?
   end
+
+  def test_age
+    birthdate = Time.new(2004, 2, 29, 6, 0, 0)
+    user.update_attribute(:date_of_birth, birthdate)
+
+    Timecop.freeze(birthdate + 1.month) { assert_equal 0, user.age }
+    Timecop.freeze(birthdate.change(year: 2005, day: 28)) { assert_equal 0, user.age }
+    Timecop.freeze(birthdate.change(year: 2005, month: 3, day: 1)) { assert_equal 1, user.age }
+  end
+
 end


### PR DESCRIPTION
Closes [111](https://github.com/PopulateTools/issues/issues/111)

## :v: What does this PR do?

Anonymizes poll answers and includes encrypted demographic information (+ custom records) within each answer DB record.

## :mag: How should this be manually tested?

* You can answer a poll from the UI - http://madrid.gobify.net/participacion/p/proceso-imagenes-encuestas/encuestas/38/answers/new
* The results page continues to work correctly (data was migrated): http://al*******s.gobify.net/admin/participation/processes/18/polls/10/answers
* You can check the migrated data in staging with something like:

```ruby
puts JSON.pretty_generate ::GobiertoParticipation::PollAnswer.pluck(:encrypted_meta).map { |meta| SecretAttribute.decrypt(meta) }
```

## :shipit: Does this PR changes any configuration file?

Nope