### PR TITLE
1776 vocabulary and term models

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/terms_controller.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class TermsController < BaseController
+
+      def index
+        @terms = tree(terms_relation)
+      end
+
+      def show
+        @term = find_term
+      end
+
+      def new
+        @term_form = TermForm.new(site_id: current_site.id, vocabulary_id: vocabulary.id)
+        @parent_terms = parent_terms_for_select(terms_relation)
+        @parent_term = nil
+      end
+
+      def create
+        @term_form = TermForm.new(term_params.merge(site_id: current_site.id, vocabulary_id: vocabulary.id))
+
+        if @term_form.save
+          redirect_to(
+            edit_admin_common_term_path(@term_form.term),
+            notice: t(".success")
+          )
+        else
+          @parent_terms = parent_terms_for_select(terms_relation)
+          @parent_term = @term_form.term&.parent_term
+          render :new
+        end
+      end
+
+      def edit
+        term = find_term
+        @term_form = TermForm.new(term.attributes.except(*ignored_term_attributes).merge(site_id: current_site.id))
+        @vocabulary ||= term.vocabulary
+        @parent_terms = parent_terms_for_select(terms_relation.where.not(id: term.id))
+        @parent_term = term.term_id
+      end
+
+      def update
+        term = find_term
+        @term_form = TermForm.new(term_params.merge(id: params[:id], site_id: current_site.id, vocabulary_id: term.vocabulary_id))
+        if @term_form.save
+          redirect_to(
+            edit_admin_common_term_path(@term_form.term),
+            notice: t(".success")
+          )
+        else
+          @vocabulary ||= term.vocabulary
+          @parent_terms = parent_terms_for_select(terms_relation.where.not(id: term.id))
+          @parent_term = term.term_id
+          render :edit
+        end
+      end
+
+      def destroy
+        term = find_term
+        @vocabulary ||= term.vocabulary
+        if term.destroy
+          redirect_to admin_common_vocabulary_terms_path(@vocabulary), notice: t(".success")
+        else
+          redirect_to admin_common_vocabulary_terms_path(@vocabulary), alert: t(".destroy_failed")
+        end
+      end
+
+      private
+
+      def term_params
+        params.require(:term).permit(
+          :slug,
+          :term_id,
+          name_translations: [*I18n.available_locales],
+          description_translations: [*I18n.available_locales]
+        )
+      end
+
+      def ignored_term_attributes
+        %w(created_at updated_at site_id level position)
+      end
+
+      def find_term
+        terms_relation.find(params[:id])
+      end
+
+      def vocabulary
+        @vocabulary ||= params[:vocabulary_id] ? current_site.vocabularies.find(params[:vocabulary_id]) : nil
+      end
+
+      def parent_terms_for_select(relation)
+        relation.map do |term|
+          [term.name, term.id]
+        end
+      end
+
+      def terms_relation
+        (vocabulary || current_site).terms
+      end
+
+      def tree(relation, level = 0)
+        level_relation = relation.where(level: level).order(position: :asc)
+        return [] if level_relation.blank?
+        relation.where(level: level).map do |node|
+          [node, tree(node.terms, level + 1)].flatten
+        end.flatten
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class VocabulariesController < BaseController
+
+      def index
+        @vocabularies = vocabularies_relation.order(updated_at: :desc)
+      end
+
+      def show
+        @vocabulary = find_vocabulary
+        @terms_count = @vocabulary.terms.count
+      end
+
+      def new
+        @vocabulary_form = VocabularyForm.new(site_id: current_site.id)
+      end
+
+      def create
+        @vocabulary_form = VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id))
+
+        if @vocabulary_form.save
+          track_create_activity
+          redirect_to(
+            edit_admin_common_vocabulary_path(@vocabulary_form.vocabulary),
+            notice: t(".success")
+          )
+        else
+          render :new
+        end
+      end
+
+      def edit
+        vocabulary = find_vocabulary
+        @vocabulary_form = VocabularyForm.new(vocabulary.attributes.except(*ignored_vocabulary_attributes).merge(site_id: current_site.id))
+      end
+
+      def update
+        @vocabulary_form = VocabularyForm.new(vocabulary_params.merge(id: params[:id], site_id: current_site.id))
+        if @vocabulary_form.save
+          track_update_activity
+          redirect_to(
+            edit_admin_common_vocabulary_path(@vocabulary_form.vocabulary),
+            notice: t(".success")
+          )
+        else
+          render :edit
+        end
+      end
+
+      def destroy
+        vocabulary = find_vocabulary
+        if vocabulary.destroy
+          redirect_to admin_common_vocabularies_path, notice: t(".success")
+        else
+          redirect_to admin_common_vocabularies_path, alert: t(".destroy_failed")
+        end
+      end
+
+      private
+
+      def vocabulary_params
+        params.require(:vocabulary).permit(:name)
+      end
+
+      def ignored_vocabulary_attributes
+        %w(created_at updated_at site_id)
+      end
+
+      def find_vocabulary
+        vocabularies_relation.find(params[:id])
+      end
+
+      def vocabularies_relation
+        current_site.vocabularies
+      end
+
+      def track_create_activity
+        # pending
+      end
+
+      def track_update_activity
+        # pending
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class TermForm < BaseForm
+
+      attr_accessor(
+        :id,
+        :site_id,
+        :vocabulary_id,
+        :name_translations,
+        :description_translations,
+        :slug,
+        :term_id
+      )
+
+      delegate :persisted?, to: :term
+
+      validates :name_translations, :site, :vocabulary, presence: true
+
+      def term
+        @term ||= term_relation.find_by(id: id) || build_term
+      end
+
+      def build_term
+        vocabulary.terms.new
+      end
+
+      def save
+        save_term if valid?
+      end
+
+      private
+
+      def vocabulary
+        @vocabulary ||= begin
+                          if vocabulary_id
+                            site.vocabularies.find_by_id(vocabulary_id)
+                          else
+                            term_relation.find_by_id(id)&.vocabulary
+                          end
+                        end
+      end
+
+      def save_term
+        @term = term.tap do |attributes|
+          attributes.vocabulary_id = vocabulary_id
+          attributes.name_translations = name_translations
+          attributes.description_translations = description_translations
+          attributes.slug = slug
+          attributes.term_id = term_id
+        end
+
+        return @term if @term.save
+
+        promote_errors(@term.errors)
+        false
+      end
+
+      def term_relation
+        site.terms
+      end
+
+      def site
+        Site.find(site_id)
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class VocabularyForm < BaseForm
+
+      attr_accessor(
+        :id,
+        :site_id,
+        :name
+      )
+
+      delegate :persisted?, to: :vocabulary
+
+      validates :name, presence: true
+      validates :site, presence: true
+
+      def vocabulary
+        @vocabulary ||= vocabulary_relation.find_by(id: id) || build_vocabulary
+      end
+
+      def build_vocabulary
+        vocabulary_relation.new
+      end
+
+      def save
+        save_vocabulary if valid?
+      end
+
+      private
+
+      def save_vocabulary
+        @vocabulary = vocabulary.tap do |attributes|
+          attributes.site_id = site_id
+          attributes.name = name
+        end
+
+        return @vocabulary if @vocabulary.save
+
+        promote_errors(@vocabulary.errors)
+        false
+      end
+
+      def vocabulary_relation
+        site.vocabularies
+      end
+
+      def site
+        Site.find(site_id)
+      end
+    end
+  end
+end

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class Term < ApplicationRecord
+    before_validation :calculate_level, :set_vocabulary
+    include GobiertoCommon::Sluggable
+
+    belongs_to :vocabulary
+
+    has_many :terms
+    belongs_to :parent_term, class_name: name, foreign_key: :term_id
+
+    validates :vocabulary, :name_translations, :slug, :position, :level, presence: true
+    validates :slug, uniqueness: { scope: :vocabulary_id }
+
+    translates :name, :description
+
+    def attributes_for_slug
+      [vocabulary_name, name]
+    end
+
+    def vocabulary_name
+      vocabulary.name
+    end
+
+    private
+
+    def calculate_level
+      if parent_term.present?
+        self.level = parent_term.level + 1
+      end
+    end
+
+    def set_vocabulary
+      if parent_term.present?
+        self.vocabulary_id = parent_term.vocabulary_id
+      end
+    end
+  end
+end

--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class Vocabulary < ApplicationRecord
+    belongs_to :site
+    validates :site, :name, presence: true
+    validates :name, uniqueness: { scope: :site }
+  end
+end

--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -3,6 +3,8 @@
 module GobiertoCommon
   class Vocabulary < ApplicationRecord
     belongs_to :site
+    has_many :terms, dependent: :destroy
+
     validates :site, :name, presence: true
     validates :name, uniqueness: { scope: :site }
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -17,6 +17,7 @@ class Site < ApplicationRecord
   has_many :custom_user_fields, dependent: :destroy, class_name: "GobiertoCommon::CustomUserField"
 
   has_many :vocabularies, dependent: :destroy, class_name: "GobiertoCommon::Vocabulary"
+  has_many :terms, through: :vocabularies, class_name: "GobiertoCommon::Term"
 
   # User integrations
   has_many :subscriptions, dependent: :destroy, class_name: "User::Subscription"

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -16,6 +16,8 @@ class Site < ApplicationRecord
   has_many :content_blocks, dependent: :destroy, class_name: "GobiertoCommon::ContentBlock"
   has_many :custom_user_fields, dependent: :destroy, class_name: "GobiertoCommon::CustomUserField"
 
+  has_many :vocabularies, dependent: :destroy, class_name: "GobiertoCommon::Vocabulary"
+
   # User integrations
   has_many :subscriptions, dependent: :destroy, class_name: "User::Subscription"
   has_many :notifications, dependent: :destroy, class_name: "User::Notification"

--- a/app/views/gobierto_admin/gobierto_common/terms/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/terms/_form.html.erb
@@ -1,0 +1,48 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @term_form %>
+
+<%= form_for(
+  @term_form, as: :term,
+  url: @term_form.persisted? ? admin_common_term_path(@term_form) : admin_common_vocabulary_terms_path(@vocabulary),
+  data: { "globalized-form-container" => true }) do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+
+      <div class="globalized_fields">
+        <%= render "gobierto_admin/shared/form_locale_switchers" %>
+        <% current_site.configuration.available_locales.each do |locale| %>
+
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "term[name_translations][#{locale}]" do %>
+              <%= f.object.class.human_attribute_name(:name) %>
+              <%= attribute_indication_tag required: true %>
+            <% end %>
+            <%= text_field_tag "term[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym) %>
+          </div>
+
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "term[description_translations][#{locale}]" do %>
+              <%= f.object.class.human_attribute_name(:description) %>
+            <% end %>
+            <%= text_field_tag "term[description_translations][#{locale}]", f.object.description_translations && f.object.description_translations[locale], placeholder: t(".placeholders.description", locale: locale.to_sym) %>
+          </div>
+        <% end %>
+
+        <div class="form_item input_text">
+          <%= f.label :slug %>
+          <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
+        </div>
+
+        <div class="form_item select_control">
+          <%= f.label :term_id %>
+          <%= f.select :term_id,
+            options_for_select(@parent_terms, selected: @parent_term),
+            { include_blank: true } %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="actions right">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_common/terms/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/terms/edit.html.erb
@@ -1,0 +1,9 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
+  <%= link_to @vocabulary.name, admin_common_vocabulary_terms_path(@vocabulary) %> »
+  <%= t(".edit", term: @term_form.term.name) %>
+</div>
+
+<h1><%= t(".edit", term: @term_form.term.name) %></h1>
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/terms/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/terms/index.html.erb
@@ -1,0 +1,53 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
+  <%= @vocabulary.name %>
+</div>
+
+<h1><%= t(".title", vocabulary: @vocabulary.name) %></h1>
+
+<div class="admin_tools right">
+  <%= link_to t(".new"), new_admin_common_vocabulary_term_path(@vocabulary), class: "button" %>
+</div>
+
+<table class="user-list">
+  <tr>
+    <th class='icon_col'></th>
+    <th><%= t(".header.name") %></th>
+    <th><%= t(".header.description") %></th>
+    <th><%= t(".header.parent") %></th>
+    <th><%= t(".header.level") %></th>
+    <th class='icon_col'></th>
+  </tr>
+
+  <tbody>
+    <% @terms.each do |term| %>
+      <tr id="term-item-<%= term.id %>" class="<%= cycle("odd", "even") %>">
+        <td>
+          <%= link_to edit_admin_common_term_path(term) do %>
+            <i class="fa fa-edit"></i>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to edit_admin_common_term_path(term) do %>
+            <%= term.name %>
+          <% end %>
+        </td>
+        <td>
+            <%= term.description %>
+        </td>
+        <td>
+            <%= term.parent_term&.name %>
+        </td>
+        <td>
+            <%= term.level %>
+        </td>
+        <td>
+          <%= link_to admin_common_term_path(term), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
+            <i class="fa fa-trash"></i>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/gobierto_admin/gobierto_common/terms/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/terms/new.html.erb
@@ -1,0 +1,9 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
+  <%= link_to @vocabulary.name, admin_common_vocabulary_terms_path(@vocabulary) %> »
+  <%= t(".new") %>
+</div>
+
+<h1><%= t(".new") %></h1>
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/_form.html.erb
@@ -1,0 +1,18 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @vocabulary_form %>
+
+<%= form_for(
+  @vocabulary_form, as: :vocabulary,
+  url: @vocabulary_form.persisted? ? admin_common_vocabulary_path(@vocabulary_form) : admin_common_vocabularies_path(@vocabulary)) do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+      <div class="form_item input_text">
+        <%= f.label :name %>
+        <%= f.text_field :name, placeholder: t(".placeholders.name") %>
+      </div>
+    </div>
+  </div>
+
+  <div class="actions right">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/_form.html.erb
@@ -2,11 +2,14 @@
 
 <%= form_for(
   @vocabulary_form, as: :vocabulary,
-  url: @vocabulary_form.persisted? ? admin_common_vocabulary_path(@vocabulary_form) : admin_common_vocabularies_path(@vocabulary)) do |f| %>
+  url: @vocabulary_form.persisted? ? admin_common_vocabulary_path(@vocabulary_form) : admin_common_vocabularies_path) do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
       <div class="form_item input_text">
-        <%= f.label :name %>
+        <%= f.label :name do %>
+          <%= f.object.class.human_attribute_name(:name) %>
+          <%= attribute_indication_tag required: true %>
+        <% end %>
         <%= f.text_field :name, placeholder: t(".placeholders.name") %>
       </div>
     </div>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/edit.html.erb
@@ -4,4 +4,5 @@
   <%= t(".edit", vocabulary: @vocabulary_form.name) %>
 </div>
 
+<h1><%= t(".edit", vocabulary: @vocabulary_form.name) %></h1>
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/edit.html.erb
@@ -1,0 +1,7 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
+  <%= t(".edit", vocabulary: @vocabulary_form.name) %>
+</div>
+
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -12,9 +12,9 @@
 <table class="user-list">
   <tr>
     <th class='icon_col'></th>
-    <th class='icon_col'></th>
     <th><%= t(".header.name") %></th>
     <th></th>
+    <th class='icon_col'></th>
   </tr>
 
   <tbody>
@@ -26,11 +26,6 @@
           <% end %>
         </td>
         <td>
-          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
-            <i class="fa fa-trash"></i>
-          <% end %>
-        </td>
-        <td>
           <%= link_to edit_admin_common_vocabulary_path(vocabulary) do %>
             <%= vocabulary.name %>
           <% end %>
@@ -39,6 +34,11 @@
           <%= link_to admin_common_vocabulary_path(vocabulary), class: "view_item" do %>
             <i class="fa fa-eye"></i>
             <%= t(".view_vocabulary") %>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
+            <i class="fa fa-trash"></i>
           <% end %>
         </td>
       </tr>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -1,0 +1,47 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= t('.title') %>
+</div>
+
+<h1><%= t(".title") %></h1>
+
+<div class="admin_tools right">
+  <%= link_to t(".new"), new_admin_common_vocabulary_path, class: "button" %>
+</div>
+
+<table class="user-list">
+  <tr>
+    <th class='icon_col'></th>
+    <th class='icon_col'></th>
+    <th><%= t(".header.name") %></th>
+    <th></th>
+  </tr>
+
+  <tbody>
+    <% @vocabularies.each do |vocabulary| %>
+      <tr id="vocabulary-item-<%= vocabulary.id %>" class="<%= cycle("odd", "even") %>">
+        <td>
+          <%= link_to edit_admin_common_vocabulary_path(vocabulary) do %>
+            <i class="fa fa-edit"></i>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
+            <i class="fa fa-trash"></i>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to edit_admin_common_vocabulary_path(vocabulary) do %>
+            <%= vocabulary.name %>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to admin_common_vocabulary_path(vocabulary), class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view_vocabulary") %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -26,12 +26,12 @@
           <% end %>
         </td>
         <td>
-          <%= link_to edit_admin_common_vocabulary_path(vocabulary) do %>
+          <%= link_to admin_common_vocabulary_terms_path(vocabulary) do %>
             <%= vocabulary.name %>
           <% end %>
         </td>
         <td>
-          <%= link_to admin_common_vocabulary_path(vocabulary), class: "view_item" do %>
+          <%= link_to admin_common_vocabulary_terms_path(vocabulary), class: "view_item" do %>
             <i class="fa fa-eye"></i>
             <%= t(".view_vocabulary") %>
           <% end %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/new.html.erb
@@ -4,4 +4,5 @@
   <%= t(".new") %>
 </div>
 
+<h1><%= t(".new") %></h1>
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/new.html.erb
@@ -1,0 +1,7 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
+  <%= t(".new") %>
+</div>
+
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/show.html.erb
@@ -1,0 +1,17 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
+  <%= @vocabulary.name %>
+</div>
+
+<h1><%= @vocabulary.name %></h1>
+
+<p>
+  <strong><%= t('.created_at') %></strong>:
+  <%= l(@vocabulary.created_at, format: :short) %>
+</p>
+
+<p>
+  <strong><%= t('.terms') %></strong>:
+  <%= t(".terms_count", count: @terms_count) %>
+</p>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -163,6 +163,7 @@
                 <ul>
                   <li><%= link_to t(".issues"), admin_issues_path %></li>
                   <li><%= link_to t(".scopes"), admin_scopes_path %></li>
+                  <li><%= link_to t(".vocabularies"), admin_common_vocabularies_path %></li>
                   <li><%= link_to t(".templates"), admin_gobierto_core_templates_path %></li>
                 </ul>
               </li>

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -8,8 +8,14 @@ ca:
         item_type: Tipus
         slug: URL
         title: Títol
+      gobierto_admin/gobierto_common/term_form:
+        description: Descripció
+        name: Nom
+        parent_term: Térme Pare
+        slug: Slug
       gobierto_admin/gobierto_common/vocabulary_form:
         name: Nom
     models:
       gobierto_admin/gobierto_common/collection_form: Col·lecció
+      gobierto_admin/gobierto_common/term_form: Terme
       gobierto_admin/gobierto_common/vocabulary_form: Vocabulari

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -8,5 +8,8 @@ ca:
         item_type: Tipus
         slug: URL
         title: Títol
+      gobierto_admin/gobierto_common/vocabulary_form:
+        name: Nom
     models:
       gobierto_admin/gobierto_common/collection_form: Col·lecció
+      gobierto_admin/gobierto_common/vocabulary_form: Vocabulari

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -8,8 +8,14 @@ en:
         item_type: Type
         slug: URL
         title: Title
+      gobierto_admin/gobierto_common/term_form:
+        description: Description
+        name: Name
+        parent_term: Parent Term
+        slug: Slug
       gobierto_admin/gobierto_common/vocabulary_form:
         name: Name
     models:
       gobierto_admin/gobierto_common/collection_form: Collection
+      gobierto_admin/gobierto_common/term_form: Term
       gobierto_admin/gobierto_common/vocabulary_form: Vocabulary

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -8,5 +8,8 @@ en:
         item_type: Type
         slug: URL
         title: Title
+      gobierto_admin/gobierto_common/vocabulary_form:
+        name: Name
     models:
       gobierto_admin/gobierto_common/collection_form: Collection
+      gobierto_admin/gobierto_common/vocabulary_form: Vocabulary

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -8,8 +8,14 @@ es:
         item_type: Tipo
         slug: URL
         title: Título
+      gobierto_admin/gobierto_common/term_form:
+        description: Descripción
+        name: Nombre
+        parent_term: Término Padre
+        slug: Slug
       gobierto_admin/gobierto_common/vocabulary_form:
         name: Nombre
     models:
       gobierto_admin/gobierto_common/collection_form: Colección
+      gobierto_admin/gobierto_common/term_form: Término
       gobierto_admin/gobierto_common/vocabulary_form: Vocabulario

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -8,5 +8,8 @@ es:
         item_type: Tipo
         slug: URL
         title: Título
+      gobierto_admin/gobierto_common/vocabulary_form:
+        name: Nombre
     models:
       gobierto_admin/gobierto_common/collection_form: Colección
+      gobierto_admin/gobierto_common/vocabulary_form: Vocabulario

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/ca.yml
@@ -1,0 +1,12 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_common:
+      terms:
+        create:
+          success: El terme s'ha creat correctament.
+        destroy:
+          destroy_failed: El terme no ha pogut ser eliminat.
+          success: El terme ha estat eliminat correctament.
+        update:
+          success: El terme s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/en.yml
@@ -1,0 +1,12 @@
+---
+en:
+  gobierto_admin:
+    gobierto_common:
+      terms:
+        create:
+          success: Term created successfully.
+        destroy:
+          destroy_failed: Term couldn't be deleted.
+          success: Term deleted successfully.
+        update:
+          success: Term updated successfully.

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/es.yml
@@ -1,0 +1,12 @@
+---
+es:
+  gobierto_admin:
+    gobierto_common:
+      terms:
+        create:
+          success: El término se ha creado correctamente.
+        destroy:
+          destroy_failed: El término no ha podido ser eliminado.
+          success: El término ha sido eliminado correctamente.
+        update:
+          success: El término se ha actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
@@ -1,0 +1,23 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_common:
+      terms:
+        edit:
+          edit: Editar %{term}
+        form:
+          placeholders:
+            description: El cavall és un mamífer herbívor
+            name: Cavall
+            slug: regne-animal-cavall
+        index:
+          delete_confirm: Estàs segur? Aquesta operació no és reversible
+          header:
+            description: Descripció
+            level: Nivell
+            name: Nom
+            parent: Pare
+          new: Nou
+          title: Termes de %{vocabulary}
+        new:
+          new: Nou Terme

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
@@ -1,0 +1,23 @@
+---
+en:
+  gobierto_admin:
+    gobierto_common:
+      terms:
+        edit:
+          edit: Edit %{term}
+        form:
+          placeholders:
+            description: The horse is a herbivorous mammal
+            name: Horse
+            slug: reino-animal-caballo
+        index:
+          delete_confirm: Are you sure? This operation can not be undone
+          header:
+            description: Description
+            level: Level
+            name: Name
+            parent: Parent
+          new: New
+          title: Terms of %{vocabulary}
+        new:
+          new: New term

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
@@ -1,0 +1,23 @@
+---
+es:
+  gobierto_admin:
+    gobierto_common:
+      terms:
+        edit:
+          edit: Editar %{term}
+        form:
+          placeholders:
+            description: El caballo es un mamífero herbívoro
+            name: Caballo
+            slug: reino-animal-caballo
+        index:
+          delete_confirm: Estás seguro? Esta operación no es reversible
+          header:
+            description: Descripción
+            level: Nivel
+            name: Nombre
+            parent: Padre
+          new: Nuevo
+          title: Términos de %{vocabulary}
+        new:
+          new: Nuevo Término

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/controllers/ca.yml
@@ -1,0 +1,12 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_common:
+      vocabularies:
+        create:
+          success: El vocabulari s'ha creat correctament.
+        destroy:
+          destroy_failed: El vocabulari no ha pogut ser eliminat.
+          success: El vocabulari ha estat eliminat correctament.
+        update:
+          success: El vocabulari s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/controllers/en.yml
@@ -1,0 +1,12 @@
+---
+en:
+  gobierto_admin:
+    gobierto_common:
+      vocabularies:
+        create:
+          success: Vocabulary created successfully.
+        destroy:
+          destroy_failed: Vocabulary couldn't be deleted.
+          success: Vocabulary deleted successfully.
+        update:
+          success: Vocabulary updated successfully.

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/controllers/es.yml
@@ -1,0 +1,12 @@
+---
+es:
+  gobierto_admin:
+    gobierto_common:
+      vocabularies:
+        create:
+          success: El vocabulario se ha creado correctamente.
+        destroy:
+          destroy_failed: El vocabulario no ha podido ser eliminado.
+          success: El vocabulario ha sido eliminado correctamente.
+        update:
+          success: El vocabulario se ha actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
@@ -1,0 +1,23 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_common:
+      vocabularies:
+        edit:
+          edit: Editar %{vocabulary}
+        form:
+          placeholders:
+            name: Regne animal
+        index:
+          delete_confirm: Estàs segur? Aquesta operació no és reversible
+          header:
+            name: Nom
+          new: Nou
+          title: Vocabularis
+          view_vocabulary: Veure vocabulari
+        new:
+          new: Nou Vocabulari
+        show:
+          created_at: Creació
+          terms: Termes
+          terms_count: "%{count} termes"

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
@@ -1,0 +1,23 @@
+---
+en:
+  gobierto_admin:
+    gobierto_common:
+      vocabularies:
+        edit:
+          edit: Edit %{vocabulary}
+        form:
+          placeholders:
+            name: Animal kingdom
+        index:
+          delete_confirm: Are you sure? This operation can not be undone
+          header:
+            name: Name
+          new: New
+          title: Vocabularies
+          view_vocabulary: See vocabulary
+        new:
+          new: New Vocabulary
+        show:
+          created_at: Created at
+          terms: Terms
+          terms_count: "%{count} terms"

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
@@ -1,0 +1,23 @@
+---
+es:
+  gobierto_admin:
+    gobierto_common:
+      vocabularies:
+        edit:
+          edit: Editar %{vocabulary}
+        form:
+          placeholders:
+            name: Reino animal
+        index:
+          delete_confirm: Seguro? Esta operación no tiene marcha atrás.
+          header:
+            name: Nombre
+          new: Nuevo
+          title: Vocabularios
+          view_vocabulary: Ver vocabulario
+        new:
+          new: Nuevo Vocabulario
+        show:
+          created_at: Creación
+          terms: Términos
+          terms_count: "%{count} términos"

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -27,3 +27,4 @@ ca:
         templates: Plantilles
         users: Usuaris
         view_site: Veure site
+        vocabularies: Vocabularis

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -27,3 +27,4 @@ en:
         templates: Templates
         users: Users
         view_site: View site
+        vocabularies: Vocabularies

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -27,3 +27,4 @@ es:
         templates: Plantillas
         users: Usuarios
         view_site: Ver site
+        vocabularies: Vocabularios

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,7 +129,9 @@ Rails.application.routes.draw do
     namespace :gobierto_common, as: :common, path: nil do
       resources :collections, only: [:show, :new, :create, :edit, :update]
       resources :content_blocks, only: [:new, :create, :edit, :update, :destroy]
-      resources :vocabularies
+      resources :vocabularies do
+        resources :terms, shallow: true, except: [:show]
+      end
     end
 
     namespace :gobierto_plans, as: :plans, path: :plans do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,7 @@ Rails.application.routes.draw do
     namespace :gobierto_common, as: :common, path: nil do
       resources :collections, only: [:show, :new, :create, :edit, :update]
       resources :content_blocks, only: [:new, :create, :edit, :update, :destroy]
+      resources :vocabularies
     end
 
     namespace :gobierto_plans, as: :plans, path: :plans do

--- a/db/migrate/20180716085128_create_vocabularies.rb
+++ b/db/migrate/20180716085128_create_vocabularies.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateVocabularies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vocabularies do |t|
+      t.references :site
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180716092050_create_terms.rb
+++ b/db/migrate/20180716092050_create_terms.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateTerms < ActiveRecord::Migration[5.2]
+  def change
+    create_table :terms do |t|
+      t.references :vocabulary
+      t.jsonb :name_translations
+      t.jsonb :description_translations
+      t.string :slug
+      t.integer :position, null: false, default: 0
+      t.integer :level, default: 0, null: false
+      t.references :term
+
+      t.timestamps
+    end
+
+    add_index :terms, [:slug, :vocabulary_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -880,6 +880,21 @@ ActiveRecord::Schema.define(version: 2018_07_16_092701) do
     t.index ["title_translations"], name: "index_sites_on_title_translations", using: :gin
   end
 
+  create_table "terms", force: :cascade do |t|
+    t.bigint "vocabulary_id"
+    t.jsonb "name_translations"
+    t.jsonb "description_translations"
+    t.string "slug"
+    t.integer "position", default: 0, null: false
+    t.integer "level", default: 0, null: false
+    t.bigint "term_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug", "vocabulary_id"], name: "index_terms_on_slug_and_vocabulary_id"
+    t.index ["term_id"], name: "index_terms_on_term_id"
+    t.index ["vocabulary_id"], name: "index_terms_on_vocabulary_id"
+  end
+
   create_table "translations", id: :serial, force: :cascade do |t|
     t.string "locale"
     t.string "key"
@@ -975,6 +990,14 @@ ActiveRecord::Schema.define(version: 2018_07_16_092701) do
     t.text "object"
     t.datetime "created_at"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  create_table "vocabularies", force: :cascade do |t|
+    t.bigint "site_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id"], name: "index_vocabularies_on_site_id"
   end
 
   add_foreign_key "gc_events", "collections", on_delete: :cascade

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -1,0 +1,46 @@
+mammal:
+  vocabulary: animals
+  name_translations: <%= { es: "Mamífero", en: "Mammal" }.to_json %>
+  description_translations: <%= { es: "Vertebrado caracterizado por presentar glándulas mamarias", en: "Vertebrates characterised by the possession of mammary glands" }.to_json %>
+  slug: <%= "animals-mammal" %>
+  position: 0
+  level: 0
+dog:
+  vocabulary: animals
+  name_translations: <%= { es: "Perro", en: "Dog" }.to_json %>
+  description_translations: <%= { es: "Mamífero que ladra", en: "Mammal who barks" }.to_json %>
+  slug: <%= "animals-dog" %>
+  position: 0
+  level: 1
+  term_id: <%= ActiveRecord::FixtureSet.identify(:mammal) %>
+cat:
+  vocabulary: animals
+  name_translations: <%= { es: "Gato", en: "Cat" }.to_json %>
+  description_translations: <%= { es: "Mamífero que maúlla", en: "Mammal who meows" }.to_json %>
+  slug: <%= "animals-cat" %>
+  position: 1
+  level: 1
+  term_id: <%= ActiveRecord::FixtureSet.identify(:mammal) %>
+bird:
+  vocabulary: animals
+  name_translations: <%= { es: "Pájaro", en: "Bird" }.to_json %>
+  description_translations: <%= { es: "Grupo de vertebrados, de sangre caliente, que caminan, caracterizados por poner huevos con cáscara dura, entre otras cosas", en: "Group of endothermic vertebrates, characterised by the laying of hard-shelled eggs among other things" }.to_json %>
+  slug: <%= "animals-bird" %>
+  position: 0
+  level: 0
+swift:
+  vocabulary: animals
+  name_translations: <%= { es: "Vencejo", en: "Swift" }.to_json %>
+  description_translations: <%= { es: "Ave que vuela casi todo el tiempo", en: "Bird that flies almost all the time" }.to_json %>
+  slug: <%= "animals-swift" %>
+  position: 0
+  level: 1
+  term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>
+pigeon:
+  vocabulary: animals
+  name_translations: <%= { es: "Paloma", en: "Pigeon" }.to_json %>
+  description_translations: <%= { es: "Ave que suele encontrarse donde hay humanos", en: "Bird that is usually where there are humans" }.to_json %>
+  slug: <%= "animals-pigeon" %>
+  position: 1
+  level: 1
+  term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -1,0 +1,7 @@
+animals:
+  site: madrid
+  name: Animals
+
+plan_categories:
+  site: madrid
+  name: Government Plan

--- a/test/models/gobierto_common/term_test.rb
+++ b/test/models/gobierto_common/term_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TermTest < ActiveSupport::TestCase
+  def vocabulary
+    @vocabulary ||= gobierto_common_vocabularies(:animals)
+  end
+
+  def root_level_term
+    @root_level_term ||= gobierto_common_terms(:mammal)
+  end
+
+  def dependent_level_term
+    @dependent_level_term ||= gobierto_common_terms(:dog)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_valid
+    assert root_level_term.valid?
+    assert dependent_level_term.valid?
+  end
+
+  def test_creation_of_dependent_term
+    new_term = root_level_term.terms.new(name_translations: { en: "Wolve", es: "Lobo" })
+    assert new_term.valid?
+    new_term.save
+    assert_equal root_level_term.level + 1, new_term.level
+    assert_equal vocabulary, new_term.vocabulary
+    assert_equal 3, root_level_term.terms.count
+    assert_equal root_level_term, new_term.parent_term
+  end
+
+  def test_creation_of_free_term
+    new_term = vocabulary.terms.new(name_translations: { en: "Reptile", es: "Reptil" })
+    assert new_term.valid?
+    new_term.save
+    assert_equal 0, new_term.level
+    assert_equal vocabulary, new_term.vocabulary
+    assert_equal nil, new_term.parent_term
+    assert_equal 0, new_term.terms.count
+  end
+end

--- a/test/models/gobierto_common/vocabulary_test.rb
+++ b/test/models/gobierto_common/vocabulary_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VocabularyTest < ActiveSupport::TestCase
+  def vocabulary
+    @vocabulary ||= gobierto_common_vocabularies(:animals)
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_valid
+    assert vocabulary.valid?
+  end
+
+  def test_unique_name_scoped_to_site
+    invalid_vocabulary = site.vocabularies.new(name: vocabulary.name)
+    refute invalid_vocabulary.valid?
+  end
+end


### PR DESCRIPTION
Related with #1776 and #1777

## :v: What does this PR do?
Adds two new models: `GobiertoCommon::Vocabulary` and `GobiertoCommon::Term` and includes controllers views and forms to manage them in admin

## :mag: How should this be manually tested?
### Via console
* Create a vocabulary:
  ```ruby
  vocabulary = Site.last.vocabularies.create(name: "Instruments")
  ```
* Create a term of the vocabulary:
  ```ruby
  cordophone = vocabulary.terms.create(name_translations: {en: "Chordophone", es: "De cuerda"})
  ```
* Create a term dependent of another term:
  ```ruby
  cello = cordophone.terms.create(name_translations: {en: "Cello", es: "Violonchelo"})
  ```
* Check, for example: 
  ```ruby
  cello.parent_term == cordophone # => true
  cordophone.terms.include? cello # => true
  cello.level > cordophone.level # => true
  cello.vocabulary == cordophone.vocabulary # => true
  ```
### From admin

![vocabularies 1](https://user-images.githubusercontent.com/446459/42881887-8834e4ce-8a98-11e8-85af-df0420623a17.gif)

## :shipit: Does this PR changes any configuration file?
No