### PR TITLE
1785 issues scopes migrations to vocabularies

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class OrderedTermsController < BaseController
+      helper_method :term_preview_url
+
+      def index
+        @terms = current_site.send(association)
+        @term_form = OrderedTermForm.new(site_id: current_site.id, association: association)
+        @vocabulary = find_vocabulary
+      end
+
+      def new
+        @term_form = OrderedTermForm.new(site_id: current_site.id, association: association)
+
+        render(:new_modal, layout: false) && return if request.xhr?
+      end
+
+      def edit
+        @term = find_term
+        @term_form = OrderedTermForm.new(
+          @term.attributes.except(*ignored_term_attributes).merge(site_id: current_site.id, association: association)
+        )
+
+        render(:edit_modal, layout: false) && return if request.xhr?
+      end
+
+      def create
+        @term_form = OrderedTermForm.new(term_params.merge(site_id: current_site.id, association: association))
+
+        if @term_form.save
+          track_create_activity
+
+          redirect_to(
+            admin_ordered_vocabulary_terms_path(module: params[:module], vocabulary: params[:vocabulary], id: @term),
+            notice: t(".success", link: send(:"gobierto_participation_#{ params[:vocabulary] }_url", @term_form.term.slug, host: current_site.domain))
+          )
+        else
+          render(:new_modal, layout: false) && return if request.xhr?
+          render :new
+        end
+      end
+
+      def update
+        @term = find_term
+        @term_form = OrderedTermForm.new(
+          term_params.merge(id: params[:id], site_id: current_site.id, association: association)
+        )
+
+        if @term_form.save
+          track_update_activity
+
+          redirect_to(
+            admin_ordered_vocabulary_terms_path(module: params[:module], vocabulary: params[:vocabulary], id: @term),
+            notice: t(".success", link: send(:"gobierto_participation_#{ params[:vocabulary] }_url", @term_form.term.slug, host: current_site.domain))
+          )
+        else
+          render(:edit_modal, layout: false) && return if request.xhr?
+          render :edit
+        end
+      end
+
+      def destroy
+        @term = find_term
+
+        if current_site.processes.where(association.singularize => @term).blank? && @term.destroy
+          redirect_to admin_ordered_vocabulary_terms_path(module: params[:module], vocabulary: params[:vocabulary]), notice: t(".success")
+        else
+          redirect_to admin_ordered_vocabulary_terms_path(module: params[:module], vocabulary: params[:vocabulary]), alert: t(".destroy_failed")
+        end
+      end
+
+      private
+
+      def association
+        @association ||= begin
+                           if current_site.send(:"#{ params[:module] }_settings")&.send(:"#{ params[:vocabulary] }_vocabulary_id").present?
+                             params[:vocabulary]
+                           else
+                             redirect_to(
+                               admin_root_path,
+                               alert: t(".not_defined")
+                             )
+                           end
+                         end
+      end
+
+      def find_vocabulary
+        current_site.vocabularies.find(current_site.send(:"#{ params[:module] }_settings")&.send(:"#{ params[:vocabulary] }_vocabulary_id"))
+      end
+
+      def track_create_activity
+        case params[:vocabulary]
+        when "issues"
+          Publishers::IssueActivity.broadcast_event("issue_created", default_activity_params.merge(subject: @term_form.term))
+        when "scopes"
+          Publishers::ScopeActivity.broadcast_event("scope_created", default_activity_params.merge(subject: @term_form.term))
+        end
+      end
+
+      def track_update_activity
+        case params[:vocabulary]
+        when "issues"
+          Publishers::IssueActivity.broadcast_event("issue_updated", default_activity_params.merge(subject: @term))
+        when "scopes"
+          Publishers::ScopeActivity.broadcast_event("scope_updated", default_activity_params.merge(subject: @term))
+        end
+      end
+
+      def default_activity_params
+        { ip: remote_ip, author: current_admin, site_id: current_site.id }
+      end
+
+      def term_params
+        params.require(:term).permit(
+          :slug,
+          name_translations: [*I18n.available_locales],
+          description_translations: [*I18n.available_locales]
+        )
+      end
+
+      def ignored_term_attributes
+        %w(position created_at updated_at level term_id vocabulary_id)
+      end
+
+      def find_term
+        current_site.send(association).find(params[:id])
+      end
+
+      def term_preview_url(term, options = {})
+        options[:preview_token] = current_admin.preview_token unless term.active?
+        send(:"gobierto_participation_#{ params[:vocabulary] }_url", term.slug, options)
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_sort_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_sort_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class OrderedTermsSortController < BaseController
+      def create
+        vocabulary.terms.update_positions(issue_sort_params)
+        head :no_content
+      end
+
+      private
+
+      def vocabulary
+        @vocabulary ||= begin
+                          vocabulary_id = current_site.send(:"#{ params[:module] }_settings")&.send(:"#{ params[:vocabulary] }_vocabulary_id")
+                          current_site.vocabularies.find(vocabulary_id)
+                        end
+      end
+
+      def issue_sort_params
+        params.require(:positions).permit!
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_participation/configuration/settings_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/configuration/settings_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoParticipation
+    module Configuration
+      class SettingsController < BaseController
+        def edit
+          @settings_form = SettingsForm.new(site_id: current_site.id)
+        end
+
+        def update
+          @settings_form = SettingsForm.new(settings_params.merge(site_id: current_site.id))
+
+          if @settings_form.save
+            redirect_to edit_admin_participation_configuration_settings_path, notice: t(".success")
+          else
+            redirect_to edit_admin_participation_configuration_settings_path, notice: t(".error")
+          end
+        end
+
+        private
+
+        def settings_params
+          params.require(:gobierto_participation_settings).permit(:issues_vocabulary_id, :scopes_vocabulary_id)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/issues_controller.rb
+++ b/app/controllers/gobierto_admin/issues_controller.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
     end
 
     def new
-      @issue_form = IssueForm.new
+      @issue_form = IssueForm.new(site_id: current_site.id)
 
       render(:new_modal, layout: false) && return if request.xhr?
     end
@@ -22,7 +22,7 @@ module GobiertoAdmin
     def edit
       @issue = find_issue
       @issue_form = IssueForm.new(
-        @issue.attributes.except(*ignored_issue_attributes)
+        @issue.attributes.except(*ignored_issue_attributes).merge(site_id: current_site.id)
       )
 
       render(:edit_modal, layout: false) && return if request.xhr?
@@ -47,7 +47,7 @@ module GobiertoAdmin
     def update
       @issue = find_issue
       @issue_form = IssueForm.new(
-        issue_params.merge(id: params[:id])
+        issue_params.merge(id: params[:id], site_id: current_site.id)
       )
 
       if @issue_form.save
@@ -66,7 +66,7 @@ module GobiertoAdmin
     def destroy
       @issue = find_issue
 
-      if @issue.destroy
+      if current_site.processes.where(issue: @issue).blank? && @issue.destroy
         redirect_to admin_issues_path(@issue), notice: t(".success")
       else
         redirect_to admin_issues_path(@issue), alert: t(".has_items")
@@ -96,7 +96,7 @@ module GobiertoAdmin
     end
 
     def ignored_issue_attributes
-      %w(position created_at updated_at)
+      %w(position created_at updated_at level term_id vocabulary_id)
     end
 
     def find_issue

--- a/app/controllers/gobierto_participation/activities_controller.rb
+++ b/app/controllers/gobierto_participation/activities_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoParticipation
   class ActivitiesController < GobiertoParticipation::ApplicationController
     def index
-      @issues = current_site.issues
+      @issues = find_issues
 
       @issue = find_issue if params[:issue_id]
 
@@ -15,10 +15,6 @@ module GobiertoParticipation
     end
 
     private
-
-    def find_issue
-      current_site.issues.find_by_slug!(params[:issue_id])
-    end
 
     def find_participation_activities_issue(issue)
       ActivityCollectionDecorator.new(Activity.no_admin

--- a/app/controllers/gobierto_participation/application_controller.rb
+++ b/app/controllers/gobierto_participation/application_controller.rb
@@ -8,6 +8,14 @@ module GobiertoParticipation
 
     before_action { module_enabled!(current_site, 'GobiertoParticipation') }
 
+    def find_issues
+      CollectionDecorator.new(current_site.issues, decorator: ProcessTermDecorator)
+    end
+
+    def find_issue
+      ProcessTermDecorator.new(current_site.issues.find_by_slug!(params[:issue_id]))
+    end
+
     protected
 
     def current_process

--- a/app/controllers/gobierto_participation/application_controller.rb
+++ b/app/controllers/gobierto_participation/application_controller.rb
@@ -16,6 +16,14 @@ module GobiertoParticipation
       ProcessTermDecorator.new(current_site.issues.find_by_slug!(params[:issue_id]))
     end
 
+    def find_scopes
+      CollectionDecorator.new(current_site.scopes, decorator: ProcessTermDecorator)
+    end
+
+    def find_scope
+      ProcessTermDecorator.new(current_site.scopes.find_by_slug!(params[:scope_id]))
+    end
+
     protected
 
     def current_process

--- a/app/controllers/gobierto_participation/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/attachments_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class AttachmentsController < GobiertoParticipation::ApplicationController
     def index
       @issue = find_issue if params[:issue_id]
-      @issues = current_site.issues
+      @issues = find_issues
       @filtered_issue = find_issue if params[:issue_id]
       @attachments = if @filtered_issue
                        GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @issue).page(params[:page])
@@ -14,10 +14,6 @@ module GobiertoParticipation
     end
 
     private
-
-    def find_issue
-      current_site.issues.find_by_slug!(params[:issue_id])
-    end
 
     def find_attachments
       attachments = ::GobiertoAttachments::Attachment.attachments_in_collections_and_container_type(current_site, "GobiertoParticipation")

--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -4,7 +4,7 @@ module GobiertoParticipation
   class EventsController < GobiertoParticipation::ApplicationController
     def index
       @issue = find_issue if params[:issue_id]
-      @issues = current_site.issues
+      @issues = find_issues
 
       container_events
       set_events
@@ -20,10 +20,6 @@ module GobiertoParticipation
     end
 
     private
-
-    def find_issue
-      current_site.issues.find_by_slug!(params[:issue_id])
-    end
 
     def set_events
       @events = if params[:date]

--- a/app/controllers/gobierto_participation/issues/activities_controller.rb
+++ b/app/controllers/gobierto_participation/issues/activities_controller.rb
@@ -12,10 +12,6 @@ module GobiertoParticipation
 
       private
 
-      def find_issue
-        current_site.issues.find_by_slug!(params[:issue_id])
-      end
-
       def find_issue_activities
         ActivityCollectionDecorator.new(Activity.in_site(current_site).no_admin.in_process(@issue.processes).sorted.includes(:subject, :author, :recipient).page(params[:page]))
       end

--- a/app/controllers/gobierto_participation/issues/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/issues/attachments_controller.rb
@@ -12,10 +12,6 @@ module GobiertoParticipation
 
       private
 
-      def find_issue
-        current_site.issues.find_by_slug!(params[:issue_id])
-      end
-
       def find_issue_attachments
         ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @issue)
       end

--- a/app/controllers/gobierto_participation/issues/events_controller.rb
+++ b/app/controllers/gobierto_participation/issues/events_controller.rb
@@ -24,10 +24,6 @@ module GobiertoParticipation
 
       private
 
-      def find_issue
-        current_site.issues.find_by_slug!(params[:issue_id])
-      end
-
       def find_participation_events
         ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted
       end

--- a/app/controllers/gobierto_participation/issues_controller.rb
+++ b/app/controllers/gobierto_participation/issues_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoParticipation
   class IssuesController < GobiertoParticipation::ApplicationController
     def index
-      @issues = current_site.issues
+      @issues = find_issues
     end
 
     def show
@@ -22,7 +22,7 @@ module GobiertoParticipation
     end
 
     def find_issue
-      current_site.issues.find_by!(slug: params[:id])
+      ProcessTermDecorator.new(current_site.issues.find_by!(slug: params[:id]))
     end
 
     def find_issue_news

--- a/app/controllers/gobierto_participation/news_controller.rb
+++ b/app/controllers/gobierto_participation/news_controller.rb
@@ -5,7 +5,7 @@ module GobiertoParticipation
     before_action :load_issue, :load_scope
 
     def index
-      @issues = current_site.issues
+      @issues = find_issues
       @pages = participation_module_news.sorted.active.page(params[:page])
     end
 
@@ -13,7 +13,7 @@ module GobiertoParticipation
 
     def load_issue
       if params[:issue_id]
-        @issue = current_site.issues.find_by_slug!(params[:issue_id])
+        @issue = find_issue
       end
     end
 

--- a/app/controllers/gobierto_participation/news_controller.rb
+++ b/app/controllers/gobierto_participation/news_controller.rb
@@ -19,7 +19,7 @@ module GobiertoParticipation
 
     def load_scope
       if params[:scope_id]
-        @scope = current_site.scopes.find_by_slug!(params[:scope_id])
+        @scope = find_scope
       end
     end
 

--- a/app/controllers/gobierto_participation/processes/activities_controller.rb
+++ b/app/controllers/gobierto_participation/processes/activities_controller.rb
@@ -6,7 +6,7 @@ module GobiertoParticipation
       include ::PreviewTokenHelper
 
       def index
-        @issues = current_site.issues
+        @issues = find_issues
 
         @issue = find_issue if params[:issue_id]
 
@@ -21,10 +21,6 @@ module GobiertoParticipation
       end
 
       private
-
-      def find_issue
-        current_site.issues.find_by_slug!(params[:issue_id])
-      end
 
       def find_process_activities
         ActivityCollectionDecorator.new(Activity.in_site(current_site)

--- a/app/controllers/gobierto_participation/processes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/processes/attachments_controller.rb
@@ -6,7 +6,7 @@ module GobiertoParticipation
       include ::PreviewTokenHelper
 
       def index
-        @issues = current_site.issues
+        @issues = find_issues
         @filtered_issue = find_issue if params[:issue_id]
         @issue = find_issue if params[:issue_id]
         @attachments = if @issue
@@ -18,10 +18,6 @@ module GobiertoParticipation
       end
 
       private
-
-      def find_issue
-        current_site.issues.find_by_slug!(params[:issue_id])
-      end
 
       def find_process_attachments
         ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, current_process)

--- a/app/controllers/gobierto_participation/processes/events_controller.rb
+++ b/app/controllers/gobierto_participation/processes/events_controller.rb
@@ -12,7 +12,7 @@ module GobiertoParticipation
       end
 
       def index
-        @issues = current_site.issues
+        @issues = find_issues
 
         @issue = find_issue if params[:issue_id]
 
@@ -25,10 +25,6 @@ module GobiertoParticipation
       end
 
       private
-
-      def find_issue
-        current_site.issues.find_by_slug!(params[:issue_id])
-      end
 
       def find_process_events
         ::GobiertoCalendars::Event.events_in_collections_and_container(current_site, current_process).sorted

--- a/app/controllers/gobierto_participation/scopes/activities_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/activities_controller.rb
@@ -12,10 +12,6 @@ module GobiertoParticipation
 
       private
 
-      def find_scope
-        current_site.scopes.find_by_slug!(params[:scope_id])
-      end
-
       def find_scope_activities
         ActivityCollectionDecorator.new(Activity.in_site(current_site).no_admin.in_process(@scope.processes).sorted.includes(:subject, :author, :recipient).page(params[:page]))
       end

--- a/app/controllers/gobierto_participation/scopes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/attachments_controller.rb
@@ -12,10 +12,6 @@ module GobiertoParticipation
 
       private
 
-      def find_scope
-        current_site.scopes.find_by_slug!(params[:scope_id])
-      end
-
       def find_scope_attachments
         ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @scope)
       end

--- a/app/controllers/gobierto_participation/scopes/events_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/events_controller.rb
@@ -24,10 +24,6 @@ module GobiertoParticipation
 
       private
 
-      def find_scope
-        current_site.scopes.find_by_slug!(params[:scope_id])
-      end
-
       def find_participation_events
         ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted
       end

--- a/app/controllers/gobierto_participation/scopes_controller.rb
+++ b/app/controllers/gobierto_participation/scopes_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoParticipation
   class ScopesController < GobiertoParticipation::ApplicationController
     def index
-      @scopes = current_site.scopes
+      @scopes = find_scopes
     end
 
     def show
@@ -22,7 +22,7 @@ module GobiertoParticipation
     end
 
     def find_scope
-      current_site.scopes.find_by!(slug: params[:id])
+      ProcessTermDecorator.new(current_site.scopes.find_by_slug!(params[:id]))
     end
 
     def find_scope_news

--- a/app/controllers/gobierto_participation/welcome_controller.rb
+++ b/app/controllers/gobierto_participation/welcome_controller.rb
@@ -6,7 +6,7 @@ module GobiertoParticipation
 
     def index
       @processes = current_site.processes.process.active
-      @issues = current_site.issues
+      @issues = find_issues
       @events = find_participation_events
       @news = find_participation_news
       @activities = find_participation_activities

--- a/app/decorators/gobierto_participation/process_term_decorator.rb
+++ b/app/decorators/gobierto_participation/process_term_decorator.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module GobiertoParticipation
+  class ProcessTermDecorator < BaseDecorator
+    def initialize(term)
+      @object = term
+    end
+
+    def active_pages
+      GobiertoCms::Page.pages_in_collections_and_container(site, object).sorted.active
+    end
+
+    def site
+      @site ||= object.vocabulary.site
+    end
+
+    def number_contributions
+      contributions.size
+    end
+
+    def number_contributing_neighbours
+      contributions.pluck(:user_id).uniq.size
+    end
+
+    def contributions
+      return GobiertoParticipation::Contribution.none unless association_with_processes
+      terms_key = GobiertoParticipation::Process.reflections[association_with_processes.to_s].foreign_key
+      processes_table = GobiertoParticipation::Process.table_name
+      containers_table = GobiertoParticipation::ContributionContainer.table_name
+
+      GobiertoParticipation::Contribution.joins(contribution_container: :process)
+                                         .where("#{ containers_table }.visibility_level = ?", 1)
+                                         .where("#{ processes_table }.#{terms_key} = ?", id)
+    end
+
+    def events
+      collection_items_table = ::GobiertoCommon::CollectionItem.table_name
+      item_type = ::GobiertoCalendars::Event
+      site.events.distinct.joins("INNER JOIN #{collection_items_table} ON \
+                        #{collection_items_table}.item_id = #{item_type.table_name}.id AND \
+                        #{collection_items_table}.item_type = '#{item_type}' AND \
+                            container_type = '#{object.class.name}' AND \
+                            container_id = #{object.id}\
+                        ")
+    end
+
+    def processes
+      return GobiertoParticipation::Process.none unless association_with_processes
+      GobiertoParticipation::Process.where(association_with_processes => object)
+    end
+
+    protected
+
+    def association_with_processes
+      @association_with_processes ||= begin
+                                        return unless participation_settings.present?
+                                        GobiertoParticipation::Process.vocabularies.find do |_, setting|
+                                          participation_settings.send(setting).to_i == object.vocabulary_id.to_i
+                                        end&.first
+                                      end
+    end
+
+    def participation_settings
+      @participation_settings ||= site.gobierto_participation_settings
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_common/ordered_term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/ordered_term_form.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class OrderedTermForm < BaseForm
+
+      attr_accessor(
+        :id,
+        :site_id,
+        :name_translations,
+        :description_translations,
+        :slug,
+        :association
+      )
+
+      delegate :persisted?, to: :term
+
+      validates :name_translations, :site, presence: true
+
+      def term
+        @term ||= terms_relation.find_by(id: id) || build_term
+      end
+
+      def save
+        save_term if valid?
+      end
+
+      private
+
+      def build_term
+        terms_relation.new
+      end
+
+      def save_term
+        @term = term.tap do |attributes|
+          attributes.name_translations = name_translations
+          attributes.description_translations = description_translations
+          attributes.slug = slug
+        end
+
+        return @term if @term.save
+
+        promote_errors(@term.errors)
+        false
+      end
+
+      def terms_relation
+        site.send(association)
+      end
+
+      def site
+        Site.find_by(id: site_id)
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_participation/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_participation/settings_form.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoParticipation
+    class SettingsForm < BaseForm
+
+      attr_accessor(
+        :issues_vocabulary_id,
+        :scopes_vocabulary_id
+      )
+
+      attr_writer :site_id
+
+      delegate :persisted?, to: :gobierto_module_settings
+      validates :issues_vocabulary, :scopes_vocabulary, presence: true
+
+      def save
+        valid? && save_settings
+      end
+
+      def gobierto_module_settings
+        @gobierto_module_settings ||= gobierto_module_settings_class.find_by(site_id: site_id, module_name: "GobiertoParticipation") || build_gobierto_module_settings
+      end
+
+      def site_id
+        @site_id ||= gobierto_module_settings.site_id
+      end
+
+      def site
+        @site ||= Site.find site_id
+      end
+
+      def vocabularies_options
+        site.vocabularies.map do |vocabulary|
+          [vocabulary.name, vocabulary.id]
+        end
+      end
+
+      private
+
+      def gobierto_module_settings_class
+        ::GobiertoModuleSettings
+      end
+
+      def build_gobierto_module_settings
+        gobierto_module_settings_class.new
+      end
+
+      def save_settings
+        @gobierto_module_settings = gobierto_module_settings.tap do |settings_attributes|
+          settings_attributes.module_name = "GobiertoParticipation"
+          settings_attributes.site_id = site_id
+          settings_attributes.issues_vocabulary_id = issues_vocabulary_id
+          settings_attributes.scopes_vocabulary_id = scopes_vocabulary_id
+        end
+
+        if @gobierto_module_settings.save
+          true
+        else
+          promote_errors(@gobierto_module_settings.errors)
+          false
+        end
+      end
+
+      def issues_vocabulary
+        @issues_vocabulary ||= site.vocabularies.find_by_id(issues_vocabulary_id)
+      end
+
+      def scopes_vocabulary
+        @scopes_vocabulary ||= site.vocabularies.find_by_id(scopes_vocabulary_id)
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_participation/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_participation/settings_form.rb
@@ -12,7 +12,7 @@ module GobiertoAdmin
       attr_writer :site_id
 
       delegate :persisted?, to: :gobierto_module_settings
-      validates :issues_vocabulary, :scopes_vocabulary, presence: true
+      validates :site, presence: true
 
       def save
         valid? && save_settings

--- a/app/forms/gobierto_admin/issue_form.rb
+++ b/app/forms/gobierto_admin/issue_form.rb
@@ -23,10 +23,6 @@ module GobiertoAdmin
       @issue ||= issue_class.find_by(id: id).presence || build_issue
     end
 
-    def site_id
-      @site_id ||= issue.site_id
-    end
-
     def site
       @site ||= Site.find_by(id: site_id)
     end
@@ -38,12 +34,11 @@ module GobiertoAdmin
     end
 
     def issue_class
-      ::Issue
+      site.issues
     end
 
     def save_issue
       @issue = issue.tap do |issue_attributes|
-        issue_attributes.site_id = site_id
         issue_attributes.name_translations = name_translations
         issue_attributes.description_translations = description_translations
         issue_attributes.slug = slug

--- a/app/helpers/subscription_helper.rb
+++ b/app/helpers/subscription_helper.rb
@@ -3,8 +3,15 @@
 module SubscriptionHelper
   def subscription_message(object, action)
     class_name = object.class.name
-    item = class_name == "GobiertoParticipation::Process" ? object.process_type : class_name.demodulize.downcase
-
+    item = if class_name == "GobiertoParticipation::Process"
+             object.process_type
+           elsif class_name == "GobiertoCommon::Term" && (participation_settings = current_site.gobierto_participation_settings).present?
+             ["issue", "scope"].find do |type|
+               participation_settings.send(:"#{type.tableize}_vocabulary_id").to_i == object.vocabulary_id.to_i
+             end
+           else
+             class_name.demodulize.downcase
+           end
     if action == "followed"
       t(".#{item}_followed")
     elsif action == "follow"

--- a/app/models/concerns/gobierto_common/has_vocabulary.rb
+++ b/app/models/concerns/gobierto_common/has_vocabulary.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module HasVocabulary
+    extend ActiveSupport::Concern
+
+    included do
+      class_variable_set :@@vocabularies, {}
+    end
+
+    class_methods do
+      def has_vocabulary(name, opts = {})
+        vocabularies = class_variable_get :@@vocabularies
+
+        singularized_name = name.to_s.singularize.to_sym
+        extra_opts = { foreign_key: opts[:column_name] }.compact
+        vocabulary_module_setting = opts[:vocabulary_module_setting] || :"#{ name }_vocabulary_id"
+        module_name = self.name.deconstantize
+        vocabularies[singularized_name] = vocabulary_module_setting
+
+        belongs_to singularized_name, extra_opts.merge(class_name: "GobiertoCommon::Term")
+
+        define_singleton_method :vocabularies do
+          vocabularies
+        end
+
+        define_singleton_method name do |site = nil|
+          site ||= GobiertoCore::CurrentScope.current_site
+          return GobiertoCommon::Term.none unless site.settings_for_module(module_name)
+          site.vocabularies.find(site.settings_for_module(module_name).send(vocabulary_module_setting)).terms
+        end
+
+        scope :"of_#{singularized_name}", ->(term) { where(singularized_name => term) }
+
+        class_variable_set :@@vocabularies, vocabularies
+      end
+    end
+  end
+end

--- a/app/models/concerns/gobierto_common/has_vocabulary.rb
+++ b/app/models/concerns/gobierto_common/has_vocabulary.rb
@@ -26,7 +26,7 @@ module GobiertoCommon
 
         define_singleton_method name do |site = nil|
           site ||= GobiertoCore::CurrentScope.current_site
-          return GobiertoCommon::Term.none unless site.settings_for_module(module_name)
+          return GobiertoCommon::Term.none unless site.settings_for_module(module_name)&.send(vocabulary_module_setting)&.present?
           site.vocabularies.find(site.settings_for_module(module_name).send(vocabulary_module_setting)).terms
         end
 

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -157,12 +157,6 @@ module GobiertoCalendars
       locations.first
     end
 
-    def first_issue
-      collection_item = GobiertoCommon::CollectionItem.issues.where(item: self).first
-
-      collection_item.container if collection_item
-    end
-
     def searchable_description
       searchable_translated_attribute(description_translations)
     end

--- a/app/models/gobierto_common/collection.rb
+++ b/app/models/gobierto_common/collection.rb
@@ -113,6 +113,7 @@ module GobiertoCommon
         site_for_container(container), gobierto_module_for_container(container),
         area_for_container(container), issue_for_container(container),
         scope_for_container(container),
+        term_for_container(container),
         gobierto_module_instance_for_container(container)
       ].compact.uniq
     end
@@ -153,6 +154,12 @@ module GobiertoCommon
 
     def gobierto_module_instance_for_container(container)
       if !container.is_a?(Module) && !container_is_a_collector?(container)
+        [container.class.name, container.id]
+      end
+    end
+
+    def term_for_container(container)
+      if container.is_a?(GobiertoCommon::Term)
         [container.class.name, container.id]
       end
     end

--- a/app/models/gobierto_common/collection_item.rb
+++ b/app/models/gobierto_common/collection_item.rb
@@ -12,7 +12,6 @@ module GobiertoCommon
     scope :pages, -> { where(item_type: %w(GobiertoCms::Page GobiertoCms::News)) }
     scope :attachments, -> { where(item_type: 'GobiertoAttachments::Attachment') }
     scope :events, -> { where(item_type: 'GobiertoCalendars::Event') }
-    scope :issues, -> { where(item_type: 'Issue') }
     scope :pages_and_news, -> { where(item_type: %W(GobiertoCms::News GobiertoCms::Page)) }
 
     scope :by_container_type, ->(container_type) { where(container_type: container_type) }

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -12,7 +12,7 @@ module GobiertoCommon
     has_many :terms, dependent: :nullify
     belongs_to :parent_term, class_name: name, foreign_key: :term_id
 
-    validates :vocabulary, :name_translations, :slug, :position, :level, presence: true
+    validates :vocabulary, :name, :slug, :position, :level, presence: true
     validates :slug, uniqueness: { scope: :vocabulary_id }
 
     translates :name, :description

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -26,7 +26,7 @@ module GobiertoCommon
     end
 
     def vocabulary_name
-      vocabulary.name
+      vocabulary&.name
     end
 
     private

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -3,6 +3,8 @@
 module GobiertoCommon
   class Term < ApplicationRecord
     before_validation :calculate_level, :set_vocabulary
+    include GobiertoCommon::Sortable
+    include User::Subscribable
     include GobiertoCommon::Sluggable
     after_save :update_children_levels
     before_destroy :free_children
@@ -14,6 +16,8 @@ module GobiertoCommon
 
     validates :vocabulary, :name, :slug, :position, :level, presence: true
     validates :slug, uniqueness: { scope: :vocabulary_id }
+
+    scope :sorted, -> { order(position: :asc, created_at: :desc) }
 
     translates :name, :description
 

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -26,7 +26,7 @@ module GobiertoParticipation
 
     belongs_to :site
     has_vocabulary :issues
-    belongs_to :scope, class_name: "GobiertoCommon::Scope"
+    has_vocabulary :scopes
     has_many :stages, -> { sorted }, dependent: :delete_all, class_name: "GobiertoParticipation::ProcessStage", autosave: true
     has_many :published_stages, -> { published.sorted }, class_name: "GobiertoParticipation::ProcessStage"
     has_many :polls

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -13,6 +13,7 @@ module GobiertoParticipation
     include GobiertoCommon::Searchable
     include GobiertoCommon::ActsAsCollectionContainer
     include GobiertoAttachments::Attachable
+    include GobiertoCommon::HasVocabulary
 
     algoliasearch_gobierto do
       attribute :site_id, :updated_at, :title_en, :title_es, :title_ca, :body_en, :body_es, :body_ca
@@ -24,7 +25,7 @@ module GobiertoParticipation
     translates :title, :body, :body_source, :information_text
 
     belongs_to :site
-    belongs_to :issue
+    has_vocabulary :issues
     belongs_to :scope, class_name: "GobiertoCommon::Scope"
     has_many :stages, -> { sorted }, dependent: :delete_all, class_name: "GobiertoParticipation::ProcessStage", autosave: true
     has_many :published_stages, -> { published.sorted }, class_name: "GobiertoParticipation::ProcessStage"

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -65,7 +65,6 @@ class Site < ApplicationRecord
   has_many :module_settings, dependent: :destroy, class_name: "GobiertoModuleSettings"
 
   # Gobierto Participation integration
-  has_many :scopes, -> { sorted }, dependent: :destroy, class_name: "GobiertoCommon::Scope"
   has_many :processes, dependent: :destroy, class_name: "GobiertoParticipation::Process"
   has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"
   has_many :contributions, dependent: :destroy, class_name: "GobiertoParticipation::Contribution"
@@ -101,6 +100,10 @@ class Site < ApplicationRecord
 
   def issues
     GobiertoParticipation::Process.issues(self).sorted
+  end
+
+  def scopes
+    GobiertoParticipation::Process.scopes(self).sorted
   end
 
   def gobierto_people_settings

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -112,6 +112,17 @@ class Site < ApplicationRecord
                                    end
   end
 
+  def gobierto_participation_settings
+    @gobierto_participation_settings ||= if configuration.gobierto_participation_enabled?
+                                           module_settings.find_by(module_name: "GobiertoParticipation")
+                                         end
+  end
+
+  def settings_for_module(module_name)
+    return unless respond_to?(method = "#{ module_name.underscore }_settings")
+    send(method)
+  end
+
   # If the organization_id corresponds to a municipality ID,
   # this method will return an instance of INE::Places::Place
   def place

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -65,7 +65,6 @@ class Site < ApplicationRecord
   has_many :module_settings, dependent: :destroy, class_name: "GobiertoModuleSettings"
 
   # Gobierto Participation integration
-  has_many :issues, -> { sorted }, dependent: :destroy, class_name: "Issue"
   has_many :scopes, -> { sorted }, dependent: :destroy, class_name: "GobiertoCommon::Scope"
   has_many :processes, dependent: :destroy, class_name: "GobiertoParticipation::Process"
   has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"
@@ -98,6 +97,10 @@ class Site < ApplicationRecord
     unless reserved_domains.include?(domain)
       find_by(domain: domain)
     end
+  end
+
+  def issues
+    GobiertoParticipation::Process.issues(self)
   end
 
   def gobierto_people_settings

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -100,7 +100,7 @@ class Site < ApplicationRecord
   end
 
   def issues
-    GobiertoParticipation::Process.issues(self)
+    GobiertoParticipation::Process.issues(self).sorted
   end
 
   def gobierto_people_settings

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
@@ -1,0 +1,35 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @term_form %>
+
+<%= form_for(
+  @term_form, as: :term,
+  url: @term_form.persisted? ? admin_ordered_vocabulary_term_path(id: @term_form) : admin_ordered_vocabulary_terms_path, data: { "globalized-form-container" => true}) do |f| %>
+
+  <div class="globalized_fields">
+    <%= render "gobierto_admin/shared/form_locale_switchers" %>
+
+    <% current_site.configuration.available_locales.each do |locale| %>
+      <div class="form_item input_text" data-locale="<%= locale %>">
+        <%= label_tag "term[name_translations][#{locale}]" do %>
+          <%= f.object.class.human_attribute_name(:name) %>
+          <%= attribute_indication_tag required: true %>
+        <% end %>
+        <%= text_field_tag "term[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym) %>
+      </div>
+
+      <div class="form_item input_text" data-locale="<%= locale %>">
+        <%= label_tag "term[description_translations][#{locale}]", f.object.class.human_attribute_name(:description) %>
+        <%= text_area_tag "term[description_translations][#{locale}]", f.object.description_translations && f.object.description_translations[locale], placeholder: t(".placeholders.description", locale: locale.to_sym) %>
+      </div>
+    <% end %>
+
+    <div class="form_item input_text">
+      <%= f.label :slug %>
+      <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
+    </div>
+  </div>
+
+  <div class="actions right">
+    <%= f.submit %>
+  </div>
+
+<% end %>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/edit_modal.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/edit_modal.html.erb
@@ -1,0 +1,4 @@
+<div class="modal">
+  <h2><%= t(".title", term: @term.name) %></h2>
+  <%= render "form" %>
+</div>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/index.html.erb
@@ -1,0 +1,57 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.layouts.application.edit_site"), edit_admin_site_path(current_site) %> »
+  <%= t("gobierto_admin.layouts.application.#{params[:vocabulary]}") %>
+</div>
+
+<h1><%= t("gobierto_admin.layouts.application.#{params[:vocabulary]}") %> (<%= @vocabulary.name %>)</h1>
+
+<div class="admin_tools right">
+  <%= link_to t(".new"), new_admin_ordered_vocabulary_term_path, class: 'button open_remote_modal' %>
+</div>
+
+<table>
+  <tr>
+    <th class="icon_col"></th>
+    <th class="icon_col"></th>
+    <th><%= t('.header.name') %></th>
+    <th><%= t('.header.created_at') %></th>
+    <th></th>
+    <th></th>
+  </tr>
+
+  <tbody data-behavior="sortable" data-sortable-target="<%= admin_ordered_vocabulary_terms_sort_path %>">
+    <% @terms.each do |term| %>
+      <tr id="term-item-<%= term.id %>" data-id="<%= term.id %>" class="<%= cycle("odd", "even") %>">
+        <td>
+          <%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_ordered_vocabulary_term_path(id: term), class: 'open_remote_modal', title: t('views.edit') %>
+        </td>
+        <td>
+          <%= link_to "<i class='fa fa-trash'></i>".html_safe, admin_ordered_vocabulary_term_path(id: term), method: :delete, title: t('views.delete'), data: { confirm: t(".delete_confirm") } %>
+
+        </td>
+        <td>
+          <%= link_to term.name, edit_admin_ordered_vocabulary_term_path(id: term), class: 'open_remote_modal' %>
+        </td>
+        <td>
+          <%= time_ago_in_words(term.created_at) %>
+        </td>
+        <td>
+          <%= link_to send(:"gobierto_participation_#{ params[:vocabulary].singularize }_path", term.slug ,host: current_site.domain), target: "_blank", class: "view_item" do %>
+            <i class="fa fa-eye"></i>
+            <%= t(".view") %>
+          <% end %>
+        </td>
+        <td>
+          <i class="sort-handler fa fa-bars tipsit custom_handle" title="<%= t('.drag_to_sort') %>"></i>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<% content_for :javascript_hook do %>
+  <%= javascript_tag do %>
+    window.GobiertoAdmin.issues_controller.index();
+  <% end %>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/new.html.erb
@@ -1,0 +1,1 @@
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/new_modal.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/new_modal.html.erb
@@ -1,0 +1,6 @@
+<div class="modal">
+
+  <h2><%= t(".title") %></h2>
+  <%= render "form" %>
+
+</div>

--- a/app/views/gobierto_admin/gobierto_participation/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/configuration/settings/edit.html.erb
@@ -1,0 +1,27 @@
+<%= form_for @settings_form, as: :gobierto_participation_settings, url: admin_participation_configuration_settings_path,  method: :patch, html: { autocomplete: "off" } do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+      <div class="form_item select_control">
+        <%= f.label :issues_vocabulary_id %>
+        <%= f.select :issues_vocabulary_id,
+          options_for_select(@settings_form.vocabularies_options, selected: @settings_form.gobierto_module_settings.issues_vocabulary_id),
+          { include_blank: true } %>
+    </div>
+
+    <div class="form_item select_control">
+      <%= f.label :scopes_vocabulary_id %>
+      <%= f.select :scopes_vocabulary_id,
+        options_for_select(@settings_form.vocabularies_options, selected: @settings_form.gobierto_module_settings.scopes_vocabulary_id),
+        { include_blank: true } %>
+  </div>
+    </div>
+
+    <div class="pure-u-1 pure-u-md-2-24"></div>
+
+    <div class="pure-u-1 pure-u-md-1-4 ">
+      <div class="widget_save stick_in_parent">
+        <%= f.submit t(".update"), class: "button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_participation/welcome/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/welcome/index.html.erb
@@ -5,6 +5,13 @@
 
 <h1><%= t('.title') %></h1>
 
+<div class="admin_tools right">
+  <%= link_to edit_admin_participation_configuration_settings_path do %>
+    <i class="fa fa-cog"></i>
+    <%= t(".configuration") %>
+  <% end %>
+</div>
+
 <div class="pure-g">
   <div class="pure-u-1 pure-u-md-16-24 p_h_r_2">
     <h3 class="m_t_0"><%= t('.next_elements_to_close') %></h3>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -165,9 +165,13 @@
                   <span><%= t(".edit_site") %></span>
                 <% end %>
                 <ul>
-                  <li><%= link_to t(".issues"), admin_issues_path %></li>
-                  <li><%= link_to t(".scopes"), admin_scopes_path %></li>
                   <% if current_admin.can_edit_vocabularies? %>
+                    <% if current_site.gobierto_participation_settings&.issues_vocabulary_id.present? %>
+                      <li><%= link_to t(".issues"), admin_issues_path %></li>
+                    <% end %>
+                    <% if current_site.gobierto_participation_settings&.scopes_vocabulary_id.present? %>
+                      <li><%= link_to t(".scopes"), admin_scopes_path %></li>
+                    <% end %>
                     <li><%= link_to t(".vocabularies"), admin_common_vocabularies_path %></li>
                   <% end %>
                   <% if current_admin.can_edit_templates? %>

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/ca.yml
@@ -2,6 +2,16 @@
 ca:
   gobierto_admin:
     gobierto_common:
+      ordered_terms:
+        association:
+          not_defined: El vocabulari associat a aquesta funcionalitat no està definit
+        create:
+          success: El terme s'ha creat correctament.
+        destroy:
+          destroy_failed: No pots esborrar un terme mentre tingui elements associats.
+          success: El terme ha estat eliminat correctament.
+        update:
+          success: El terme s'ha actualitzat correctament.
       terms:
         create:
           success: El terme s'ha creat correctament.

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/en.yml
@@ -2,6 +2,16 @@
 en:
   gobierto_admin:
     gobierto_common:
+      ordered_terms:
+        association:
+          not_defined: The vocabulary associated with this functionality is not set
+        create:
+          success: Term created successfully.
+        destroy:
+          destroy_failed: You can't delete a term while it has associated elements.
+          success: Term deleted successfully.
+        update:
+          success: Term updated successfully.
       terms:
         create:
           success: Term created successfully.

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/es.yml
@@ -2,11 +2,21 @@
 es:
   gobierto_admin:
     gobierto_common:
-      terms:
+      ordered_terms:
+        association:
+          not_defined: El vocabulario asociado a esta funcionalidad no está definido
         create:
           success: El término se ha creado correctamente.
         destroy:
           destroy_failed: El término no ha podido ser eliminado.
+          success: El término ha sido eliminado correctamente.
+        update:
+          success: El término se ha actualizado correctamente.
+      terms:
+        create:
+          success: El término se ha creado correctamente.
+        destroy:
+          destroy_failed: No puedes borrar un término mientras tenga elementos asociados.
           success: El término ha sido eliminado correctamente.
         update:
           success: El término se ha actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
@@ -2,6 +2,25 @@
 ca:
   gobierto_admin:
     gobierto_common:
+      ordered_terms:
+        edit_modal:
+          title: Edita %{term}
+        form:
+          placeholders:
+            description: Descripció del terme
+            name: Nom del terme
+            slug: terme
+        index:
+          delete_confirm: Estàs segur? Aquesta operació no és reversible
+          drag_to_sort: Arrastra per a ordenar
+          header:
+            created_at: Creació
+            name: Nom
+          new: Nou
+          title: Térmes
+          view: Veure terme
+        new_modal:
+          title: Nou terme
       terms:
         edit:
           edit: Editar %{term}

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
@@ -17,7 +17,6 @@ ca:
             created_at: Creació
             name: Nom
           new: Nou
-          title: Térmes
           view: Veure terme
         new_modal:
           title: Nou terme

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
@@ -17,7 +17,6 @@ en:
             created_at: Created at
             name: Name
           new: New
-          title: Terms
           view: View term
         new_modal:
           title: New term

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
@@ -2,6 +2,25 @@
 en:
   gobierto_admin:
     gobierto_common:
+      ordered_terms:
+        edit_modal:
+          title: Edit %{term}
+        form:
+          placeholders:
+            description: Term description
+            name: Term name
+            slug: term
+        index:
+          delete_confirm: Are you sure? This operation can not be undone
+          drag_to_sort: Drag to sort
+          header:
+            created_at: Created at
+            name: Name
+          new: New
+          title: Terms
+          view: View term
+        new_modal:
+          title: New term
       terms:
         edit:
           edit: Edit %{term}

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
@@ -17,7 +17,6 @@ es:
             created_at: Creado
             name: Nombre
           new: Nuevo
-          title: Términos
           view: Ver término
         new_modal:
           title: Nuevo término

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
@@ -2,6 +2,25 @@
 es:
   gobierto_admin:
     gobierto_common:
+      ordered_terms:
+        edit_modal:
+          title: Editar %{term}
+        form:
+          placeholders:
+            description: Descripción del término
+            name: Nombre del término
+            slug: termino
+        index:
+          delete_confirm: Estás seguro? Esta operación no es reversible
+          drag_to_sort: Arrastra para ordenar
+          header:
+            created_at: Creado
+            name: Nombre
+          new: Nuevo
+          title: Términos
+          view: Ver término
+        new_modal:
+          title: Nuevo término
       terms:
         edit:
           edit: Editar %{term}

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/processes/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/processes/ca.yml
@@ -1,0 +1,9 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_participation:
+      configuration:
+        settings:
+          update:
+            error: Hi ha hagut un error al desar la configuració
+            success: Configuració guardada correctament

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/processes/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/processes/en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  gobierto_admin:
+    gobierto_participation:
+      configuration:
+        settings:
+          update:
+            error: There was a problem when saving configuration
+            success: Configuration stored successfully

--- a/config/locales/gobierto_admin/gobierto_participation/controllers/processes/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/controllers/processes/es.yml
@@ -1,0 +1,9 @@
+---
+es:
+  gobierto_admin:
+    gobierto_participation:
+      configuration:
+        settings:
+          update:
+            error: Se ha producido un error al actualizar la configuración
+            success: Configuración guardada correctamente

--- a/config/locales/gobierto_admin/gobierto_participation/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/ca.yml
@@ -2,6 +2,10 @@
 ca:
   gobierto_admin:
     gobierto_participation:
+      configuration:
+        settings:
+          edit:
+            update: Actualitzar
       shared:
         navigation:
           agenda: Agenda
@@ -16,6 +20,7 @@ ca:
           votings: Votacions
       welcome:
         index:
+          configuration: Configuració
           element: Element
           finishes_in: Acaba ...
           group_process: Grup/Procés

--- a/config/locales/gobierto_admin/gobierto_participation/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/en.yml
@@ -2,6 +2,10 @@
 en:
   gobierto_admin:
     gobierto_participation:
+      configuration:
+        settings:
+          edit:
+            update: Update
       shared:
         navigation:
           agenda: Agenda
@@ -16,6 +20,7 @@ en:
           votings: Votings
       welcome:
         index:
+          configuration: Configuration
           element: Element
           finishes_in: It finishes in...
           group_process: Group/Process

--- a/config/locales/gobierto_admin/gobierto_participation/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/es.yml
@@ -2,6 +2,10 @@
 es:
   gobierto_admin:
     gobierto_participation:
+      configuration:
+        settings:
+          edit:
+            update: Actualizar
       shared:
         navigation:
           agenda: Agenda
@@ -16,6 +20,7 @@ es:
           votings: Votaciones
       welcome:
         index:
+          configuration: Configuración
           element: Elemento
           finishes_in: Termina en...
           group_process: Grupo/Proceso

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,10 @@ Rails.application.routes.draw do
           put :recover
         end
       end
+
+      namespace :configuration do
+        resource :settings, only: [:edit, :update], path: :settings
+      end
     end
 
     namespace :gobierto_common, as: :common, path: nil do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,12 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :ordered_vocabulary_terms, path: ":module/:vocabulary/ordered_terms", controller: "gobierto_common/ordered_terms", except: [:show]  do
+      collection do
+        resource :ordered_vocabulary_terms_sort, only: [:create], controller: "gobierto_common/ordered_terms_sort"
+      end
+    end
+
     namespace :sites do
       resource :sessions, only: [:create, :destroy]
     end

--- a/lib/tasks/gobierto_common/migrate_to_vocabularies.rake
+++ b/lib/tasks/gobierto_common/migrate_to_vocabularies.rake
@@ -9,7 +9,8 @@ namespace :common do
         next if Issue.where(site: site).blank?
         puts "== Migrating issues of #{ site.domain }"
         issues = site.vocabularies.find_or_create_by(name: "issues")
-        settings = ::GobiertoAdmin::GobiertoParticipation::SettingsForm.new(site_id: site.id, issues_vocabulary_id: issues.id)
+        scopes_vocabulary_id = site.gobierto_participation_settings&.scopes_vocabulary_id
+        settings = ::GobiertoAdmin::GobiertoParticipation::SettingsForm.new(site_id: site.id, issues_vocabulary_id: issues.id, scopes_vocabulary_id: scopes_vocabulary_id)
         settings.save
         Issue.where(site: site).each do |issue|
           next if issues.terms.where(slug: issue.slug).exists?
@@ -71,20 +72,78 @@ namespace :common do
     task scopes: :environment do
       ignored_attributes = %w(id site_id created_at updated_at)
       Site.all.each do |site|
-        next if site.scopes.blank?
+        next if GobiertoCommon::Scope.where(site: site).blank?
         puts "== Migrating scopes of #{ site.domain }"
         scopes = site.vocabularies.find_or_create_by(name: "scopes")
-        site.scopes.each do |scope|
+        issues_vocabulary_id = site.gobierto_participation_settings&.issues_vocabulary_id
+        settings = ::GobiertoAdmin::GobiertoParticipation::SettingsForm.new(site_id: site.id, scopes_vocabulary_id: scopes.id, issues_vocabulary_id: issues_vocabulary_id)
+        settings.save
+        GobiertoCommon::Scope.where(site: site).each do |scope|
           next if scopes.terms.where(slug: scope.slug).exists?
           term = scopes.terms.create(scope.attributes.except(*ignored_attributes))
           puts "== Created term of scopes vocabulary: #{ term.name }"
         end
+      end
+
+      GobiertoCommon::Collection.where(container_type: "GobiertoCommon::Scope").each do |collection|
+        move_scope_to_term(
+          scope: collection.container,
+          site: collection.site,
+          target: collection,
+          prefix: "container"
+        )
+      end
+
+      GobiertoCommon::CollectionItem.where(container_type: "GobiertoCommon::Scope").each do |collection_item|
+        move_scope_to_term(
+          scope: collection_item.container,
+          site: collection_item.collection.site,
+          target: collection_item,
+          prefix: "container"
+        )
+      end
+
+      Activity.where(subject_type: "GobiertoCommon::Scope").each do |activity|
+        scope = activity.subject || activity.site.scopes.find_by_id(activity.subject_id)
+        move_scope_to_term(
+          scope: scope,
+          site: activity.site,
+          target: activity,
+          prefix: "subject"
+        )
+      end
+
+      User::Subscription.where(subscribable_type: "GobiertoCommon::Scope").each do |subscription|
+        scope = subscription.subscribable || subscription.site.scopes.find_by_id(subscription.subscribable_id)
+        move_scope_to_term(
+          scope: subscription.subscribable,
+          site: subscription.site,
+          target: subscription,
+          prefix: "subscribable"
+        )
+      end
+
+      GobiertoParticipation::Process.where.not(scope_id: nil).each do |process|
+        site = process.site
+        next if (scope = GobiertoCommon::Scope.where(site: site).find_by_id(process.scope_id)).blank?
+        term = site.scopes.find_by(name_translations: scope.name_translations)
+        if term.blank?
+          term = site.scopes.terms.create(scope.attributes.except(*ignored_attributes))
+        end
+        process.update_attribute(:scope_id, term.id)
       end
     end
 
     def move_issue_to_term(issue:, site:, target:, prefix:)
       return if issue.blank?
       term = site.issues.find_by(name_translations: issue.name_translations)
+      return if term.blank?
+      target.update_attributes("#{ prefix }_type" => "GobiertoCommon::Term", "#{ prefix }_id" => term.id)
+    end
+
+    def move_scope_to_term(scope:, site:, target:, prefix:)
+      return if scope.blank?
+      term = site.scopes.find_by(name_translations: scope.name_translations)
       return if term.blank?
       target.update_attributes("#{ prefix }_type" => "GobiertoCommon::Term", "#{ prefix }_id" => term.id)
     end

--- a/lib/tasks/gobierto_common/migrate_to_vocabularies.rake
+++ b/lib/tasks/gobierto_common/migrate_to_vocabularies.rake
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+namespace :common do
+  namespace :migrate_to_vocabularies do
+    desc "Generate a vocabulary for each site from existing issues"
+    task issues: :environment do
+      ignored_attributes = %w(id site_id created_at updated_at)
+      Site.all.each do |site|
+        next if Issue.where(site: site).blank?
+        puts "== Migrating issues of #{ site.domain }"
+        issues = site.vocabularies.find_or_create_by(name: "issues")
+        settings = ::GobiertoAdmin::GobiertoParticipation::SettingsForm.new(site_id: site.id, issues_vocabulary_id: issues.id)
+        settings.save
+        Issue.where(site: site).each do |issue|
+          next if issues.terms.where(slug: issue.slug).exists?
+          term = issues.terms.create(issue.attributes.except(*ignored_attributes))
+          puts "== Created term of issues vocabulary: #{ term.name }"
+        end
+      end
+
+      GobiertoCommon::Collection.where(container_type: "Issue").each do |collection|
+        move_issue_to_term(
+          issue: collection.container,
+          site: collection.site,
+          target: collection,
+          prefix: "container"
+        )
+      end
+
+      GobiertoCommon::CollectionItem.where(container_type: "Issue").each do |collection_item|
+        move_issue_to_term(
+          issue: collection_item.container,
+          site: collection_item.collection.site,
+          target: collection_item,
+          prefix: "container"
+        )
+      end
+
+      Activity.where(subject_type: "Issue") do |activity|
+        move_issue_to_term(
+          issue: activity.subject,
+          site: activity.site,
+          target: activity,
+          prefix: "subject"
+        )
+      end
+
+      GobiertoParticipation::Process.where.not(issue_id: nil).each do |process|
+        next if (issue = Issue.find_by_id(process.issue_id)).blank?
+        site = process.site
+        term = site.issues.find_by(name_translations: issue.name_translations)
+        if term.blank?
+          term = issues.terms.create(issue.attributes.except(*ignored_attributes))
+        end
+        process.update_attribute(:issue_id, term.id)
+      end
+    end
+
+    desc "Generate a vocabulary for each site from existing scopes"
+    task scopes: :environment do
+      ignored_attributes = %w(id site_id created_at updated_at)
+      Site.all.each do |site|
+        next if site.scopes.blank?
+        puts "== Migrating scopes of #{ site.domain }"
+        scopes = site.vocabularies.find_or_create_by(name: "scopes")
+        site.scopes.each do |scope|
+          next if scopes.terms.where(slug: scope.slug).exists?
+          term = scopes.terms.create(scope.attributes.except(*ignored_attributes))
+          puts "== Created term of scopes vocabulary: #{ term.name }"
+        end
+      end
+    end
+
+    def move_issue_to_term(issue:, site:, target:, prefix:)
+      term = site.issues.find_by(name_translations: issue.name_translations)
+      return if term.blank?
+      target.update_attributes("#{ prefix }_type" => "GobiertoCommon::Term", "#{ prefix }_id" => term.id)
+    end
+  end
+end

--- a/test/controllers/gobierto_admin/gobierto_common/configuration/scopes_sort_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_common/configuration/scopes_sort_controller_test.rb
@@ -11,11 +11,11 @@ module GobiertoAdmin
         end
 
         def scope_1
-          @scope_1 ||= gobierto_common_scopes(:center)
+          @scope_1 ||= gobierto_common_terms(:center_term)
         end
 
         def scope_2
-          @scope_2 ||= gobierto_common_scopes(:old_town)
+          @scope_2 ||= gobierto_common_terms(:old_town_term)
         end
 
         def setup

--- a/test/controllers/gobierto_admin/gobierto_participation/configuration/issues_sort_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_participation/configuration/issues_sort_controller_test.rb
@@ -11,11 +11,11 @@ module GobiertoAdmin
         end
 
         def issue_1
-          @issue_1 ||= issues(:culture)
+          @issue_1 ||= gobierto_common_terms(:culture_term)
         end
 
         def issue_2
-          @issue_2 ||= issues(:women)
+          @issue_2 ||= gobierto_common_terms(:women_term)
         end
 
         def setup

--- a/test/fixtures/gobierto_common/collection_items.yml
+++ b/test/fixtures/gobierto_common/collection_items.yml
@@ -26,7 +26,7 @@ collection_item_attachment_on_issue:
 collection_item_attachment_on_scope:
   collection: gender_violence_process_documents
   item: pdf_collection_attachment (GobiertoAttachments::Attachment)
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # xlsx_attachment_event
 
@@ -54,7 +54,7 @@ xlsx_attachment_event_on_issue:
 xlsx_attachment_event_on_scope:
   collection: gender_violence_process_documents
   item: xlsx_attachment_event (GobiertoAttachments::Attachment)
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # participation_documents
 
@@ -137,7 +137,7 @@ themes_on_scope:
   collection: news
   item: themes
   item_type: 'GobiertoCms::News'
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # themes_draft
 
@@ -169,7 +169,7 @@ themes_draft_on_scope:
   collection: news
   item: themes_draft (GobiertoAttachments::Attachment)
   item_type: 'GobiertoCms::News'
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # notice_1
 
@@ -201,7 +201,7 @@ notice_1_on_scope:
   collection: gender_violence_process_news
   item: notice_1
   item_type: 'GobiertoCms::News'
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # notice_2
 
@@ -233,7 +233,7 @@ notice_2_on_scope:
   collection: gender_violence_process_news
   item: notice_2
   item_type: 'GobiertoCms::News'
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # about_site
 
@@ -612,7 +612,7 @@ reading_club_on_issue:
 reading_club_on_scope:
   collection: gender_violence_process_calendar
   item: reading_club (GobiertoCalendars::Event)
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # swimming_lessons
 
@@ -639,7 +639,7 @@ swimming_lessons_on_issue:
 swimming_lessons_on_scope:
   collection: gender_violence_process_calendar
   item: swimming_lessons (GobiertoCalendars::Event)
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # intervention_with_children
 
@@ -666,7 +666,7 @@ intervention_with_children_on_issue:
 intervention_with_children_on_scope:
   collection: gender_violence_process_calendar
   item: intervention_with_children (GobiertoCalendars::Event)
-  container: old_town (GobiertoCommon::Scope)
+  container: old_town_term (GobiertoCommon::Term)
 
 # participation_calendar
 

--- a/test/fixtures/gobierto_common/collection_items.yml
+++ b/test/fixtures/gobierto_common/collection_items.yml
@@ -21,7 +21,7 @@ pdf_collection_attachment_on_participation_on_participation:
 collection_item_attachment_on_issue:
   collection: gender_violence_process_documents
   item: pdf_collection_attachment (GobiertoAttachments::Attachment)
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 collection_item_attachment_on_scope:
   collection: gender_violence_process_documents
@@ -49,7 +49,7 @@ xlsx_attachment_event_on_participation:
 xlsx_attachment_event_on_issue:
   collection: gender_violence_process_documents
   item: xlsx_attachment_event (GobiertoAttachments::Attachment)
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 xlsx_attachment_event_on_scope:
   collection: gender_violence_process_documents
@@ -131,7 +131,7 @@ themes_on_issue:
   collection: news
   item: themes
   item_type: 'GobiertoCms::News'
-  container: culture (Issue)
+  container: culture_term (GobiertoCommon::Term)
 
 themes_on_scope:
   collection: news
@@ -163,7 +163,7 @@ themes_draft_on_issue:
   collection: news
   item: themes_draft (GobiertoAttachments::Attachment)
   item_type: 'GobiertoCms::News'
-  container: culture (Issue)
+  container: culture_term (GobiertoCommon::Term)
 
 themes_draft_on_scope:
   collection: news
@@ -195,7 +195,7 @@ notice_1_on_issue:
   collection: gender_violence_process_news
   item: notice_1
   item_type: 'GobiertoCms::News'
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 notice_1_on_scope:
   collection: gender_violence_process_news
@@ -227,7 +227,7 @@ notice_2_on_issue:
   collection: gender_violence_process_news
   item: notice_2
   item_type: 'GobiertoCms::News'
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 notice_2_on_scope:
   collection: gender_violence_process_news
@@ -607,7 +607,7 @@ reading_club_on_participation:
 reading_club_on_issue:
   collection: gender_violence_process_calendar
   item: reading_club (GobiertoCalendars::Event)
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 reading_club_on_scope:
   collection: gender_violence_process_calendar
@@ -634,7 +634,7 @@ swimming_lessons_on_participation:
 swimming_lessons_on_issue:
   collection: gender_violence_process_calendar
   item: swimming_lessons (GobiertoCalendars::Event)
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 swimming_lessons_on_scope:
   collection: gender_violence_process_calendar
@@ -661,7 +661,7 @@ intervention_with_children_on_participation:
 intervention_with_children_on_issue:
   collection: gender_violence_process_calendar
   item: intervention_with_children (GobiertoCalendars::Event)
-  container: women (Issue)
+  container: women_term (GobiertoCommon::Term)
 
 intervention_with_children_on_scope:
   collection: gender_violence_process_calendar

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -44,3 +44,31 @@ pigeon:
   position: 1
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>
+culture_term:
+  vocabulary: issues_vocabulary
+  name_translations: <%= { 'en' => 'Culture', 'es' => 'Cultura' }.to_json %>
+  description_translations: <%= { 'en' => 'Culture description', 'es' => 'Descriptión de cultura' }.to_json %>
+  slug: culture
+  position: 1
+  level: 0
+women_term:
+  vocabulary: issues_vocabulary
+  name_translations: <%= { 'en' => 'Women', 'es' => 'Mujer' }.to_json %>
+  description_translations: <%= { 'en' => 'Women description', 'es' => 'Descripción de mujeres' }.to_json %>
+  slug: women
+  position: 2
+  level: 0
+economy_term:
+  vocabulary: issues_vocabulary
+  name_translations: <%= { 'en' => 'Economy', 'es' => 'Economía' }.to_json %>
+  description_translations: <%= { 'en' => 'Economy description', 'es' => 'Descrión de economía' }.to_json %>
+  slug: economy
+  position: 3
+  level: 0
+sports_term:
+  vocabulary: issues_vocabulary
+  name_translations: <%= { 'en' => 'Sports', 'es' => 'Deportes' }.to_json %>
+  description_translations: <%= { 'en' => 'Sport description', 'es' => 'Descriptión de deportes' }.to_json %>
+  slug: sport
+  position: 4
+  level: 0

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -72,3 +72,17 @@ sports_term:
   slug: sport
   position: 4
   level: 0
+center_term:
+  vocabulary: scopes_vocabulary
+  name_translations: <%= { 'en' => 'Center', 'es' => 'Centro' }.to_json %>
+  description_translations: <%= { 'en' => 'Center of the city', 'es' => 'Zona centro de la ciudad' }.to_json %>
+  slug: center
+  position: 1
+  level: 0
+old_town_term:
+  vocabulary: scopes_vocabulary
+  name_translations: <%= { 'en' => 'Old town', 'es' => 'Casco histórico' }.to_json %>
+  description_translations: <%= { 'en' => 'Historic part of town', 'es' => 'Centro histórico de la ciudad' }.to_json %>
+  slug: old-town
+  position: 2
+  level: 0

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -9,3 +9,7 @@ plan_categories:
 issues_vocabulary:
   site: madrid
   name: Issues Vocabulary
+
+scopes_vocabulary:
+  site: madrid
+  name: Scopes Vocabulary

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -5,3 +5,7 @@ animals:
 plan_categories:
   site: madrid
   name: Government Plan
+
+issues_vocabulary:
+  site: madrid
+  name: Issues Vocabulary

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -10,6 +10,14 @@ gobierto_people_settings_madrid:
     "submodules_enabled": ["officials", "agendas", "statements", "blogs", "departments"]
   }.to_json %>
 
+gobierto_participation_settings_madrid:
+  site: madrid
+  module_name: "GobiertoParticipation"
+  settings: <%= {
+    "issues_vocabulary_id": ActiveRecord::FixtureSet.identify(:issues_vocabulary),
+    "scopes_vocabulary_id": ActiveRecord::FixtureSet.identify(:issues_vocabulary)
+    }.to_json %>
+
 gobierto_budgets_settings_madrid:
   site: madrid
   module_name: "GobiertoBudgets"

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -15,7 +15,7 @@ gobierto_participation_settings_madrid:
   module_name: "GobiertoParticipation"
   settings: <%= {
     "issues_vocabulary_id": ActiveRecord::FixtureSet.identify(:issues_vocabulary),
-    "scopes_vocabulary_id": ActiveRecord::FixtureSet.identify(:issues_vocabulary)
+    "scopes_vocabulary_id": ActiveRecord::FixtureSet.identify(:scopes_vocabulary)
     }.to_json %>
 
 gobierto_budgets_settings_madrid:

--- a/test/fixtures/gobierto_participation/processes.yml
+++ b/test/fixtures/gobierto_participation/processes.yml
@@ -18,7 +18,7 @@ cultural_city_group_draft:
   slug: ciudad-cultural
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels["draft"] %>
-  issue: culture
+  issue: culture_term
 
 public_debates_group_future:
   site: madrid
@@ -43,7 +43,7 @@ dance_studio_group_ended:
   starts:
   ends: <%= 1.week.ago %>
   scope: center
-  issue: culture
+  issue: culture_term
 
 bowling_group_very_active:
   site: madrid
@@ -62,7 +62,7 @@ bowling_group_very_active:
   slug: grupo-de-petanca
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
-  issue: culture
+  issue: culture_term
   header_image_url: /assets/samples/process-b31e99553977f5da46a9f71d9c37a6ae90e8e3d7980363fa429f1c2a27c9f7ae.jpg
 
 # Processes
@@ -77,7 +77,7 @@ sport_city_process:
   visibility_level: <%= Site.visibility_levels["active"] %>
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
-  issue: culture
+  issue: culture_term
   scope: old_town
 
 local_budgets_process:
@@ -90,7 +90,7 @@ local_budgets_process:
   visibility_level: <%= Site.visibility_levels['active'] %>
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
-  issue: economy
+  issue: economy_term
 
 gender_violence_process:
   site: madrid
@@ -111,7 +111,7 @@ gender_violence_process:
   visibility_level: <%= Site.visibility_levels['active'] %>
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
-  issue: women
+  issue: women_term
   scope: old_town
   header_image_url: /assets/samples/process-b31e99553977f5da46a9f71d9c37a6ae90e8e3d7980363fa429f1c2a27c9f7ae.jpg
 
@@ -134,7 +134,7 @@ commission_for_carnival_festivities:
   visibility_level: <%= Site.visibility_levels['active'] %>
   starts: <%= 5.months.ago %>
   ends: <%= 6.months.from_now %>
-  issue: culture
+  issue: culture_term
   header_image_url: /assets/samples/process-b31e99553977f5da46a9f71d9c37a6ae90e8e3d7980363fa429f1c2a27c9f7ae.jpg
 
 center_scope_process:
@@ -147,5 +147,5 @@ center_scope_process:
   visibility_level: <%= Site.visibility_levels["active"] %>
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
-  issue: culture
+  issue: culture_term
   scope: center

--- a/test/fixtures/gobierto_participation/processes.yml
+++ b/test/fixtures/gobierto_participation/processes.yml
@@ -8,7 +8,7 @@ green_city_group_active_empty:
   slug: ciudad-verde
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>
-  scope: center
+  scope: center_term
 
 cultural_city_group_draft:
   site: madrid
@@ -30,7 +30,7 @@ public_debates_group_future:
   visibility_level: <%= Site.visibility_levels['active'] %>
   starts: <%= 1.week.from_now %>
   ends:
-  scope: center
+  scope: center_term
 
 dance_studio_group_ended:
   site: madrid
@@ -42,7 +42,7 @@ dance_studio_group_ended:
   visibility_level: <%= Site.visibility_levels['active'] %>
   starts:
   ends: <%= 1.week.ago %>
-  scope: center
+  scope: center_term
   issue: culture_term
 
 bowling_group_very_active:
@@ -78,7 +78,7 @@ sport_city_process:
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
   issue: culture_term
-  scope: old_town
+  scope: old_town_term
 
 local_budgets_process:
   site: madrid
@@ -112,7 +112,7 @@ gender_violence_process:
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
   issue: women_term
-  scope: old_town
+  scope: old_town_term
   header_image_url: /assets/samples/process-b31e99553977f5da46a9f71d9c37a6ae90e8e3d7980363fa429f1c2a27c9f7ae.jpg
 
 commission_for_carnival_festivities:
@@ -148,4 +148,4 @@ center_scope_process:
   starts: <%= 3.days.ago %>
   ends: <%= 30.days.from_now %>
   issue: culture_term
-  scope: center
+  scope: center_term

--- a/test/forms/gobierto_admin/gobierto_common/scope_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_common/scope_form_test.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
       end
 
       def scope
-        @scope ||= gobierto_common_scopes(:center)
+        @scope ||= gobierto_common_terms(:center_term)
       end
 
       def site

--- a/test/forms/gobierto_admin/issue_form_test.rb
+++ b/test/forms/gobierto_admin/issue_form_test.rb
@@ -7,8 +7,8 @@ module GobiertoAdmin
     def valid_issue_form
       @valid_issue_form ||= IssueForm.new(
         site_id: site.id,
-        name_translations: { I18n.locale => issue.name },
-        description_translations: { I18n.locale => issue.description },
+        name_translations: { I18n.locale => "test" },
+        description_translations: { I18n.locale => "test description" },
         slug: nil
       )
     end

--- a/test/forms/gobierto_admin/issue_form_test.rb
+++ b/test/forms/gobierto_admin/issue_form_test.rb
@@ -23,11 +23,11 @@ module GobiertoAdmin
     end
 
     def issue
-      @issue ||= issues(:culture)
+      @issue ||= gobierto_common_terms(:culture_term)
     end
 
     def site
-      @site ||= sites(:santander)
+      @site ||= sites(:madrid)
     end
 
     def test_save_with_valid_attributes

--- a/test/integration/gobierto_admin/create_issue_test.rb
+++ b/test/integration/gobierto_admin/create_issue_test.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
   class CreateIssueTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = admin_issues_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "issues")
     end
 
     def admin
@@ -40,28 +40,28 @@ module GobiertoAdmin
 
             click_link "New"
 
-            fill_in "issue_name_translations_en", with: "My theme"
-            fill_in "issue_description_translations_en", with: "My theme description"
-            fill_in "issue_slug", with: "new-theme"
+            fill_in "term_name_translations_en", with: "My theme"
+            fill_in "term_description_translations_en", with: "My theme description"
+            fill_in "term_slug", with: "new-theme"
 
             click_link "ES"
-            fill_in "issue_name_translations_es", with: "Mi tema"
-            fill_in "issue_description_translations_es", with: "Descripción de mi tema"
+            fill_in "term_name_translations_es", with: "Mi tema"
+            fill_in "term_description_translations_es", with: "Descripción de mi tema"
 
             click_button "Create"
 
-            assert has_message?("Theme was successfully created.")
+            assert has_message?("Term created successfully.")
 
             click_link "My theme"
 
-            assert has_field?("issue_name_translations_en", with: "My theme")
-            assert has_field?("issue_description_translations_en", with: "My theme description")
-            assert has_field?("issue_slug", with: "new-theme")
+            assert has_field?("term_name_translations_en", with: "My theme")
+            assert has_field?("term_description_translations_en", with: "My theme description")
+            assert has_field?("term_slug", with: "new-theme")
 
             click_link "ES"
 
-            assert has_field?("issue_name_translations_es", with: "Mi tema")
-            assert has_field?("issue_description_translations_es", with: "Descripción de mi tema")
+            assert has_field?("term_name_translations_es", with: "Mi tema")
+            assert has_field?("term_description_translations_es", with: "Descripción de mi tema")
 
             issue = site.issues.first
             activity = Activity.last

--- a/test/integration/gobierto_admin/delete_issue_test.rb
+++ b/test/integration/gobierto_admin/delete_issue_test.rb
@@ -7,7 +7,7 @@ module GobiertoAdmin
 
     def setup
       super
-      @path = admin_issues_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "issues")
     end
 
     def admin
@@ -31,11 +31,11 @@ module GobiertoAdmin
         with_current_site(site) do
           visit @path
 
-          within "#issue-item-#{issue.id}" do
+          within "#term-item-#{issue.id}" do
             find("a[data-method='delete']").click
           end
 
-          assert has_message?('Theme was successfully destroyed.')
+          assert has_message?("Term deleted successfully.")
 
           refute site.issues.exists?(id: issue.id)
         end
@@ -47,11 +47,11 @@ module GobiertoAdmin
         with_current_site(site) do
           visit @path
 
-          within "#issue-item-#{issue_with_items.id}" do
+          within "#term-item-#{issue_with_items.id}" do
             find("a[data-method='delete']").click
           end
 
-          assert has_message?("You can't delete a theme while it has associated elements.")
+          assert has_message?("You can't delete a term while it has associated elements.")
 
           assert site.issues.exists?(id: issue_with_items.id)
         end

--- a/test/integration/gobierto_admin/delete_issue_test.rb
+++ b/test/integration/gobierto_admin/delete_issue_test.rb
@@ -19,11 +19,11 @@ module GobiertoAdmin
     end
 
     def issue
-      @issue ||= issues(:sports)
+      @issue ||= gobierto_common_terms(:sports_term)
     end
 
     def issue_with_items
-      @issue_with_items ||= issues(:culture)
+      @issue_with_items ||= gobierto_common_terms(:culture_term)
     end
 
     def test_delete_issue

--- a/test/integration/gobierto_admin/issue_index_test.rb
+++ b/test/integration/gobierto_admin/issue_index_test.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
   class IssueIndexTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = admin_issues_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "issues")
     end
 
     def admin
@@ -30,9 +30,9 @@ module GobiertoAdmin
             assert has_selector?("tr", count: issues.size)
 
             issues.each do |issue|
-              assert has_selector?("tr#issue-item-#{issue.id}")
+              assert has_selector?("tr#term-item-#{issue.id}")
 
-              within "tr#issue-item-#{issue.id}" do
+              within "tr#term-item-#{issue.id}" do
                 assert has_link?(issue.name.to_s)
               end
             end

--- a/test/integration/gobierto_admin/scopes/create_scope_test.rb
+++ b/test/integration/gobierto_admin/scopes/create_scope_test.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
   class CreateScopeTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = admin_scopes_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "scopes")
     end
 
     def admin
@@ -40,17 +40,17 @@ module GobiertoAdmin
 
             click_link "New"
 
-            fill_in "scope_name_translations_en", with: "New scope name"
-            fill_in "scope_description_translations_en", with: "New scope description"
+            fill_in "term_name_translations_en", with: "New scope name"
+            fill_in "term_description_translations_en", with: "New scope description"
 
             click_link "ES"
 
-            fill_in "scope_name_translations_es", with: "Nombre del nuevo ámbito"
-            fill_in "scope_description_translations_es", with: "Descripción del nuevo ámbito"
+            fill_in "term_name_translations_es", with: "Nombre del nuevo ámbito"
+            fill_in "term_description_translations_es", with: "Descripción del nuevo ámbito"
 
             click_button "Create"
 
-            assert has_message?("Scope was successfully created")
+            assert has_message?("Term created successfully")
 
             assert has_content?("New scope name")
 

--- a/test/integration/gobierto_admin/scopes/delete_scope_test.rb
+++ b/test/integration/gobierto_admin/scopes/delete_scope_test.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
   class DeleteScopeTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = admin_scopes_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "scopes")
       site.processes.where(scope: scope).update_all(scope_id: nil)
     end
 
@@ -19,11 +19,11 @@ module GobiertoAdmin
     end
 
     def scope
-      @scope ||= gobierto_common_scopes(:old_town)
+      @scope ||= gobierto_common_terms(:old_town_term)
     end
 
     def scope_with_items
-      @scope_with_items ||= gobierto_common_scopes(:center)
+      @scope_with_items ||= gobierto_common_terms(:center_term)
     end
 
     def test_delete_scope
@@ -31,11 +31,11 @@ module GobiertoAdmin
         with_current_site(site) do
           visit @path
 
-          within "#scope-item-#{scope.id}" do
+          within "#term-item-#{scope.id}" do
             find("a[data-method='delete']").click
           end
 
-          assert has_message?("Scope was successfully destroyed.")
+          assert has_message?("Term deleted successfully.")
 
           refute site.scopes.exists?(id: scope.id)
         end
@@ -47,11 +47,11 @@ module GobiertoAdmin
         with_current_site(site) do
           visit @path
 
-          within "#scope-item-#{scope_with_items.id}" do
+          within "#term-item-#{scope_with_items.id}" do
             find("a[data-method='delete']").click
           end
 
-          assert has_message?("You can't delete a scope while it has associated elements.")
+          assert has_message?("You can't delete a term while it has associated elements.")
 
           assert site.scopes.exists?(id: scope_with_items.id)
         end

--- a/test/integration/gobierto_admin/scopes/scopes_index_test.rb
+++ b/test/integration/gobierto_admin/scopes/scopes_index_test.rb
@@ -7,7 +7,7 @@ module GobiertoAdmin
 
     def setup
       super
-      @path = admin_scopes_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "scopes")
     end
 
     def admin
@@ -31,7 +31,7 @@ module GobiertoAdmin
             assert has_selector?('tr', count: scopes.size)
 
             scopes.each do |scope|
-              within "#scope-item-#{scope.id}" do
+              within "#term-item-#{scope.id}" do
                 assert has_link?(scope.name.to_s)
               end
             end

--- a/test/integration/gobierto_admin/scopes/update_scope_test.rb
+++ b/test/integration/gobierto_admin/scopes/update_scope_test.rb
@@ -7,7 +7,7 @@ module GobiertoAdmin
     
     def setup
       super
-      @path = admin_scopes_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "scopes")
     end
 
     def admin
@@ -19,7 +19,7 @@ module GobiertoAdmin
     end
 
     def scope
-      @scope ||= gobierto_common_scopes(:old_town)
+      @scope ||= gobierto_common_terms(:old_town_term)
     end
 
     def test_update_scope
@@ -30,12 +30,12 @@ module GobiertoAdmin
 
             click_link scope.name
 
-            fill_in 'scope_name_translations_en', with: 'Updated scope name'
-            fill_in 'scope_description_translations_en', with: 'Updated scope description'
+            fill_in 'term_name_translations_en', with: 'Updated scope name'
+            fill_in 'term_description_translations_en', with: 'Updated scope description'
 
             click_button 'Update'
 
-            assert has_message?('Scope was successfully updated')
+            assert has_message?('Term updated successfully.')
 
             # assert scope was updated
 

--- a/test/integration/gobierto_admin/update_issue_test.rb
+++ b/test/integration/gobierto_admin/update_issue_test.rb
@@ -18,7 +18,7 @@ module GobiertoAdmin
     end
 
     def participation_issue
-      @participation_issue ||= issues(:culture)
+      @participation_issue ||= gobierto_common_terms(:culture_term)
     end
 
     def test_update_issue

--- a/test/integration/gobierto_admin/update_issue_test.rb
+++ b/test/integration/gobierto_admin/update_issue_test.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
   class UpdateIssueTest < ActionDispatch::IntegrationTest
     def setup
       super
-      @path = admin_issues_path
+      @path = admin_ordered_vocabulary_terms_path(module: "gobierto_participation", vocabulary: "issues")
     end
 
     def admin
@@ -29,21 +29,21 @@ module GobiertoAdmin
 
             click_link participation_issue.name
 
-            within "form.edit_issue" do
-              fill_in "issue_name_translations_en", with: "Theme Culture updated"
-              fill_in "issue_description_translations_en", with: "Description Culture updated"
-              fill_in "issue_slug", with: "theme-culture-updated"
+            within "form.edit_term" do
+              fill_in "term_name_translations_en", with: "Theme Culture updated"
+              fill_in "term_description_translations_en", with: "Description Culture updated"
+              fill_in "term_slug", with: "theme-culture-updated"
 
               click_button "Update"
             end
 
-            assert has_message?("Theme was successfully updated.")
+            assert has_message?("Term updated successfully.")
 
             click_link participation_issue.name
 
-            assert has_field?("issue_name_translations_en", with: "Theme Culture updated")
-            assert has_field?("issue_description_translations_en", with: "Description Culture updated")
-            assert has_field?("issue_slug", with: "theme-culture-updated")
+            assert has_field?("term_name_translations_en", with: "Theme Culture updated")
+            assert has_field?("term_description_translations_en", with: "Description Culture updated")
+            assert has_field?("term_slug", with: "theme-culture-updated")
           end
         end
       end

--- a/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
@@ -9,7 +9,7 @@ module GobiertoParticipation
     end
 
     def issue
-      @issue ||= issues(:women)
+      @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
     def issue_attachments_path

--- a/test/integration/gobierto_participation/issues/issue_events_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_events_index_test.rb
@@ -9,7 +9,7 @@ module GobiertoParticipation
     end
 
     def issue
-      @issue ||= issues(:women)
+      @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
     def issue_events_path

--- a/test/integration/gobierto_participation/issues/issue_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_index_test.rb
@@ -14,7 +14,7 @@ module GobiertoParticipation
     end
 
     def issues
-      @issues ||= site.issues.sorted
+      @issues ||= Process.issues(site).sorted
     end
 
     def test_breadcrumb_items

--- a/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
@@ -9,7 +9,7 @@ module GobiertoParticipation
     end
 
     def issue
-      @issue ||= issues(:women)
+      @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
     def issue_pages_path

--- a/test/integration/gobierto_participation/issues/issue_show_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_show_test.rb
@@ -18,7 +18,7 @@ module GobiertoParticipation
     end
 
     def issue
-      @issue ||= issues(:women)
+      @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
     def processes

--- a/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
@@ -9,7 +9,7 @@ module GobiertoParticipation
     end
 
     def scope
-      @scope ||= gobierto_common_scopes(:old_town)
+      @scope ||= ProcessTermDecorator.new(gobierto_common_terms(:old_town_term))
     end
 
     def scope_attachments_path

--- a/test/integration/gobierto_participation/scopes/scope_events_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_events_index_test.rb
@@ -9,7 +9,7 @@ module GobiertoParticipation
     end
 
     def scope
-      @scope ||= gobierto_common_scopes(:old_town)
+      @scope ||= ProcessTermDecorator.new(gobierto_common_terms(:old_town_term))
     end
 
     def scope_events_path

--- a/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
@@ -9,7 +9,7 @@ module GobiertoParticipation
     end
 
     def scope
-      @scope ||= gobierto_common_scopes(:old_town)
+      @scope ||= gobierto_common_terms(:old_town_term)
     end
 
     def scope_pages_path

--- a/test/integration/gobierto_participation/scopes/scope_show_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_show_test.rb
@@ -18,7 +18,7 @@ module GobiertoParticipation
     end
 
     def scope_center
-      @scope_center ||= gobierto_common_scopes(:center)
+      @scope_center ||= ProcessTermDecorator.new(gobierto_common_terms(:center_term))
     end
 
     def processes

--- a/test/integration/gobierto_participation/welcome/welcome_index_test.rb
+++ b/test/integration/gobierto_participation/welcome/welcome_index_test.rb
@@ -22,7 +22,7 @@ module GobiertoParticipation
     end
 
     def issues
-      @issues ||= site.issues.sorted
+      @issues ||= Process.issues(site).sorted
     end
 
     def processes

--- a/test/models/gobierto_common/scope_test.rb
+++ b/test/models/gobierto_common/scope_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ScopeTest < ActiveSupport::TestCase
   def scope
-    @scope ||= gobierto_common_scopes(:center)
+    @scope ||= gobierto_common_terms(:center_term)
   end
 
   def test_valid

--- a/test/models/gobierto_common/term_test.rb
+++ b/test/models/gobierto_common/term_test.rb
@@ -40,7 +40,7 @@ class TermTest < ActiveSupport::TestCase
     new_term.save
     assert_equal 0, new_term.level
     assert_equal vocabulary, new_term.vocabulary
-    assert_equal nil, new_term.parent_term
+    assert_nil new_term.parent_term
     assert_equal 0, new_term.terms.count
   end
 end

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_common/has_vocabulary_test"
 
 module GobiertoParticipation
   class ProcessTest < ActiveSupport::TestCase
+
+    include ::GobiertoCommon::HasVocabularyTest
+
+    def setup
+      super
+      setup_has_vocabulary_module(
+        model: GobiertoParticipation::Process,
+        vocabularies: [:issues],
+        site_with_vocabularies: sites(:madrid),
+        site_without_vocabularies: sites(:organization_wadus)
+      )
+    end
 
     def green_city_group
       @green_city_group ||= gobierto_participation_processes(:green_city_group_active_empty)

--- a/test/models/gobierto_participation/process_test.rb
+++ b/test/models/gobierto_participation/process_test.rb
@@ -12,7 +12,7 @@ module GobiertoParticipation
       super
       setup_has_vocabulary_module(
         model: GobiertoParticipation::Process,
-        vocabularies: [:issues],
+        vocabularies: [:issues, :scopes],
         site_with_vocabularies: sites(:madrid),
         site_without_vocabularies: sites(:organization_wadus)
       )

--- a/test/pub_sub/subscribers/scope_activity_test.rb
+++ b/test/pub_sub/subscribers/scope_activity_test.rb
@@ -16,7 +16,7 @@ class Subscribers::ScopeActivityTest < ActiveSupport::TestCase
   end
 
   def scope
-    @scope ||= gobierto_common_scopes(:old_town)
+    @scope ||= gobierto_common_terms(:old_town_term)
   end
 
   def admin


### PR DESCRIPTION
Closes #1785

## :v: What does this PR do?
* Adds methods to replace issues and scopes functionalities to use terms of a vocabulary instead of own models.
* Replaces issues and scopes with terms of vocabularies 
* Adds a gobierto_participation configuration form to set vocabularies for issues or scopes
* Uses a common controller to manage issues and scopes terms as a ordered list, not including the parent relation between terms
## :mag: How should this be manually tested?

Go to the admin section and change configurations

## :eyes: Screenshots

https://www.dropbox.com/s/6hmjr41o7c77ju8/issues_scopes.mov?dl=0

## :shipit: Does this PR changes any configuration file?
No