### PR TITLE
Improve unemployment in observatory

### DIFF
--- a/app/javascript/observatory/modules/get_unemployment_age_data.js
+++ b/app/javascript/observatory/modules/get_unemployment_age_data.js
@@ -56,7 +56,7 @@ export var GetUnemploymentAgeData = Class.extend({
         }.bind(this));
 
         // Filtering values to start from the first data points
-        this.data = unemployed.filter(function(d) { return d.date >=this.parseTime('2011-01') }.bind(this));
+        this.data = unemployed.filter(function(d) { return d.age_range != '<25' && d.date >=this.parseTime('2011-01') }.bind(this));
 
         window.unemplAgeData = this.data;
 

--- a/app/javascript/observatory/modules/vis_unemployment_age.js
+++ b/app/javascript/observatory/modules/vis_unemployment_age.js
@@ -143,7 +143,7 @@ export var VisUnemploymentAge = Class.extend({
 
     this.focus.attr('transform', 'translate(' + this.xScale(d.data.date) + ',' + this.yScale(d.data.pct) + ')');
     this.focus.select('text').attr('text-anchor', d.data.date >= this.parseTime('2014-01') ? 'end' : 'start');
-    this.focus.select('tspan').text(this._getAgeRange(d.data.age_range) + ': ' + this.pctFormat(d.data.pct));
+    this.focus.select('tspan').text(`${this._getAgeRange(d.data.age_range)}: ${this.pctFormat(d.data.pct)} (${d.data.date.toLocaleString(I18n.locale, {month: 'short'})} ${d.data.date.getFullYear()})`);
   },
   _mouseout: function() {
     this.focus.attr('transform', 'translate(-100,-100)');

--- a/app/javascript/observatory/modules/vis_unemployment_rate.js
+++ b/app/javascript/observatory/modules/vis_unemployment_rate.js
@@ -185,7 +185,7 @@ export var VisUnemploymentRate = Class.extend({
 
     this.focus.attr('transform', 'translate(' + this.xScale(d.data.date) + ',' + this.yScale(d.data.value) + ')');
     this.focus.select('text').attr('text-anchor', d.data.date >= this.parseTime('2014-01') ? 'end' : 'start');
-    this.focus.select('tspan').text(this._getPlaceType(d.data.location_type) + ': ' + d.data.value + '%');
+    this.focus.select('tspan').text(`${this._getPlaceType(d.data.location_type)}: ${d.data.value}% (${d.data.date.toLocaleString(I18n.locale, {month: 'short'})} ${d.data.date.getFullYear()})`);
   },
   _mouseout: function() {
     this.focus.attr('transform', 'translate(-100,-100)');

--- a/app/javascript/observatory/modules/vis_unemployment_rate.js
+++ b/app/javascript/observatory/modules/vis_unemployment_rate.js
@@ -99,7 +99,8 @@ export var VisUnemploymentRate = Class.extend({
   updateRender: function() {
     this.xScale
       .rangeRound([0, this.width])
-      .domain([this.parseTime('2011-01'), d3.max(this.data, function(d) { return d.date; })]);
+      // TODO: restore 2011-01
+      .domain([this.parseTime('2015-11'), d3.max(this.data, function(d) { return d.date; })]);
 
     this.yScale
       .rangeRound([this.height, 0])

--- a/app/javascript/observatory/modules/vis_unemployment_sex.js
+++ b/app/javascript/observatory/modules/vis_unemployment_sex.js
@@ -194,7 +194,7 @@ export var VisUnemploymentSex = Class.extend({
     this.focus.select('circle').attr('stroke', this.color(d.data.sex));
     this.focus.attr('transform', 'translate(' + this.xScale(d.data.date) + ',' + this.yScale(d.data.pct) + ')');
     this.focus.select('text').attr('text-anchor', d.data.date >= this.parseTime('2014-01') ? 'end' : 'start');
-    this.focus.select('tspan').text(this._getLabel(d.data.sex) + ': ' + this.pctFormat(d.data.pct));
+    this.focus.select('tspan').text(`${this._getLabel(d.data.sex)}: ${this.pctFormat(d.data.pct)} (${d.data.date.toLocaleString(I18n.locale, {month: 'short'})} ${d.data.date.getFullYear()})`);
   },
   _mouseout: function() {
     this.focus.attr('transform', 'translate(-100,-100)');


### PR DESCRIPTION
Closes [#421](/PopulateTools/issues/issues/421)

## :v: What does this PR do?

- adds the month and the year to the tooltip
- removes the line with unemployment rate for people under 25 years old

## :mag: How should this be manually tested?

Visit an observatory in staging and check both points

## :eyes: Screenshots

### After this PR

![screen shot 2018-07-25 at 14 51 26](https://user-images.githubusercontent.com/17616/43202753-9af0ec8c-901c-11e8-8f13-12c4df62297f.png)
