### PR TITLE
1792 - Admin permissions for site, vocabularies and templates

### DIFF
--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -109,7 +109,7 @@ menu.main {
       li {
         padding: 0;
 
-        a {
+        a,span {
           padding: 0 0 0 2em;
         }
       }
@@ -121,7 +121,7 @@ menu.main {
       padding-top: 1em;
     }
 
-    a {
+    a,span {
       padding: 0.25em 1em;
       display: block;
       // color: $color_text;

--- a/app/controllers/gobierto_admin/admins_controller.rb
+++ b/app/controllers/gobierto_admin/admins_controller.rb
@@ -15,6 +15,7 @@ module GobiertoAdmin
 
       set_admin_policy
       set_site_modules
+      set_site_options
       set_sites
       set_people
       set_authorization_levels
@@ -27,12 +28,14 @@ module GobiertoAdmin
         @admin.attributes.except(*ignored_admin_attributes).merge(
           permitted_sites: @admin.sites.pluck(:id),
           permitted_modules:  @admin.modules_permissions.pluck(:resource_name),
-          permitted_people: @admin.people_permissions.pluck(:resource_id)
+          permitted_people: @admin.people_permissions.pluck(:resource_id),
+          permitted_site_options: @admin.site_options_permissions.pluck(:resource_name)
         )
       )
 
       set_admin_policy
       set_site_modules
+      set_site_options
       set_sites
       set_people
       set_authorization_levels
@@ -46,6 +49,7 @@ module GobiertoAdmin
 
       set_admin_policy
       set_site_modules
+      set_site_options
       set_sites
       set_people
       set_authorization_levels
@@ -67,6 +71,7 @@ module GobiertoAdmin
       @admin_form = AdminForm.new(admin_params.merge(id: params[:id]))
 
       set_site_modules
+      set_site_options
       set_sites
       set_people
       set_authorization_levels
@@ -96,7 +101,8 @@ module GobiertoAdmin
         :all_people_permitted,
         permitted_sites: [],
         permitted_modules: [],
-        permitted_people: []
+        permitted_people: [],
+        permitted_site_options: []
       )
     end
 
@@ -115,6 +121,15 @@ module GobiertoAdmin
     def set_site_modules
       @site_modules = APP_CONFIG["site_modules"].map do |site_module|
         OpenStruct.new(site_module)
+      end
+    end
+
+    def set_site_options
+      @site_options = Permission::SiteOption::RESOURCE_NAMES.map do |option_name|
+        OpenStruct.new(
+          name: option_name,
+          label_text: Permission::SiteOption.label_text(option_name)
+        )
       end
     end
 

--- a/app/controllers/gobierto_admin/gobierto_core/site_templates_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_core/site_templates_controller.rb
@@ -3,6 +3,9 @@
 module GobiertoAdmin
   module GobiertoCore
     class SiteTemplatesController < BaseController
+
+      before_action :check_permissions!
+
       def create
         @template = find_template
         @site_template_form = SiteTemplateForm.new(site_template_params.merge(site_id: current_site.id,
@@ -68,6 +71,11 @@ module GobiertoAdmin
       def find_template
         ::GobiertoCore::Template.find(params[:template_id])
       end
+
+      def check_permissions!
+        raise_module_not_allowed unless current_admin.can_edit_templates?
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_core/templates_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_core/templates_controller.rb
@@ -3,6 +3,9 @@
 module GobiertoAdmin
   module GobiertoCore
     class TemplatesController < BaseController
+
+      before_action :check_permissions!
+
       def index
         template = ::GobiertoCore::Template.first
         load_site_template_variables(template)
@@ -54,6 +57,11 @@ module GobiertoAdmin
 
         @default_template = File.read("app/views/" + template.template_path + ".liquid")
       end
+
+      def check_permissions!
+        raise_module_not_allowed unless current_admin.can_edit_templates?
+      end
+
     end
   end
 end

--- a/app/controllers/gobierto_admin/sites_controller.rb
+++ b/app/controllers/gobierto_admin/sites_controller.rb
@@ -2,7 +2,7 @@ module GobiertoAdmin
   class SitesController < BaseController
     def index
       site_policy = SitePolicy.new(current_admin)
-      raise Errors::NotAuthorized unless site_policy.view?
+      raise Errors::NotAuthorized unless site_policy.list?
 
       @sites = SiteCollectionDecorator.new(current_admin.sites.sorted)
     end

--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -16,6 +16,7 @@ module GobiertoAdmin
     has_many :global_permissions, class_name: 'Permission::Global'
     has_many :modules_permissions, -> { for_modules }, class_name: '::GobiertoAdmin::Permission'
     has_many :people_permissions,  -> { for_people }, class_name: '::GobiertoAdmin::Permission'
+    has_many :site_options_permissions, -> { for_site_options }, class_name: "GobiertoAdmin::Permission"
 
     has_many :gobierto_development_permissions, class_name: 'Permission::GobiertoDevelopment'
     has_many :gobierto_budgets_permissions, class_name: 'Permission::GobiertoBudgets'
@@ -72,6 +73,18 @@ module GobiertoAdmin
 
     def module_allowed?(module_namespace)
       managing_user? || send(module_namespace.underscore + '_permissions').any?
+    end
+
+    def can_customize_site?
+      managing_user? || site_options_permissions.exists?(resource_name: :customize)
+    end
+
+    def can_edit_vocabularies?
+      managing_user? || site_options_permissions.exists?(resource_name: :vocabularies)
+    end
+
+    def can_edit_templates?
+      managing_user? || site_options_permissions.exists?(resource_name: :templates)
     end
 
     private

--- a/app/models/gobierto_admin/permission.rb
+++ b/app/models/gobierto_admin/permission.rb
@@ -6,6 +6,7 @@ module GobiertoAdmin
 
     scope :for_modules, -> { where(namespace: 'site_module') }
     scope :for_people, -> { where(namespace: 'gobierto_people', resource_name: 'person') }
+    scope :for_site_options, -> { where(namespace: "site_options") }
 
     validates :admin_id, presence: true
     validates :namespace, presence: true

--- a/app/models/gobierto_admin/permission/site_option.rb
+++ b/app/models/gobierto_admin/permission/site_option.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class Permission::SiteOption < Permission
+
+    RESOURCE_NAMES = %i(customize vocabularies templates).freeze
+
+    def self.label_text(resource_name)
+      I18n.t("activerecord.attributes.gobierto_admin/permission/site_option.resource_names.#{resource_name}")
+    end
+
+  end
+end

--- a/app/policies/gobierto_admin/site_policy.rb
+++ b/app/policies/gobierto_admin/site_policy.rb
@@ -7,7 +7,7 @@ module GobiertoAdmin
       @site = site
     end
 
-    def view?
+    def list?
       manage?
     end
 
@@ -16,7 +16,7 @@ module GobiertoAdmin
     end
 
     def update?
-      manage?
+      admin.can_customize_site?
     end
 
     def delete?

--- a/app/views/gobierto_admin/admins/_form.html.erb
+++ b/app/views/gobierto_admin/admins/_form.html.erb
@@ -114,6 +114,25 @@
 
           </div>
 
+          <!-- Site options permissions -->
+          <h3><%= t(".site_options_permissions") %></h3>
+
+          <div class="form_item">
+            <div class="options compact">
+              <%= f.collection_check_boxes(:permitted_site_options, Array(@site_options), :name, :name) do |b| %>
+                <div class="option">
+                  <%= b.check_box(checked: @admin && @admin.site_options_permissions.exists?(resource_name: b.object.name)) %>
+                  <%= b.label do %>
+                    <span></span>
+                    <%= b.object.label_text %>
+                  <% end %>
+                </div>
+
+              <% end %>
+            </div>
+          </div>
+          <!-- ./ Site config permissions -->
+
         </div>
         <!-- ./ Module permissions -->
 

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -159,7 +159,11 @@
 
             <% if current_site %>
               <li>
-                <%= link_to_if current_admin.can_customize_site?, t(".edit_site"), edit_admin_site_path(current_site) %>
+                <% if false && current_admin.can_customize_site? %>
+                  <%= link_to t(".edit_site"), edit_admin_site_path(current_site) %>
+                <% else %>
+                  <span><%= t(".edit_site") %></span>
+                <% end %>
                 <ul>
                   <li><%= link_to t(".issues"), admin_issues_path %></li>
                   <li><%= link_to t(".scopes"), admin_scopes_path %></li>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -157,14 +157,18 @@
 
             <li><%= link_to t(".users"), admin_users_path %></li>
 
-            <% if managing_site? %>
+            <% if current_site %>
               <li>
-                <%= link_to t(".edit_site"), edit_admin_site_path(current_site) %>
+                <%= link_to_if current_admin.can_customize_site?, t(".edit_site"), edit_admin_site_path(current_site) %>
                 <ul>
                   <li><%= link_to t(".issues"), admin_issues_path %></li>
                   <li><%= link_to t(".scopes"), admin_scopes_path %></li>
-                  <li><%= link_to t(".vocabularies"), admin_common_vocabularies_path %></li>
-                  <li><%= link_to t(".templates"), admin_gobierto_core_templates_path %></li>
+                  <% if current_admin.can_edit_vocabularies? %>
+                    <li><%= link_to t(".vocabularies"), admin_common_vocabularies_path %></li>
+                  <% end %>
+                  <% if current_admin.can_edit_templates? %>
+                    <li><%= link_to t(".templates"), admin_gobierto_core_templates_path %></li>
+                  <% end %>
                 </ul>
               </li>
             <% end %>

--- a/config/locales/gobierto_admin/models/ca.yml
+++ b/config/locales/gobierto_admin/models/ca.yml
@@ -64,3 +64,10 @@ ca:
       gobierto_admin/user_form: Usuari
       gobierto_admin/user_password_form: Canvi de contrasenya
       gobierto_admin/user_welcome_message_form: Email de benvinguda
+  activerecord:
+    attributes:
+      gobierto_admin/permission/site_option:
+        resource_names:
+          customize: Personalitzar site
+          templates: Plantilles
+          vocabularies: Vocabularis

--- a/config/locales/gobierto_admin/models/en.yml
+++ b/config/locales/gobierto_admin/models/en.yml
@@ -64,3 +64,10 @@ en:
       gobierto_admin/user_form: User
       gobierto_admin/user_password_form: Password change
       gobierto_admin/user_welcome_message_form: Welcome message
+  activerecord:
+    attributes:
+      gobierto_admin/permission/site_option:
+        resource_names:
+          customize: Customize site
+          templates: Templates
+          vocabularies: Vocabularies

--- a/config/locales/gobierto_admin/models/es.yml
+++ b/config/locales/gobierto_admin/models/es.yml
@@ -64,3 +64,10 @@ es:
       gobierto_admin/user_form: Usuario
       gobierto_admin/user_password_form: Cambio de contraseña
       gobierto_admin/user_welcome_message_form: Email de bienvenida
+  activerecord:
+    attributes:
+      gobierto_admin/permission/site_option:
+        resource_names:
+          customize: Personalizar sitio
+          templates: Plantillas
+          vocabularies: Vocabularios

--- a/config/locales/gobierto_admin/views/admins/ca.yml
+++ b/config/locales/gobierto_admin/views/admins/ca.yml
@@ -16,6 +16,7 @@ ca:
         placeholders:
           email: fgonzalez@gmail.com
           name: Fernando González
+        site_options_permissions: Lloc web
         sites_block: Sites amb accés
       index:
         header:

--- a/config/locales/gobierto_admin/views/admins/en.yml
+++ b/config/locales/gobierto_admin/views/admins/en.yml
@@ -16,6 +16,7 @@ en:
         placeholders:
           email: fgonzalez@gmail.com
           name: Fernando González
+        site_options_permissions: Site
         sites_block: Allowed sites
       index:
         header:

--- a/config/locales/gobierto_admin/views/admins/es.yml
+++ b/config/locales/gobierto_admin/views/admins/es.yml
@@ -16,6 +16,7 @@ es:
         placeholders:
           email: fgonzalez@gmail.com
           name: Fernando González
+        site_options_permissions: Sitio web
         sites_block: Sites con acceso
       index:
         header:

--- a/test/controllers/gobierto_admin/sites_controller_test.rb
+++ b/test/controllers/gobierto_admin/sites_controller_test.rb
@@ -15,8 +15,12 @@ module GobiertoAdmin
       @admin ||= gobierto_admin_admins(:natasha)
     end
 
+    def regular_admin_with_customize_permissions
+      @regular_admin_with_customize_permissions ||= gobierto_admin_admins(:tony)
+    end
+
     def regular_admin
-      @regular_admin ||= gobierto_admin_admins(:tony)
+      @regular_admin ||= gobierto_admin_admins(:steve)
     end
 
     def site
@@ -54,6 +58,11 @@ module GobiertoAdmin
           get admin_sites_url
           assert_redirected_to admin_root_path
         end
+
+        with_signed_in_admin(regular_admin_with_customize_permissions) do
+          get admin_sites_url
+          assert_redirected_to admin_root_path
+        end
       end
     end
 
@@ -72,12 +81,22 @@ module GobiertoAdmin
           get new_admin_site_url
           assert_redirected_to admin_root_path
         end
+
+        with_signed_in_admin(regular_admin_with_customize_permissions) do
+          get new_admin_site_url
+          assert_redirected_to admin_root_path
+        end
       end
     end
 
     def test_edit
       with_current_site(site) do
         with_signed_in_admin(admin) do
+          get edit_admin_site_url(site)
+          assert_response :success
+        end
+
+        with_signed_in_admin(regular_admin_with_customize_permissions) do
           get edit_admin_site_url(site)
           assert_response :success
         end
@@ -108,12 +127,22 @@ module GobiertoAdmin
           post admin_sites_url, params: { site: valid_site_params }
           assert_redirected_to admin_root_path
         end
+
+        with_signed_in_admin(regular_admin_with_customize_permissions) do
+          post admin_sites_url, params: { site: valid_site_params }
+          assert_redirected_to admin_root_path
+        end
       end
     end
 
     def test_update
       with_current_site(site) do
         with_signed_in_admin(admin) do
+          patch admin_site_url(site), params: { site: valid_site_params }
+          assert_redirected_to edit_admin_site_path(site)
+        end
+
+        with_signed_in_admin(regular_admin_with_customize_permissions) do
           patch admin_site_url(site), params: { site: valid_site_params }
           assert_redirected_to edit_admin_site_path(site)
         end
@@ -141,6 +170,11 @@ module GobiertoAdmin
     def test_destroy_not_authorized
       with_current_site(site) do
         with_signed_in_admin(regular_admin) do
+          delete admin_site_url(site)
+          assert_redirected_to admin_root_path
+        end
+
+        with_signed_in_admin(regular_admin_with_customize_permissions) do
           delete admin_site_url(site)
           assert_redirected_to admin_root_path
         end

--- a/test/fixtures/gobierto_admin/permissions.yml
+++ b/test/fixtures/gobierto_admin/permissions.yml
@@ -29,3 +29,15 @@ tony_tamara:
   resource_name: person
   resource_id: <%= ActiveRecord::FixtureSet.identify(:tamara) %>
   action_name: manage
+
+tony_site_options_customize:
+  admin: tony
+  namespace: site_options
+  resource_name: customize
+  action_name: manage
+
+tony_site_options_vocabularies:
+  admin: tony
+  namespace: site_options
+  resource_name: vocabularies
+  action_name: manage

--- a/test/forms/gobierto_admin/admin_form_test.rb
+++ b/test/forms/gobierto_admin/admin_form_test.rb
@@ -321,5 +321,31 @@ module GobiertoAdmin
       assert madrid_and_santander_admin.people_permissions.empty?
     end
 
+    def test_grant_site_options_permissions
+      admin_form = AdminForm.new(admin_params.merge(
+        id: tony.id,
+        permitted_site_options: %w(customize vocabularies templates)
+      ))
+
+      assert_equal 2, tony.site_options_permissions.size
+
+      assert admin_form.save
+
+      assert_equal 3, tony.site_options_permissions.size
+    end
+
+    def test_revoke_site_options_permissions
+      admin_form = AdminForm.new(admin_params.merge(
+        id: tony.id,
+        permitted_site_options: %w(templates)
+      ))
+
+      assert_equal 2, tony.site_options_permissions.size
+
+      assert admin_form.save
+
+      assert_equal 1, tony.site_options_permissions.size
+    end
+
   end
 end

--- a/test/integration/gobierto_admin/admins/admin_create_test.rb
+++ b/test/integration/gobierto_admin/admins/admin_create_test.rb
@@ -98,7 +98,7 @@ module GobiertoAdmin
       assert has_message?("Data updated successfully")
     end
 
-    def test_create_admin_with_sites_modules_and_people
+    def test_create_regular_admin_with_custom_permissions
       with_javascript do
         with_signed_in_admin(admin) do
           visit @path
@@ -118,6 +118,9 @@ module GobiertoAdmin
           # grant permissions for Richard Rider
           find("label[for='admin_permitted_people_#{richard.id}']", visible: false).trigger(:click)
 
+          # grant permissions for Templates
+          find("label[for='admin_permitted_site_options_templates']").click
+
           click_button "Create"
 
           assert has_message?("Admin was successfully created")
@@ -126,8 +129,9 @@ module GobiertoAdmin
 
       new_admin = ::GobiertoAdmin::Admin.last
       permissions = new_admin.permissions
-      module_permission = permissions.find_by(resource_name: "gobierto_people")
-      person_permission = permissions.find_by(resource_name: "person")
+      module_permission = new_admin.modules_permissions.first
+      person_permission = new_admin.people_permissions.first
+      site_option_permission = new_admin.site_options_permissions.first
 
       # assert site permissions
 
@@ -135,7 +139,7 @@ module GobiertoAdmin
 
       # assert total permissions
 
-      assert_equal 2, permissions.size
+      assert_equal 3, permissions.size
 
       # assert module permissions
 
@@ -148,6 +152,12 @@ module GobiertoAdmin
       assert_equal "gobierto_people", person_permission.namespace
       assert_equal richard.id, person_permission.resource_id
       assert_equal "manage", person_permission.action_name
+
+      # assert site options permissions
+
+      assert_equal "site_options", site_option_permission.namespace
+      assert_equal "templates", site_option_permission.resource_name
+      assert_equal "manage", site_option_permission.action_name
     end
   end
 end

--- a/test/integration/gobierto_admin/admins/admin_update_test.rb
+++ b/test/integration/gobierto_admin/admins/admin_update_test.rb
@@ -44,6 +44,9 @@ module GobiertoAdmin
             check "madrid.gobierto.test"
           end
 
+          uncheck "Vocabularies"
+          check "Templates"
+
           within ".admin-authorization-level-radio-buttons" do
             choose "Regular"
           end
@@ -66,6 +69,9 @@ module GobiertoAdmin
             assert has_no_checked_field?("santander.gobierto.test")
             assert has_checked_field?("madrid.gobierto.test")
           end
+
+          assert has_no_checked_field?("Vocabularies")
+          assert has_checked_field?("Templates")
 
           within ".admin-authorization-level-radio-buttons" do
             assert has_checked_field?("Regular")

--- a/test/integration/gobierto_admin/gobierto_core/templates/index_templates_test.rb
+++ b/test/integration/gobierto_admin/gobierto_core/templates/index_templates_test.rb
@@ -14,6 +14,10 @@ module GobiertoAdmin
         @admin ||= gobierto_admin_admins(:nick)
       end
 
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:tony)
+      end
+
       def site
         @site ||= sites(:madrid)
       end
@@ -30,6 +34,19 @@ module GobiertoAdmin
             within ".file_browser" do
               assert has_link? template.template_path.split("/").last
             end
+          end
+        end
+      end
+
+      def test_index_when_unauthorized
+        unauthorized_admin.site_options_permissions.destroy_all
+
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_core/templates/site_templates_test.rb
+++ b/test/integration/gobierto_admin/gobierto_core/templates/site_templates_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCore
+    class SiteTemplatesTest < ActionDispatch::IntegrationTest
+
+      include PermissionHelpers
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def regular_admin
+        @regular_admin ||= gobierto_admin_admins(:tony)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def setup
+        grant_templates_permission(regular_admin)
+        super
+      end
+
+      def test_create_when_unauthorized
+        with_signed_in_admin(regular_admin) do
+          with_current_site(site) do
+            visit admin_root_path
+
+            click_link "Templates"
+
+            revoke_templates_permission(regular_admin)
+
+            click_button "Save"
+
+            assert has_content? "You are not authorized to perform this action"
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+      def test_edit_when_unauthorized
+        with_signed_in_admin(regular_admin) do
+          with_current_site(site) do
+            visit admin_root_path
+
+            click_link "Templates"
+
+            revoke_templates_permission(regular_admin)
+
+            click_link "application"
+
+            assert has_content? "You are not authorized to perform this action"
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+      def test_destroy_when_unauthorized
+        with_signed_in_admin(regular_admin) do
+          with_current_site(site) do
+            visit admin_root_path
+
+            click_link "Templates"
+
+            revoke_templates_permission(regular_admin)
+
+            click_button "Reset"
+
+            assert has_content? "You are not authorized to perform this action"
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/test/policies/gobierto_admin/site_policy_test.rb
+++ b/test/policies/gobierto_admin/site_policy_test.rb
@@ -4,8 +4,13 @@ require "test_helper"
 
 module GobiertoAdmin
   class SitePolicyTest < ActiveSupport::TestCase
+
+    def regular_admin_with_customize_permissions
+      @regular_admin_with_customize_permissions ||= gobierto_admin_admins(:tony)
+    end
+
     def regular_admin
-      @regular_admin ||= gobierto_admin_admins(:tony)
+      @regular_admin ||= gobierto_admin_admins(:steve)
     end
 
     def manager_admin
@@ -16,24 +21,28 @@ module GobiertoAdmin
       @site ||= sites(:madrid)
     end
 
-    def test_view?
-      assert SitePolicy.new(manager_admin, site).view?
-      refute SitePolicy.new(regular_admin, site).view?
+    def test_list
+      assert SitePolicy.new(manager_admin, site).list?
+      refute SitePolicy.new(regular_admin, site).list?
+      refute SitePolicy.new(regular_admin_with_customize_permissions, site).list?
     end
 
     def test_create?
       assert SitePolicy.new(manager_admin, site).create?
       refute SitePolicy.new(regular_admin, site).create?
+      refute SitePolicy.new(regular_admin_with_customize_permissions, site).create?
     end
 
     def test_update?
       assert SitePolicy.new(manager_admin, site).update?
       refute SitePolicy.new(regular_admin, site).update?
+      assert SitePolicy.new(regular_admin_with_customize_permissions, site).update?
     end
 
     def test_delete?
       assert SitePolicy.new(manager_admin, site).delete?
       refute SitePolicy.new(regular_admin, site).delete?
+      refute SitePolicy.new(regular_admin_with_customize_permissions, site).delete?
     end
   end
 end

--- a/test/support/permission_helpers.rb
+++ b/test/support/permission_helpers.rb
@@ -48,4 +48,27 @@ module PermissionHelpers
     admin.save
   end
 
+  def grant_templates_permission(admin)
+    admin.permissions.build(
+      namespace: "site_options",
+      resource_name: "templates",
+      action_name: "manage"
+    )
+    admin.save
+  end
+
+  def revoke_templates_permission(admin)
+    admin.site_options_permissions.where(
+      resource_name: "templates",
+      action_name: "manage"
+    ).destroy_all
+  end
+
+  def revoke_customize_site_permission(admin)
+    admin.site_options_permissions.where(
+      resource_name: "customize",
+      action_name: "manage"
+    ).destroy_all
+  end
+
 end


### PR DESCRIPTION
Closes #1792 

## :v: What does this PR do?

Permits granting/revoking permissions to regular admins so they may:

* Customize the sites they have access to
* Edit the templates of the sites they have access to
* Manage the vocabularies of the sites they have access to

## :mag: How should this be manually tested?

1. Login in two different brosers in madrid.gobify.net/admin, in one as admin and in other as regular
2. Test granting/revoking the new permissions to the regular admin, and in the window of the regular admin check everything gets updated accordingly.

## :eyes: Screencast

Search for link in Slack with #1792 

## :shipit: Does this PR changes any configuration file?

No

## Pending work

- [ ] Fix the styles of "Customize site" in sidebar when it is not displayed as a link but as text.
- [x] The "Vocabularies" tabs is hidden when there are no permissions, but protecting controller actions with filters dependes on pull [#1799](https://github.com/PopulateTools/gobierto/pull/1799). Also the integration tests for this case are pending.