### PR TITLE
Improve support for IBM Notes time zones

### DIFF
--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -7,10 +7,10 @@ module GobiertoPeople
       def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
-          @events = @person.attending_events.by_date(@filtering_date)
+          @events = @person.attending_events.by_date(@filtering_date).published
           @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         else
-          @events = QueryWithEvents.new(source: @person.attending_events,
+          @events = QueryWithEvents.new(source: @person.attending_events.published,
                                         start_date: filter_start_date,
                                         end_date: filter_end_date).upcoming.sorted.page params[:page]
         end
@@ -54,7 +54,7 @@ module GobiertoPeople
       end
 
       def set_calendar_events
-        @calendar_events = @person.attending_events
+        @calendar_events = @person.attending_events.published
       end
 
       def person_events_scope

--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -36,7 +36,7 @@ module IbmNotes
           when "Europe/Madrid"
             ActiveSupport::TimeZone["Madrid"]
           else
-            raise "Unknown timezone #{event["start"]["tzid"]}"
+            Rollbar.error(Exception.new("[GobiertoCalendars] Unknown IBM Notes time zone #{event["start"]["tzid"]}"))
           end
       end
 

--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -25,8 +25,20 @@ module IbmNotes
     end
 
     def set_start_and_end_date(event)
-      if event["start"]["tzid"].present? && event["start"]["tzid"] == "Romance Standard Time"
-        time_zone = ActiveSupport::TimeZone["Madrid"]
+      time_zone = if event["start"]["tzid"].present?
+        case event["start"]["tzid"]
+          when "Romance Standard Time"
+            ActiveSupport::TimeZone["Madrid"]
+          when "Western/Central Europe"
+            ActiveSupport::TimeZone["CET"]
+          when "GMT+1 Standard Time"
+            ActiveSupport::TimeZone["Madrid"]
+          else
+            raise "Unknown timezone #{event["start"]["tzid"]}"
+          end
+      end
+
+      if time_zone
         @starts_at = time_zone.parse("#{event["start"]["date"]} #{event["start"]["time"]}").utc
         @ends_at = time_zone.parse("#{event["end"]["date"]} #{event["end"]["time"]}").utc || starts_at + 1.hour
       else # assume UTC

--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -30,8 +30,10 @@ module IbmNotes
           when "Romance Standard Time"
             ActiveSupport::TimeZone["Madrid"]
           when "Western/Central Europe"
-            ActiveSupport::TimeZone["CET"]
+            ActiveSupport::TimeZone["Madrid"]
           when "GMT+1 Standard Time"
+            ActiveSupport::TimeZone["Madrid"]
+          when "Europe/Madrid"
             ActiveSupport::TimeZone["Madrid"]
           else
             raise "Unknown timezone #{event["start"]["tzid"]}"

--- a/test/lib/ibm_notes/person_event_test.rb
+++ b/test/lib/ibm_notes/person_event_test.rb
@@ -68,6 +68,26 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
     assert_equal utc_time("2017-04-11 11:00:00"), persisted_ibm_notes_event.ends_at
   end
 
+  def test_parse_time_zones
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(start: { "date" => "2017-04-11", "time" => "10:00:00", "tzid" => "GMT+1 Standard Time" }))
+
+    assert_equal utc_time("2017-04-11 08:00:00"), ibm_notes_event.starts_at
+  end
+
+  def test_parse_unknown_time_zone
+    assert_raise do
+      IbmNotes::PersonEvent.new(person, response_data(start: { "date" => "2017-04-11", "time" => "10:00:00", "tzid" => "Unkown" }))
+    end
+  end
+
+  def test_parse_unknown_time_zone
+    assert_equal "Ibm Notes persisted event ID", persisted_ibm_notes_event.id
+    assert_equal "Ibm Notes persisted event title", persisted_ibm_notes_event.title
+    assert_equal person, persisted_ibm_notes_event.person
+    assert_equal utc_time("2017-04-11 10:00:00"), persisted_ibm_notes_event.starts_at
+    assert_equal utc_time("2017-04-11 11:00:00"), persisted_ibm_notes_event.ends_at
+  end
+
   def test_initialize_event_location
     ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(location: nil))
 


### PR DESCRIPTION
Closes [#422](/PopulateTools/issues/issues/422)

## :v: What does this PR do?

- Adds support to new timezones from IBM Notes
- Raises a Rollbar exception when a new timezone is detected
- Fixes query that renders calendar widget to consider only published events

## :mag: How should this be manually tested?

- import events from an IBM Notes account
- check no days are marked in the calendar if there are no published events
