### PR TITLE
Fix controller scopes when date filtering is not configured

### DIFF
--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -41,8 +41,10 @@ module GobiertoPeople
     private
 
     def site_configuration_date_range
-      @site_configuration_date_range ||= { start_date: parse_date(current_site.configuration.configuration_variables["gobierto_people_default_filter_start_date"]),
-                                           end_date: parse_date(current_site.configuration.configuration_variables["gobierto_people_default_filter_end_date"]) }
+      @site_configuration_date_range ||= {
+        start_date: parse_date(current_site.configuration.configuration_variables["gobierto_people_default_filter_start_date"].to_s),
+        end_date: parse_date(current_site.configuration.configuration_variables["gobierto_people_default_filter_end_date"].to_s)
+      }
     end
 
     def parse_date(date, fallback = nil)

--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -15,11 +15,15 @@ module GobiertoPeople
     end
 
     def all_start_date
-      current_site.events.published.order(starts_at: :asc).first.starts_at if site_configuration_date_range[:start_date].present?
+      if site_configuration_date_range[:start_date].present? && current_site.events.any?
+        current_site.events.published.order(starts_at: :asc).first.starts_at
+      end
     end
 
     def all_end_date
-      current_site.events.published.order(ends_at: :desc).first.ends_at if site_configuration_date_range[:end_date].present?
+      if site_configuration_date_range[:end_date].present? && current_site.events.any?
+        current_site.events.published.order(ends_at: :desc).first.ends_at
+      end
     end
 
     def filter_start_date

--- a/app/controllers/gobierto_people/departments/people_controller.rb
+++ b/app/controllers/gobierto_people/departments/people_controller.rb
@@ -15,11 +15,15 @@ module GobiertoPeople
           end_date: filter_end_date
         ).sorted
 
-        @sidebar_departments = QueryWithEvents.new(
-          source: current_site.departments,
-          start_date: filter_start_date,
-          end_date: filter_end_date
-        )
+        @sidebar_departments = current_site.departments
+
+        if current_site.date_filter_configured?
+          @sidebar_departments = QueryWithEvents.new(
+            source: @sidebar_departments,
+            start_date: filter_start_date,
+            end_date: filter_end_date
+          )
+        end
 
         render "gobierto_people/people/index"
       end

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -94,11 +94,16 @@ module GobiertoPeople
     end
 
     def set_people
-      @people = QueryWithEvents.new(
-        source: current_site.people.active,
-        start_date: filter_start_date,
-        end_date: filter_end_date
-      ).sorted
+      @people = current_site.people.active.sorted
+
+      if current_site.date_filter_configured?
+        @people = QueryWithEvents.new(
+          source: @people,
+          start_date: filter_start_date,
+          end_date: filter_end_date
+        ).sorted
+      end
+
       @people = @people.send(Person.categories.key(@person_category)) if @person_category
       @people = @people.send(Person.parties.key(@person_party)) if @person_party
     end

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -16,10 +16,7 @@ module GobiertoPeople
       set_events
       set_present_groups
 
-      # TODO: this info is only needed for custom engine
-      @gifts = current_site.gifts.limit(4).between_dates(filter_start_date, filter_end_date)
-      @invitations = current_site.invitations.limit(4).between_dates(filter_start_date, filter_end_date)
-      load_home_statistics
+      load_custom_engine_data if current_site.date_filter_configured?
     end
 
     private
@@ -44,7 +41,11 @@ module GobiertoPeople
       current_site.gobierto_people_settings&.send("home_text_#{I18n.locale}")
     end
 
-    def load_home_statistics
+    def load_custom_engine_data
+      @gifts = current_site.gifts.limit(4).between_dates(filter_start_date, filter_end_date)
+      @invitations = current_site.invitations.limit(4).between_dates(filter_start_date, filter_end_date)
+
+      # home statistics
       people = QueryWithEvents.new(source: current_site.event_attendances,
                                    start_date: filter_start_date,
                                    end_date: filter_end_date,
@@ -58,5 +59,6 @@ module GobiertoPeople
         total_people_with_attendances: people.select(:person_id).distinct.count
       }
     end
+
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -161,6 +161,16 @@ class Site < ApplicationRecord
     departments.any? && gobierto_people_settings.submodules_enabled.include?("departments")
   end
 
+  def date_filter_configured?
+    [
+      Time.zone.parse(configuration.configuration_variables["gobierto_people_default_filter_start_date"].to_s),
+      Time.zone.parse(configuration.configuration_variables["gobierto_people_default_filter_end_date"].to_s)
+    ].any?
+  rescue StandardError => e
+    Rollbar.error(e)
+    false
+  end
+
   private
 
   def site_configuration_attributes

--- a/test/integration/gobierto_people/departments/index_test.rb
+++ b/test/integration/gobierto_people/departments/index_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  module Departments
+    class IndexTest < ActionDispatch::IntegrationTest
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def justice_department
+        @justice_department ||= gobierto_people_departments(:justice_department)
+      end
+
+      def culture_department
+        @culture_department ||= gobierto_people_departments(:culture_department)
+      end
+
+      def set_default_dates
+        conf = site.configuration
+        conf.raw_configuration_variables = <<-YAML
+gobierto_people_default_filter_start_date: "2010-01-01"
+YAML
+        site.save
+      end
+
+      def setup
+        culture_department.events.destroy_all
+        super
+      end
+
+      def test_without_date_filtering_configured
+        with_current_site(site) do
+          visit gobierto_people_departments_path
+
+          assert has_link? justice_department.name
+          assert has_link? culture_department.name
+        end
+      end
+
+      def test_with_date_filtering_configured
+        set_default_dates
+
+        with_current_site(site) do
+          visit gobierto_people_departments_path
+
+          assert has_link? justice_department.name
+          refute has_link? culture_department.name
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -67,6 +67,29 @@ YAML
         ".pure-u-1.pure-u-md-7-24"
       end
 
+      def test_sidebar_contents
+        culture_department.events.destroy_all
+
+        with_current_site(site) do
+          # without date filtering configured
+          visit gobierto_people_department_people_path(justice_department)
+
+          within departments_sidebar do
+            assert has_link? justice_department.name
+            assert has_link? culture_department.name
+          end
+
+          # with date filtering configured
+          set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
+          visit gobierto_people_department_people_path(justice_department)
+
+          within departments_sidebar do
+            assert has_link? justice_department.name
+            refute has_link? culture_department.name
+          end
+        end
+      end
+
       def test_index
         with_current_site(site) do
           visit gobierto_people_department_people_path(justice_department)

--- a/test/integration/gobierto_people/departments/show_test.rb
+++ b/test/integration/gobierto_people/departments/show_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPeople
+  module Departments
+    class ShowTest < ActionDispatch::IntegrationTest
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def department
+        @department ||= gobierto_people_departments(:justice_department)
+      end
+
+      def test_show
+        with_current_site(site) do
+          visit gobierto_people_department_path(department)
+
+          assert has_content? department.name
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -19,11 +19,19 @@ module GobiertoPeople
       @site ||= sites(:madrid)
     end
 
+    def richard
+      @richard ||= gobierto_people_people(:richard)
+    end
+
+    def tamara
+      @tamara ||= gobierto_people_people(:tamara)
+    end
+
     def people
       @people ||= [
-        gobierto_people_people(:richard),
+        richard,
         gobierto_people_people(:nelson),
-        gobierto_people_people(:tamara),
+        tamara,
         gobierto_people_people(:neil)
       ]
     end
@@ -49,11 +57,20 @@ module GobiertoPeople
       ".pure-u-1.pure-u-md-7-24"
     end
 
+    def available_filters
+      ["Government Team", "Opposition", "Executive", "All", "Political groups"]
+    end
+
     def set_default_dates
       conf = site.configuration
       conf.raw_configuration_variables = <<-YAML
 gobierto_people_default_filter_start_date: "2010-01-01"
 YAML
+      site.save
+    end
+
+    def clear_default_dates
+      site.configuration.raw_configuration_variables = nil
       site.save
     end
 
@@ -66,11 +83,45 @@ YAML
         assert has_selector?("h2", text: "#{site.name}'s organization chart")
 
         within ".filter_boxed" do
-          assert has_link?("Government Team")
-          assert has_link?("Opposition")
-          assert has_link?("Executive")
-          assert has_link?("All")
-          assert has_link?("Political groups")
+          available_filters.each { |filter| assert has_link?(filter) }
+        end
+      end
+    end
+
+    def test_when_date_filering_enabled
+      disable_submodule(site, :departments)
+      tamara.attending_events.destroy_all
+      set_default_dates
+
+      with_current_site(site) do
+        visit @path
+
+        within ".filter_boxed" do
+          available_filters.each { |filter| assert has_link?(filter) }
+        end
+
+        within ".people-summary" do
+          assert has_content? richard.name
+          refute has_content? tamara.name # hide people without events
+        end
+      end
+    end
+
+    def test_when_date_filtering_disabled
+      disable_submodule(site, :departments)
+      tamara.attending_events.destroy_all
+      clear_default_dates
+
+      with_current_site(site) do
+        visit @path
+
+        within ".filter_boxed" do
+          available_filters.each { |filter| assert has_link?(filter) }
+        end
+
+        within ".people-summary" do
+          assert has_content? richard.name
+          assert has_content? tamara.name # show people without events
         end
       end
     end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -99,4 +99,45 @@ class SiteTest < ActiveSupport::TestCase
     site.save
     assert site.errors.messages[:base].one?
   end
+
+  def test_date_filter_configured?
+    conf = site.configuration
+
+    refute site.date_filter_configured?
+
+    # only start_date
+    conf.raw_configuration_variables = <<-YAML
+gobierto_people_default_filter_start_date: 2010-01-23
+    YAML
+    site.save
+
+    assert site.date_filter_configured?
+
+    # only end_date
+    conf.raw_configuration_variables = <<-YAML
+gobierto_people_default_filter_end_date: "2010-01-23"
+    YAML
+    site.save
+
+    assert site.date_filter_configured?
+
+    # both dates
+    conf.raw_configuration_variables = <<-YAML
+gobierto_people_default_filter_start_date: "2010-01-23"
+gobierto_people_default_filter_end_date: "2010-01-23"
+    YAML
+    site.save
+
+    assert site.date_filter_configured?
+
+    # blank options
+    conf.raw_configuration_variables = <<-YAML
+gobierto_people_default_filter_start_date: ""
+gobierto_people_default_filter_end_date:
+    YAML
+    site.save
+
+    refute site.date_filter_configured?
+  end
+
 end


### PR DESCRIPTION
## What does this PR do?

* Fixes the scope of several controllers when the date filter is not configured
* Makes setting the date filter variable more robust by supporting things like nil, "" and 2010-01-02 (without quotes)
* Adds a few missing tests

## How to test this

* In staging, check that a person without events (for example: http://madrid.gobify.net/admin/people/people/1359/edit) is shown in http://madrid.gobify.net/personas.
* I compared the content and counters of several pages in development with staging for the site we have with the custom engine and it looked the same