### PR TITLE
Add Central Europe Standard Time to IBM Notes time zone

### DIFF
--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -35,6 +35,8 @@ module IbmNotes
             ActiveSupport::TimeZone["Madrid"]
           when "Europe/Madrid"
             ActiveSupport::TimeZone["Madrid"]
+          when "Central Europe Standard Time"
+            ActiveSupport::TimeZone["Madrid"]
           else
             Rollbar.error(Exception.new("[GobiertoCalendars] Unknown IBM Notes time zone #{event["start"]["tzid"]}"))
           end


### PR DESCRIPTION
Unexpected


## :v: What does this PR do?

Add Central Europe Standard Time to IBM Notes time zone