### PR TITLE
1787 migrate political groups to vocabularies

### DIFF
--- a/app/controllers/concerns/gobierto_people/political_groups_helper.rb
+++ b/app/controllers/concerns/gobierto_people/political_groups_helper.rb
@@ -6,7 +6,8 @@ module GobiertoPeople
 
     def get_political_groups
       person_table = Person.table_name
-      PoliticalGroup.includes(:people).where.not(person_table => { political_group_id: nil }).where(person_table => { site_id: current_site.id, visibility_level: 1 }).all
+      join_clause = "JOIN #{person_table} ON #{person_table}.political_group_id = terms.id"
+      current_site.political_groups.distinct.joins(join_clause).where.not(person_table => { political_group_id: nil }).where(person_table => { site_id: current_site.id, visibility_level: 1 }).all
     end
   end
 end

--- a/app/controllers/concerns/gobierto_people/political_groups_helper.rb
+++ b/app/controllers/concerns/gobierto_people/political_groups_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoPeople
   module PoliticalGroupsHelper
     extend ActiveSupport::Concern
@@ -7,7 +9,16 @@ module GobiertoPeople
     def get_political_groups
       person_table = Person.table_name
       join_clause = "JOIN #{person_table} ON #{person_table}.political_group_id = terms.id"
-      current_site.political_groups.distinct.joins(join_clause).where.not(person_table => { political_group_id: nil }).where(person_table => { site_id: current_site.id, visibility_level: 1 }).all
+      current_site.political_groups.distinct.joins(join_clause).where.not(
+        person_table => {
+          political_group_id: nil
+        }
+      ).where(
+        person_table => {
+          site_id: current_site.id,
+          visibility_level: 1
+        }
+      ).all
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_people/configuration/settings_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/configuration/settings_controller.rb
@@ -32,6 +32,7 @@ module GobiertoAdmin
             :calendar_integration,
             :ibm_notes_usr,
             :ibm_notes_pwd,
+            :political_groups_vocabulary_id,
             submodules_enabled: []
           )
         end

--- a/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_people/people_controller.rb
@@ -94,7 +94,7 @@ module GobiertoAdmin
       end
 
       def get_political_groups
-        ::GobiertoPeople::PoliticalGroup.all
+        current_site.political_groups
       end
 
       def person_params

--- a/app/controllers/gobierto_people/political_groups/base_controller.rb
+++ b/app/controllers/gobierto_people/political_groups/base_controller.rb
@@ -8,13 +8,13 @@ module GobiertoPeople
       private
 
       def set_political_group
-        @political_group = find_political_group
+        @political_group = PersonTermDecorator.new(find_political_group)
       end
 
       protected
 
       def find_political_group
-        PoliticalGroup.find_by!(slug: params[:political_group_slug])
+        current_site.political_groups.find_by!(slug: params[:political_group_slug])
       end
     end
   end

--- a/app/decorators/gobierto_people/person_term_decorator.rb
+++ b/app/decorators/gobierto_people/person_term_decorator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class PersonTermDecorator < BaseDecorator
+    def initialize(term)
+      @object = term
+    end
+
+    def people
+      return GobiertoPeople::Person.none unless association_with_people
+      GobiertoPeople::Person.where(association_with_people => object)
+    end
+
+    def events
+      collections_table = GobiertoCommon::Collection.table_name
+      site.events.distinct.includes(:collection).where(collections_table => { container: people })
+    end
+
+    def site
+      @site ||= object.vocabulary.site
+    end
+
+    protected
+
+    def association_with_people
+      @association_with_people ||= begin
+                                     return unless people_settings.present?
+                                     GobiertoPeople::Person.vocabularies.find do |_, setting|
+                                       people_settings.send(setting).to_i == object.vocabulary_id.to_i
+                                     end&.first
+                                   end
+    end
+
+    def people_settings
+      @people_settings ||= site.gobierto_people_settings
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_people/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/settings_form.rb
@@ -11,7 +11,8 @@ module GobiertoAdmin
         :home_text_es,
         :home_text_ca,
         :home_text_en,
-        :submodules_enabled
+        :submodules_enabled,
+        :political_groups_vocabulary_id
       )
 
       delegate :persisted?, to: :gobierto_module_settings
@@ -67,6 +68,16 @@ module GobiertoAdmin
         html_dummy_for_encrypted_setting(ibm_notes_pwd)
       end
 
+      def site
+        @site ||= Site.find site_id
+      end
+
+      def vocabularies_options
+        site.vocabularies.map do |vocabulary|
+          [vocabulary.name, vocabulary.id]
+        end
+      end
+
       private
 
       def gobierto_module_settings_class
@@ -86,6 +97,7 @@ module GobiertoAdmin
           settings_attributes.home_text_en = home_text_en
           settings_attributes.submodules_enabled = submodules_enabled.select{|m| m.present?}
           settings_attributes.calendar_integration = calendar_integration
+          settings_attributes.political_groups_vocabulary_id = political_groups_vocabulary_id&.to_i
 
           set_ibm_notes_integration_settings(settings_attributes)
         end

--- a/app/models/gobierto_people.rb
+++ b/app/models/gobierto_people.rb
@@ -3,6 +3,10 @@ module GobiertoPeople
     "gp_"
   end
 
+  def self.classes_with_vocabularies
+    [GobiertoPeople::Person]
+  end
+
   def self.searchable_models
     [ GobiertoPeople::Person, GobiertoPeople::PersonPost, GobiertoPeople::PersonStatement ]
   end

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -8,6 +8,7 @@ module GobiertoPeople
     include GobiertoCommon::Sortable
     include GobiertoCommon::Searchable
     include GobiertoCommon::Sluggable
+    include GobiertoCommon::HasVocabulary
 
     translates :charge, :bio
 
@@ -20,7 +21,7 @@ module GobiertoPeople
 
     belongs_to :admin, class_name: "GobiertoAdmin::Admin"
     belongs_to :site
-    belongs_to :political_group
+    has_vocabulary :political_groups
 
     has_many :attending_person_events, class_name: "GobiertoCalendars::EventAttendee", dependent: :destroy
     has_many :attending_events, class_name: "GobiertoCalendars::Event", through: :attending_person_events, source: :event

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -106,6 +106,10 @@ class Site < ApplicationRecord
     GobiertoParticipation::Process.scopes(self).sorted
   end
 
+  def political_groups
+    GobiertoPeople::Person.political_groups(self).sorted
+  end
+
   def gobierto_people_settings
     @gobierto_people_settings ||= if configuration.available_module?("GobiertoPeople") && configuration.gobierto_people_enabled?
                                     module_settings.find_by(module_name: "GobiertoPeople")

--- a/app/views/gobierto_admin/gobierto_people/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_people/configuration/settings/edit.html.erb
@@ -37,6 +37,12 @@
         </div>
       </div>
 
+      <div class="form_item select_control">
+        <%= f.label :political_groups_vocabulary_id %>
+        <%= f.select :political_groups_vocabulary_id,
+          options_for_select(@settings_form.vocabularies_options, selected: @settings_form.gobierto_module_settings.political_groups_vocabulary_id),
+          { include_blank: true } %>
+      </div>
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/lib/tasks/gobierto_common/migrate_to_vocabularies.rake
+++ b/lib/tasks/gobierto_common/migrate_to_vocabularies.rake
@@ -136,7 +136,6 @@ namespace :common do
 
     desc "Generate a vocabulary for each site from existing political groups"
     task political_groups: :environment do
-      ignored_attributes = %w(id site_id admin_id created_at updated_at name)
       GobiertoPeople::Person.where.not(political_group_id: nil).each do |person|
         move_political_group_to_term(person)
       end
@@ -152,11 +151,12 @@ namespace :common do
       settings = site.gobierto_people_settings
       unless settings.political_groups_vocabulary_id == vocabulary.id
         settings.tap do |conf|
-        conf.political_groups_vocabulary_id = vocabulary.id
+          conf.political_groups_vocabulary_id = vocabulary.id
         end.save
       end
       terms = vocabulary.terms
-      term = terms.find_by(slug: political_group.slug) || terms.create(political_group.attributes.except(*ignored_attributes).merge("name_#{ default_locale }" => political_group.name))
+      term = terms.find_by(slug: political_group.slug) ||
+             terms.create(political_group.attributes.except(*ignored_attributes).merge("name_#{ default_locale }" => political_group.name))
       person.update_attribute(:political_group_id, term.id)
     end
 

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -86,3 +86,15 @@ old_town_term:
   slug: old-town
   position: 2
   level: 0
+marvel_term:
+  vocabulary: madrid_political_groups_vocabulary
+  name_translations: <%= { "en" => "Marvel", "es" => "Marvel" }.to_json %>
+  slug: marvel
+  position: 1
+  level: 0
+dc_term:
+  vocabulary: madrid_political_groups_vocabulary
+  name_translations: <%= { "en" => "DC", "es" => "DC" }.to_json %>
+  slug: dc
+  position: 2
+  level: 0

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -13,3 +13,7 @@ issues_vocabulary:
 scopes_vocabulary:
   site: madrid
   name: Scopes Vocabulary
+
+madrid_political_groups_vocabulary:
+  site: madrid
+  name: Madrid Political Groups Vocabulary

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -7,7 +7,8 @@ gobierto_people_settings_madrid:
   settings: <%= {
     "home_text_es": "",
     "home_text_en": "Home text English",
-    "submodules_enabled": ["officials", "agendas", "statements", "blogs", "departments"]
+    "submodules_enabled": ["officials", "agendas", "statements", "blogs", "departments"],
+    "political_groups_vocabulary_id": ActiveRecord::FixtureSet.identify(:madrid_political_groups_vocabulary)
   }.to_json %>
 
 gobierto_participation_settings_madrid:

--- a/test/fixtures/gobierto_people/people.yml
+++ b/test/fixtures/gobierto_people/people.yml
@@ -17,7 +17,7 @@ richard:
   visibility_level: <%= GobiertoPeople::Person.visibility_levels["active"] %>
   category: <%= GobiertoPeople::Person.categories["politician"] %>
   party: <%= GobiertoPeople::Person.parties["government"] %>
-  political_group: marvel
+  political_group: marvel_term
   position: 1
   email: richard@example.com
   google_calendar_token: gct1
@@ -41,7 +41,7 @@ nelson:
   visibility_level: <%= GobiertoPeople::Person.visibility_levels["active"] %>
   category: <%= GobiertoPeople::Person.categories["politician"] %>
   party: <%= GobiertoPeople::Person.parties["government"] %>
-  political_group: marvel
+  political_group: marvel_term
   position: 2
   email: nelson@example.com
   google_calendar_token: gct2
@@ -137,7 +137,7 @@ neil:
   visibility_level: <%= GobiertoPeople::Person.visibility_levels["active"] %>
   category: <%= GobiertoPeople::Person.categories["politician"] %>
   party: <%= GobiertoPeople::Person.parties["opposition"] %>
-  political_group: dc
+  political_group: dc_term
   position: 5
   email: neil@example.com
   google_calendar_token: gct5

--- a/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_create_test.rb
@@ -26,7 +26,7 @@ module GobiertoAdmin
       end
 
       def political_group
-        @political_group ||= gobierto_people_political_groups(:marvel)
+        @political_group ||= gobierto_common_terms(:marvel_term)
       end
 
       def content_context

--- a/test/integration/gobierto_admin/gobierto_people/person_update_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/person_update_test.rb
@@ -30,7 +30,7 @@ module GobiertoAdmin
       end
 
       def political_group
-        @political_group ||= gobierto_people_political_groups(:marvel)
+        @political_group ||= gobierto_common_terms(:marvel_term)
       end
 
       def test_person_update

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -38,8 +38,8 @@ module GobiertoPeople
 
     def political_groups
       @political_groups ||= [
-        gobierto_people_political_groups(:marvel),
-        gobierto_people_political_groups(:dc)
+        gobierto_common_terms(:marvel_term),
+        gobierto_common_terms(:dc_term)
       ]
     end
 

--- a/test/integration/gobierto_people/people_political_groups_test.rb
+++ b/test/integration/gobierto_people/people_political_groups_test.rb
@@ -17,8 +17,8 @@ module GobiertoPeople
 
     def political_groups
       @political_groups ||= [
-        gobierto_people_political_groups(:marvel),
-        gobierto_people_political_groups(:dc)
+        gobierto_common_terms(:marvel_term),
+        gobierto_common_terms(:dc_term)
       ]
     end
 

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -39,8 +39,8 @@ module GobiertoPeople
 
     def political_groups
       @political_groups ||= [
-        gobierto_people_political_groups(:marvel),
-        gobierto_people_political_groups(:dc)
+        gobierto_common_terms(:marvel_term),
+        gobierto_common_terms(:dc_term)
       ]
     end
 

--- a/test/integration/gobierto_people/welcome_index_test.rb
+++ b/test/integration/gobierto_people/welcome_index_test.rb
@@ -26,8 +26,8 @@ module GobiertoPeople
 
     def political_groups
       @political_groups ||= [
-        gobierto_people_political_groups(:marvel),
-        gobierto_people_political_groups(:dc)
+        gobierto_common_terms(:marvel_term),
+        gobierto_common_terms(:dc_term)
       ]
     end
 

--- a/test/models/gobierto_common/term_test.rb
+++ b/test/models/gobierto_common/term_test.rb
@@ -15,6 +15,18 @@ class TermTest < ActiveSupport::TestCase
     @dependent_level_term ||= gobierto_common_terms(:dog)
   end
 
+  def terms_with_dependencies
+    @terms_with_dependencies ||= {
+      issue:  gobierto_common_terms(:culture_term),
+      scope:  gobierto_common_terms(:center_term),
+      political_group: gobierto_common_terms(:marvel_term)
+    }
+  end
+
+  def term_without_dependencies
+    @term_without_dependencies ||= gobierto_common_terms(:cat)
+  end
+
   def site
     @site ||= sites(:madrid)
   end
@@ -42,5 +54,15 @@ class TermTest < ActiveSupport::TestCase
     assert_equal vocabulary, new_term.vocabulary
     assert_nil new_term.parent_term
     assert_equal 0, new_term.terms.count
+  end
+
+  def test_destroy_of_term_with_dependencies
+    terms_with_dependencies.each do |_, term|
+      refute term.destroy
+    end
+  end
+
+  def test_destroy_of_term_without_dependencies
+    assert term_without_dependencies.destroy
   end
 end

--- a/test/pub_sub/subscribers/site_activity_test.rb
+++ b/test/pub_sub/subscribers/site_activity_test.rb
@@ -136,8 +136,9 @@ class Subscribers::SiteActivityTest < ActiveSupport::TestCase
 
   def test_site_deleted_event_handling
 
-    # manually deassociate scopes and ids from items, so they can be destroyed
+    # manually deassociate terms from items, so they can be destroyed
     site.processes.update_all(scope_id: nil, issue_id: nil)
+    site.people.update_all(political_group_id: nil)
 
     assert_difference "Activity.count" do
       site.destroy


### PR DESCRIPTION
Related with #1787


## :v: What does this PR do?
* Migrates `GobiertoPeople::PoliticalGroup` model and data to vocabularies
* Adds a task to migrate existing political groups to corresponding term in a vocabulary.

## :mag: How should this be manually tested?
Create a vocabulary and configure it for political groups in gobierto people settings.

## :shipit: Does this PR changes any configuration file?
No