### PR TITLE
Filter published events

### DIFF
--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -31,7 +31,7 @@ module GobiertoPeople
     end
 
     def set_events
-      @events = GobiertoCalendars::Event.by_site(current_site).person_events.page params[:page]
+      @events = GobiertoCalendars::Event.by_site(current_site).person_events.published.page params[:page]
       @events = @events.by_person_category(@person_category) if @person_category
       @events = @events.by_person_party(@person_party) if @person_party
 
@@ -52,7 +52,7 @@ module GobiertoPeople
     end
 
     def set_calendar_events
-      @calendar_events = GobiertoCalendars::Event.by_site(current_site).person_events.within_range(calendar_date_range)
+      @calendar_events = GobiertoCalendars::Event.by_site(current_site).person_events.published.within_range(calendar_date_range)
       @calendar_events = @calendar_events.by_person_category(@person_category) if @person_category
       @calendar_events = @calendar_events.by_person_party(@person_party) if @person_party
     end

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -93,6 +93,23 @@ module GobiertoPeople
       end
     end
 
+    def test_person_events_by_date
+      government_member.events.destroy_all
+
+      10.times do |i|
+        create_event(person: government_member, starts_at: (Time.now.tomorrow - i.days).to_s, title: "Event #{i}")
+      end
+      ::GobiertoCalendars::Event.update_all(state: :pending)
+
+      with_current_site(site) do
+        visit gobierto_people_events_path(date: Date.yesterday.to_s)
+
+        assert has_no_link?("Event 1")
+        assert has_no_link?("Event 2")
+        assert has_no_link?("Event 3")
+      end
+    end
+
     def test_person_events_filter
       with_current_site(site) do
         visit @path


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR filters published events when a date was provided as argument.

## :mag: How should this be manually tested?

- Go to past events by date
- No draft events should be displayed
## :eyes: Screenshots

### Before this PR

![screen shot 2018-08-01 at 11 48 10](https://user-images.githubusercontent.com/17616/43514598-ce54f53c-9580-11e8-89f1-0b0d1cd6fac2.png)

### After this PR


![screen shot 2018-08-01 at 11 48 15](https://user-images.githubusercontent.com/17616/43514597-ce34ad04-9580-11e8-8fb6-675a9490c91c.png)
