### PR TITLE
Minor fixes in events sync

### DIFF
--- a/app/controllers/gobierto_people/departments_controller.rb
+++ b/app/controllers/gobierto_people/departments_controller.rb
@@ -32,7 +32,7 @@ module GobiertoPeople
 
     def show
       @department = site_departments.find_by_slug!(params[:id])
-      people = QueryWithEvents.new(source: @department.people.with_event_attendances,
+      people = QueryWithEvents.new(source: @department.people.active.with_event_attendances,
                                    start_date: filter_start_date,
                                    end_date: filter_end_date)
 

--- a/app/controllers/gobierto_people/interest_groups_controller.rb
+++ b/app/controllers/gobierto_people/interest_groups_controller.rb
@@ -18,7 +18,7 @@ module GobiertoPeople
 
     def show
       @interest_group = @site.interest_groups.find_by_slug!(params[:id])
-      events = QueryWithEvents.new(source: @interest_group.events,
+      events = QueryWithEvents.new(source: @interest_group.events.published,
                                    start_date: filter_start_date,
                                    end_date: filter_end_date)
       @total_events = events.count
@@ -32,7 +32,7 @@ module GobiertoPeople
     protected
 
     def events_with_interest_group
-      QueryWithEvents.new(source: @site.events,
+      QueryWithEvents.new(source: @site.events.published,
                           start_date: filter_start_date,
                           end_date: filter_end_date,
                           not_null: [:interest_group_id])

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -51,9 +51,15 @@ module GobiertoPeople
       @latest_activity = ActivityCollectionDecorator.new(Activity.for_recipient(@person).limit(30).sorted.page(params[:page]))
 
       # custom engine
-      @last_events = QueryWithEvents.new(source: @person.attending_events.with_interest_group.sorted_backwards.limit(LAST_ITEMS_SIZE),
-                                         start_date: filter_start_date,
-                                         end_date: filter_end_date)
+      @last_events = QueryWithEvents.new(
+        source: @person.attending_events
+                       .published
+                       .with_interest_group
+                       .sorted_backwards
+                       .limit(LAST_ITEMS_SIZE),
+        start_date: filter_start_date,
+        end_date: filter_end_date
+      )
 
       last_trips_relation = @person.trips.between_dates(filter_start_date, filter_end_date).sorted.limit(LAST_ITEMS_SIZE)
       @last_trips = CollectionDecorator.new(last_trips_relation, decorator: TripDecorator)

--- a/app/decorators/gobierto_people/person_decorator.rb
+++ b/app/decorators/gobierto_people/person_decorator.rb
@@ -73,7 +73,7 @@ module GobiertoPeople
     end
 
     def meetings_with_interest_groups(start_date: nil, end_date: nil)
-      QueryWithEvents.new(source: events.with_interest_group,
+      QueryWithEvents.new(source: events.with_interest_group.published,
                           start_date: start_date,
                           end_date: end_date)
     end

--- a/app/services/gobierto_people/calendar_service_helpers.rb
+++ b/app/services/gobierto_people/calendar_service_helpers.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "#{Rails.root}/lib/utils/string_obfuscator"
+
 module GobiertoPeople
   module CalendarServiceHelpers
 
@@ -23,12 +27,18 @@ module GobiertoPeople
       log_message("Found #{events_count} available events for this person.")
     end
 
-    def log_invalid_event(error_messages)
-      log_message("Invalid event: #{error_messages}")
+    def log_saved_event(event_form)
+      log_message("Saved: #{event_form.title} on #{event_form.starts_at}")
     end
 
-    def log_destroy_rule
-      log_message("Event destroyed by filter rule")
+    def log_invalid_event(event_form)
+      log_message("Invalid: #{event_form.errors.messages}")
+    end
+
+    def log_destroy_rule(title = nil)
+      msg = "Destroyed by filter rule"
+      msg += ": #{::StringObfuscator.obfuscate(title, percent: 50)}" if title
+      log_message msg
     end
 
   end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -132,13 +132,14 @@ module GobiertoPeople
         event_form = GobiertoPeople::CalendarSyncEventForm.new(event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
-          log_destroy_rule
+          log_destroy_rule(event_form.title)
           event_form.destroy
         else
           if event_form.save
+            log_saved_event(event_form)
             received_event_ids.push(event.id)
           else
-            log_invalid_event(event_form.errors.messages)
+            log_invalid_event(event_form)
           end
         end
       end

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -100,11 +100,15 @@ module GobiertoPeople
         event_form = GobiertoPeople::CalendarSyncEventForm.new(person_event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
-          log_destroy_rule
+          log_destroy_rule(event_form.title)
           event_form.destroy
           nil
         else
-          if !event_form.save then log_invalid_event(event_form.errors.messages) end
+          if event_form.save
+            log_saved_event(event_form)
+          else
+            log_invalid_event(event_form)
+          end
           event_form.external_id
         end
       end

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -118,10 +118,12 @@ module GobiertoPeople
         event_form = GobiertoPeople::CalendarSyncEventForm.new(event_params)
 
         if filter_result.action == GobiertoCalendars::FilteringRuleApplier::REMOVE
-          log_destroy_rule
+          log_destroy_rule(event_form.title)
           event_form.destroy
-        elsif !event_form.save
-          log_invalid_event(event_form.errors.messages)
+        elsif event_form.save
+          log_saved_event(event_form)
+        else
+          log_invalid_event(event_form)
         end
       end
 

--- a/db/migrate/20170814214010_add_description_to_issues.rb
+++ b/db/migrate/20170814214010_add_description_to_issues.rb
@@ -3,6 +3,5 @@
 class AddDescriptionToIssues < ActiveRecord::Migration[5.1]
   def change
     add_column :issues, :description_translations, :jsonb
-    Issue.update_all(description_translations: { "en": "Description", "es": "Descripción" })
   end
 end

--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -4,6 +4,15 @@ module IbmNotes
   class PersonEvent
     attr_accessor :id, :title, :description, :starts_at, :ends_at, :person, :location, :attendees
 
+    MADRID_TIMEZONES = [
+      "Romance Standard Time",
+      "Western/Central Europe",
+      "GMT+1 Standard Time",
+      "Europe/Madrid",
+      "Central Europe Standard Time",
+      "Fus horari desconegut (1) Standard Time"
+    ].freeze
+
     def initialize(person, response_event)
       @id = set_id(response_event)
       @title = response_event["summary"]
@@ -26,21 +35,13 @@ module IbmNotes
 
     def set_start_and_end_date(event)
       time_zone = if event["start"]["tzid"].present?
-        case event["start"]["tzid"]
-          when "Romance Standard Time"
-            ActiveSupport::TimeZone["Madrid"]
-          when "Western/Central Europe"
-            ActiveSupport::TimeZone["Madrid"]
-          when "GMT+1 Standard Time"
-            ActiveSupport::TimeZone["Madrid"]
-          when "Europe/Madrid"
-            ActiveSupport::TimeZone["Madrid"]
-          when "Central Europe Standard Time"
-            ActiveSupport::TimeZone["Madrid"]
-          else
-            Rollbar.error(Exception.new("[GobiertoCalendars] Unknown IBM Notes time zone #{event["start"]["tzid"]}"))
-          end
-      end
+                    if MADRID_TIMEZONES.include?(event["start"]["tzid"])
+                      ActiveSupport::TimeZone["Madrid"]
+                    else
+                      Rollbar.error(Exception.new("[GobiertoCalendars] Unknown IBM Notes time zone #{event["start"]["tzid"]}"))
+                      nil
+                    end
+                  end
 
       if time_zone
         @starts_at = time_zone.parse("#{event["start"]["date"]} #{event["start"]["time"]}").utc

--- a/lib/utils/string_obfuscator.rb
+++ b/lib/utils/string_obfuscator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "bigdecimal"
+
+# Credit to https://github.com/wealthsimple/string-obfuscator
+
+class StringObfuscator
+
+  def self.obfuscate(value, percent: nil, length: nil, from: :left, max_unobfuscated_length: nil, min_obfuscated_length: nil)
+    raise ArgumentError, "must specify percent or length to obfuscate by" if percent.nil? && length.nil?
+    raise ArgumentError, "percent must be between 0 - 100" if !percent.nil? && (percent > 100 || percent.negative?)
+    raise ArgumentError, "length must be > 0" if !length.nil? && length.negative?
+    return value unless value.is_a?(String)
+
+    if !percent.nil?
+      percent = BigDecimal.new(percent.to_s)
+      obfuscated_length = (value.length * (percent / 100)).ceil
+    else
+      obfuscated_length = length
+    end
+    obfuscated_length = [obfuscated_length, min_obfuscated_length].max if min_obfuscated_length
+    obfuscated_length = [obfuscated_length, value.length].min
+    visible_length = value.length - obfuscated_length
+
+    # If `max_unobfuscated_length` is set, ensure that we don't show more than that.
+    if !max_unobfuscated_length.nil? && visible_length > max_unobfuscated_length
+      visible_length = max_unobfuscated_length
+      obfuscated_length = value.length - visible_length
+    end
+
+    obfuscation_value = "*" * obfuscated_length
+    if visible_length.zero?
+      obfuscation_value
+    elsif from.to_sym == :left
+      obfuscation_value + value[-visible_length..-1]
+    else
+      value[0..(visible_length - 1)] + obfuscation_value
+    end
+  end
+
+end

--- a/test/decorators/gobierto_people/person_decorator_test.rb
+++ b/test/decorators/gobierto_people/person_decorator_test.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/event_helpers"
 
 module GobiertoPeople
   class PersonDecoratorTest < ActiveSupport::TestCase
+
+    include ::EventHelpers
+
     def setup
       super
       @subject = PersonDecorator.new(person)
@@ -11,6 +15,10 @@ module GobiertoPeople
 
     def person
       @person ||= gobierto_people_people(:richard)
+    end
+
+    def interest_group
+      @interest_group ||= gobierto_people_interest_groups(:google)
     end
 
     def test_contact_email
@@ -48,5 +56,18 @@ module GobiertoPeople
     def test_instagram_url
       assert_equal "https://instagram.com/richard", @subject.instagram_url
     end
+
+    def test_meetings_with_interest_groups
+      person.events.destroy_all
+      person.attending_events.destroy_all
+
+      create_event(title: "Visible", person: person, interest_group: interest_group)
+      create_event(title: "Hidden", person: person, interest_group: interest_group, state: :pending)
+
+      event_titles = @subject.meetings_with_interest_groups.map(&:title)
+
+      assert_equal event_titles, %w(Visible)
+    end
+
   end
 end

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -67,7 +67,9 @@ module GobiertoPeople
         richard.events.destroy_all
         far_past_event = create_event(title: "Richard far past event", starts_at: :far_past)
         past_event = create_event(title: "Richard past event", starts_at: :past)
+        pending_past_event = create_event(title: "Richard past pending event", starts_at: :past, state: :pending)
         future_event = create_event(title: "Richard future event", starts_at: :future)
+        pending_future_event = create_event(title: "Richard future pending event", starts_at: :future, state: :pending)
         far_future_event = create_event(title: "Richard far future event", starts_at: :far_future)
 
         with_javascript do
@@ -79,6 +81,7 @@ module GobiertoPeople
             within ".events-summary" do
               assert has_no_content?(far_past_event.title)
               assert has_no_content?(past_event.title)
+              assert has_no_content?(pending_future_event.title)
               assert ordered_elements(page, [future_event.title, far_future_event.title])
             end
 
@@ -87,6 +90,7 @@ module GobiertoPeople
             within ".events-summary" do
               assert has_no_content?(future_event.title)
               assert has_no_content?(far_future_event.title)
+              assert has_no_content?(pending_past_event.title)
               assert ordered_elements(page, [past_event.title, far_past_event.title])
             end
           end

--- a/test/support/event_helpers.rb
+++ b/test/support/event_helpers.rb
@@ -19,7 +19,7 @@ module EventHelpers
       description: "Event description",
       starts_at: parse_start_date(options),
       ends_at: parse_end_date(options),
-      state: GobiertoCalendars::Event.states["published"],
+      state: parse_state(options),
       collection: collection,
       external_id: options[:external_id],
       interest_group_id: interest_group_id(options),
@@ -56,6 +56,12 @@ module EventHelpers
     else
       parse_start_date(options) + 1.hour
     end
+  end
+
+  def parse_state(options)
+    GobiertoCalendars::Event.states[
+      (options[:state].to_s == "pending") ? "pending" : "published"
+    ]
   end
 
   def interest_group_id(options)


### PR DESCRIPTION
## :v: What does this PR do?

* Adds missing timezone (was in staging from 2 days back, but forgot to make PR). I chery-picked it.
* Removes old model from migration
* Fixes scopes to prevent leak of draft items
* Improves logging. When successfully saving an event it'll print in the log:

```
[SYNC-AGENDAS][IBM Notes] Saved: Junta de Portaveus on 2018-09-10 17:00:00 UTC
```

if the event was marked for destroy by a filter rule it'll print something like:

```
[SYNC-AGENDAS][IBM Notes] Destroyed by filter rule: ***********rs polític
```

**Notes**: 

> I copied the code from the [string-obfuscator gem](https://github.com/wealthsimple/string-obfuscator) gem instead of adding it as a dependency because it had no [depedents](https://github.com/wealthsimple/string-obfuscator/network/dependents) and I thought this was more prudent given it's MIT.

> There are more tests in https://github.com/PopulateTools/gobierto-gencat-engine/commit/af7c31ed8120408b36f8d43d61eff1a8c34d8a10, waiting for this to be merged so the master build does not break