### PR TITLE
Vocabularies and terms improvements

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
@@ -17,6 +17,7 @@ module GobiertoAdmin
 
       def new
         @vocabulary_form = VocabularyForm.new(site_id: current_site.id)
+        render(:new_modal, layout: false) && return if request.xhr?
       end
 
       def create
@@ -25,10 +26,11 @@ module GobiertoAdmin
         if @vocabulary_form.save
           track_create_activity
           redirect_to(
-            edit_admin_common_vocabulary_path(@vocabulary_form.vocabulary),
+            admin_common_vocabularies_path,
             notice: t(".success")
           )
         else
+          render(:new_modal, layout: false) && return if request.xhr?
           render :new
         end
       end
@@ -36,6 +38,7 @@ module GobiertoAdmin
       def edit
         vocabulary = find_vocabulary
         @vocabulary_form = VocabularyForm.new(vocabulary.attributes.except(*ignored_vocabulary_attributes).merge(site_id: current_site.id))
+        render(:edit_modal, layout: false) && return if request.xhr?
       end
 
       def update
@@ -43,10 +46,11 @@ module GobiertoAdmin
         if @vocabulary_form.save
           track_update_activity
           redirect_to(
-            edit_admin_common_vocabulary_path(@vocabulary_form.vocabulary),
+            admin_common_vocabularies_path,
             notice: t(".success")
           )
         else
+          render(:edit_modal, layout: false) && return if request.xhr?
           render :edit
         end
       end

--- a/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
@@ -63,7 +63,7 @@ module GobiertoAdmin
       private
 
       def vocabulary_params
-        params.require(:vocabulary).permit(:name)
+        params.require(:vocabulary).permit(:slug, name_translations: [*I18n.available_locales])
       end
 
       def ignored_vocabulary_attributes

--- a/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
@@ -7,12 +7,13 @@ module GobiertoAdmin
       attr_accessor(
         :id,
         :site_id,
-        :name
+        :name_translations,
+        :slug
       )
 
       delegate :persisted?, to: :vocabulary
 
-      validates :name, presence: true
+      validates :name_translations, presence: true
       validates :site, presence: true
 
       def vocabulary
@@ -32,7 +33,8 @@ module GobiertoAdmin
       def save_vocabulary
         @vocabulary = vocabulary.tap do |attributes|
           attributes.site_id = site_id
-          attributes.name = name
+          attributes.name_translations = name_translations
+          attributes.slug = slug
         end
 
         return @vocabulary if @vocabulary.save

--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -2,9 +2,18 @@
 
 module GobiertoCommon
   class Vocabulary < ApplicationRecord
+    include GobiertoCommon::Sluggable
+
     belongs_to :site
     has_many :terms, dependent: :destroy
 
-    validates :site, :name, presence: true
+    validates :site, :name, :slug, presence: true
+    validates :slug, uniqueness: { scope: :site_id }
+
+    translates :name
+
+    def attributes_for_slug
+      [name]
+    end
   end
 end

--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -6,6 +6,5 @@ module GobiertoCommon
     has_many :terms, dependent: :destroy
 
     validates :site, :name, presence: true
-    validates :name, uniqueness: { scope: :site }
   end
 end

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/index.html.erb
@@ -13,20 +13,16 @@
 <table>
   <tr>
     <th class="icon_col"></th>
-    <th class="icon_col"></th>
     <th><%= t('.header.name') %></th>
     <th><%= t('.header.created_at') %></th>
     <th></th>
+    <th class="icon_col"></th>
   </tr>
   <tbody data-behavior="sortable" data-sortable-target="<%= admin_common_vocabulary_terms_sort_path %>">
     <% @terms.each do |term| %>
       <tr id="term-item-<%= term.id %>" data-id="<%= term.id %>" class="<%= cycle("odd", "even") %>">
         <td>
           <%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_common_term_path(term), class: 'open_remote_modal', title: t('views.edit') %>
-        </td>
-        <td>
-          <%= link_to "<i class='fa fa-trash'></i>".html_safe, admin_common_term_path(term), method: :delete, title: t('views.delete'), data: { confirm: t(".delete_confirm") } %>
-
         </td>
         <td>
           <%= link_to term.name, edit_admin_common_term_path(term), class: 'open_remote_modal' %>
@@ -36,6 +32,9 @@
         </td>
         <td>
           <i class="sort-handler fa fa-bars tipsit custom_handle" title="<%= t('.drag_to_sort') %>"></i>
+        </td>
+        <td>
+          <%= link_to "<i class='fa fa-trash'></i>".html_safe, admin_common_term_path(term), method: :delete, title: t('views.delete'), data: { confirm: t(".delete_confirm") } %>
         </td>
       </tr>
     <% end %>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/index.html.erb
@@ -1,6 +1,6 @@
 <div class="admin_breadcrumb">
   <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
-  <%= link_to t("gobierto_admin.layouts.application.edit_site"), edit_admin_site_path(current_site) %> »
+  <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
   <%= @vocabulary.name %>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/_form.html.erb
@@ -2,16 +2,23 @@
 
 <%= form_for(
   @vocabulary_form, as: :vocabulary,
-  url: @vocabulary_form.persisted? ? admin_common_vocabulary_path(@vocabulary_form) : admin_common_vocabularies_path) do |f| %>
-  <div class="pure-g">
-    <div class="pure-u-1 pure-u-md-16-24">
-      <div class="form_item input_text">
-        <%= f.label :name do %>
+  url: @vocabulary_form.persisted? ? admin_common_vocabulary_path(@vocabulary_form) : admin_common_vocabularies_path, data: { "globalized-form-container" => true}) do |f| %>
+  <div class="globalized_fields">
+    <%= render "gobierto_admin/shared/form_locale_switchers" %>
+
+    <% current_site.configuration.available_locales.each do |locale| %>
+      <div class="form_item input_text" data-locale="<%= locale %>">
+        <%= label_tag "vocabulary[name_translations][#{locale}]" do %>
           <%= f.object.class.human_attribute_name(:name) %>
           <%= attribute_indication_tag required: true %>
         <% end %>
-        <%= f.text_field :name, placeholder: t(".placeholders.name") %>
+        <%= text_field_tag "vocabulary[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym) %>
       </div>
+    <% end %>
+
+    <div class="form_item input_text">
+      <%= f.label :slug %>
+      <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
     </div>
   </div>
 

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/edit.html.erb
@@ -1,8 +1,8 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t("gobierto_admin.gobierto_common.vocabularies.index.title"), admin_common_vocabularies_path %> »
-  <%= t(".edit", vocabulary: @vocabulary_form.name) %>
+  <%= t(".edit", vocabulary: @vocabulary_form.vocabulary.name) %>
 </div>
 
-<h1><%= t(".edit", vocabulary: @vocabulary_form.name) %></h1>
+<h1><%= t(".edit", vocabulary: @vocabulary_form.vocabulary.name) %></h1>
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/edit_modal.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/edit_modal.html.erb
@@ -1,0 +1,4 @@
+<div class="modal">
+  <h2><%= t(".title", vocabulary: @vocabulary_form.vocabulary.name) %></h2>
+  <%= render "form" %>
+</div>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -37,7 +37,7 @@
         </td>
         <td>
           <%= link_to admin_common_vocabulary_terms_path(vocabulary), class: "view_item" do %>
-            <i class="fa fa-eye"></i>
+            <i class="fa fa-cog"></i>
             <%= t(".view_vocabulary") %>
           <% end %>
         </td>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -12,9 +12,9 @@
 <table class="user-list">
   <tr>
     <th class='icon_col'></th>
+    <th class='icon_col'></th>
     <th><%= t(".header.name") %></th>
     <th></th>
-    <th class='icon_col'></th>
   </tr>
 
   <tbody>
@@ -26,7 +26,12 @@
           <% end %>
         </td>
         <td>
-          <%= link_to admin_common_vocabulary_terms_path(vocabulary) do %>
+          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
+            <i class="fa fa-trash"></i>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to edit_admin_common_vocabulary_path(vocabulary), class: "open_remote_modal" do %>
             <%= vocabulary.name %>
           <% end %>
         </td>
@@ -34,11 +39,6 @@
           <%= link_to admin_common_vocabulary_terms_path(vocabulary), class: "view_item" do %>
             <i class="fa fa-eye"></i>
             <%= t(".view_vocabulary") %>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
-            <i class="fa fa-trash"></i>
           <% end %>
         </td>
       </tr>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -6,7 +6,7 @@
 <h1><%= t(".title") %></h1>
 
 <div class="admin_tools right">
-  <%= link_to t(".new"), new_admin_common_vocabulary_path, class: "button" %>
+  <%= link_to t(".new"), new_admin_common_vocabulary_path, class: "button open_remote_modal" %>
 </div>
 
 <table class="user-list">
@@ -21,7 +21,7 @@
     <% @vocabularies.each do |vocabulary| %>
       <tr id="vocabulary-item-<%= vocabulary.id %>" class="<%= cycle("odd", "even") %>">
         <td>
-          <%= link_to edit_admin_common_vocabulary_path(vocabulary) do %>
+          <%= link_to edit_admin_common_vocabulary_path(vocabulary), class: "open_remote_modal" do %>
             <i class="fa fa-edit"></i>
           <% end %>
         </td>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -12,9 +12,9 @@
 <table class="user-list">
   <tr>
     <th class='icon_col'></th>
-    <th class='icon_col'></th>
     <th><%= t(".header.name") %></th>
     <th></th>
+    <th class='icon_col'></th>
   </tr>
 
   <tbody>
@@ -26,11 +26,6 @@
           <% end %>
         </td>
         <td>
-          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
-            <i class="fa fa-trash"></i>
-          <% end %>
-        </td>
-        <td>
           <%= link_to edit_admin_common_vocabulary_path(vocabulary), class: "open_remote_modal" do %>
             <%= vocabulary.name %>
           <% end %>
@@ -39,6 +34,11 @@
           <%= link_to admin_common_vocabulary_terms_path(vocabulary), class: "view_item" do %>
             <i class="fa fa-cog"></i>
             <%= t(".view_vocabulary") %>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to admin_common_vocabulary_path(vocabulary), method: :delete, title: t("views.delete"), data: { confirm: t(".delete_confirm") } do %>
+            <i class="fa fa-trash"></i>
           <% end %>
         </td>
       </tr>

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/new_modal.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/new_modal.html.erb
@@ -1,0 +1,6 @@
+<div class="modal">
+
+  <h2><%= t(".title") %></h2>
+  <%= render "form" %>
+
+</div>

--- a/app/views/gobierto_admin/gobierto_participation/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_participation/configuration/settings/edit.html.erb
@@ -1,3 +1,20 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_participation.welcome.index.title"), admin_participation_path %> »
+  <%= link_to t(".title"), edit_admin_participation_configuration_settings_path %> »
+    <%= t("gobierto_admin.gobierto_participation.configuration.settings.title") %>
+</div>
+
+<h1><%= t(".title") %></h1>
+
+<div class="tabs">
+  <ul>
+    <li class="active">
+      <%= link_to t("gobierto_admin.gobierto_participation.configuration.settings.title"), edit_admin_participation_configuration_settings_path %>
+    </li>
+  </ul>
+</div>
+
 <%= form_for @settings_form, as: :gobierto_participation_settings, url: admin_participation_configuration_settings_path,  method: :patch, html: { autocomplete: "off" } do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
@@ -6,14 +23,14 @@
         <%= f.select :issues_vocabulary_id,
           options_for_select(@settings_form.vocabularies_options, selected: @settings_form.gobierto_module_settings.issues_vocabulary_id),
           { include_blank: true } %>
-    </div>
+      </div>
 
-    <div class="form_item select_control">
-      <%= f.label :scopes_vocabulary_id %>
-      <%= f.select :scopes_vocabulary_id,
-        options_for_select(@settings_form.vocabularies_options, selected: @settings_form.gobierto_module_settings.scopes_vocabulary_id),
-        { include_blank: true } %>
-  </div>
+      <div class="form_item select_control">
+        <%= f.label :scopes_vocabulary_id %>
+        <%= f.select :scopes_vocabulary_id,
+          options_for_select(@settings_form.vocabularies_options, selected: @settings_form.gobierto_module_settings.scopes_vocabulary_id),
+          { include_blank: true } %>
+      </div>
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -11,8 +11,8 @@ ca:
       gobierto_admin/gobierto_common/term_form:
         description: Descripció
         name: Nom
-        parent_term: Térme Pare
         slug: Slug
+        term_id: Térme Pare
       gobierto_admin/gobierto_common/vocabulary_form:
         name: Nom
     models:

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -11,8 +11,8 @@ en:
       gobierto_admin/gobierto_common/term_form:
         description: Description
         name: Name
-        parent_term: Parent Term
         slug: Slug
+        term_id: Parent Term
       gobierto_admin/gobierto_common/vocabulary_form:
         name: Name
     models:

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -11,8 +11,8 @@ es:
       gobierto_admin/gobierto_common/term_form:
         description: Descripción
         name: Nombre
-        parent_term: Término Padre
         slug: Slug
+        term_id: Término Padre
       gobierto_admin/gobierto_common/vocabulary_form:
         name: Nombre
     models:

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
@@ -8,6 +8,7 @@ ca:
         form:
           placeholders:
             name: Regne animal
+            slug: regne_animal
         index:
           delete_confirm: Estàs segur? Aquesta operació no és reversible
           header:

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
@@ -5,6 +5,8 @@ ca:
       vocabularies:
         edit:
           edit: Editar %{vocabulary}
+        edit_modal:
+          title: Editar %{vocabulary}
         form:
           placeholders:
             name: Regne animal
@@ -18,6 +20,8 @@ ca:
           view_vocabulary: Veure vocabulari
         new:
           new: Nou Vocabulari
+        new_modal:
+          title: Nou Vocabulari
         show:
           created_at: Creació
           terms: Termes

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/ca.yml
@@ -17,7 +17,7 @@ ca:
             name: Nom
           new: Nou
           title: Vocabularis
-          view_vocabulary: Veure vocabulari
+          view_vocabulary: Veure termes
         new:
           new: Nou Vocabulari
         new_modal:

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
@@ -5,6 +5,8 @@ en:
       vocabularies:
         edit:
           edit: Edit %{vocabulary}
+        edit_modal:
+          title: Edit %{vocabulary}
         form:
           placeholders:
             name: Animal kingdom
@@ -18,6 +20,8 @@ en:
           view_vocabulary: See vocabulary
         new:
           new: New Vocabulary
+        new_modal:
+          title: New Vocabulary
         show:
           created_at: Created at
           terms: Terms

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
@@ -17,7 +17,7 @@ en:
             name: Name
           new: New
           title: Vocabularies
-          view_vocabulary: See vocabulary
+          view_vocabulary: See terms
         new:
           new: New Vocabulary
         new_modal:

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/en.yml
@@ -8,6 +8,7 @@ en:
         form:
           placeholders:
             name: Animal kingdom
+            slug: animal_kingdom
         index:
           delete_confirm: Are you sure? This operation can not be undone
           header:

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
@@ -8,6 +8,7 @@ es:
         form:
           placeholders:
             name: Reino animal
+            slug: reino_animal
         index:
           delete_confirm: Seguro? Esta operación no tiene marcha atrás.
           header:

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
@@ -5,6 +5,8 @@ es:
       vocabularies:
         edit:
           edit: Editar %{vocabulary}
+        edit_modal:
+          title: Editar %{vocabulary}
         form:
           placeholders:
             name: Reino animal
@@ -18,6 +20,8 @@ es:
           view_vocabulary: Ver vocabulario
         new:
           new: Nuevo Vocabulario
+        new_modal:
+          title: Nuevo Vocabulario
         show:
           created_at: Creación
           terms: Términos

--- a/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/vocabularies/views/es.yml
@@ -17,7 +17,7 @@ es:
             name: Nombre
           new: Nuevo
           title: Vocabularios
-          view_vocabulary: Ver vocabulario
+          view_vocabulary: Ver términos
         new:
           new: Nuevo Vocabulario
         new_modal:

--- a/config/locales/gobierto_admin/gobierto_participation/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/ca.yml
@@ -5,7 +5,9 @@ ca:
       configuration:
         settings:
           edit:
+            title: Configuració
             update: Actualitzar
+          title: Preferencies
       shared:
         navigation:
           agenda: Agenda

--- a/config/locales/gobierto_admin/gobierto_participation/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/en.yml
@@ -5,7 +5,9 @@ en:
       configuration:
         settings:
           edit:
+            title: Configuration
             update: Update
+          title: Preferences
       shared:
         navigation:
           agenda: Agenda

--- a/config/locales/gobierto_admin/gobierto_participation/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_participation/views/es.yml
@@ -5,7 +5,9 @@ es:
       configuration:
         settings:
           edit:
+            title: Configuración
             update: Actualizar
+          title: Preferencias
       shared:
         navigation:
           agenda: Agenda

--- a/db/migrate/20180801142224_add_name_translations_and_slug_to_vocabularies.rb
+++ b/db/migrate/20180801142224_add_name_translations_and_slug_to_vocabularies.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddNameTranslationsAndSlugToVocabularies < ActiveRecord::Migration[5.2]
+  def up
+    add_column :vocabularies, :name_translations, :jsonb
+    add_column :vocabularies, :slug, :string
+    GobiertoCommon::Vocabulary.all.each do |vocabulary|
+      vocabulary.update(name_translations: localized_name_attr(vocabulary), slug: slug(vocabulary))
+    end
+    remove_column :vocabularies, :name
+  end
+
+  def down
+    add_column :vocabularies, :name, :string
+    GobiertoCommon::Vocabulary.all.each do |vocabulary|
+      vocabulary.update(name: delocalized_name_attr(vocabulary))
+    end
+    remove_column :vocabularies, :slug
+    remove_column :vocabularies, :name_translations
+  end
+
+  def localized_name_attr(vocabulary)
+    { vocabulary.site.configuration.default_locale => vocabulary.name }
+  end
+
+  def slug(vocabulary)
+    slug_core = vocabulary.name.tr(" ", "_").parameterize
+    return slug_core unless vocabulary.site.vocabularies.where(slug: slug_core).exists?
+    "#{ slug_core }-#{ vocabulary.site.vocabularies.where(slug: slug_core).count + 1 }"
+  end
+
+  def delocalized_name_attr(vocabulary)
+    vocabulary.name_translations[vocabulary.site.configuration.default_locale.to_s]
+  end
+end

--- a/db/migrate/20180801142224_add_name_translations_and_slug_to_vocabularies.rb
+++ b/db/migrate/20180801142224_add_name_translations_and_slug_to_vocabularies.rb
@@ -5,7 +5,7 @@ class AddNameTranslationsAndSlugToVocabularies < ActiveRecord::Migration[5.2]
     add_column :vocabularies, :name_translations, :jsonb
     add_column :vocabularies, :slug, :string
     GobiertoCommon::Vocabulary.all.each do |vocabulary|
-      vocabulary.update(name_translations: localized_name_attr(vocabulary), slug: slug(vocabulary))
+      vocabulary.update_columns(name_translations: localized_name_attr(vocabulary), slug: slug(vocabulary))
     end
     remove_column :vocabularies, :name
   end
@@ -13,18 +13,18 @@ class AddNameTranslationsAndSlugToVocabularies < ActiveRecord::Migration[5.2]
   def down
     add_column :vocabularies, :name, :string
     GobiertoCommon::Vocabulary.all.each do |vocabulary|
-      vocabulary.update(name: delocalized_name_attr(vocabulary))
+      vocabulary.update_columns(name: delocalized_name_attr(vocabulary))
     end
     remove_column :vocabularies, :slug
     remove_column :vocabularies, :name_translations
   end
 
   def localized_name_attr(vocabulary)
-    { vocabulary.site.configuration.default_locale => vocabulary.name }
+    { vocabulary.site.configuration.default_locale => vocabulary.attributes["name"] }
   end
 
   def slug(vocabulary)
-    slug_core = vocabulary.name.tr(" ", "_").parameterize
+    slug_core = vocabulary.attributes["name"].tr(" ", "_").parameterize
     return slug_core unless vocabulary.site.vocabularies.where(slug: slug_core).exists?
     "#{ slug_core }-#{ vocabulary.site.vocabularies.where(slug: slug_core).count + 1 }"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_165523) do
+ActiveRecord::Schema.define(version: 2018_08_01_142224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -945,9 +945,10 @@ ActiveRecord::Schema.define(version: 2018_07_31_165523) do
 
   create_table "vocabularies", force: :cascade do |t|
     t.bigint "site_id"
-    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "name_translations"
+    t.string "slug"
     t.index ["site_id"], name: "index_vocabularies_on_site_id"
   end
 

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -1,19 +1,24 @@
 animals:
   site: madrid
-  name: Animals
+  name_translations: <%= { es: "Animales", en: "Animals" }.to_json %>
+  slug: animals
 
 plan_categories:
   site: madrid
-  name: Government Plan
+  name_translations: <%= { es: "Plan de gobierno", en: "Government Plan" }.to_json %>
+  slug: government_plan
 
 issues_vocabulary:
   site: madrid
-  name: Issues Vocabulary
+  name_translations: <%= { es: "Vocabulario de Temas", en: "Issues Vocabulary" }.to_json %>
+  slug: issues_vocabulary
 
 scopes_vocabulary:
   site: madrid
-  name: Scopes Vocabulary
+  name_translations: <%= { es: "Vocabulario de Ámbitos", en: "Scopes Vocabulary" }.to_json %>
+  slug: scopes_vocabulary
 
 madrid_political_groups_vocabulary:
   site: madrid
-  name: Madrid Political Groups Vocabulary
+  name_translations: <%= { es: "Vocabulario de Grupos Políticos de Madrid", en: "Madrid Political Groups Vocabulary" }.to_json %>
+  slug: madrid_political_groups_vocabulary

--- a/test/integration/gobierto_admin/gobierto_common/terms/terms_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/terms_index_test.rb
@@ -71,13 +71,13 @@ module GobiertoCommon
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
-            ordered_names = page.all(:xpath, '(.//tr//td[3])').map(&:text)
+            ordered_names = page.all(:xpath, "(.//tr//td[2])").map(&:text)
             assert_equal terms.sorted.map(&:name), ordered_names
 
             first_term.update_attribute(:position, 1000)
 
             visit @path
-            ordered_names = page.all(:xpath, '(.//tr//td[3])').map(&:text)
+            ordered_names = page.all(:xpath, "(.//tr//td[2])").map(&:text)
             assert_equal first_term.name, ordered_names.last
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
@@ -16,7 +16,21 @@ module GobiertoAdmin
         end
 
         def admin
-          @admin ||= gobierto_admin_admins(:nick)
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
         end
 
         def test_create_vocabulary_errors

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module Vocabularies
+      class CreateVocabularyTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_common_vocabularies_path
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def test_create_vocabulary_errors
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                click_link "New"
+                click_button "Create"
+
+                assert has_alert?("Name can't be blank")
+              end
+            end
+          end
+        end
+
+        def test_create_vocabulary
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                click_link "New"
+
+                fill_in "vocabulary_name_translations_en", with: "Monetary Systems"
+                fill_in "vocabulary_slug", with: "monetary-systems-new"
+
+                click_link "ES"
+                fill_in "vocabulary_name_translations_es", with: "Sistemas Monetarios"
+
+                click_button "Create"
+
+                assert has_message?("Vocabulary created successfully.")
+
+                click_link "Monetary Systems"
+
+                assert has_field?("vocabulary_name_translations_en", with: "Monetary Systems")
+                assert has_field?("vocabulary_slug", with: "monetary-systems-new")
+
+                click_link "ES"
+
+                assert has_field?("vocabulary_name_translations_es", with: "Sistemas Monetarios")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/delete_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/delete_vocabulary_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module GobiertoAdmin
+    module Vocabularies
+      class DeleteVocabularyTest < ActionDispatch::IntegrationTest
+
+        def setup
+          super
+          @path = admin_common_vocabularies_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def vocabulary
+          @vocabulary ||= gobierto_common_vocabularies(:animals)
+        end
+
+        def vocabulary_with_associated_items
+          @vocabulary_with_associated_items ||= gobierto_common_vocabularies(:issues_vocabulary)
+        end
+
+        def test_delete_vocabulary
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "#vocabulary-item-#{vocabulary.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("Vocabulary deleted successfully.")
+
+              refute site.vocabularies.exists?(id: vocabulary.id)
+            end
+          end
+        end
+
+        def test_delete_vocabulary_with_associated_items
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "#vocabulary-item-#{vocabulary_with_associated_items.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("Vocabulary couldn't be deleted.")
+
+              assert site.vocabularies.exists?(id: vocabulary_with_associated_items.id)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/delete_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/delete_vocabulary_test.rb
@@ -13,7 +13,11 @@ module GobiertoCommon
         end
 
         def admin
-          @admin ||= gobierto_admin_admins(:nick)
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
         end
 
         def site
@@ -26,6 +30,16 @@ module GobiertoCommon
 
         def vocabulary_with_associated_items
           @vocabulary_with_associated_items ||= gobierto_common_vocabularies(:issues_vocabulary)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
         end
 
         def test_delete_vocabulary

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module GobiertoAdmin
+    module Vocabulary
+      class UpdateVocabularyTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_common_vocabularies_path
+        end
+
+        def vocabulary
+          @vocabulary ||= gobierto_common_vocabularies(:animals)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def test_update_vocabulary
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                click_link vocabulary.name
+
+                within "form.edit_vocabulary" do
+                  fill_in "vocabulary_name_translations_en", with: "Animals updated"
+                  fill_in "vocabulary_slug", with: "animals-updated"
+
+                  click_button "Update"
+                end
+
+                assert has_message?("Vocabulary updated successfully.")
+
+                click_link vocabulary.name
+
+                assert has_field? "vocabulary_name_translations_en", with: "Animals updated"
+                assert has_field? "vocabulary_slug", with: "animals-updated"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
@@ -16,11 +16,25 @@ module GobiertoCommon
         end
 
         def admin
-          @admin ||= gobierto_admin_admins(:nick)
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
         end
 
         def site
           @site ||= sites(:madrid)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
         end
 
         def test_update_vocabulary

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/vocabularies_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/vocabularies_index_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module GobiertoAdmin
+    module Vocabularies
+      class VocabulariesIndexTest < ActionDispatch::IntegrationTest
+
+        def setup
+          super
+          @path = admin_common_vocabularies_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def vocabularies
+          @vocabularies ||= site.vocabularies
+        end
+
+        def test_vocabularies_index
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "table tbody" do
+                assert has_selector?("tr", count: vocabularies.count)
+
+                vocabularies.each do |vocabulary|
+                  assert has_selector?("tr#vocabulary-item-#{vocabulary.id}")
+
+                  within "tr#vocabulary-item-#{vocabulary.id}" do
+                    assert has_link?(vocabulary.name.to_s)
+                  end
+                end
+              end
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/vocabularies_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/vocabularies_index_test.rb
@@ -13,7 +13,11 @@ module GobiertoCommon
         end
 
         def admin
-          @admin ||= gobierto_admin_admins(:nick)
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
         end
 
         def site
@@ -22,6 +26,16 @@ module GobiertoCommon
 
         def vocabularies
           @vocabularies ||= site.vocabularies
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
         end
 
         def test_vocabularies_index

--- a/test/models/gobierto_common/vocabulary_test.rb
+++ b/test/models/gobierto_common/vocabulary_test.rb
@@ -15,8 +15,8 @@ class VocabularyTest < ActiveSupport::TestCase
     assert vocabulary.valid?
   end
 
-  def test_unique_name_scoped_to_site
-    invalid_vocabulary = site.vocabularies.new(name: vocabulary.name)
+  def test_unique_slug_scoped_to_site
+    invalid_vocabulary = site.vocabularies.new(name: "test", slug: vocabulary.slug)
     refute invalid_vocabulary.valid?
   end
 end


### PR DESCRIPTION


## :v: What does this PR do?
* Changes `GobiertoCommon::Vocabulary` model to have a jsonb `name_translations` column instead of string `name` column and adds a `slug` column with uniqueness validation for site scope.
* Makes some changes to admin management of vocabularies:
  * Updates the form to edit translated name and slug
  * Reorders index columns to have delete icon at left, as terms have
  * Uses modal windows to new / edit action and redirects to index on successful creation / update
  * Changes link on vocabularies names from terms to edit form
  * Changes icon and text on link to vocabulary terms index
  * Adds integration tests
* Fixes a wrong breadcrumb element on terms index
* Adds a breadcrumb and tab to `GobiertoParticipation::Settings`

## :mag: How should this be manually tested?
Go to admin and manage vocabularies

## :eyes: Screenshots

### Before this PR
<img width="1028" alt="screen shot 2018-08-02 at 11 22 29" src="https://user-images.githubusercontent.com/446459/43575819-119fccdc-9648-11e8-9470-db5a6a6169d0.png">
<img width="1061" alt="screen shot 2018-08-02 at 11 22 56" src="https://user-images.githubusercontent.com/446459/43575845-1f748c26-9648-11e8-99fd-a5e7c7c12d51.png">
<img width="351" alt="screen shot 2018-08-02 at 11 33 27" src="https://user-images.githubusercontent.com/446459/43575863-2c619ff0-9648-11e8-8fc5-482352755994.png">
<img width="1090" alt="screen shot 2018-08-02 at 11 33 57" src="https://user-images.githubusercontent.com/446459/43575881-3912300c-9648-11e8-85cc-a21b6e7bc08a.png">
<img width="1058" alt="screen shot 2018-08-02 at 14 45 58" src="https://user-images.githubusercontent.com/446459/43584563-053ed864-9663-11e8-808b-f88de48f6276.png">

### After this PR
<img width="1057" alt="screen shot 2018-08-02 at 11 22 38" src="https://user-images.githubusercontent.com/446459/43575820-11bdfe50-9648-11e8-9977-cf8770b2c5b0.png">
<img width="893" alt="screen shot 2018-08-02 at 11 32 50" src="https://user-images.githubusercontent.com/446459/43575846-1f988482-9648-11e8-8bc1-49bed63f5f1a.png">
<img width="354" alt="screen shot 2018-08-02 at 11 33 34" src="https://user-images.githubusercontent.com/446459/43575864-2c85bec6-9648-11e8-8560-b7ded54db71c.png">
<img width="1053" alt="screen shot 2018-08-02 at 11 33 46" src="https://user-images.githubusercontent.com/446459/43575880-38f54b9a-9648-11e8-9d29-48b3540dc08c.png">
<img width="1041" alt="screen shot 2018-08-02 at 14 46 39" src="https://user-images.githubusercontent.com/446459/43584564-055d0ea6-9663-11e8-9117-d4d2e49c79d0.png">

## :shipit: Does this PR changes any configuration file?
No