### PR TITLE
Custom ranges for integrations

### DIFF
--- a/app/forms/gobierto_people/calendar_sync_event_form.rb
+++ b/app/forms/gobierto_people/calendar_sync_event_form.rb
@@ -7,10 +7,11 @@ module GobiertoPeople
 
     attr_accessor(
       :title,
-      :description
+      :description,
+      :integration_name
     )
 
-    validates :external_id, :title, presence: true
+    validates :external_id, :title, :integration_name, presence: true
     validate :event_in_sync_range_window
 
     trackable_on :event
@@ -75,7 +76,12 @@ module GobiertoPeople
     private
 
     def event_in_sync_range_window
-      errors.add(:starts_at, "is out of sync range") unless GobiertoCalendars.sync_range.cover?(starts_at)
+      range = if GobiertoCalendars.respond_to?("sync_range_#{integration_name}".to_sym)
+                GobiertoCalendars.send("sync_range_#{integration_name}")
+              else
+                GobiertoCalendars.sync_range
+              end
+      errors.add(:starts_at, "is out of sync range") unless range.cover?(starts_at)
     end
 
     def title_translations

--- a/app/models/gobierto_calendars.rb
+++ b/app/models/gobierto_calendars.rb
@@ -20,4 +20,16 @@ module GobiertoCalendars
     sync_range_start..sync_range_end
   end
 
+  def self.sync_range_start_ibm_notes
+    DateTime.now - 2.days
+  end
+
+  def self.sync_range_end_ibm_notes
+    DateTime.now + 10.months
+  end
+
+  def self.sync_range_ibm_notes
+    sync_range_start_ibm_notes..sync_range_end_ibm_notes
+  end
+
 end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -120,7 +120,8 @@ module GobiertoPeople
           ends_at: parse_date(event.end),
           state: state,
           attendees: event_attendees(event),
-          notify: occurrence.nil? || occurrence == 0
+          notify: occurrence.nil? || occurrence == 0,
+          integration_name: @configuration.integration_name
         }
 
         if event.location.present?

--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -94,7 +94,8 @@ module GobiertoPeople
           state: state,
           attendees: ibm_notes_event.attendees,
           locations_attributes: {"0" => locations_attributes },
-          notify: true
+          notify: true,
+          integration_name: calendar_configuration.integration_name
         }
 
         event_form = GobiertoPeople::CalendarSyncEventForm.new(person_event_params)
@@ -177,7 +178,7 @@ module GobiertoPeople
       end
 
       def sync_range_start
-        GobiertoCalendars.sync_range_start.iso8601.split('+')[0].concat('Z')
+        (GobiertoCalendars.sync_range_start - 2.days).iso8601.split('+')[0].concat('Z')
       end
 
       def plain_text_password

--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -106,7 +106,8 @@ module GobiertoPeople
           title: filter_result.event_attributes[:title],
           description: filter_result.event_attributes[:description],
           site_id: site.id,
-          person_id: person.id
+          person_id: person.id,
+          integration_name: configuration.integration_name
         }
 
         event_params[:locations_attributes] = if event.location.present?

--- a/test/forms/gobierto_people/calendar_sync_event_form_test.rb
+++ b/test/forms/gobierto_people/calendar_sync_event_form_test.rb
@@ -29,8 +29,8 @@ module GobiertoPeople
       @nelson ||= gobierto_people_people(:nelson)
     end
 
-    def event_attributes
-      @event_attributes ||= {
+    def event_attributes(attrs = {})
+      {
         external_id: "123",
         site_id: site.id,
         person_id: person.id,
@@ -40,8 +40,9 @@ module GobiertoPeople
         ends_at: event.ends_at,
         state: event.state,
         locations: [],
-        attendees: []
-      }
+        attendees: [],
+        integration_name: 'google'
+      }.merge(attrs)
     end
 
     def valid_event_form
@@ -59,7 +60,8 @@ module GobiertoPeople
         ends_at: nil,
         state: nil,
         locations: [],
-        attendees: []
+        attendees: [],
+        integration_name: 'google'
       )
     end
 
@@ -110,5 +112,9 @@ module GobiertoPeople
       assert_equal "Nelson event", event_3_form.event.title
     end
 
+    def test_event_in_sync_range_validation
+      refute CalendarSyncEventForm.new(event_attributes(starts_at: Time.now - 1.day, integration_name: 'google')).valid?
+      assert CalendarSyncEventForm.new(event_attributes(starts_at: Time.now - 1.day, integration_name: 'ibm_notes')).valid?
+    end
   end
 end


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR brings IBM Notes events from the last couple of days by default, overwritting the sync range only for this integration.