### PR TITLE
1808 protect terms and vocabularies with permissions

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
@@ -4,6 +4,8 @@ module GobiertoAdmin
   module GobiertoCommon
     class OrderedTermsController < BaseController
 
+      before_action :check_permissions!
+
       def index
         @vocabulary = find_vocabulary
         @terms = tree(@vocabulary.terms)
@@ -124,6 +126,9 @@ module GobiertoAdmin
         end.flatten
       end
 
+      def check_permissions!
+        raise_module_not_allowed unless current_admin.can_edit_vocabularies?
+      end
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_common/terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/terms_controller.rb
@@ -4,6 +4,8 @@ module GobiertoAdmin
   module GobiertoCommon
     class TermsController < BaseController
 
+      before_action :check_permissions!
+
       def index
         @terms = tree(terms_relation)
       end
@@ -106,6 +108,10 @@ module GobiertoAdmin
         relation.where(level: level).map do |node|
           [node, tree(node.terms, level + 1)].flatten
         end.flatten
+      end
+
+      def check_permissions!
+        raise_module_not_allowed unless current_admin.can_edit_vocabularies?
       end
     end
   end

--- a/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/vocabularies_controller.rb
@@ -4,6 +4,8 @@ module GobiertoAdmin
   module GobiertoCommon
     class VocabulariesController < BaseController
 
+      before_action :check_permissions!
+
       def index
         @vocabularies = vocabularies_relation.order(updated_at: :desc)
       end
@@ -82,6 +84,10 @@ module GobiertoAdmin
 
       def track_update_activity
         # pending
+      end
+
+      def check_permissions!
+        raise_module_not_allowed unless current_admin.can_edit_vocabularies?
       end
     end
   end

--- a/test/integration/gobierto_admin/gobierto_common/terms/create_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/create_term_test.rb
@@ -16,11 +16,25 @@ module GobiertoAdmin
         end
 
         def admin
-          @admin ||= gobierto_admin_admins(:nick)
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
         end
 
         def site
           @site ||= sites(:madrid)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
         end
 
         def test_create_term_errors

--- a/test/integration/gobierto_admin/gobierto_common/terms/delete_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/delete_term_test.rb
@@ -16,7 +16,11 @@ module GobiertoCommon
       end
 
       def admin
-        @admin ||= gobierto_admin_admins(:nick)
+        @admin ||= gobierto_admin_admins(:tony)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
       end
 
       def site
@@ -29,6 +33,16 @@ module GobiertoCommon
 
       def term_with_associated_items
         @term_with_associated_items ||= gobierto_common_terms(:culture_term)
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
       end
 
       def test_delete_term

--- a/test/integration/gobierto_admin/gobierto_common/terms/terms_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/terms_index_test.rb
@@ -16,7 +16,11 @@ module GobiertoCommon
       end
 
       def admin
-        @admin ||= gobierto_admin_admins(:nick)
+        @admin ||= gobierto_admin_admins(:tony)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
       end
 
       def site
@@ -29,6 +33,16 @@ module GobiertoCommon
 
       def first_term
         @first_term ||= terms.sorted.first
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
       end
 
       def test_terms_index

--- a/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
@@ -15,7 +15,11 @@ module GobiertoCommon
       end
 
       def admin
-        @admin ||= gobierto_admin_admins(:nick)
+        @admin ||= gobierto_admin_admins(:tony)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
       end
 
       def site
@@ -28,6 +32,16 @@ module GobiertoCommon
 
       def other_term
         @other_term ||= gobierto_common_terms(:cat)
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
       end
 
       def test_update_term


### PR DESCRIPTION
Closes #1808


## :v: What does this PR do?
Includes a filter to check if an admin has permissions to edit vocabularies and terms and redirects him in case it doesn't.

## :mag: How should this be manually tested?
Update an admin to be regular and don't check the Vocabularies checkbox. An admin with this profile shouldn't be available to reach `/admin/vocabularies` path.

## :shipit: Does this PR changes any configuration file?
No