### PR TITLE
Fix default locales for :ca and :es month and day names

### DIFF
--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -6,20 +6,60 @@ ca:
         record_invalid: 'La validació ha fallat: %{errors}'
   country: Espanya
   date:
-    abbr_day_names: '["dg", "dl", "dm", "dc", "dj", "dv", "ds"]'
-    abbr_month_names: '[nil, "gen", "feb", "mar", "abr", "mai", "jun", "jul", "ago",
-      "set", "oct", "nov", "des"]'
-    day_names: '["diumenge", "dilluns", "dimarts", "dimecres", "dijous", "divendres",
-      "dissabte"]'
+    abbr_day_names:
+    - dg
+    - dl
+    - dm
+    - dc
+    - dj
+    - dv
+    - ds
+    abbr_month_names:
+    - 
+    - gen
+    - feb
+    - mar
+    - abr
+    - mai
+    - jun
+    - jul
+    - ago
+    - set
+    - oct
+    - nov
+    - des
+    day_names:
+    - diumenge
+    - dilluns
+    - dimarts
+    - dimecres
+    - dijous
+    - divendres
+    - dissabte
     formats:
       day_month: "%d/%m"
       default: "%d-%m-%Y"
       long: "%d de %B de %Y"
       short: "%d de %b"
       shortest: "%d %b %y"
-    month_names: '[nil, "gener", "febrer", "març", "abril", "maig", "juny", "juliol",
-      "agost", "setembre", "octubre", "novembre", "desembre"]'
-    order: "[:day, :month, :year]"
+    month_names:
+    - 
+    - gener
+    - febrer
+    - març
+    - abril
+    - maig
+    - juny
+    - juliol
+    - agost
+    - setembre
+    - octubre
+    - novembre
+    - desembre
+    order:
+    - :day
+    - :month
+    - :year
   datetime:
     distance_in_words:
       about_x_hours:

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -6,19 +6,60 @@ es:
         record_invalid: 'La validación falló: %{errors}'
   country: España
   date:
-    abbr_day_names: '["dom", "lun", "mar", "mié", "jue", "vie", "sáb"]'
-    abbr_month_names: '[nil, "ene", "feb", "mar", "abr", "may", "jun", "jul", "ago",
-      "sep", "oct", "nov", "dic"]'
-    day_names: '["domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado"]'
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    - 
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
     formats:
       day_month: "%d/%m"
       default: "%d/%m/%Y"
       long: "%d de %B de %Y"
       short: "%d %b %Y"
       shortest: "%d %b %y"
-    month_names: '[nil, "enero", "febrero", "marzo", "abril", "mayo", "junio", "julio",
-      "agosto", "septiembre", "octubre", "noviembre", "diciembre"]'
-    order: "[:day, :month, :year]"
+    month_names:
+    - 
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
   datetime:
     distance_in_words:
       about_x_hours:


### PR DESCRIPTION

## :v: What does this PR do?
Fixes default month and day names for es and ca locales expanding a string containing the list of names with an array in yaml

## :mag: How should this be manually tested?
Take a look to a page with calendars

## :eyes: Screenshots

### Before this PR
<img width="390" alt="screen shot 2018-08-07 at 09 25 20" src="https://user-images.githubusercontent.com/446459/43763409-faaac77a-9a2a-11e8-9077-edecc89a575d.png">

### After this PR
<img width="402" alt="screen shot 2018-08-07 at 10 20 24" src="https://user-images.githubusercontent.com/446459/43763634-88f2e7ce-9a2b-11e8-9f6c-0100c8648cd8.png">

## :shipit: Does this PR changes any configuration file?
No