### PR TITLE
1820 highlight current political group

### DIFF
--- a/app/views/gobierto_people/people/_people_filter.html.erb
+++ b/app/views/gobierto_people/people/_people_filter.html.erb
@@ -32,7 +32,7 @@
       <div>
         <ul role="tablist" aria-label="<%= t('.political_groups', name: whom(@site.name)) %>">
           <% @political_groups.each do |political_group| %>
-            <li role="presentation" class="<%= class_if('active', @political_group == political_group) %>">
+            <li role="presentation" class="<%= class_if('active', @political_group.id == political_group.id) %>">
               <%= link_to political_group.name, gobierto_people_political_group_people_path(political_group.slug), tab_attributes(@political_group == political_group).merge('aria-controls' => 'people-list').merge('aria-controls' => 'people-list') %>
             </li>
           <% end %>

--- a/test/integration/gobierto_people/people_political_groups_test.rb
+++ b/test/integration/gobierto_people/people_political_groups_test.rb
@@ -30,6 +30,15 @@ module GobiertoPeople
       gobierto_people_people(:kali)
     end
 
+    def test_current_political_group_higlight
+      with_current_site(site) do
+        visit @path
+        within 'menu div div li.active' do
+          assert has_link?('Marvel')
+        end
+      end
+    end
+
     def test_absence_of_empty_political_group
       with_current_site(site) do
         visit @path

--- a/test/integration/gobierto_people/people_political_groups_test.rb
+++ b/test/integration/gobierto_people/people_political_groups_test.rb
@@ -33,8 +33,8 @@ module GobiertoPeople
     def test_current_political_group_higlight
       with_current_site(site) do
         visit @path
-        within 'menu div div li.active' do
-          assert has_link?('Marvel')
+        within "menu div div li.active" do
+          assert has_link?("Marvel")
         end
       end
     end
@@ -43,19 +43,19 @@ module GobiertoPeople
       with_current_site(site) do
         visit @path
 
-        within '.filter_boxed' do
-          assert has_link?('Marvel')
-          assert has_link?('DC')
+        within ".filter_boxed" do
+          assert has_link?("Marvel")
+          assert has_link?("DC")
         end
         dc_member.delete
         other_site_member.update(political_group: political_groups.last)
 
-        click_link 'Political groups'
+        click_link "Political groups"
         sleep 1
 
-        within '.filter_boxed' do
-          assert has_link?('Marvel')
-          assert has_no_link?('DC')
+        within ".filter_boxed" do
+          assert has_link?("Marvel")
+          assert has_no_link?("DC")
         end
       end
     end


### PR DESCRIPTION
Closes #1820


## :v: What does this PR do?
* Highlights the current political group in the gobierto people political groups filter.
* Adds a test to check that 

## :mag: How should this be manually tested?

## :eyes: Screenshots

### Before this PR
<img width="968" alt="screen shot 2018-08-10 at 16 00 01" src="https://user-images.githubusercontent.com/446459/43962153-3e38965a-9cb7-11e8-99b1-69d5e769c0c1.png">

### After this PR
<img width="965" alt="screen shot 2018-08-10 at 16 02 01" src="https://user-images.githubusercontent.com/446459/43962161-42e8cdc8-9cb7-11e8-8df3-3d1fcf8c9d53.png">

## :shipit: Does this PR changes any configuration file?
No