### PR TITLE
Fix subscriptions when referer is not available

### DIFF
--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -7,7 +7,7 @@ class MetaWelcomeController < ApplicationController
     render_404 and return if current_site.nil?
 
     if current_site.configuration.home_page != "GobiertoCms"
-      redirect_to eval("#{current_site.configuration.home_page.underscore}_root_path")
+      redirect_to(current_site.root_path)
     else
       # This code allows the homepage to render a page without redirecting to the page url
       item = GlobalID::Locator.locate(current_site.configuration.home_page_item_id)

--- a/app/controllers/user/subscriptions_controller.rb
+++ b/app/controllers/user/subscriptions_controller.rb
@@ -41,8 +41,7 @@ class User::SubscriptionsController < User::BaseController
             sign_in_path: new_user_sessions_path(host: current_site.domain)
           )
         end
-
-        redirect_to request.referrer
+        redirect_to(request.referrer || root_path)
       end
       format.js
     end

--- a/app/controllers/user/subscriptions_controller.rb
+++ b/app/controllers/user/subscriptions_controller.rb
@@ -50,7 +50,7 @@ class User::SubscriptionsController < User::BaseController
             sign_in_path: new_user_sessions_path(host: current_site.domain)
           )
         end
-        redirect_to(request.referrer || root_path)
+        redirect_back(fallback_location: root_path)
       end
       format.js
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -175,6 +175,10 @@ class Site < ApplicationRecord
     false
   end
 
+  def root_path
+    url_helpers.send("#{configuration.home_page.underscore}_root_path")
+  end
+
   private
 
   def site_configuration_attributes

--- a/test/integration/user/subscription_create_test.rb
+++ b/test/integration/user/subscription_create_test.rb
@@ -59,7 +59,8 @@ class User::SubscriptionCreateTest < ActionDispatch::IntegrationTest
   end
 
   def test_create_without_referer
-    ::ActionDispatch::Request.any_instance.stubs(:referrer).returns(nil)
+    ActionDispatch::Http::Headers.any_instance.expects(:[]).with("Referer").returns(nil)
+    ActionDispatch::Http::Headers.any_instance.expects(:[]).with("Turbolinks-Referrer").at_least_once.returns(nil)
 
     with_current_site(site) do
       visit gobierto_people_root_path

--- a/test/integration/user/subscription_create_test.rb
+++ b/test/integration/user/subscription_create_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class User::SubscriptionCreateTest < ActionDispatch::IntegrationTest
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def test_create_with_referer
+    with_current_site(site) do
+      visit gobierto_people_root_path
+
+      within "footer" do
+        fill_in :user_subscription_user_email, with: "email@example.com"
+        click_button "Subscribe"
+      end
+
+      assert_equal gobierto_people_root_path, current_path
+    end
+  end
+
+  def test_create_without_referer
+    ::ActionDispatch::Request.any_instance.stubs(:referrer).returns(nil)
+
+    with_current_site(site) do
+      visit gobierto_people_root_path
+
+      within "footer" do
+        fill_in :user_subscription_user_email, with: "email@example.com"
+        click_button "Subscribe"
+      end
+
+      assert_equal site.root_path, current_path
+    end
+  end
+
+end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -31,6 +31,10 @@ class SiteTest < ActiveSupport::TestCase
     assert site.valid?
   end
 
+  def test_root_path
+    assert_equal "/participacion", site.root_path
+  end
+
   # -- Initialization
   def test_admins_initialization
     site.admin_sites.delete_all


### PR DESCRIPTION
Fixes rollbar [#1202](https://rollbar.com/Populate/gobierto/items/1202/occurrences/49905012625/)

## What does this PR do

When creating a new subscription, if the referer is not available it redirects to the home page.