### PR TITLE
Rescue IBM Notes timeouts

### DIFF
--- a/app/services/gobierto_people/ibm_notes/calendar_integration.rb
+++ b/app/services/gobierto_people/ibm_notes/calendar_integration.rb
@@ -58,7 +58,7 @@ module GobiertoPeople
         log_message("Invalid credentials for site")
         raise ::GobiertoCalendars::CalendarIntegration::AuthError
       rescue ::IbmNotes::ServiceUnavailable
-        log_message("IBM Notes calendar API is down")
+        log_message("Timeout error for #{person.name} (id: #{person.id})")
         raise ::GobiertoCalendars::CalendarIntegration::TimeoutError
       rescue ::JSON::ParserError
         log_message("JSON parser error")

--- a/lib/ibm_notes/api.rb
+++ b/lib/ibm_notes/api.rb
@@ -60,6 +60,8 @@ module IbmNotes
           form.Password = params[:password]
         end.submit
       end
+    rescue *timeout_error_classes
+      raise IbmNotes::ServiceUnavailable
     end
     private_class_method :get_response_page
 
@@ -67,5 +69,11 @@ module IbmNotes
       Rails.logger.info "[SYNC-AGENDAS][IBM Notes]#{message}"
     end
     private_class_method :log_message
+
+    def self.timeout_error_classes
+      [::Net::HTTP::Persistent::Error, ::Net::ReadTimeout]
+    end
+    private_class_method :timeout_error_classes
+
   end
 end


### PR DESCRIPTION
Fixes rollbar [#1146](https://rollbar.com/Populate/gobierto/items/1146/)

## :v: What does this PR do?

Rescues Mechanize timeouts and raises `IbmNotes::ServiceUnavailable` instead.
