### PR TITLE
1821 - Integrate invisible captcha

### DIFF
--- a/app/controllers/gobierto_budgets/feedback_controller.rb
+++ b/app/controllers/gobierto_budgets/feedback_controller.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 class GobiertoBudgets::FeedbackController < GobiertoBudgets::ApplicationController
   respond_to :js
 
   before_action :set_params
+
+  invisible_captcha only: [:follow], honeypot: :ic_email
 
   def step1
   end
@@ -35,7 +39,15 @@ class GobiertoBudgets::FeedbackController < GobiertoBudgets::ApplicationControll
         site: current_site
       }).deliver_later
     end
-    user_subscription_form = User::SubscriptionForm.new site: current_site, creation_ip: remote_ip, subscribable_type: "Site", subscribable_id: current_site.id, user_email: params[:email]
+
+    user_subscription_form = User::SubscriptionForm.new(
+      site: current_site,
+      creation_ip: remote_ip,
+      subscribable_type: "Site",
+      subscribable_id: current_site.id,
+      user_email: params[:email]
+    )
+
     user_subscription_form.save
     @success = true
   end

--- a/app/controllers/gobierto_people/people/person_messages_controller.rb
+++ b/app/controllers/gobierto_people/people/person_messages_controller.rb
@@ -1,16 +1,24 @@
+# frozen_string_literal: true
+
 module GobiertoPeople
   module People
     class PersonMessagesController < BaseController
+
       before_action :check_person_has_email
+      invisible_captcha(
+        only: [:create],
+        honeypot: :ic_email,
+        scope: :gobierto_people_person_message
+      )
 
       def new
         @person_message = GobiertoPeople::PersonMessage.new(default_params)
       end
 
       def create
-        @person_message = GobiertoPeople::PersonMessage.new(person_message_params.merge(default_params.merge({
-          person: @person
-        })))
+        @person_message = GobiertoPeople::PersonMessage.new(
+          person_message_params.merge(default_params.merge(person: @person))
+        )
 
         if @person_message.valid?
           @person_message.deliver!

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 class User::RegistrationsController < User::BaseController
+
   before_action :require_no_authentication
+  invisible_captcha honeypot: :ic_email, scope: :user_registration
 
   layout "user/layouts/sessions"
 
@@ -10,12 +14,10 @@ class User::RegistrationsController < User::BaseController
 
     if @user_registration_form.save
       flash[:notice] = t(".success")
+    elsif @user_registration_form.errors.added?(:email, "has already been taken")
+      flash[:notice] = t(".email_taken")
     else
-      if @user_registration_form.errors.added?(:email, "has already been taken")
-        flash[:notice] = t(".email_taken")
-      else
-        flash[:alert] = t(".error")
-      end
+      flash[:alert] = t(".error")
     end
 
     redirect_to new_user_sessions_path

--- a/app/controllers/user/subscriptions_controller.rb
+++ b/app/controllers/user/subscriptions_controller.rb
@@ -1,5 +1,14 @@
+# frozen_string_literal: true
+
 class User::SubscriptionsController < User::BaseController
+
   before_action :authenticate_user!, only: [:index, :destroy]
+
+  invisible_captcha(
+    only: [:create],
+    honeypot: :ic_email,
+    scope: :user_subscription
+  )
 
   def index
     @user_notification_frequencies = get_user_notification_frequencies

--- a/app/views/gobierto_budgets/feedback/_ask_more_information.html.erb
+++ b/app/views/gobierto_budgets/feedback/_ask_more_information.html.erb
@@ -1,13 +1,14 @@
 <% id = nil unless defined?(id) %>
+
 <div class="slim_box">
   <%= form_tag gobierto_budgets_feedback_follow_path(ask_for_feedback: true, id: id), remote: true, class: "new_user" do %>
     <p><%= t('.ask_for_feedback', your_organization_name: @site.determined_organization_name(:your)) %>:</p>
-    <input placeholder="<%= t('.your_email') %>" type="email" name="email">
-    <input type="submit" name="commit" value="<%= t('.send') %>">
+    <%= email_field_tag :email, nil, placeholder: t(".your_email") %>
+    <%= submit_tag t(".send") %>
+    <%= invisible_captcha :ic_email %>
     <p class="small"><%= privacy_policy_page_link %></p>
   <% end %>
 </div>
 
 <div class="share_post_submit" id="ask_success">
 </div>
-

--- a/app/views/gobierto_budgets/feedback/_follow.html.erb
+++ b/app/views/gobierto_budgets/feedback/_follow.html.erb
@@ -1,12 +1,12 @@
 <div class="slim_box">
   <%= form_tag gobierto_budgets_feedback_follow_path, remote: true, class: "new_user" do %>
-    <p><%= t('.follow') %>:</p>
-    <input placeholder="<%= t('.your_email') %>" type="email" name="email">
-    <input type="submit" name="commit" value="<%= t('.follow') %>">
+    <p><%= t(".follow") %>:</p>
+    <%= email_field_tag :email, nil, placeholder: t(".your_email") %>
+    <%= submit_tag t(".follow") %>
+    <%= invisible_captcha :ic_email %>
     <p class="small"><%= privacy_policy_page_link %></p>
   <% end %>
 </div>
 
 <div class="share_post_submit" id="follow_success">
 </div>
-

--- a/app/views/gobierto_budgets/feedback/follow.js.erb
+++ b/app/views/gobierto_budgets/feedback/follow.js.erb
@@ -3,5 +3,7 @@
 <% else %>
   $('#follow_success').html('<%=j render('gobierto_budgets/feedback/follow_success') %>');
 <% end %>
-window.shareContent.attachTo('[data-share]');
 
+if (window.shareContent) {
+  window.shareContent.attachTo('[data-share]');
+}

--- a/app/views/gobierto_people/people/person_messages/new.html.erb
+++ b/app/views/gobierto_people/people/person_messages/new.html.erb
@@ -19,12 +19,13 @@
       </div>
     <% end %>
 
+    <%= f.invisible_captcha :ic_email %>
+
     <div class="form_item textarea">
       <%= f.label :body %>
       <%= f.text_area :body, placeholder: t('.placeholders.body') %>
     </div>
 
-    <%= invisible_captcha %>
     <%= f.submit t('.submit') %>
   <% end %>
 </div>

--- a/app/views/user/sessions/_registration_form.html.erb
+++ b/app/views/user/sessions/_registration_form.html.erb
@@ -9,6 +9,7 @@
 
   <div class="disclaimer"><%= privacy_policy_page_link %></div>
 
+  <%= f.invisible_captcha :ic_email %>
   <%= f.hidden_field :referrer_url %>
   <%= f.hidden_field :referrer_entity %>
   <%= f.submit t(".submit"), class: "button" %>

--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -31,6 +31,7 @@
         <%= f.hidden_field :subscribable_id %>
         <label class="screen-hidden" for="user_subscription_user_email"><%= defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %></label>
         <%= f.email_field :user_email, placeholder: defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %>
+        <%= f.invisible_captcha :ic_email %>
 
         <%= f.submit t(".form.submit"), role: "button" %>
         <div class="disclaimer"><%= privacy_policy_page_link %></div>

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+InvisibleCaptcha.setup do |config|
+  config.honeypots << %w(ic_email)
+  config.sentence_for_humans = false
+  config.timestamp_threshold = Rails.env.test? ? 0 : 0.5
+  config.visual_honeypots = false
+end

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -20,6 +20,18 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
     GobiertoBudgets::SearchEngineConfiguration::Year.last
   end
 
+  def feedback_ack_message
+    "100 % of the people who voted said that don't understand this budget line"
+  end
+
+  def subscription_ack_message
+    "Good! Check your email and click the link"
+  end
+
+  def enable_budget_line_feedback
+    ApplicationController.any_instance.stubs(:budget_lines_feedback_active?).returns(true)
+  end
+
   def test_budget_line_information
     with_each_current_site(placed_site, organization_site) do
       visit @path
@@ -49,4 +61,91 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
       assert_equal 400, status_code
     end
   end
+
+  def test_request_more_information_and_subscribe
+    enable_budget_line_feedback
+
+    with_javascript do
+      with_current_site(placed_site) do
+        visit @path
+
+        click_link "Ask your #{placed_site.organization_name}"
+
+        within("#load_ask_more_information") do
+          fill_in :email, with: "user@email.com"
+        end
+
+        click_button "Send"
+
+        assert has_content? subscription_ack_message
+      end
+    end
+  end
+
+  def test_request_more_information_and_subscribe_as_spam
+    enable_budget_line_feedback
+
+    with_javascript do
+      with_current_site(placed_site) do
+        visit @path
+
+        click_link "Ask your #{placed_site.organization_name}"
+
+        within("#load_ask_more_information") do
+          fill_in :email, with: "spam@email.com"
+          fill_in :ic_email, with: "spam@email.com"
+        end
+
+        click_button "Send"
+
+        refute has_content? subscription_ack_message
+      end
+    end
+  end
+
+  def test_send_feedback_and_subscribe
+    enable_budget_line_feedback
+
+    with_javascript do
+      with_current_site(placed_site) do
+        visit @path
+
+        click_link "Raise your hand"
+
+        within(".yes_no") { click_link "No" }
+
+        assert has_content? feedback_ack_message
+
+        fill_in :email, with: "user@email.com"
+
+        click_button "Follow"
+
+        assert has_content? subscription_ack_message
+      end
+    end
+  end
+
+  def test_send_feedback_and_subscribe_as_spam
+    enable_budget_line_feedback
+
+    with_javascript do
+      with_current_site(placed_site) do
+        visit @path
+
+        click_link "Raise your hand"
+
+        within(".yes_no") { click_link "No" }
+
+        assert has_content? feedback_ack_message
+
+        fill_in :email, with: "spam@email.com"
+        fill_in :ic_email, with: "spam@email.com"
+
+        click_button "Follow"
+
+        refute has_content? subscription_ack_message
+      end
+    end
+  end
+
 end

--- a/test/integration/gobierto_people/people/person_message_test.rb
+++ b/test/integration/gobierto_people/people/person_message_test.rb
@@ -47,6 +47,23 @@ module GobiertoPeople
         end
       end
 
+      def test_send_message_as_anonymous_spam_user
+        with_current_site(site) do
+          visit @path
+
+          click_link "Send an email"
+
+          fill_in :gobierto_people_person_message_name, with: "Sender"
+          fill_in :gobierto_people_person_message_email, with: "spam@example.com"
+          fill_in :gobierto_people_person_message_ic_email, with: "spam@example.com"
+          fill_in :gobierto_people_person_message_body, with: "This is my message"
+
+          click_button "Send"
+
+          assert ActionMailer::Base.deliveries.empty?
+        end
+      end
+
       def test_send_message_as_logged_user
         with_signed_in_user(user) do
           visit @path

--- a/test/integration/user/registration_test.rb
+++ b/test/integration/user/registration_test.rb
@@ -20,23 +20,40 @@ class User::RegistrationTest < ActionDispatch::IntegrationTest
     @other_site ||= sites(:santander)
   end
 
+  def registration_ack_message
+    "Please check your inbox to confirm your email address"
+  end
+
   def test_registration
     with_current_site(site) do
       visit @registration_path
 
       within "form#user-registration-form.new_user_registration" do
-        within "label" do
-          within "span.indication" do
-            assert has_content?("Required")
-          end
+        within "span.indication" do
+          assert has_content?("Required")
         end
       end
 
       fill_in :user_registration_email, with: "user@email.dev"
 
-      click_on "Let's go"
+      assert_difference "User.count", 1 do
+        click_on "Let's go"
+      end
 
-      assert has_message?("Please check your inbox to confirm your email address")
+      assert has_message? registration_ack_message
+    end
+  end
+
+  def test_registration_as_spam
+    with_current_site(site) do
+      visit @registration_path
+
+      fill_in :user_registration_email, with: "spam@email.dev"
+      fill_in :user_registration_ic_email, with: "spam@email.dev"
+
+      assert_no_difference "User.count" do
+        click_on "Let's go"
+      end
     end
   end
 
@@ -82,7 +99,7 @@ class User::RegistrationTest < ActionDispatch::IntegrationTest
 
       click_on "Let's go"
 
-      assert has_message?("Please check your inbox to confirm your email address")
+      assert has_message? registration_ack_message
     end
   end
 end

--- a/test/integration/user/subscription_create_test.rb
+++ b/test/integration/user/subscription_create_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class User::SubscriptionCreateTest < ActionDispatch::IntegrationTest
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def subscriptions_count
+    -> { User::Subscription.count }
+  end
+
+  def honeypot_redirect_path
+    "/user/subscriptions"
+  end
+
+  def test_create_subscription
+    with_current_site(site) do
+      visit root_path
+
+      fill_in :user_subscription_user_email, with: "user@email.com"
+
+      assert_difference subscriptions_count, 1 do
+        click_button "Subscribe"
+      end
+
+      assert_equal gobierto_participation_root_path, current_path
+    end
+  end
+
+  def test_create_spam_subscription
+    with_current_site(site) do
+      visit root_path
+
+      fill_in :user_subscription_user_email, with: "spam@email.com"
+      fill_in :user_subscription_ic_email, with: "spam@email.com"
+
+      assert_no_difference subscriptions_count do
+        click_button "Subscribe"
+      end
+
+      assert_equal honeypot_redirect_path, current_path
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #1821 

## :v: What does this PR do?

Integrates invisible captcha for:

* Budget line feedback
* Person messages
* User registrations
* User subscriptions

## :mag: How should this be manually tested?

Go to 
http://madrid.gobify.net/cargos-y-agendas

* If you fill in the email subscription at the bottom of the page, everything should work as before (you'll get a green flash).
* If apart from filling the email, you inspect and fill in the hidden `ic_email` and click submit, you should get a 200 OK and be redirected to a blank page (means spam was detected and subscription was not made).

## :shipit: Does this PR changes any configuration file?

No