### PR TITLE
Prevent destroying pages that have linked items

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -166,7 +166,7 @@ module GobiertoAdmin
           "<a href='#{edit_page_path}'>#{stage_page.process.title}</a>"
         end.join(", ").html_safe
 
-        t(".error_associated_items", links: associated_items_html).html_safe
+        t("gobierto_admin.gobierto_cms.pages.destroy.error_associated_items", links: associated_items_html).html_safe
       end
 
     end

--- a/app/forms/gobierto_admin/gobierto_participation/process_form.rb
+++ b/app/forms/gobierto_admin/gobierto_participation/process_form.rb
@@ -23,8 +23,6 @@ module GobiertoAdmin
       )
 
       delegate :persisted?, to: :process
-      delegate :polls_stage?, to: :process
-      delegate :information_stage?, to: :process
 
       validates :site, :process_type, presence: true
       validates :title_translations, translated_attribute_presence: true

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -94,6 +94,10 @@ module GobiertoCms
       active? && public_parent?
     end
 
+    def destroyable?
+      process_stage_pages.empty?
+    end
+
     def parameterize
       params = { id: slug }
       page? && section ? params.merge(slug_section: section.slug) : params

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -49,22 +49,6 @@ module GobiertoParticipation
       title
     end
 
-    def information_stage?
-      active_stage?(ProcessStage.stage_types[:information])
-    end
-
-    def polls_stage?
-      active_stage?(ProcessStage.stage_types[:polls])
-    end
-
-    def contributions_stage?
-      active_stage?(ProcessStage.stage_types[:contributions])
-    end
-
-    def results_stage?
-      active_stage?(ProcessStage.stage_types[:results])
-    end
-
     def active_stage?(stage_type)
       stages.exists?(stage_type: stage_type)
     end

--- a/app/models/gobierto_participation/process_stage_page.rb
+++ b/app/models/gobierto_participation/process_stage_page.rb
@@ -8,7 +8,7 @@ module GobiertoParticipation
     belongs_to :page, class_name: "GobiertoCms::Page"
 
     def process
-      Process.find(process_stage.process_id)
+      ::GobiertoParticipation::Process.find(process_stage.process_id)
     end
 
     def public?

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/pages/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/pages/ca.yml
@@ -7,8 +7,9 @@ ca:
           success_html: La pàgina ha estat creada correctament. <a href="%{link}">Veure
             la pàgina</a>.
         destroy:
+          error_associated_items: 'No es pot eliminar la pàgina perquè encara té elements
+            associats: %{links}'
           success: La pàgina ha estat eliminada correctament
-          error_associated_items: "No es pot eliminar la pàgina perquè encara té elements associats: %{links}"
         recover:
           success: La pàgina ha estat recuperada correctament
         update:

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/pages/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/pages/ca.yml
@@ -8,6 +8,7 @@ ca:
             la pàgina</a>.
         destroy:
           success: La pàgina ha estat eliminada correctament
+          error_associated_items: "No es pot eliminar la pàgina perquè encara té elements associats: %{links}"
         recover:
           success: La pàgina ha estat recuperada correctament
         update:

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/pages/en.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/pages/en.yml
@@ -7,6 +7,7 @@ en:
           success_html: Page created successfully. <a href="%{link}">View the page</a>.
         destroy:
           success: Page archived successfully
+          error_associated_items: "The page can not be deleted because it still has associated elements: %{links}"
         recover:
           success: The page has been successfully recovered
         update:

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/pages/en.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/pages/en.yml
@@ -6,8 +6,9 @@ en:
         create:
           success_html: Page created successfully. <a href="%{link}">View the page</a>.
         destroy:
+          error_associated_items: 'The page can not be deleted because it still has
+            associated elements: %{links}'
           success: Page archived successfully
-          error_associated_items: "The page can not be deleted because it still has associated elements: %{links}"
         recover:
           success: The page has been successfully recovered
         update:

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/pages/es.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/pages/es.yml
@@ -8,6 +8,7 @@ es:
             la página</a>.
         destroy:
           success: La página ha sido eliminada correctamente
+          error_associated_items: "No se puede eliminar la página porque todavía tiene elementos asociados: %{links}"
         recover:
           success: La página ha sido recuperada correctamente
         update:

--- a/config/locales/gobierto_admin/gobierto_cms/controllers/pages/es.yml
+++ b/config/locales/gobierto_admin/gobierto_cms/controllers/pages/es.yml
@@ -7,8 +7,9 @@ es:
           success_html: La página ha sido creada correctamente. <a href="%{link}">Ver
             la página</a>.
         destroy:
+          error_associated_items: 'No se puede eliminar la página porque todavía tiene
+            elementos asociados: %{links}'
           success: La página ha sido eliminada correctamente
-          error_associated_items: "No se puede eliminar la página porque todavía tiene elementos asociados: %{links}"
         recover:
           success: La página ha sido recuperada correctamente
         update:

--- a/test/fixtures/gobierto_cms/pages.yml
+++ b/test/fixtures/gobierto_cms/pages.yml
@@ -29,27 +29,27 @@ privacy:
   published_on: <%= Date.current %>
 
 cookies:
-  title_translations: <%= {'en' => 'Cookies' }.to_json %>
-  body_translations: <%= {'en' => 'These are the cookies terms' }.to_json %>
-  body_source_translations: <%= {'en' => 'These are the cookies terms' }.to_json %>
+  title_translations: <%= {'en' => 'Cookies', 'es' => 'Cookies' }.to_json %>
+  body_translations: <%= {'en' => 'These are the cookies terms', 'es' => 'Estas son las condiciones de las cookies' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the cookies terms', 'es' => 'Estas son las condiciones de las cookies' }.to_json %>
   slug: 'cookies'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
   published_on: <%= Date.current %>
 
 about:
-  title_translations: <%= {'en' => 'About' }.to_json %>
-  body_translations: <%= {'en' => 'About santander' }.to_json %>
-  body_source_translations: <%= {'en' => 'About santander' }.to_json %>
+  title_translations: <%= {'en' => 'About', 'es' => 'Acerca de' }.to_json %>
+  body_translations: <%= {'en' => 'About santander', 'es' => 'Acerca de Santander' }.to_json %>
+  body_source_translations: <%= {'en' => 'About santander', 'es' => 'Acerca de Santander' }.to_json %>
   slug: 'about'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: santander
   published_on: <%= Date.current %>
 
 themes:
-  title_translations: <%= {'en' => 'Themes in the site' }.to_json %>
-  body_translations: <%= {'en' => 'These are the themes' }.to_json %>
-  body_source_translations: <%= {'en' => 'These are the themes' }.to_json %>
+  title_translations: <%= {'en' => 'Themes in the site', 'es' => 'Temas en el sitio' }.to_json %>
+  body_translations: <%= {'en' => 'These are the themes', 'es' => 'Estos son los temas' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the themes', 'es' => 'Estos son los temas' }.to_json %>
   slug: 'themes'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -57,9 +57,9 @@ themes:
   published_on: <%= Date.current %>
 
 themes_draft:
-  title_translations: <%= {'en' => 'Themes draft' }.to_json %>
-  body_translations: <%= {'en' => 'These are the themes (draft)' }.to_json %>
-  body_source_translations: <%= {'en' => 'These are the themes (draft)' }.to_json %>
+  title_translations: <%= {'en' => 'Themes draft', 'es' => 'Borrador de temas' }.to_json %>
+  body_translations: <%= {'en' => 'These are the themes (draft)', 'es' => 'Estos son los temas(borrador)' }.to_json %>
+  body_source_translations: <%= {'en' => 'These are the themes (draft)', 'es' => 'Estos son los temas(borrador)' }.to_json %>
   slug: 'themes-draft'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
@@ -67,9 +67,9 @@ themes_draft:
   published_on: <%= Date.current %>
 
 notice_1:
-  title_translations: <%= {'en' => 'Notice 1 title' }.to_json %>
-  body_translations: <%= {'en' => 'Notice 1 <strong>body</strong>' }.to_json %>
-  body_source_translations: <%= {'en' => 'Notice 1 <strong>body</strong>' }.to_json %>
+  title_translations: <%= {'en' => 'Notice 1 title', 'es' => 'Título de la noticia 1' }.to_json %>
+  body_translations: <%= {'en' => 'Notice 1 <strong>body</strong>', 'es' => '<strong>Cuerpo</strong> de la noticia 1' }.to_json %>
+  body_source_translations: <%= {'en' => 'Notice 1 <strong>body</strong>', 'es' => '<strong>Cuerpo</strong> de la noticia 1' }.to_json %>
   slug: 'notice-1'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -77,9 +77,9 @@ notice_1:
   published_on: <%= Date.current %>
 
 notice_2:
-  title_translations: <%= {'en' => 'Notice 2 title' }.to_json %>
-  body_translations: <%= {'en' => 'Notice 2 body' }.to_json %>
-  body_source_translations: <%= {'en' => 'Notice 2 body' }.to_json %>
+  title_translations: <%= {'en' => 'Notice 2 title', 'es' => 'Título de la noticia 2' }.to_json %>
+  body_translations: <%= {'en' => 'Notice 2 body', 'es' => 'Cuerpo de la noticia 2' }.to_json %>
+  body_source_translations: <%= {'en' => 'Notice 2 body', 'es' => 'Cuerpo de la noticia 2' }.to_json %>
   slug: 'notice-2'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -88,8 +88,14 @@ notice_2:
 
 about_site:
   title_translations: <%= { 'es' => 'Sobre el sitio', 'en' => 'About site' }.to_json %>
-  body_translations: <%= { "en" => "This is the <strong>body</strong> of the page that contains an image:<br><img src='#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:png_attachment_uploaded), host: 'madrid.gobierto.test')}' alt='The image'> and a <a href='#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:pdf_attachment_uploaded), host: 'madrid.gobierto.test')}'>link to a doc</a>." }.to_json %>
-  body_source_translations: <%= { "en" => "This is the **body** of a page that contains an image:\r\n\r\n![The image](#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:png_attachment_uploaded), host: 'madrid.gobierto.test')})\r\n\r\n and a [link to a doc](#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:pdf_attachment_uploaded), host: 'madrid.gobierto.test')})." }.to_json %>
+  body_translations: <%= {
+    "en" => "This is the <strong>body</strong> of the page that contains an image:<br><img src='#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:png_attachment_uploaded), host: 'madrid.gobierto.test')}' alt='The image'> and a <a href='#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:pdf_attachment_uploaded), host: 'madrid.gobierto.test')}'>link to a doc</a>.",
+    "es" => "Esto es el <strong>cuerpo</strong> de la página que contiene una imagen:<br><img src='#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:png_attachment_uploaded), host: 'madrid.gobierto.test')}' alt='La imagen'> y un <a href='#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:pdf_attachment_uploaded), host: 'madrid.gobierto.test')}'>enlace a un doc</a>."
+  }.to_json %>
+  body_source_translations: <%= {
+    "en" => "This is the **body** of a page that contains an image:\r\n\r\n![The image](#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:png_attachment_uploaded), host: 'madrid.gobierto.test')})\r\n\r\n and a [link to a doc](#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:pdf_attachment_uploaded), host: 'madrid.gobierto.test')}).",
+    "en" => "Esto es el **cuerpo** de la página que contiene una imagen:\r\n\r\n![La imagen](#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:png_attachment_uploaded), host: 'madrid.gobierto.test')})\r\n\r\n y un [enlace a un doc](#{Rails.application.routes.url_helpers.gobierto_attachments_attachment_url(ActiveRecord::FixtureSet.identify(:pdf_attachment_uploaded), host: 'madrid.gobierto.test')})."
+  }.to_json %>
   slug: 'about-site'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -97,9 +103,18 @@ about_site:
   published_on: <%= Date.current %>
 
 about_participation:
-  title_translations: <%= {'en' => 'About participation' }.to_json %>
-  body_translations: <%= {"en" => "<p>About participation description\r\n {% list_children_pages about-participation %}</p>\r\n", "es" => ""}.to_json %>
-  body_source_translations: <%= {"en" => "About participation description\r\n {% list_children_pages about-participation %}", "es" => ""}.to_json %>
+  title_translations: <%= {
+    'en' => 'About participation',
+    'es' => 'Acerca de participación'
+  }.to_json %>
+  body_translations: <%= {
+    "en" => "<p>About participation description\r\n {% list_children_pages about-participation %}</p>\r\n",
+    "es" => "<p>Acerca de participación (descripción):\r\n {% list_children_pages about-participation %}</p>\r\n"
+  }.to_json %>
+  body_source_translations: <%= {
+    "en" => "About participation description\r\n {% list_children_pages about-participation %}",
+    "es" => "cerca de participación (descripción):\r\n {% list_children_pages about-participation %}"
+  }.to_json %>
   slug: 'about-participation'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -107,9 +122,18 @@ about_participation:
   published_on: <%= Date.current %>
 
 about_participation_details:
-  title_translations: <%= {'en' => 'About participation details' }.to_json %>
-  body_translations: <%= {'en' => 'Detalles sobre participación' }.to_json %>
-  body_source_translations: <%= {'en' => 'Detalles sobre participación' }.to_json %>
+  title_translations: <%= {
+    'en' => 'About participation details',
+    'es' => 'Detalles sobre participación'
+  }.to_json %>
+  body_translations: <%= {
+    'en' => 'About participation details',
+    'es' => 'Detalles sobre participación'
+  }.to_json %>
+  body_source_translations: <%= {
+    'en' => 'About participation details',
+    'es' => 'Detalles sobre participación'
+  }.to_json %>
   slug: 'about-participation-details'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
@@ -117,18 +141,36 @@ about_participation_details:
   published_on: <%= Date.current %>
 
 generic_site_page:
-  title_translations: <%= {'en' => 'Generic page' }.to_json %>
-  body_translations: <%= {'en' => 'Generic page' }.to_json %>
-  body_source_translations: <%= {'en' => 'Generic page' }.to_json %>
+  title_translations: <%= {
+    'en' => 'Generic page',
+    'es' => 'Página genérica'
+  }.to_json %>
+  body_translations: <%= {
+    'en' => 'Generic page',
+    'es' => 'Página genérica'
+  }.to_json %>
+  body_source_translations: <%= {
+    'en' => 'Generic page',
+    'es' => 'Página genérica'
+  }.to_json %>
   slug: 'generic-page'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   published_on: <%= Date.current %>
 
 how_to_participate:
-  title_translations: <%= {'en' => 'How to participate' }.to_json %>
-  body_translations: <%= {'en' => 'How to participate' }.to_json %>
-  body_source_translations: <%= {'en' => 'How to participate' }.to_json %>
+  title_translations: <%= {
+    'en' => 'How to participate',
+    'es' => 'Cómo participar'
+  }.to_json %>
+  body_translations: <%= {
+    'en' => 'How to participate',
+    'es' => 'Cómo participar'
+  }.to_json %>
+  body_source_translations: <%= {
+    'en' => 'How to participate',
+    'es' => 'Cómo participar'
+  }.to_json %>
   slug: 'how-to-participate'
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid

--- a/test/integration/gobierto_admin/gobierto_cms/archive_page_test.rb
+++ b/test/integration/gobierto_admin/gobierto_cms/archive_page_test.rb
@@ -26,6 +26,14 @@ module GobiertoAdmin
         @themes_page ||= gobierto_cms_pages(:themes)
       end
 
+      def consultation_faq_page
+        @consultation_faq_page ||= gobierto_cms_pages(:consultation_faq)
+      end
+
+      def site_pages_collection
+        ::GobiertoCommon::Collection.find_by(container: site, item_type: "GobiertoCms::Page")
+      end
+
       def test_archive_restore_page
         with_javascript do
           with_signed_in_admin(admin) do
@@ -49,6 +57,23 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_archive_error
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit admin_common_collection_path(site_pages_collection)
+
+              within "#page-item-#{consultation_faq_page.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("The page can not be deleted because it still has associated elements")
+            end
+          end
+        end
+      end
+
     end
   end
 end

--- a/test/models/gobierto_cms/page_test.rb
+++ b/test/models/gobierto_cms/page_test.rb
@@ -36,6 +36,7 @@ module GobiertoCms
     def attachable_without_attachment
       @attachable_without_attachment ||= gobierto_cms_pages(:privacy)
     end
+    alias process_information_page attachable_without_attachment
 
     def test_valid
       assert page.valid?
@@ -56,6 +57,16 @@ module GobiertoCms
       page.destroy
 
       assert page.slug.include?("archived-")
+    end
+
+    def test_destroyable?
+      refute process_information_page.destroyable?
+
+      ::GobiertoParticipation::ProcessStagePage.where(
+        page_id: process_information_page.id
+      ).destroy_all
+
+      assert process_information_page.reload.destroyable?
     end
 
     def test_public?


### PR DESCRIPTION
Fixes rollbar [#1237](https://rollbar.com/Populate/gobierto/items/1237/) and [#1242](https://rollbar.com/Populate/gobierto/items/1242/)

I've already deleted in staging the *orphan* process stage pages in staging. In case we have to check again: `::GobiertoParticipation::ProcessStagePage.select { |stage_page| stage_page.page.nil? }`

## :v: What does this PR do?

Prevents destroying pages that have linked items, so Process#show does not break
 
## :mag: How should this be manually tested?

1. Go to http://madrid.gobify.net/admin/collections/41 and try to archive the page "Página información grupo usuarios java". It will say it's still used.
2. Associate a different page in http://madrid.gobify.net/admin/participation/processes/2/process_stages/5/process_stage_page/25/edit If you try again, now it should succeed.
3. http://madrid.gobify.net/participacion/p/java-4tw should continue to work all the time.

## Screenshots

![captura de pantalla 2018-09-05 a las 13 05 24](https://user-images.githubusercontent.com/9287468/45089416-6199e680-b10c-11e8-9add-c76b1f04a3b3.png)

## :shipit: Does this PR changes any configuration file?

No