### PR TITLE
Add Unknown1 Standard Time

### DIFF
--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -12,6 +12,7 @@ module IbmNotes
       "Central Europe Standard Time",
       "Fus horari desconegut (1) Standard Time",
       "W. Europe Standard Time",
+      "Unknown1 Standard Time",
     ].freeze
 
     def initialize(person, response_event)


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

Adds type "Add Unknown1 Standard Time" to ibm notes time zones.
