### PR TITLE
Remove misleading rescue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  rescue_from ActionController::RoutingError, with: :render_404
   rescue_from ActionController::UnknownFormat, with: :render_404
 
   helper_method(
@@ -25,7 +24,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_site, :authenticate_user_in_site, :set_locale, :apply_engines_overrides
 
   def render_404
-    render file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]
+    render(file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]) and return
   end
 
   def helpers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_site, :authenticate_user_in_site, :set_locale, :apply_engines_overrides
 
   def render_404
-    render(file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]) and return
+    render file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]
   end
 
   def helpers


### PR DESCRIPTION
This rescue is not useful because `ActionController::RoutingError` errors are raised before any controller gets instantiated: https://stackoverflow.com/a/37174557/4156152

We don't see the rollbars because they're being ignored in https://github.com/PopulateTools/gobierto/blob/master/config/initializers/rollbar.rb#L11.

## :mag: How should this be manually tested?

You can test this in local - If in `master` you visit something like http://madrid.gobierto.test/a/b/c/d/e/f/g/h/i/j/k the exception is not being rescued.