### PR TITLE
Social share contributions

### DIFF
--- a/app/assets/stylesheets/theme-participation.scss
+++ b/app/assets/stylesheets/theme-participation.scss
@@ -1148,7 +1148,7 @@ $lighter_black: rgba($color_headers, 0.7);
       color: $green;
     }
 
-    .button {
+    .button, a.social_share {
       color: $color_main_negative;
     }
 

--- a/app/javascript/shared/modules/shareContent.js
+++ b/app/javascript/shared/modules/shareContent.js
@@ -102,6 +102,6 @@ export var shareContent = flight.component(function(){
   };
 });
 
-$(document).on('turbolinks:load', function() {
+$(document).on('turbolinks:load ajax:complete ajaxSuccess', function() {
   shareContent.attachTo('[data-share]');
 });

--- a/app/models/gobierto_participation/contribution.rb
+++ b/app/models/gobierto_participation/contribution.rb
@@ -64,7 +64,7 @@ module GobiertoParticipation
       )
     end
 
-    def to_path
+    def js_endpoint_path
       Rails.application.routes.url_helpers.gobierto_participation_process_contribution_container_contribution_path(
         process_id: contribution_container.process.slug,
         contribution_container_id: contribution_container.slug,
@@ -72,13 +72,12 @@ module GobiertoParticipation
       )
     end
 
+    def to_path
+      "#{contribution_container.to_path}##{slug}"
+    end
+
     def to_url(options = {})
-      host = site.domain
-      Rails.application.routes.url_helpers.gobierto_participation_process_contribution_container_path(
-        process_id: contribution_container.process.slug,
-        id: contribution_container.slug,
-        host: host
-      )
+      "#{contribution_container.to_url(options)}##{slug}"
     end
 
     def votes_fdiv(numerator, denominator, args = {})
@@ -151,7 +150,7 @@ module GobiertoParticipation
 
     def self.json_attributes
       all.map{ |c| { title: c.title, votes_count: c.votes_count, user_id: c.user_id, slug: c.slug,
-                     to_path: c.to_path, love_pct: c.love_pct, like_pct: c.like_pct, neutral_pct: c.neutral_pct,
+                     to_path: c.js_endpoint_path, love_pct: c.love_pct, like_pct: c.like_pct, neutral_pct: c.neutral_pct,
                      hate_pct: c.hate_pct, created_at_ymd: c.created_at_ymd } }
     end
   end

--- a/app/views/gobierto_participation/processes/contribution_containers/show.html.erb
+++ b/app/views/gobierto_participation/processes/contribution_containers/show.html.erb
@@ -20,7 +20,15 @@
         <div class="pure-u-1 pure-u-md-5-24 contribution_action">
           <% if @contribution_container.contributions_allowed? %>
             <% if current_user %>
-              <%= link_to t(".put_#{@contribution_container.contribution_type}"), new_gobierto_participation_process_contribution_container_contribution_path(process_id: current_process.slug, contribution_container_id: @contribution_container.slug), class: "button", remote: true %></a>
+              <%= link_to(
+                    t(".put_#{@contribution_container.contribution_type}"),
+                    new_gobierto_participation_process_contribution_container_contribution_path(
+                      process_id: current_process.slug,
+                      contribution_container_id: @contribution_container.slug
+                    ),
+                    class: "button",
+                    remote: true
+                  ) %>
             <% else %>
               <%= link_to t(".login_signup_#{@contribution_container.contribution_type}"), new_user_sessions_path(open_modal: true), class: 'button open_remote_modal' %>
             <% end %>
@@ -81,4 +89,23 @@
 
 <%= javascript_tag do %>
   contributionContainerData = JSON.parse('<%= raw @contribution_container_data.to_json %>');
+
+  function getPageAnchor() {
+    var splittedUrl = window.location.href.split("#");
+
+    if (splittedUrl.length > 1) {
+      return splittedUrl[splittedUrl.length - 1];
+    } else {
+      return undefined;
+    }
+  }
+
+  if (getPageAnchor()) {
+    $.ajax({
+      url: '<%= @contribution_container.to_path %>/contributions/' + getPageAnchor(),
+      dataType: 'script',
+      method: 'GET'
+    });
+  }
+
 <% end %>

--- a/app/views/gobierto_participation/processes/contributions/_contribution.html.erb
+++ b/app/views/gobierto_participation/processes/contributions/_contribution.html.erb
@@ -18,6 +18,13 @@
           </div>
         </div>
 
+        <div class='social_links_container f_right' data-share>
+          <a href='#' class='social_share twitter' data-share-network='twitter' data-track-event='Social Share|Click Twitter|Header'><i class='fa fa-twitter'></i></a>
+          <a href='#' class='social_share facebook' data-share-network='facebook' data-track-event='Social Share|Click Facebook|Header'><i class='fa fa-facebook'></i></a>
+          <a href='#' class='social_share whatsapp' data-share-network='whatsapp' data-track-event='Social Share|Click Whatsapp|Header'><i class='fa fa-whatsapp'></i></a>
+          <a href='#' class='social_share telegram' data-share-network='telegram' data-track-event='Social Share|Click telegram|Header'><i class='fa fa-telegram'></i></a>
+        </div>
+
         <%= render partial: 'gobierto_participation/processes/contributions/comments', locals: { commentable: @contribution, disabled: @contribution.contribution_container.contributions_forbidden? } %>
       </div>
 

--- a/app/views/gobierto_participation/processes/contributions/show.js.erb
+++ b/app/views/gobierto_participation/processes/contributions/show.js.erb
@@ -29,6 +29,10 @@ $('.contribution_card_expanded .modal_like_control .mfp-close').on('click', func
   e.preventDefault();
   $('.contribution_card_expanded').velocity('fadeOut', { duration: 150 });
   $('.contribution_tools_overlay').velocity('fadeOut', { duration: 150 });
+  // PhantomJS detects this as an attempt to break security
+  <% unless Rails.env.test? %>
+    window.history.pushState({}, '<%= @contribution_container.title %>', '<%= @contribution_container.to_url %>');
+  <% end %>
 });
 
 $('a.action_button').each(function(){
@@ -49,3 +53,5 @@ $('.card').on('click', function(e){
 // Height definition, ToDo make it dynamic
 // var contribution_card_expanded_container = $('.contributions_container .contributions_content').height();
 $('.contribution_card_expanded_main_col').height('650');
+
+window.history.pushState({}, '<%= @contribution.title %>', '<%= @contribution.to_path %>');

--- a/app/views/gobierto_participation/processes/contributions/show.js.erb
+++ b/app/views/gobierto_participation/processes/contributions/show.js.erb
@@ -41,15 +41,6 @@ $('a.action_button').each(function(){
   }
 });
 
-$('.card').on('click', function(e){
-  e.preventDefault();
-  // ToDo decide where we position the expanded card
-  $('.contributions_content').append($('.contribution_card_expanded'));
-  $('.contribution_card_expanded').velocity('fadeIn', { duration: 150 });
-  $('.contributions_content').append($('.contribution_tools_overlay'));
-  $('.contribution_tools_overlay').velocity('fadeIn', { duration: 150 });
-});
-
 // Height definition, ToDo make it dynamic
 // var contribution_card_expanded_container = $('.contributions_container .contributions_content').height();
 $('.contribution_card_expanded_main_col').height('650');

--- a/test/integration/gobierto_participation/processes/process_contribution_containers_show_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contribution_containers_show_test.rb
@@ -105,7 +105,7 @@ module GobiertoParticipation
       end
     end
 
-    def test_best_ratings_contributions_show
+    def test_best_ratings_filter
       with_javascript do
         with_current_site(site) do
           visit container_path
@@ -121,7 +121,7 @@ module GobiertoParticipation
       end
     end
 
-    def test_worst_ratings_contributions_show
+    def test_worst_ratings_filter
       with_javascript do
         with_current_site(site) do
           visit container_path
@@ -133,7 +133,7 @@ module GobiertoParticipation
       end
     end
 
-    def test_recent_contributions_show
+    def test_recent_contributions_filter
       with_javascript do
         with_current_site(site) do
           visit container_path
@@ -155,7 +155,23 @@ module GobiertoParticipation
           visit container_path
 
           page.find('[data-url="/participacion/p/ciudad-deportiva/aportaciones/children-contributions/contributions/carril-bici"]', visible: false).trigger("click")
-          assert has_content? "Carril bici hasta el Juan Carlos I"
+          assert has_selector?("h1", text: "Carril bici hasta el Juan Carlos I")
+        end
+      end
+    end
+
+    def test_contribution_show_via_permalink
+      with_javascript do
+        with_current_site(site) do
+          visit contribution.to_path
+
+          assert has_selector?("h1", text: "Carril bici hasta el Juan Carlos I")
+          assert current_url.include?("/p/ciudad-deportiva/aportaciones/children-contributions#carril-bici")
+
+          within(".contribution_card_expanded_wrapper") { click_button "×" }
+
+          assert has_selector?("h2", text: "What activities for children we can start up?")
+          assert has_no_selector?("h1", text: "Carril bici hasta el Juan Carlos I")
         end
       end
     end

--- a/test/models/gobierto_participation/contribution_test.rb
+++ b/test/models/gobierto_participation/contribution_test.rb
@@ -17,6 +17,14 @@ module GobiertoParticipation
       @peter ||= users(:peter)
     end
 
+    def process
+      @process ||= gobierto_participation_processes(:bowling_group_very_active)
+    end
+
+    def contribution_container
+      @contribution_container ||= gobierto_participation_contribution_containers(:bowling_group_contributions_current)
+    end
+
     def contribution
       @contribution ||= gobierto_participation_contributions(:bad_losers_contribution)
     end
@@ -45,6 +53,16 @@ module GobiertoParticipation
 
       # reed & susan are comment authors, peter voted
       assert_equal 3, contribution.participants_count
+    end
+
+    def test_to_path
+      expected_path = "/participacion/p/#{process.slug}/aportaciones/#{contribution_container.slug}##{contribution.slug}"
+      assert_equal expected_path, contribution.to_path
+    end
+
+    def test_to_url
+      expected_url = "http://madrid.gobierto.test/participacion/p/#{process.slug}/aportaciones/#{contribution_container.slug}##{contribution.slug}"
+      assert_equal expected_url, contribution.to_url
     end
 
   end


### PR DESCRIPTION
Closes #1893 

## :v: What does this PR do?

Adds support for accessing contributions via permalink and sharing them via social networks.

## :mag: How should this be manually tested?

You can now access a contribution via permalink: http://newal******as.gobify.net/participacion/p/planmaestro-al******as-programa-de-renovacion-urbana/aportaciones/que-acciones-harias-para-mejorar-tu-distrito#aumentar-el-ancho-de-las-aceras and share it.

Also, now if you open/close several cards, the blinking is gone.