### PR TITLE
Add knwon time zones as option

### DIFF
--- a/lib/ibm_notes/person_event.rb
+++ b/lib/ibm_notes/person_event.rb
@@ -45,8 +45,11 @@ module IbmNotes
         elsif UTC_TIMEZONES.include?(time_zone)
           ActiveSupport::TimeZone["UTC"]
         else
-          Rollbar.error(Exception.new("[GobiertoCalendars] Unknown IBM Notes time zone #{time_zone}"))
-          nil
+          tz = ActiveSupport::TimeZone[time_zone]
+          if tz.nil?
+            Rollbar.error(Exception.new("[GobiertoCalendars] Unknown IBM Notes time zone #{time_zone}"))
+            nil
+          end
         end
       end
 

--- a/test/lib/ibm_notes/person_event_test.rb
+++ b/test/lib/ibm_notes/person_event_test.rb
@@ -74,6 +74,12 @@ class IbmNotes::PersonEventTest < ActiveSupport::TestCase
     assert_equal utc_time("2017-04-11 08:00:00"), ibm_notes_event.starts_at
   end
 
+  def test_parse_known_time_zones
+    ibm_notes_event = IbmNotes::PersonEvent.new(person, response_data(start: { "date" => "2017-04-11", "time" => "10:00:00", "tzid" => "Europe/Lisbon" }))
+
+    assert_equal utc_time("2017-04-11 10:00:00"), ibm_notes_event.starts_at
+  end
+
   def test_parse_unknown_time_zone
     assert_raise do
       IbmNotes::PersonEvent.new(person, response_data(start: { "date" => "2017-04-11", "time" => "10:00:00", "tzid" => "Unkown" }))


### PR DESCRIPTION
This PR allows IBM Notes to use known time zones, such as Europe/Lisbon
