### PR TITLE
Fix budget indicators

### DIFF
--- a/app/controllers/gobierto_budgets/indicators_controller.rb
+++ b/app/controllers/gobierto_budgets/indicators_controller.rb
@@ -21,7 +21,7 @@ class GobiertoBudgets::IndicatorsController < GobiertoBudgets::ApplicationContro
   end
 
   def available_years
-    @available_years ||= GobiertoBudgets::SearchEngineConfiguration::Year.all.delete_if { |x| x == current_year }
+    @available_years ||= GobiertoBudgets::SearchEngineConfiguration::Year.all.delete_if { |x| x >= current_year - 1 }
   end
 
   def current_year

--- a/app/javascript/budgets/modules/indicators_controller.js
+++ b/app/javascript/budgets/modules/indicators_controller.js
@@ -22,49 +22,47 @@ window.GobiertoBudgets.IndicatorsController = (function() {
   };
 
   function _runIndicatorsApplication() {
-    $(document).on('turbolinks:load', function() {
-      var grossSavingCard = new GrossSavingCard('.gross_saving_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      grossSavingCard.render();
+    var grossSavingCard = new GrossSavingCard('.gross_saving_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    grossSavingCard.render();
 
-      var netSavingCard = new NetSavingCard('.net_saving_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      netSavingCard.render();
+    var netSavingCard = new NetSavingCard('.net_saving_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    netSavingCard.render();
 
-      var taxAutonomyCard = new TaxAutonomyCard('.tax_autonomy_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      taxAutonomyCard.render();
+    var taxAutonomyCard = new TaxAutonomyCard('.tax_autonomy_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    taxAutonomyCard.render();
 
-      var selfFinancingCapacityCard = new SelfFinancingCapacityCard('.self_financing_capacity_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      selfFinancingCapacityCard.render();
+    var selfFinancingCapacityCard = new SelfFinancingCapacityCard('.self_financing_capacity_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    selfFinancingCapacityCard.render();
 
-      var financialChargeCard = new FinancialChargeCard('.financial_charge_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      financialChargeCard.render();
+    var financialChargeCard = new FinancialChargeCard('.financial_charge_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    financialChargeCard.render();
 
-      var liabilityCostCard = new LiabilityCostCard('.liability_cost_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      liabilityCostCard.render();
+    var liabilityCostCard = new LiabilityCostCard('.liability_cost_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    liabilityCostCard.render();
 
-      var investmentFinancingCard = new InvestmentFinancingCard('.investment_financing_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      investmentFinancingCard.render();
+    var investmentFinancingCard = new InvestmentFinancingCard('.investment_financing_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    investmentFinancingCard.render();
 
-      var grossSavingsRateCard = new GrossSavingsRateCard('.gross_savings_rate_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      grossSavingsRateCard.render();
+    var grossSavingsRateCard = new GrossSavingsRateCard('.gross_savings_rate_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    grossSavingsRateCard.render();
 
-      var netSavingsRateCard = new NetSavingsRateCard('.net_savings_rate_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      netSavingsRateCard.render();
+    var netSavingsRateCard = new NetSavingsRateCard('.net_savings_rate_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    netSavingsRateCard.render();
 
-      var perCapitaInvestmentCard = new PerCapitaInvestmentCard('.per_capita_investment_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      perCapitaInvestmentCard.render();
+    var perCapitaInvestmentCard = new PerCapitaInvestmentCard('.per_capita_investment_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    perCapitaInvestmentCard.render();
 
-      var debtLevelCard = new DebtLevelCard('.debt_level_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      debtLevelCard.render();
+    var debtLevelCard = new DebtLevelCard('.debt_level_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    debtLevelCard.render();
 
-      var perCapitaTaxBurdenCard = new PerCapitaTaxBurdenCard('.per_capita_tax_burden_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      perCapitaTaxBurdenCard.render();
+    var perCapitaTaxBurdenCard = new PerCapitaTaxBurdenCard('.per_capita_tax_burden_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    perCapitaTaxBurdenCard.render();
 
-      var financialRiskCard = new FinancialRiskCard('.financial_risk_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      financialRiskCard.render();
+    var financialRiskCard = new FinancialRiskCard('.financial_risk_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    financialRiskCard.render();
 
-      var expenditureRigidityCard = new ExpenditureRigidityCard('.expenditure_rigidity_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
-      expenditureRigidityCard.render();
-    });
+    var expenditureRigidityCard = new ExpenditureRigidityCard('.expenditure_rigidity_card', window.populateData.municipalityId, window.populateDataYear.currentYear);
+    expenditureRigidityCard.render();
   }
 
   return IndicatorsController;

--- a/app/views/gobierto_budgets/indicators/index.html.erb
+++ b/app/views/gobierto_budgets/indicators/index.html.erb
@@ -55,7 +55,4 @@
 
 <% content_for :javascript_hook do %>
   window.GobiertoBudgets.indicators_controller.index();
-  window.populateDataYear = {
-    currentYear: <%= @selected_year %>
-  }
 <% end %>

--- a/app/views/layouts/_gobierto_head.html.erb
+++ b/app/views/layouts/_gobierto_head.html.erb
@@ -55,6 +55,11 @@
     year: <%= APP_CONFIG["gobierto_observatory"]["year"] %>,
     endpoint: "<%= APP_CONFIG["populate_data"]["endpoint"] %>"
   }
+  <% if @selected_year %>
+  window.populateDataYear = {
+    currentYear: <%= @selected_year %>
+  }
+  <% end %>
 </script>
 
 <%= csrf_meta_tags %>


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR fixes javascript of budgets indicator page

Because 2017 data is kind of broken I've disabled temorally that year from the dropdown

## :mag: How should this be manually tested?

Visit budgets indicators page from any municipality.

## :eyes: Screenshots

![screen shot 2018-10-09 at 11 11 51](https://user-images.githubusercontent.com/17616/46658969-3d6e7100-cbb4-11e8-8070-82f4da27d550.png)
