### PR TITLE
Fix treemap relaod after clicking in the tabs

### DIFF
--- a/app/javascript/budgets/modules/application.js
+++ b/app/javascript/budgets/modules/application.js
@@ -16,12 +16,7 @@ import './intelligenceBudgetLines.js'
 import './intelligenceBudgetLinesMeans.js'
 import './visLine.js'
 
-$(document).on('turbolinks:load', function() {
-
-  if(!isDesktop()) {
-    $('.open_line_browser').hide();
-  }
-
+$(document).on('turbolinks:load ajax:complete ajaxSuccess', function() {
   if($('#expense-treemap').length && !$('#expense-treemap svg').length){
     let expenseTreemap = new TreemapVis('#expense-treemap', 'big', true);
     expenseTreemap.render($('#expense-treemap').data('functional-url'));
@@ -38,6 +33,13 @@ $(document).on('turbolinks:load', function() {
     window.addEventListener("resize", _.debounce(function () {
       expenseTreemap.render($('#treemap').data('url'));
     }, 250));
+  }
+})
+
+$(document).on('turbolinks:load', function() {
+
+  if(!isDesktop()) {
+    $('.open_line_browser').hide();
   }
 
   if($('.vis-bubbles-expense').length && $('.vis-bubbles-income').length && !$('.vis-bubbles-expense svg').length && !$('.vis-bubbles-income svg').length) {

--- a/app/views/gobierto_budgets/budgets_elaboration/index.js.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.js.erb
@@ -1,7 +1,2 @@
 $('#data-block').html('<%=j render 'data_block' %>');
-
 $('#treemap svg').html('');
-if($('#treemap').length && !$('#treemap svg').length){
-  window.expenseTreemap = new TreemapVis('#treemap', 'big', true);
-  window.expenseTreemap.render($('#treemap').data('url'));
-}


### PR DESCRIPTION
Unexpected error on elaboration page

## :v: What does this PR do?

This PR fixes treemap reload when a tab is clicked in the elaboration page.

Check expenses > Economic tab keeps the treemap open.

## :eyes: Screenshots


### After this PR

![screen shot 2018-10-09 at 14 32 05](https://user-images.githubusercontent.com/17616/46669587-1c1b7e00-cbd0-11e8-8982-367d9f70b4a5.png)
