### PR TITLE
Engines CI builds in the same branch as Gobierto

### DIFF
--- a/script/custom_engines_ci_setup
+++ b/script/custom_engines_ci_setup
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 # Setup custom engine 1
+branch=`git rev-parse --abbrev-ref HEAD`
+echo "Working in branch $branch"
 git clone git@github.com:PopulateTools/$CUSTOM_ENGINE_NAME_1.git ~/$CUSTOM_ENGINE_NAME_1
 cd ~/$CUSTOM_ENGINE_NAME_1
+git checkout $branch
 ./script/setup.sh
 ./script/create_webpacker_symlinks.sh


### PR DESCRIPTION
## :v: What does this PR do?

This PR forces the tests of the engines to run in a branch with the same name as the built branch of Gobierto.

## :mag: How should this be manually tested?

In circle, check the step `script/custom_engines_ci_setup`, you should see something like:

```
Working in branch staging
Cloning into '/home/circleci/gobierto-gencat-engine'...
remote: Enumerating objects: 159, done.        
remote: Counting objects: 100% (159/159), done.        
remote: Compressingremote: Compressing objects: 100% (114/114), done.        
remote: Total 3068 (delta 53), reused 125 (delta 31), pack-reused 2909        
Receiving objects: 100% (3068/3068), 359.25 KiB | 0 bytes/s, done.
ResolviResolving deltas: 100% (1555/1555), done.
Branch staging set up to track remote branch staging from origin.
Switched to a new branch 'staging'
Running setup script for gobierto-gencat-engine
Using dev_dir: /home/circleci
```

**Working in branch staging**
**Switched to a new branch 'staging'**
