### PR TITLE
Don't assign vocabulary_id when it's not present

### DIFF
--- a/app/forms/gobierto_admin/gobierto_people/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_people/settings_form.rb
@@ -97,7 +97,7 @@ module GobiertoAdmin
           settings_attributes.home_text_en = home_text_en
           settings_attributes.submodules_enabled = submodules_enabled.select{|m| m.present?}
           settings_attributes.calendar_integration = calendar_integration
-          settings_attributes.political_groups_vocabulary_id = political_groups_vocabulary_id&.to_i
+          settings_attributes.political_groups_vocabulary_id = political_groups_vocabulary_id
 
           set_ibm_notes_integration_settings(settings_attributes)
         end

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -1,3 +1,5 @@
+## animals
+
 mammal:
   vocabulary: animals
   name_translations: <%= { es: "Mamífero", en: "Mammal" }.to_json %>
@@ -5,6 +7,7 @@ mammal:
   slug: <%= "animals-mammal" %>
   position: 0
   level: 0
+
 dog:
   vocabulary: animals
   name_translations: <%= { es: "Perro", en: "Dog" }.to_json %>
@@ -13,6 +16,7 @@ dog:
   position: 0
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:mammal) %>
+
 cat:
   vocabulary: animals
   name_translations: <%= { es: "Gato", en: "Cat" }.to_json %>
@@ -21,6 +25,7 @@ cat:
   position: 1
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:mammal) %>
+
 bird:
   vocabulary: animals
   name_translations: <%= { es: "Pájaro", en: "Bird" }.to_json %>
@@ -28,6 +33,7 @@ bird:
   slug: <%= "animals-bird" %>
   position: 0
   level: 0
+
 swift:
   vocabulary: animals
   name_translations: <%= { es: "Vencejo", en: "Swift" }.to_json %>
@@ -36,6 +42,7 @@ swift:
   position: 0
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>
+
 pigeon:
   vocabulary: animals
   name_translations: <%= { es: "Paloma", en: "Pigeon" }.to_json %>
@@ -44,6 +51,9 @@ pigeon:
   position: 1
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>
+
+## issues_vocabulary
+
 culture_term:
   vocabulary: issues_vocabulary
   name_translations: <%= { 'en' => 'Culture', 'es' => 'Cultura' }.to_json %>
@@ -51,6 +61,7 @@ culture_term:
   slug: culture
   position: 1
   level: 0
+
 women_term:
   vocabulary: issues_vocabulary
   name_translations: <%= { 'en' => 'Women', 'es' => 'Mujer' }.to_json %>
@@ -58,6 +69,7 @@ women_term:
   slug: women
   position: 2
   level: 0
+
 economy_term:
   vocabulary: issues_vocabulary
   name_translations: <%= { 'en' => 'Economy', 'es' => 'Economía' }.to_json %>
@@ -65,6 +77,7 @@ economy_term:
   slug: economy
   position: 3
   level: 0
+
 sports_term:
   vocabulary: issues_vocabulary
   name_translations: <%= { 'en' => 'Sports', 'es' => 'Deportes' }.to_json %>
@@ -72,6 +85,7 @@ sports_term:
   slug: sport
   position: 4
   level: 0
+
 center_term:
   vocabulary: scopes_vocabulary
   name_translations: <%= { 'en' => 'Center', 'es' => 'Centro' }.to_json %>
@@ -79,6 +93,7 @@ center_term:
   slug: center
   position: 1
   level: 0
+
 old_town_term:
   vocabulary: scopes_vocabulary
   name_translations: <%= { 'en' => 'Old town', 'es' => 'Casco histórico' }.to_json %>
@@ -86,18 +101,25 @@ old_town_term:
   slug: old-town
   position: 2
   level: 0
+
+## madrid_political_groups_vocabulary
+
 marvel_term:
   vocabulary: madrid_political_groups_vocabulary
   name_translations: <%= { "en" => "Marvel", "es" => "Marvel" }.to_json %>
   slug: marvel
   position: 1
   level: 0
+
 dc_term:
   vocabulary: madrid_political_groups_vocabulary
   name_translations: <%= { "en" => "DC", "es" => "DC" }.to_json %>
   slug: dc
   position: 2
   level: 0
+
+## plan_categories_vocabulary
+
 people_and_families_plan_term:
   vocabulary: plan_categories_vocabulary
   name_translations: <%= { 'en' => 'People and families',
@@ -107,6 +129,7 @@ people_and_families_plan_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+
 welfare_payments_plan_term:
   vocabulary: plan_categories_vocabulary
   name_translations: <%= { 'en' => 'Provide social assistance to individuals and families who need it for lack of resources',
@@ -117,6 +140,7 @@ welfare_payments_plan_term:
   position: 1
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+
 center_scholarships_plan_term:
   vocabulary: plan_categories_vocabulary
   name_translations: <%= { 'en' => 'Scholarships for families in the Central District',
@@ -127,6 +151,7 @@ center_scholarships_plan_term:
   position: 2
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+
 center_basic_needs_plan_term:
   vocabulary: plan_categories_vocabulary
   name_translations: <%= { 'en' => 'Necesidades básicas de las familias del Distrito Centro',
@@ -137,6 +162,7 @@ center_basic_needs_plan_term:
   position: 3
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+
 economy_plan_term:
   vocabulary: plan_categories_vocabulary
   name_translations: <%= { 'en' => 'Economy',
@@ -146,6 +172,7 @@ economy_plan_term:
   position: 4
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+
 city_plan_term:
   vocabulary: plan_categories_vocabulary
   name_translations: <%= { 'en' => 'City',
@@ -155,6 +182,9 @@ city_plan_term:
   position: 5
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+
+## citizen_services_categories
+
 social_services_term:
   vocabulary: citizens_services_categories
   name_translations: <%= { 'en' => 'Social Services', 'es' => 'Cohesión Social y Servicios Sociales' }.to_json %>
@@ -163,6 +193,7 @@ social_services_term:
   position: 0
   created_at: 2018-09-10 00:00:00
   updated_at: 2018-09-10 00:00:00
+
 culture_service_term:
   vocabulary: citizens_services_categories
   name_translations: <%= { 'en' => 'Culture', 'es' => 'Cultura' }.to_json %>
@@ -171,6 +202,7 @@ culture_service_term:
   position: 1
   created_at: 2018-09-10 00:00:00
   updated_at: 2018-09-1 0 00:00:00
+
 sports_service_term:
   vocabulary: citizens_services_categories
   name_translations: <%= { 'en' => 'Sports', 'es' => 'Deportes' }.to_json %>


### PR DESCRIPTION
Avoid assigning `0` to `site.gobierto_people_settings. political_groups_vocabulary_id ` when no vocabulary is selected.

Linked to https://github.com/PopulateTools/gobierto-gencat-engine/pull/9

~This just makes sure than when we save the site we don't assing an ID to the vocabulary, and updates the tests so when no political groups exists, the welcome page still works. But as you said maybe we also want to enforce this vocabulary exists for all the sites that require it (all that don't have this engine configured?).~