### PR TITLE
Add a scope to belongs_to generated with has_vocabulary using settings of module

### DIFF
--- a/test/support/concerns/gobierto_common/has_vocabulary_test.rb
+++ b/test/support/concerns/gobierto_common/has_vocabulary_test.rb
@@ -38,6 +38,20 @@ module GobiertoCommon
       end
     end
 
+    def test_associated_term_is_scoped_with_vocabulary
+      singular_vocabularies.each do |method|
+        not_empty = model.where.not(method => nil).first
+        assert not_empty.send(method).present?
+
+        setting_name = model.vocabularies[method]
+        module_name = model.name.deconstantize
+        not_empty.site.settings_for_module(module_name).send("#{ setting_name }=", nil)
+        not_empty.site.settings_for_module(module_name).save
+        not_empty.reload
+        assert not_empty.send(method).blank?
+      end
+    end
+
     def test_associated_vocabulary
       singular_vocabularies.each do |method|
         vocabulary_id = site.gobierto_participation_settings.send(GobiertoParticipation::Process.vocabularies[method])


### PR DESCRIPTION
## :v: What does this PR do?

Sets the `belongs_to` association of models created with `has_vocabulary` mechanism scoping terms of vocabulary configured in the module

## :mag: How should this be manually tested?
Empty vocabulary configuration of `GobiertoPeople` for political groups in admin. All the people references to political groups should disappear in front pages.

## :eyes: Screenshots

https://www.dropbox.com/s/a89llw7pnbfxj0q/scoped.mov?dl=0

## :shipit: Does this PR changes any configuration file?
No

