### PR TITLE
Fix preview link for collections at module level

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,6 @@ class ApplicationController < ActionController::Base
     :current_module,
     :current_module_class,
     :available_locales,
-    :gobierto_calendars_event_preview_url,
     :algoliasearch_configured?,
     :cache_key_preffix
   )
@@ -126,16 +125,5 @@ class ApplicationController < ActionController::Base
     else
       head :forbidden
     end
-  end
-
-  def gobierto_calendars_event_preview_url(event, options = {})
-    options[:host] ||= current_site.domain
-
-    if ((event.collection.container.class_name == "GobiertoParticipation::Process" && event.pending?) ||
-        (event.collection.container.class_name == "GobiertoPeople::Person" && event.pending?) ||
-        (@person && @person.draft?))
-      options.merge!(preview_token: current_admin.preview_token)
-    end
-    event.to_url(options)
   end
 end

--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -12,7 +12,7 @@ module GobiertoAdmin
 
     helper_method :current_admin, :admin_signed_in?, :current_site, :managing_site?,
                   :managed_sites, :can_manage_sites?, :gobierto_cms_page_preview_path,
-                  :preview_item_url
+                  :preview_item_url, :gobierto_calendars_event_preview_url
 
     rescue_from Errors::NotAuthorized, with: :raise_admin_not_authorized
 
@@ -76,5 +76,17 @@ module GobiertoAdmin
       gobierto_cms_page_or_news_path(page, options)
     end
 
+    def gobierto_calendars_event_preview_url(event, options = {})
+      options[:host] ||= current_site.domain
+
+      if ((event.collection.container.respond_to?(:class_name) && event.collection.container.class_name == "GobiertoParticipation::Process" && event.pending?) ||
+          (event.collection.container.respond_to?(:class_name) && event.collection.container.class_name == "GobiertoPeople::Person" && event.pending?) ||
+          (event.collection.container_type == "GobiertoPeople" && event.pending?) ||
+          (event.collection.container_type == "GobiertoParticipation" && event.pending?) ||
+          (@person && @person.draft?))
+        options.merge!(preview_token: current_admin.preview_token)
+      end
+      event.to_url(options)
+    end
   end
 end

--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -12,7 +12,7 @@ module GobiertoAdmin
 
     helper_method :current_admin, :admin_signed_in?, :current_site, :managing_site?,
                   :managed_sites, :can_manage_sites?, :gobierto_cms_page_preview_path,
-                  :preview_item_url, :gobierto_calendars_event_preview_url
+                  :preview_item_url
 
     rescue_from Errors::NotAuthorized, with: :raise_admin_not_authorized
 
@@ -74,19 +74,6 @@ module GobiertoAdmin
     def gobierto_cms_page_preview_path(page, options = {})
       options[:preview_token] = current_admin.preview_token unless page.active?
       gobierto_cms_page_or_news_path(page, options)
-    end
-
-    def gobierto_calendars_event_preview_url(event, options = {})
-      options[:host] ||= current_site.domain
-
-      if ((event.collection.container.respond_to?(:class_name) && event.collection.container.class_name == "GobiertoParticipation::Process" && event.pending?) ||
-          (event.collection.container.respond_to?(:class_name) && event.collection.container.class_name == "GobiertoPeople::Person" && event.pending?) ||
-          (event.collection.container_type == "GobiertoPeople" && event.pending?) ||
-          (event.collection.container_type == "GobiertoParticipation" && event.pending?) ||
-          (@person && @person.draft?))
-        options.merge!(preview_token: current_admin.preview_token)
-      end
-      event.to_url(options)
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/events_controller.rb
@@ -58,9 +58,7 @@ module GobiertoAdmin
         if @event_form.save
           redirect_to(
             edit_admin_calendars_event_path(@event_form.event, collection_id: collection),
-            notice: t(".success_html",
-            link: gobierto_calendars_event_preview_url(@event_form.event,
-                                                       host: current_site.domain))
+            notice: t(".success_html", link: @event_form.to_url(preview: true, admin: current_admin))
           )
         else
           @attendees = get_attendees
@@ -83,9 +81,7 @@ module GobiertoAdmin
         if @event_form.save
           redirect_to(
             edit_admin_calendars_event_path(@event, collection_id: collection),
-            notice: t(".success_html",
-            link: gobierto_calendars_event_preview_url(@event_form.event,
-                                                       host: current_site.domain))
+            notice: t(".success_html", link: @event_form.to_url(preview: true, admin: current_admin))
           )
         else
           @attendees = get_attendees

--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -2,6 +2,9 @@
 
 module GobiertoParticipation
   class EventsController < GobiertoParticipation::ApplicationController
+
+    include ::PreviewTokenHelper
+
     def index
       @issue = find_issue if params[:issue_id]
       @issues = find_issues
@@ -15,7 +18,7 @@ module GobiertoParticipation
     def show
       container_events
 
-      @event = find_event
+      @event = participation_events_scope.find_by!(slug: params[:id])
       @calendar_events = @container_events
     end
 
@@ -39,12 +42,12 @@ module GobiertoParticipation
       @calendar_events = @container_events
     end
 
-    def find_event
-      current_site.events.published.find_by!(slug: params[:id])
-    end
-
     def container_events
       @container_events = GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation")
+    end
+
+    def participation_events_scope
+      valid_preview_token? ? current_site.events : current_site.events.published
     end
 
     def find_events_by_date(date)

--- a/app/forms/gobierto_admin/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_admin/gobierto_calendars/event_form.rb
@@ -12,6 +12,7 @@ module GobiertoAdmin
       )
 
       trackable_on :event
+      delegate :to_url, to: :event
 
       def ignored_constructor_attributes
         [:department_id, :meta]

--- a/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/events/_index.html.erb
@@ -79,7 +79,7 @@
             <%= t(".visibility_level.#{event.state}") %>
           </td>
           <td>
-            <%= link_to gobierto_calendars_event_preview_url(event), target: "_blank", class: "view_item" do %>
+            <%= link_to event.to_url(preview: true, admin: current_admin), target: "_blank", class: "view_item" do %>
               <i class="fa fa-eye"></i>
               <%= t(".view_event") %>
             <% end %>

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -111,6 +111,17 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_gobierto_module_events
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+            click_link "Participation events"
+
+            assert has_content?("Innovation course")
+          end
+        end
+      end
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
+++ b/test/integration/gobierto_admin/gobierto_calendars/collections_test.rb
@@ -27,6 +27,10 @@ module GobiertoAdmin
         @person ||= gobierto_people_people(:richard)
       end
 
+      def event
+        @event ||= gobierto_calendars_events(:innovation_event)
+      end
+
       def test_list_of_collections
         with_signed_in_admin(admin) do
           with_current_site(site) do
@@ -115,10 +119,25 @@ module GobiertoAdmin
       def test_gobierto_module_events
         with_signed_in_admin(admin) do
           with_current_site(site) do
+            # for published events
             visit @path
             click_link "Participation events"
 
-            assert has_content?("Innovation course")
+            assert has_content? event.title
+
+            within("#person-event-item-#{event.id}") { click_link "View event" }
+
+            assert has_selector?("h3", text: event.title)
+
+            # for pending events
+            event.pending!
+
+            visit @path
+            click_link "Participation events"
+
+            within("#person-event-item-#{event.id}") { click_link "View event" }
+            assert has_selector?("h3", text: event.title)
+            assert current_url.include?(admin.preview_token)
           end
         end
       end


### PR DESCRIPTION
Closes #1955 


## :v: What does this PR do?

This PR fixes a condition in preview link helper.

## :mag: How should this be manually tested?

Go to staging, create an events collection at module level (i.e GobiertoParticipation). 

If you add events to the collection, the list of events shouldn't raise an error.

In staging, this page should work: http://newal*****.gobify.net/admin/collections/1289