### PR TITLE
Charters improvements

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/services_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/services_controller.rb
@@ -9,6 +9,7 @@ module GobiertoAdmin
       end
 
       def new
+        set_vocabulary
         @service_form = ServiceForm.new(site_id: current_site.id)
         @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(site_id: current_site.id, item: @service_form.resource)
         render(:new_modal, layout: false) && return if request.xhr?
@@ -16,6 +17,7 @@ module GobiertoAdmin
 
       def edit
         load_service
+        set_vocabulary
 
         @service_form = ServiceForm.new(
           @service.attributes.except(*ignored_service_attributes).merge(site_id: current_site.id)
@@ -76,6 +78,10 @@ module GobiertoAdmin
       end
 
       private
+
+      def set_vocabulary
+        @vocabulary = current_site.vocabularies.find_by_id(::GobiertoCitizensCharters::Service.categories_vocabulary_id(current_site))
+      end
 
       def load_service
         @service = current_site.services.find(params[:id])

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/_commitment.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/_commitment.html.erb
@@ -15,7 +15,7 @@
   <td>
     <%= commitment.editions.count %>
     <% if commitment.editions.exists? %>
-      (<%= link_to t(".see_recent"), admin_citizens_charters_charter_editions_path(@charter, commitment.editions.recent.first.period_admin_params) %>)
+      <%= link_to t(".see_recent"), admin_citizens_charters_charter_editions_path(@charter, commitment.editions.recent.first.period_admin_params) %>
     <% end %>
   </td>
   <td class="visibility_level">

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/edit.html.erb
@@ -6,8 +6,4 @@
   <%= render("sub_breadcrumb", extra_items: [{ text: @commitment.title }]) %>
 </div>
 
-<h1>
-  <%= @commitment.title %>
-</h1>
-
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/index.html.erb
@@ -2,11 +2,13 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<div class="pure-g m_v_2">
-  <%= render("sub_breadcrumb") %>
-</div>
+<%= render("sub_breadcrumb") %>
 
 <div class="admin_tools right">
+    <%= link_to  edit_admin_citizens_charters_charter_path(@charter) do %>
+      <i class="fa fa-edit"></i>
+      <%= t("gobierto_admin.gobierto_citizens_charters.shared.edit.title", item: @charter.title) %>
+    <% end %>
   <%= link_to t(".new"), new_admin_citizens_charters_charter_commitment_path(@charter), class: "button" %>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/commitments/new.html.erb
@@ -6,8 +6,4 @@
   <%= render("sub_breadcrumb", extra_items: [{ text: t(".title") }]) %>
 </div>
 
-<h1>
-  <%= t(".title") %>
-</h1>
-
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/edit.html.erb
@@ -7,8 +7,4 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<h1>
-  <%= @charter.title %>
-</h1>
-
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/editions/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/editions/index.html.erb
@@ -2,23 +2,25 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<div class="pure-g m_v_2">
+<div>
   <div class="pure-u-3-4">
     <strong><%= @charter.title %></strong> »
     <%= link_to t("gobierto_admin.gobierto_citizens_charters.shared.navigation.editions_intervals"), admin_citizens_charters_charter_editions_intervals_path(@charter) %> »
     <%= link_to t(".#{@period_interval}_interval"), admin_citizens_charters_charter_editions_intervals_path(@charter, period_interval: @period_interval) %> »
     <%= t(".#{@period_interval}_period", @reference_edition.period_values ) %>
   </div>
-  <div class="pure-u-1-4 admin_tools right">
+  <div class="admin_tools right">
     <%= link_to admin_citizens_charters_charter_commitments_path(@charter) do %>
       <%= t("gobierto_admin.gobierto_citizens_charters.shared.navigation.commitments") %>
     <% end %>
+    <%= link_to  edit_admin_citizens_charters_charter_path(@charter) do %>
+      <i class="fa fa-edit"></i>
+      <%= t("gobierto_admin.gobierto_citizens_charters.shared.edit.title", item: @charter.title) %>
+    <% end %>
+      <%= link_to t(".new"), "#", class: "button", data: { insert: true } %>
   </div>
 </div>
 
-  <div class="admin_tools right">
-    <%= link_to t(".new"), "#", class: "button", data: { insert: true } %>
-  </div>
 
 <% if @commitments_list.present? %>
   <div id="jsGrid"></div>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/editions_intervals/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/editions_intervals/index.html.erb
@@ -12,12 +12,6 @@
       <%= t("gobierto_admin.gobierto_citizens_charters.shared.navigation.editions_intervals") %>
     <% end %>
   </div>
-  <div class="pure-u-1-4 admin_tools right">
-    <%= link_to admin_citizens_charters_charter_commitments_path(@charter) do %>
-      <%= t("gobierto_admin.gobierto_citizens_charters.shared.navigation.commitments") %>
-    <% end %>
-  </div>
-
 </div>
 
 <% if @charter.commitments.exists? %>
@@ -41,6 +35,15 @@
 
     <div class="pure-u-1 pure-u-md-2-5">
       <div class="admin_tools right">
+        <%= link_to admin_citizens_charters_charter_commitments_path(@charter) do %>
+          <%= t("gobierto_admin.gobierto_citizens_charters.shared.navigation.commitments") %>
+        <% end %>
+
+        <%= link_to  edit_admin_citizens_charters_charter_path(@charter) do %>
+          <i class="fa fa-edit"></i>
+          <%= t("gobierto_admin.gobierto_citizens_charters.shared.edit.title", item: @charter.title) %>
+        <% end %>
+
         <%= link_to t(".new"), new_admin_citizens_charters_charter_editions_interval_path(@charter), class: "button open_remote_modal" %>
       </div>
     </div>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/index.html.erb
@@ -7,7 +7,6 @@
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
 <div class="admin_tools right">
-  <%= render("gobierto_admin/gobierto_citizens_charters/shared/configuration") %>
   <%= link_to t(".new"), new_admin_citizens_charters_charter_path, class: "button" %>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/index.html.erb
@@ -6,8 +6,6 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<h1><%= title t(".title") %></h1>
-
 <div class="admin_tools right">
   <%= render("gobierto_admin/gobierto_citizens_charters/shared/configuration") %>
   <%= link_to t(".new"), new_admin_citizens_charters_charter_path, class: "button" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/charters/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/charters/new.html.erb
@@ -7,8 +7,4 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<h1>
-  <%= t(".title") %>
-</h1>
-
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/configuration/settings/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="admin_breadcrumb">
   <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
-  <%= link_to t("gobierto_admin.gobierto_citizens_charters.services.index.title"), admin_citizens_charters_path %> »
+  <%= link_to t("gobierto_admin.layouts.application.citizens_charters"), admin_citizens_charters_path %> »
   <%= t(".title") %>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_citizens_charters/services/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/services/_form.html.erb
@@ -20,7 +20,12 @@
 
       <div class="form_item select_control">
         <%= f.label :category_id do %>
-          <%= f.object.class.human_attribute_name(:category_id) %>
+          <% if @vocabulary %>
+            <%= t(".category", vocabulary: @vocabulary.name) %>
+          <% else %>
+            <%= link_to t(".set_vocabulary"), edit_admin_citizens_charters_configuration_settings_path %>
+          <% end %>
+
           <%= attribute_indication_tag required: true %>
         <% end %>
 

--- a/app/views/gobierto_admin/gobierto_citizens_charters/services/_service.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/services/_service.html.erb
@@ -14,9 +14,10 @@
   </td>
   <% if charters_enabled? %>
     <td>
-      <%== service.charters.active.map do |charter| %>
-        <% link_to(charter.title, edit_admin_citizens_charters_charter_path(charter)) %>
-      <% end.join(" - ") %>
+      <% service.charters.active.each do |charter| %>
+        <%= link_to(charter.title, edit_admin_citizens_charters_charter_path(charter)) %>
+        <br>
+      <% end %>
     </td>
   <% end %>
   <td>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/services/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/services/edit.html.erb
@@ -7,8 +7,4 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<h1>
-  <%= @service.title %>
-</h1>
-
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/services/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/services/index.html.erb
@@ -7,7 +7,6 @@
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
 <div class="admin_tools right">
-  <%= render("gobierto_admin/gobierto_citizens_charters/shared/configuration") %>
   <%= link_to t(".new"), new_admin_citizens_charters_service_path, class: "button" %>
 </div>
 

--- a/app/views/gobierto_admin/gobierto_citizens_charters/services/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/services/index.html.erb
@@ -6,8 +6,6 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<h1><%= title t(".title") %></h1>
-
 <div class="admin_tools right">
   <%= render("gobierto_admin/gobierto_citizens_charters/shared/configuration") %>
   <%= link_to t(".new"), new_admin_citizens_charters_service_path, class: "button" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/services/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/services/new.html.erb
@@ -7,8 +7,4 @@
 
 <%= render("gobierto_admin/gobierto_citizens_charters/shared/navigation") %>
 
-<h1>
-  <%= t(".title") %>
-</h1>
-
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_citizens_charters/shared/_configuration.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/shared/_configuration.html.erb
@@ -1,5 +1,0 @@
-<%= link_to edit_admin_citizens_charters_configuration_settings_path do %>
-  <i class="fa fa-cog"></i>
-  <%= t("gobierto_admin.gobierto_citizens_charters.shared.configuration.configuration") %>
-<% end %>
-

--- a/app/views/gobierto_admin/gobierto_citizens_charters/shared/_navigation.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/shared/_navigation.html.erb
@@ -1,3 +1,11 @@
+<h1><%= title t("gobierto_admin.layouts.application.citizens_charters") %></h1>
+<div class="admin_tools right">
+  <%= link_to edit_admin_citizens_charters_configuration_settings_path do %>
+    <i class="fa fa-cog"></i>
+    <%= t("gobierto_admin.gobierto_citizens_charters.shared.configuration.configuration") %>
+  <% end %>
+</div>
+
 <div class="tabs">
   <ul>
     <li class="<%= class_if("active", controller_name == "services") %>">

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
@@ -64,7 +64,7 @@ ca:
             created: Creat
             service: Servei
             status: Estat
-            title: Títol
+            title: Carta de serveis
             updated: Actualitzat
           new: Nova carta
           title: Cartes de Serveis
@@ -86,7 +86,7 @@ ca:
           header:
             max_value: Valor màxim
             percentage: Percentatge
-            title: Títol
+            title: Compromís
             value: Valor
       services:
         form:
@@ -101,7 +101,7 @@ ca:
             charters: Cartes de servei
             created: Creat
             status: Estat
-            title: Títol
+            title: Servei
             updated: Actualitzat
           new: Nou servei
           title: Serveis

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
@@ -90,9 +90,11 @@ ca:
             value: Valor
       services:
         form:
+          category: 'Categoria (vocabulari: %{vocabulary})'
           placeholders:
             slug: atencio-centres-diurns
             title: Servei de atenció a centres diürns
+          set_vocabulary: Definir vocabulari per categories
         index:
           header:
             category: Categoria

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
@@ -91,9 +91,11 @@ en:
             value: Value
       services:
         form:
+          category: 'Category (vocabulary: %{vocabulary})'
           placeholders:
             slug: day-care
             title: Day care service
+          set_vocabulary: Set a vocabulary for categories
         index:
           header:
             category: Category

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
@@ -64,7 +64,7 @@ en:
             created: Created at
             service: Service
             status: Status
-            title: Title
+            title: Service charter
             updated: Updated
           new: New charter
           title: Services Charters
@@ -87,7 +87,7 @@ en:
           header:
             max_value: Max Value
             percentage: Percentage
-            title: Title
+            title: Commitment
             value: Value
       services:
         form:
@@ -102,7 +102,7 @@ en:
             charters: Services charters
             created: Created at
             status: Status
-            title: Title
+            title: Service
             updated: Updated at
           new: New service
           title: Services

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
@@ -64,7 +64,7 @@ es:
             created: Creación
             service: Servicio
             status: Estado
-            title: Título
+            title: Carta de servicios
             updated: Actualización
           new: Nueva carta
           title: Cartas de Servicios
@@ -86,7 +86,7 @@ es:
           header:
             max_value: Objetivo
             percentage: Porcentaje
-            title: Título
+            title: Compromiso
             value: Valor
       services:
         form:
@@ -101,7 +101,7 @@ es:
             charters: Cartas de servicio
             created: Creación
             status: Estado
-            title: Título
+            title: Servicio
             updated: Actualización
           new: Nuevo servicio
           title: Servicios

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
@@ -90,9 +90,11 @@ es:
             value: Valor
       services:
         form:
+          category: 'Categoría (vocabulario: %{vocabulary})'
           placeholders:
             slug: atencion-diurna
             title: Servicio de atención diurna
+          set_vocabulary: Definir vocabulario para categorías
         index:
           header:
             category: Categoría

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -9,7 +9,7 @@ ca:
         budget_consultations: Consultes de pressupostos
         budgets: Pressupostos
         calendars: Agendes
-        citizens_charters: Serveis
+        citizens_charters: Serveis i cartes de serveis
         cms: CMS
         collapse_menu: Colapsar menú
         custom_fields: Camps personalitzats

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -9,7 +9,7 @@ en:
         budget_consultations: Budget consultations
         budgets: Budgets
         calendars: Calendars
-        citizens_charters: Services
+        citizens_charters: Services and services charters
         cms: CMS
         collapse_menu: Collapse menu
         custom_fields: Custom fields

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -9,7 +9,7 @@ es:
         budget_consultations: Consultas de presupuestos
         budgets: Presupuestos
         calendars: Agendas
-        citizens_charters: Servicios
+        citizens_charters: Servicios y cartas de servicios
         cms: CMS
         collapse_menu: Colapsar menú
         custom_fields: Campos personalizados


### PR DESCRIPTION
## :v: What does this PR do?
Makes some improvements to navigation of charters in admin:
* Displays the name of the vocabulary configured for services category or a link to settings if not configured yet
* Shows the list of charters of a service separated by lines in the services index
* Renames the title of citizens services charters in layout
* Removes some redundant titles
* Removes parentheses around link to recent editions in commitments index
* Adds a link to edit charter on commitments and editions index
* Rearranges position of links to create and configuration

## :shipit: Does this PR changes any configuration file?
No