### PR TITLE
Fix formatting of process body within teaser cards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "rollbar"
 gem "ruby_px"
 gem "before_renders"
 gem "bootsnap"
+gem "truncate_html"
 
 # Frontend
 gem "bourbon", "~> 4.3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -459,6 +459,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    truncate_html (0.9.3)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -561,6 +562,7 @@ DEPENDENCIES
   spy
   therubyracer
   timecop
+  truncate_html
   turbolinks
   uglifier (>= 1.3.0)
   vcr
@@ -568,4 +570,4 @@ DEPENDENCIES
   webpacker (~> 3.0)!
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,6 +135,21 @@ module ApplicationHelper
     end
   end
 
+  def truncated_html(html_text, options)
+    return "" unless html_text.present?
+
+    stripped_text = html_text.dup
+
+    if (options[:headers] == false)
+      stripped_text.gsub!(/<h\d(.*?)>/, "<p>")  # header opening
+      stripped_text.gsub!(/<\\h\d>/, "</p>")    # header closing
+    end
+
+    stripped_text.gsub!(/<img(.*?)>/, "") if (options[:images] == false)
+
+    truncate_html(stripped_text, options)
+  end
+
   private
 
   def parse_max_length(params)

--- a/app/views/gobierto_participation/processes/_group_teaser.html.erb
+++ b/app/views/gobierto_participation/processes/_group_teaser.html.erb
@@ -3,7 +3,7 @@
   <%= link_to gobierto_participation_process_path(group.slug), class:"content_block light" do %>
 
     <h3><%= group.title %></h3>
-    <p><%= group.body %></p>
+    <p><%== group.body %></p>
 
     <div class="meta right">
       <div class="ib"><i class="fa fa-comment"></i><%= group.interactions_count %></div>

--- a/app/views/gobierto_participation/processes/_group_teaser.html.erb
+++ b/app/views/gobierto_participation/processes/_group_teaser.html.erb
@@ -3,7 +3,8 @@
   <%= link_to gobierto_participation_process_path(group.slug), class:"content_block light" do %>
 
     <h3><%= group.title %></h3>
-    <p><%== group.body %></p>
+
+    <p><%== truncated_html(group.body, length: 350, headers: false, images: false) %></p>
 
     <div class="meta right">
       <div class="ib"><i class="fa fa-comment"></i><%= group.interactions_count %></div>

--- a/test/fixtures/gobierto_participation/processes.yml
+++ b/test/fixtures/gobierto_participation/processes.yml
@@ -3,8 +3,8 @@
 green_city_group_active_empty:
   site: madrid
   title_translations: <%= { 'en' => 'Green city', 'es' => 'Ciudad verde' }.to_json %>
-  body_translations: <%= { 'en' => 'Make Madrid a green city', 'es' => 'Hacer de Madrid una ciudad verde. Este grupo no tiene fases activas.' }.to_json %>
-  body_source_translations: <%= { 'en' => 'Make Madrid a green city', 'es' => 'Hacer de Madrid una ciudad verde. Este grupo no tiene fases activas.' }.to_json %>
+  body_translations: <%= { 'en' => '<p>Make Madrid a <i>green city</i></p>', 'es' => '<p>Hacer de Madrid una <i>ciudad verde</i>. Este grupo no tiene fases activas.</p>' }.to_json %>
+  body_source_translations: <%= { 'en' => 'Make Madrid a _green city_', 'es' => 'Hacer de Madrid una _ciudad verde_. Este grupo no tiene fases activas.' }.to_json %>
   slug: ciudad-verde
   process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
   visibility_level: <%= Site.visibility_levels['active'] %>

--- a/test/integration/gobierto_participation/processes/process_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_index_test.rb
@@ -97,6 +97,10 @@ module GobiertoParticipation
         assert has_link?(future_closed_group.title)
         assert has_link?(past_closed_group.title)
 
+        # ensure body is properly formatted
+        assert has_content? "Make Madrid a green city"
+        assert has_no_content? "Make Madrid a <i>green city</i>"
+
         # check groups details
 
         assert_equal 8, find_interactions_count_by_group_title(group_with_many_contributions.title)


### PR DESCRIPTION
Check in http://madrid.gobify.net/participacion/p

I've included an external gem that takes care of closing HTML tags when truncating text, because the Rails helpers leave unclosed tags when truncating HTML.