### PR TITLE
464 - Support for custom favicon

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,10 @@ Closes #N
 - [ ] new entry in `config/secrets.yml`?
 
 (Changes in these files might need to update the role in Ansible)
+
+## :book: Does this PR require updating the documentation?
+
+- [ ] new site configuration variable?
+- [ ] new site template?
+- [ ] new module/submodule settings?
+- [ ] significant changes in some feature?

--- a/app/helpers/site_helper.rb
+++ b/app/helpers/site_helper.rb
@@ -30,4 +30,9 @@ module SiteHelper
     end
   end
 
+  def custom_favicon_url
+    return unless current_site
+    current_site.configuration.configuration_variables["favicon_url"].presence
+  end
+
 end

--- a/app/views/layouts/_custom_favicon.html.erb
+++ b/app/views/layouts/_custom_favicon.html.erb
@@ -1,0 +1,3 @@
+<%= favicon_link_tag favicon_url %>
+<%= favicon_link_tag favicon_url, rel: "apple-touch-icon" %>
+<%= favicon_link_tag favicon_url, rel: "icon" %>

--- a/app/views/layouts/_gobierto_head.html.erb
+++ b/app/views/layouts/_gobierto_head.html.erb
@@ -65,7 +65,7 @@
 <%= render 'layouts/analytics_header_site' %>
 
 <% if custom_favicon_url %>
-  <%= favicon_link_tag custom_favicon_url %>
+  <%= render 'layouts/custom_favicon', favicon_url: custom_favicon_url %>
 <% else %>
   <%= render 'layouts/favicon' %>
 <% end %>

--- a/app/views/layouts/_gobierto_head.html.erb
+++ b/app/views/layouts/_gobierto_head.html.erb
@@ -64,6 +64,10 @@
 
 <%= render 'layouts/analytics_header_site' %>
 
-<%= render 'layouts/favicon' %>
+<% if custom_favicon_url %>
+  <%= favicon_link_tag custom_favicon_url %>
+<% else %>
+  <%= render 'layouts/favicon' %>
+<% end %>
 
 <%= render "layouts/javascript_hook" %>

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -31,6 +31,7 @@ santander:
     "default_locale" => "en",
     "available_locales" => ["en", "es", "ca"],
     "home_page" => "GobiertoPeople",
+    "raw_configuration_variables" => "favicon_url\: \"https://populate.tools/favicon.ico\"",
     "google_analytics_id" => "UA-000000-02" }.to_yaml.inspect %>
   organization_name: Santander
   organization_id: <%= INE::Places::Place.find_by_slug("santander").id %>

--- a/test/helpers/site_helper_test.rb
+++ b/test/helpers/site_helper_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SiteHelperTest < ActionView::TestCase
+
+  include SiteHelper
+
+  def madrid
+    @madrid ||= sites(:madrid)
+  end
+
+  def santander
+    @santander ||= sites(:santander)
+  end
+
+  attr_reader :current_site
+
+  def test_custom_favicon_url
+    @current_site = madrid
+    assert_nil custom_favicon_url
+    @current_site = santander
+    assert_equal "https://populate.tools/favicon.ico", custom_favicon_url
+  end
+
+end


### PR DESCRIPTION
Closes [#464](https://github.com/PopulateTools/issues/issues/464).

## :v: What does this PR do?

Creates setting for custom favicon inside raw_configuration_variables (http://madrid.gobify.net/admin/sites/2/edit).

## :mag: How should this be manually tested?

Check in http://madrid.gobify.net