### PR TITLE
Control errors when no plans available

### DIFF
--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -56,7 +56,7 @@ module GobiertoPlans
     end
 
     def find_plan
-      @plan_type.plans.find_by!(year: params[:year])
+      valid_preview_token? ? @plan_type.plans.find_by!(year: params[:year]) : @plan_type.plans.published.find_by!(year: params[:year])
     end
 
     def level_keys

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -27,7 +27,7 @@ santander:
   configuration_data: <%= {
     "links_markup" => %Q{<a href="http://santander.es">Ayuntamiento de Santander</a>},
     "logo" => "http://santander.es/sites/default/themes/custom/ayuntamiento/img/logo-ayto-santander.png",
-    "modules" => ["GobiertoBudgets", "GobiertoCms", "GobiertoPeople"],
+    "modules" => ["GobiertoBudgets", "GobiertoCms", "GobiertoPeople", "GobiertoPlans"],
     "default_locale" => "en",
     "available_locales" => ["en", "es", "ca"],
     "home_page" => "GobiertoPeople",

--- a/test/integration/gobierto_plans/plans/empty_plans_show_test.rb
+++ b/test/integration/gobierto_plans/plans/empty_plans_show_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPlans
+  class EmptyPlansShowTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = gobierto_plans_root_path
+    end
+
+    def site
+      @site ||= sites(:santander)
+    end
+
+    def test_visit_empty_plans
+      with_current_site(site) do
+        visit @path
+
+        assert_equal 404, page.status_code
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -218,63 +218,15 @@ module GobiertoPlans
           end
         end
       end
+    end
 
-      def test_open_nodes
-        with_javascript do
-          with_current_site(site) do
-            visit @path
+    def test_draft_plan
+      with_current_site(site) do
+        plan.draft!
 
-            within "section.level_0" do
-              within "div.node-root.cat_3" do
-                find("a").trigger("click")
-              end
-            end
+        visit @path
 
-            within ".planification-content" do
-              within "section.level_1.cat_3" do
-                find("h3", text: action_lines.first.name).click
-              end
-
-              within "section.level_2.cat_3" do
-                within "ul.action-line--list" do
-                  find("h3", text: actions.first.name).click
-                end
-              end
-
-              within "section.level_3 cat_3" do
-                refute has_selector?("h3", text: projects.first.name)
-              end
-            end
-
-            hash = plan.configuration_data
-            hash["open_node"] = true
-            plan.update_attribute(:configuration_data, JSON.pretty_generate(hash))
-
-            visit @path
-
-            within "section.level_0" do
-              within "div.node-root.cat_3" do
-                find("a").trigger("click")
-              end
-            end
-
-            within ".planification-content" do
-              within "section.level_1.cat_3" do
-                find("h3", text: action_lines.first.name).click
-              end
-
-              within "section.level_2.cat_3" do
-                within "ul.action-line--list" do
-                  find("h3", text: actions.first.name).click
-                end
-              end
-
-              within "section.level_3 cat_3" do
-                assert has_selector?("h3", text: projects.first.name)
-              end
-            end
-          end
-        end
+        assert_equal 404, page.status_code
       end
     end
   end


### PR DESCRIPTION
Closes #1937

## :v: What does this PR do?

This PR refactors plans controller code to avoid a 500 error when no plans where available and to make it more robust.

Also adds a test to this scenario.

## :mag: How should this be manually tested?

Go to a site with plans and unpublish all of them. You should get a 404 error and not a 500.
