### PR TITLE
Link to markdown guide in gobierto.readme.io

### DIFF
--- a/app/javascript/gobierto_admin/modules/application.js
+++ b/app/javascript/gobierto_admin/modules/application.js
@@ -41,6 +41,31 @@ $(document).on('turbolinks:load', function() {
       renderingConfig: {
         singleLineBreaks: false
       },
+      toolbar: [
+        "bold",
+        "italic",
+        "heading",
+        "|",
+        "quote",
+        "unordered-list",
+        "ordered-list",
+        "|",
+        "link",
+        "image",
+        "|",
+        "preview",
+        "side-by-side",
+        "fullscreen",
+        "|",
+        {name: "guide",
+          action: function openlink() {
+            var win = window.open("https://gobierto.readme.io/v0.1/docs/guia-de-markdown", "_blank");
+            win.focus();
+          },
+          className: "fa fa-question-circle",
+          title: "Markdown Guide",
+        default: true},
+        "|"],
       status: false
     });
 


### PR DESCRIPTION
Related with https://github.com/PopulateTools/issues/issues/459


## :v: What does this PR do?
Replaces the default help link of simplemde markdown editor with a link to https://gobierto.readme.io containing a guide translated to spanish

## :mag: How should this be manually tested?
Go to admin, and edit a charter with custom fields

## :shipit: Does this PR changes any configuration file?
No

## :book: Does this PR require updating the documentation?
- A page has been added to gobierto.readme.io https://gobierto.readme.io/v0.1/docs/guia-de-markdown
- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
