### PR TITLE
Slug fixes

### DIFF
--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -36,7 +36,7 @@ module GobiertoAttachments
     attr_accessor :file
 
     validates :site, :url, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
     # This validation is duplicated in FileAttachmentForm, but since it's still being used
     # from the API, we can't remove it.
     validates :file_digest, uniqueness: {

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -21,7 +21,7 @@ module GobiertoCalendars
     include GobiertoAttachments::Attachable
 
     validates :site, :collection, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
 
     translates :title, :description

--- a/app/models/gobierto_citizens_charters/charter.rb
+++ b/app/models/gobierto_citizens_charters/charter.rb
@@ -16,7 +16,7 @@ module GobiertoCitizensCharters
 
     enum visibility_level: { draft: 0, active: 1 }
 
-    validates :slug, uniqueness: { scope: :service }
+    validates :slug, uniqueness: { scope: :service_id }
     translates :title
     delegate :category, to: :service
 

--- a/app/models/gobierto_citizens_charters/commitment.rb
+++ b/app/models/gobierto_citizens_charters/commitment.rb
@@ -15,7 +15,7 @@ module GobiertoCitizensCharters
 
     enum visibility_level: { draft: 0, active: 1 }
 
-    validates :slug, uniqueness: { scope: :charter }
+    validates :slug, uniqueness: { scope: :charter_id }
     translates :title
     translates :description
 

--- a/app/models/gobierto_citizens_charters/service.rb
+++ b/app/models/gobierto_citizens_charters/service.rb
@@ -21,7 +21,7 @@ module GobiertoCitizensCharters
     enum visibility_level: { draft: 0, active: 1 }
 
     validates :site, :title, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
     translates :title
 
     after_restore :set_slug

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -39,7 +39,7 @@ module GobiertoCms
     enum visibility_level: { draft: 0, active: 1 }
 
     validates :site, :title, :body, :published_on, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     scope :inverse_sorted, -> { order(id: :asc) }
     scope :sorted, -> { order(id: :desc) }

--- a/app/models/gobierto_cms/section.rb
+++ b/app/models/gobierto_cms/section.rb
@@ -13,7 +13,7 @@ module GobiertoCms
     translates :title
 
     validates :site, :title, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     scope :has_section_item, -> { joins(:section_items).where("gcms_section_items.id IS NOT NULL") }
 

--- a/app/models/gobierto_common/collection.rb
+++ b/app/models/gobierto_common/collection.rb
@@ -14,7 +14,7 @@ module GobiertoCommon
     translates :title
 
     validates :site, :title, :item_type, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
     validate :container_id_with_container_type_and_item_type
 
     attr_reader :container

--- a/app/models/gobierto_participation/contribution.rb
+++ b/app/models/gobierto_participation/contribution.rb
@@ -22,7 +22,7 @@ module GobiertoParticipation
     end
 
     validates :user, :contribution_container, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     scope :sort_by_created_at, -> { reorder(created_at: :desc) }
     scope :created_at_last_week, -> { where("created_at >= ?", 1.week.ago) }

--- a/app/models/gobierto_participation/contribution_container.rb
+++ b/app/models/gobierto_participation/contribution_container.rb
@@ -32,7 +32,7 @@ module GobiertoParticipation
                                                              site.id, Time.zone.now) }
 
     validates :site, :process, :title, :description, :admin, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     def parameterize
       { process_id: process.slug, id: slug }

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -36,7 +36,7 @@ module GobiertoParticipation
     enum process_type: { process: 0, group_process: 1 }
 
     validates :site, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     scope :sorted, -> { order(id: :desc) }
 

--- a/app/models/gobierto_people/department.rb
+++ b/app/models/gobierto_people/department.rb
@@ -18,7 +18,7 @@ module GobiertoPeople
     scope :sorted, -> { order(name: :asc) }
 
     validates :name, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     SHORT_NAME_TRUNCATE_REGEX = Regexp.new([
       "Departamento de ",

--- a/app/models/gobierto_people/interest_group.rb
+++ b/app/models/gobierto_people/interest_group.rb
@@ -15,7 +15,7 @@ module GobiertoPeople
     scope :sorted, -> { order(name: :asc) }
 
     validates :name, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     metadata_attributes :status, :registry
 

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -45,7 +45,7 @@ module GobiertoPeople
 
     validates :email, format: { with: User::EMAIL_ADDRESS_REGEXP }, allow_blank: true
     validates :site, :name, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     after_create :create_events_collection
 

--- a/app/models/gobierto_people/person_post.rb
+++ b/app/models/gobierto_people/person_post.rb
@@ -11,7 +11,7 @@ module GobiertoPeople
 
     validates :person, presence: true
     validates :site, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     algoliasearch_gobierto do
       attribute :site_id, :title, :body, :updated_at

--- a/app/models/gobierto_people/person_statement.rb
+++ b/app/models/gobierto_people/person_statement.rb
@@ -11,7 +11,7 @@ module GobiertoPeople
     include GobiertoCommon::Sluggable
 
     validates :person, :site, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     translates :title
 

--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -22,7 +22,7 @@ module GobiertoPlans
 
     validates :site, :title, :introduction, :plan_type_id, :year, presence: true
     validates :year, uniqueness: { scope: :plan_type }
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     scope :sort_by_updated_at, -> { order(updated_at: :desc) }
     scope :sort_by_year, -> { order(year: :desc) }

--- a/app/models/gobierto_plans/plan_type.rb
+++ b/app/models/gobierto_plans/plan_type.rb
@@ -12,7 +12,7 @@ module GobiertoPlans
     translates :name
 
     validates :name, presence: true
-    validates :slug, uniqueness: { scope: :site }
+    validates :slug, uniqueness: { scope: :site_id }
 
     scope :sort_by_updated_at, -> { order(updated_at: :desc) }
 

--- a/test/models/gobierto_calendars/event_test.rb
+++ b/test/models/gobierto_calendars/event_test.rb
@@ -147,5 +147,27 @@ module GobiertoCalendars
       refute event.public?
     end
 
+    def test_slug_scope_check
+      madrid_event = subject_class.create!(
+        title: "Person Event Title",
+        starts_at: Time.zone.now,
+        ends_at: Time.zone.now + 1.hour,
+        site: sites(:madrid),
+        collection: person.events_collection
+      )
+
+      person = gobierto_people_people(:kali)
+      site = sites(:santander)
+
+      segovia_event = subject_class.create!(
+        title: "Person Event Title",
+        starts_at: Time.zone.now,
+        ends_at: Time.zone.now + 1.hour,
+        site: site,
+        collection: person.events_collection
+      )
+
+      assert_equal madrid_event.slug, segovia_event.slug
+    end
   end
 end


### PR DESCRIPTION
## :v: What does this PR do?
* Fixes errors detecting slugs already in use of other sites, replacing uniqueness scope reference to a foreign key instead an association
* Improves the calculation of new slug adding a counter, using a query with a regular expression instead of using a loop with a counter

### Before this PR
Create 1000 times an event with the same attributes (seconds):

user | system | total | real 
---- | -------- | ------ | ----
559.992797 | 53.032034 | 613.024831 | (903.383489)
### After this PR
Create 1000 times an event with the same attributes (seconds):

user | system | total | real 
---- | -------- | ------ | ----
27.677075 | 2.906444 | 30.583519 | ( 52.466834)


## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
