### PR TITLE
Don't remove card if the data is missing

### DIFF
--- a/app/javascript/lib/visualizations/modules/card_simple.js
+++ b/app/javascript/lib/visualizations/modules/card_simple.js
@@ -20,12 +20,6 @@ export class SimpleCard extends Card {
 
     divCard.find("div.indicator_widget.padded").find("div.widget_body").find("div.sparkline").empty();
 
-    // If no data exists for the selected year.
-    if(parsedDate.getFullYear() != window.populateDataYear.currentYear) {
-      divCard.remove();
-      return;
-    }
-
     this.div.selectAll('.tw-sharer')
       .attr('target', '_blank')
       .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' +  encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(value))  + '&url=' + window.location.href + '&via=gobierto&source=webclient');


### PR DESCRIPTION
Bugfix

## :v: What does this PR do?

This PR removes a condition on `SimpleCard` class that checks the last year of data from the card and compares it with the current year, and removed it if the year was not the same. 

Given that we are now adaptative and show the last year with data this condition is not necessary anymore.

## :mag: How should this be manually tested?

Check the observatory of a site in staging, you should see all the cards.

## :eyes: Screenshots

### Before this PR

![screen shot 2018-11-06 at 19 05 17](https://user-images.githubusercontent.com/17616/48084025-f3020380-e1f6-11e8-9b41-3edaf7781ac2.png)

### After this PR

![screen shot 2018-11-06 at 19 05 58](https://user-images.githubusercontent.com/17616/48084048-044b1000-e1f7-11e8-9cee-3733926790ec.png)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No 