### PR TITLE
Allow set slug in event_form

### DIFF
--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -18,7 +18,8 @@ module GobiertoCalendars
       :notify,
       :meta,
       :department_id,
-      :interest_group_id
+      :interest_group_id,
+      :slug
     )
     attr_writer(
       :state,
@@ -144,6 +145,7 @@ module GobiertoCalendars
         event_attributes.interest_group_id = interest_group_id
         event_attributes.locations = locations
         event_attributes.attendees = attendees
+        event_attributes.slug = slug
       end
     end
 


### PR DESCRIPTION
## :v: What does this PR do?
Adds slug to event_form. In this way the slug can be created from ETL directly

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No