### PR TITLE
Filter pages from news listings

### DIFF
--- a/app/controllers/gobierto_participation/issues_controller.rb
+++ b/app/controllers/gobierto_participation/issues_controller.rb
@@ -26,7 +26,7 @@ module GobiertoParticipation
     end
 
     def find_issue_news
-      @issue.active_pages.limit(5)
+      @issue.active_news.limit(5)
     end
 
     def find_issue_notifications

--- a/app/controllers/gobierto_participation/news_controller.rb
+++ b/app/controllers/gobierto_participation/news_controller.rb
@@ -24,10 +24,8 @@ module GobiertoParticipation
     end
 
     def participation_module_news
-      if @issue
-        GobiertoCms::Page.pages_in_collections_and_container(current_site, @issue)
-      elsif @scope
-        GobiertoCms::Page.pages_in_collections_and_container(current_site, @scope)
+      if (container = @issue || @scope)
+        ::GobiertoCms::Page.news_in_collections_and_container(current_site, container)
       else
         ::GobiertoCms::Page.news_in_collections_and_container_type(current_site, "GobiertoParticipation")
       end

--- a/app/controllers/gobierto_participation/scopes_controller.rb
+++ b/app/controllers/gobierto_participation/scopes_controller.rb
@@ -26,7 +26,7 @@ module GobiertoParticipation
     end
 
     def find_scope_news
-      @scope.active_pages.limit(5)
+      @scope.active_news.limit(5)
     end
 
     def find_scope_notifications

--- a/app/decorators/gobierto_participation/process_term_decorator.rb
+++ b/app/decorators/gobierto_participation/process_term_decorator.rb
@@ -6,8 +6,8 @@ module GobiertoParticipation
       @object = term
     end
 
-    def active_pages
-      GobiertoCms::Page.pages_in_collections_and_container(site, object).sorted.active
+    def active_news
+      GobiertoCms::Page.news_in_collections_and_container(site, object).sorted.active
     end
 
     def site

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -63,23 +63,20 @@ module GobiertoCms
     end
 
     # returns pages belonging to module pages collection
-    # sample call: *.pages_in_collections_and_container_type(current_site, 'GobiertoParticipation')
     def self.pages_in_collections_and_container_type(site, container_type)
       ids = GobiertoCommon::CollectionItem.pages.by_container_type(container_type).pluck(:item_id)
       where(id: ids, site: site)
     end
 
     # returns news belonging to module news collection
-    # sample call: *.news_in_collections_and_container_type(current_site, 'GobiertoParticipation')
     def self.news_in_collections_and_container_type(site, container_type)
       ids = GobiertoCommon::CollectionItem.news.by_container_type(container_type).pluck(:item_id)
       where(id: ids, site: site)
     end
 
-    ## Methods to find items belonging to process, issue, etc.
-    # sample call: *.pages_in_collections_and_container(current_site, @issue)
-    def self.pages_in_collections_and_container(site, container)
-      ids = GobiertoCommon::CollectionItem.pages_and_news.by_container(container).pluck(:item_id)
+    # returns news belonging to process, issue, scope, etc.
+    def self.news_in_collections_and_container(site, container)
+      ids = GobiertoCommon::CollectionItem.news.by_container(container).pluck(:item_id)
       where(id: ids, site: site)
     end
 

--- a/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
@@ -22,8 +22,8 @@ module GobiertoParticipation
       @user ||= users(:peter)
     end
 
-    def issue_pages
-      @issue_pages ||= GobiertoCms::Page.pages_in_collections_and_container(site, issue).sorted
+    def issue_news
+      @issue_news ||= GobiertoCms::Page.news_in_collections_and_container(site, issue).sorted
     end
 
     def test_menu_subsections
@@ -54,7 +54,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit issue_pages_path
 
-        assert_equal issue_pages.size, all(".news_teaser").size
+        assert_equal issue_news.size, all(".news_teaser").size
 
         assert has_link? "Notice 1 title"
         assert has_link? "Notice 2 title"

--- a/test/integration/gobierto_participation/issues/issue_show_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_show_test.rb
@@ -154,7 +154,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        assert_equal issue.active_pages.size, all(".place_news-item").size
+        assert_equal issue.active_news.size, all(".place_news-item").size
       end
     end
 

--- a/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
@@ -22,8 +22,8 @@ module GobiertoParticipation
       @user ||= users(:peter)
     end
 
-    def scope_pages
-      @scope_pages ||= GobiertoCms::Page.pages_in_collections_and_container(site, scope).sorted
+    def scope_news
+      @scope_news ||= GobiertoCms::Page.news_in_collections_and_container(site, scope).sorted
     end
 
     def test_menu_subsections
@@ -54,7 +54,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit scope_pages_path
 
-        assert_equal scope_pages.size, all(".news_teaser").size
+        assert_equal scope_news.size, all(".news_teaser").size
 
         assert has_content? "News for Old town"
       end

--- a/test/integration/gobierto_participation/scopes/scope_show_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_show_test.rb
@@ -151,7 +151,7 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
-        assert_equal scope_center.active_pages.size, all(".place_news-item").size
+        assert_equal scope_center.active_news.size, all(".place_news-item").size
       end
     end
 


### PR DESCRIPTION
Reported by customer

## :v: What does this PR do?

Modifies the queries used to retrieve last news in a process, issue or scope to only include news (and not pages).

## :mag: How should this be manually tested?

I've created [this process](http://madrid.gobify.net/participacion/p/proceso-prueba-paginas-noticias) linked to the "Deportes" topic and the "Mamífero" scope. It has a news and an information page.

Now:

- The scope page does not list the information page within the news box (http://madrid.gobify.net/participacion/ambitos/animales-caballo)
- The issue page does not list the process information page within the news box (http://madrid.gobify.net/participacion/ambitos/animales-mamifero)