### PR TITLE
474 fix document not found

### DIFF
--- a/app/controllers/gobierto_attachments/attachment_documents_controller.rb
+++ b/app/controllers/gobierto_attachments/attachment_documents_controller.rb
@@ -30,6 +30,8 @@ module GobiertoAttachments
     end
 
     def set_context
+      return unless @attachment
+
       @current_module = @attachment.module
       @current_process ||= begin
         if @collection && @collection.container_type == "GobiertoParticipation::Process"

--- a/test/fixtures/gobierto_attachments/attachments.yml
+++ b/test/fixtures/gobierto_attachments/attachments.yml
@@ -39,6 +39,34 @@ pdf_on_participation:
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
 
+pdf_on_bowling_group_very_active_process:
+  name: PDF Collection On Process
+  file_size: 10025
+  file_name: pdf-on-process.pdf
+  file_digest: 44036997d456028a88d634afa64037ae2e
+  url: http://host.com/attachments/super-long-and-ugly-aws-id/pdf-on-process.pdf
+  description: Description of a Process PDF attachment
+  current_version: 2
+  site: madrid
+  slug: pdf-on-process-slug
+  collection: bowling_group_very_active_documents
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+pdf_on_cultural_city_group:
+  name: PDF Collection On Draft Process
+  file_size: 10025
+  file_name: pdf-on-draft-process.pdf
+  file_digest: 44036997d456028a88d634afa64037ae2e
+  url: http://host.com/attachments/super-long-and-ugly-aws-id/pdf-on-draft-process.pdf
+  description: Description of a Draft Process PDF attachment
+  current_version: 2
+  site: madrid
+  slug: pdf-on-draft-process-slug
+  collection: cultural_city_group_documents
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
 xlsx_attachment:
   name: XLSX Attachment Name
   file_size: 3604

--- a/test/fixtures/gobierto_common/collections.yml
+++ b/test/fixtures/gobierto_common/collections.yml
@@ -52,21 +52,21 @@ cultural_city_group_news:
   site: madrid
   title_translations: <%= {'en' => 'News', 'es' => 'Noticias' }.to_json %>
   slug: cultural_city_group-news
-  container: cultural_city_group (GobiertoParticipation::Process)
+  container: cultural_city_group_draft (GobiertoParticipation::Process)
   item_type: GobiertoCms::News
 
 cultural_city_group_calendar:
   site: madrid
   title_translations: <%= {'en' => 'Events', 'es' => 'Eventos' }.to_json %>
   slug: cultural_city_group-calendar
-  container: cultural_city_group (GobiertoParticipation::Process)
+  container: cultural_city_group_draft (GobiertoParticipation::Process)
   item_type: GobiertoCalendars::Event
 
 cultural_city_group_documents:
   site: madrid
   title_translations: <%= {'en' => 'Documents', 'es' => 'Documentos' }.to_json %>
   slug: cultural_city_group-documents
-  container: cultural_city_group (GobiertoParticipation::Process)
+  container: cultural_city_group_draft (GobiertoParticipation::Process)
   item_type: GobiertoAttachments::Attachment
 
 # public_debates_group_future

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -62,6 +62,22 @@ pdf_attachment_uploaded_create:
   object:
   created_at: <%= Time.now %>
 
+pdf_process_attachment_uploaded_create:
+  item_type: GobiertoAttachments::Attachment
+  item_id: <%= ActiveRecord::FixtureSet.identify(:pdf_on_bowling_group_very_active_process) %>
+  event: create
+  whodunnit:
+  object:
+  created_at: <%= Time.now %>
+
+pdf_draft_process_attachment_uploaded_create:
+  item_type: GobiertoAttachments::Attachment
+  item_id: <%= ActiveRecord::FixtureSet.identify(:pdf_on_cultural_city_group) %>
+  event: create
+  whodunnit:
+  object:
+  created_at: <%= Time.now %>
+
 png_attachment_uploaded_create:
   item_type: GobiertoAttachments::Attachment
   item_id: <%= ActiveRecord::FixtureSet.identify(:png_attachment_uploaded) %>

--- a/test/integration/gobierto_attachments/attachments/attachment_documents_show_test.rb
+++ b/test/integration/gobierto_attachments/attachments/attachment_documents_show_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAttachments
+  module Attachments
+    class AttachmentDocumentsShowTest < ActionDispatch::IntegrationTest
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def participation_attachment
+        @participation_attachment ||= gobierto_attachments_attachments(:pdf_on_bowling_group_very_active_process)
+      end
+
+      def draft_participation_process_attachment
+        @draft_participation_process_attachment ||= gobierto_attachments_attachments(:pdf_on_cultural_city_group)
+      end
+
+      def participation_process
+        @participation_process ||= gobierto_participation_processes(:bowling_group_very_active)
+      end
+
+      def draft_participation_process
+        @draft_participation_process ||= gobierto_participation_processes(:cultural_city_group_draft)
+      end
+
+      def png_attachment
+        @png_attachment ||= gobierto_attachments_attachments(:png_attachment_uploaded)
+      end
+
+      def test_view_attachment_without_context
+        with_current_site(site) do
+          visit gobierto_attachments_document_url(png_attachment, host: site.domain)
+
+          assert has_content? png_attachment.description
+        end
+      end
+
+      def test_view_attachment_document_in_draft_process
+        with_current_site(site) do
+          visit gobierto_attachments_document_url(draft_participation_process_attachment, host: site.domain)
+
+          assert has_content? "The page you were looking for doesn't exist."
+        end
+      end
+
+      def test_view_attachment_document_in_participation_process_context
+        with_current_site(site) do
+          visit gobierto_attachments_document_url(participation_attachment, host: site.domain)
+
+          assert has_content? participation_attachment.description
+          assert has_content? participation_process.title
+        end
+      end
+
+      def test_wrong_url
+        with_current_site(site) do
+          visit gobierto_attachments_document_url(id: "wadus", host: site.domain)
+          assert has_content? "The page you were looking for doesn't exist."
+        end
+      end
+
+    end
+  end
+end

--- a/test/integration/gobierto_attachments/attachments/attachment_documents_show_test.rb
+++ b/test/integration/gobierto_attachments/attachments/attachment_documents_show_test.rb
@@ -42,7 +42,7 @@ module GobiertoAttachments
         with_current_site(site) do
           visit gobierto_attachments_document_url(draft_participation_process_attachment, host: site.domain)
 
-          assert has_content? "The page you were looking for doesn't exist."
+          assert_equal 404, page.status_code
         end
       end
 
@@ -58,7 +58,7 @@ module GobiertoAttachments
       def test_wrong_url
         with_current_site(site) do
           visit gobierto_attachments_document_url(id: "wadus", host: site.domain)
-          assert has_content? "The page you were looking for doesn't exist."
+          assert_equal 404, page.status_code
         end
       end
 


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/474


## :v: What does this PR do?

* Avoids an exception produced if an attachment can't be found, trying in `before_render :set_context` to access properties of a not existing `@attachment`
* Adds some integration tests to attachment_documents functionality

## :mag: How should this be manually tested?
 Visit `/documento` using an slug that has no attachments, for example `/documento/invented-name` 

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No