### PR TITLE
Use FileAttachment form

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoAdmin
   module GobiertoAttachments
     module Api
@@ -17,7 +19,7 @@ module GobiertoAdmin
                         end
 
           render(
-            json: { attachments: attachments.map{ |a| default_serializer.new(a) }}
+            json: { attachments: attachments.map { |a| default_serializer.new(a) } }
           )
         end
 
@@ -62,7 +64,7 @@ module GobiertoAdmin
         def destroy
           @attachment.destroy!
 
-          render json: { message: 'destroyed' }
+          render json: { message: "destroyed" }
         end
 
         private
@@ -72,7 +74,7 @@ module GobiertoAdmin
         end
 
         def find_attachable
-          attachable_id   = params[:attachable_id]
+          attachable_id = params[:attachable_id]
           attachable_type = params[:attachable_type]
 
           if attachable_id && attachable_type && ::GobiertoAttachments.permitted_attachable_types.include?(attachable_type)

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -4,6 +4,7 @@ module GobiertoAdmin
   module GobiertoCms
     class PagesController < BaseController
       before_action :load_collection, only: [:new, :edit, :create, :update]
+      before_action :load_site_attachments_collection, only: [:new, :edit, :create, :update]
 
       def index
         @sections = current_site.sections
@@ -98,6 +99,10 @@ module GobiertoAdmin
 
       def load_collection
         @collection = current_site.collections.find(params[:collection_id])
+      end
+
+      def load_site_attachments_collection
+        @site_attachments_collection = current_site.collections.find_by!(container: current_site, item_type: "GobiertoAttachments::Attachment")
       end
 
       def default_activity_params

--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -88,7 +88,7 @@ module GobiertoAdmin
 
     def file
       if @file.is_a?(String)
-        tmp_file = Tempfile.new('attachment_file')
+        tmp_file = Tempfile.new("attachment_file")
         tmp_file.binmode
         tmp_file.write(Base64.strict_decode64(@file))
         tmp_file.rewind

--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -29,7 +29,7 @@ module GobiertoAdmin
     validates :site, presence: true
     validate :file_is_not_duplicated, if: -> { file.present? }
     validate :file_size_within_range, if: -> { file.present? }
-    validates :collection_id, presence: true
+    validates :collection, presence: true
 
     def initialize(attributes)
       attributes = attributes.to_h.with_indifferent_access
@@ -170,7 +170,7 @@ module GobiertoAdmin
     end
 
     def admin_edit_attachment_path(attachment)
-      url_helpers.edit_admin_attachments_file_attachment_path(attachment, collection_id: c.id)
+      url_helpers.edit_admin_attachments_file_attachment_path(attachment, collection_id: attachment.collection.id)
     end
 
     def url_helpers

--- a/app/javascript/gobierto_admin/modules/gobierto_attachments_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_attachments_controller.js
@@ -4,15 +4,15 @@ Vue.config.productionTip = false
 window.GobiertoAdmin.GobiertoAttachmentsController = (function() {
   function GobiertoAttachmentsController() {}
 
-  GobiertoAttachmentsController.prototype.index = function() {
-    app();
+  GobiertoAttachmentsController.prototype.index = function(attachmentsCollectionId) {
+    app(attachmentsCollectionId);
   };
 
   function onlyUnique(value, index, self) {
     return self.indexOf(value) === index;
   }
 
-  function app() {
+  function app(attachmentsCollectionId) {
     var bus = new Vue({});
 
     var STATUS_INITIAL = 0, STATUS_SAVING = 1, STATUS_SUCCESS = 2, STATUS_FAILED = 3;
@@ -67,7 +67,8 @@ window.GobiertoAdmin.GobiertoAttachmentsController = (function() {
           uploadFieldName: 'attachment',
           attachment: {},
           errorMessage: null,
-          isDragged: false
+          isDragged: false,
+          collectionId: attachmentsCollectionId
         }
       },
       computed: {
@@ -139,6 +140,7 @@ window.GobiertoAdmin.GobiertoAttachmentsController = (function() {
 
           this.fileDragged = true;
           this.attachment.file_name = fileList[0].name;
+          this.attachment.collection_id = this.collectionId;
           bus.$emit('file-upload:fileDraggedUpdated', this.fileDragged);
           bus.$emit('site-attachments:load');
 

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency 'gobierto_attachments'
+require_dependency "gobierto_attachments"
 
 module GobiertoAttachments
   class Attachment < ApplicationRecord
@@ -18,7 +18,7 @@ module GobiertoAttachments
     include GobiertoCommon::Collectionable
 
     MAX_FILE_SIZE_IN_MBYTES = 50
-    MAX_FILE_SIZE_IN_BYTES  = MAX_FILE_SIZE_IN_MBYTES.megabytes
+    MAX_FILE_SIZE_IN_BYTES = MAX_FILE_SIZE_IN_MBYTES.megabytes
 
     default_scope { order(id: :desc) }
 
@@ -41,16 +41,15 @@ module GobiertoAttachments
     # from the API, we can't remove it.
     validates :file_digest, uniqueness: {
       scope: :site_id,
-      message: ->(object, data) do
+      message: -> (object, data) do
         url = object.site.attachments.find_by!(file_digest: object.file_digest).url
-        "#{I18n.t('activerecord.messages.gobierto_attachments/attachment.already_uploaded')} #{url})."
+        "#{I18n.t("activerecord.messages.gobierto_attachments/attachment.already_uploaded")} #{url})."
       end
     }
 
     belongs_to :site
 
     after_create :add_item_to_collection
-    before_validation :update_file_attributes
     after_restore :set_slug
     belongs_to :collection, class_name: "GobiertoCommon::Collection"
 
@@ -97,7 +96,7 @@ module GobiertoAttachments
     end
 
     def extension
-      File.extname(file_name).tr('.', '')
+      File.extname(file_name).tr(".", "")
     end
 
     def active?
@@ -133,28 +132,6 @@ module GobiertoAttachments
     end
 
     private
-
-    # This method is error-prone and should be REMOVED.
-    # This logic is duplicated in FileAttachmentForm. The reason why version is not incremented
-    # twice is because the Form Object decomposes file attribute in file_name, file_size, etc.,
-    # so this code is not executed.
-    def update_file_attributes
-      if file
-        if file.size > MAX_FILE_SIZE_IN_BYTES
-          errors.add(:base, "#{I18n.t('activerecord.messages.gobierto_attachments/attachment.file_too_big')} (#{MAX_FILE_SIZE_IN_MBYTES} Mb)")
-          throw :abort
-        end
-
-        self.file_digest = self.class.file_digest(file)
-
-        if file_digest_changed? && unique_file_digest?
-          self.file_name = file.original_filename
-          self.file_size = file.size
-          self.current_version += 1
-          self.url = ::GobiertoAdmin::FileUploadService.new(site: site, collection: 'attachments', attribute_name: :attachment, file: file).call
-        end
-      end
-    end
 
     def unique_file_digest?
       attachment_with_same_digest_id = site.attachments.where(file_digest: file_digest).pluck(:id).first

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -84,7 +84,7 @@ class Site < ApplicationRecord
   serialize :configuration_data
 
   before_save :store_configuration
-  after_create :initialize_admins
+  after_create :initialize_admins, :create_collections
   after_save :run_seeder
 
   validates :title, presence: true
@@ -254,5 +254,10 @@ class Site < ApplicationRecord
         errors[:base] << I18n.t('errors.messages.blank_for_modules')
       end
     end
+  end
+
+  def create_collections
+    # Attachments
+    collections.create! container: self, item_type: "GobiertoAttachments::Attachment", slug: "site-attachments", title: title
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -258,6 +258,6 @@ class Site < ApplicationRecord
 
   def create_collections
     # Attachments
-    collections.create! container: self, item_type: "GobiertoAttachments::Attachment", slug: "site-attachments", title: title
+    collections.create! container: self, item_type: "GobiertoAttachments::Attachment", slug: "site-attachments", title: "Documentos del site"
   end
 end

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -100,7 +100,7 @@
 
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
-    window.GobiertoAdmin.gobierto_attachments_controller.index();
+    window.GobiertoAdmin.gobierto_attachments_controller.index(<%= @site_attachments_collection.try(:id) %>);
     window.GobiertoAdmin.gobierto_cms_controller.edit("<%= @section_id.nil? ? 'null' : @section_id %>", "<%= @parent_id.nil? ? 'null' : @parent_id %>", "<%= @page_section_item_id %>");
   <% end %>
 <% end %>

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,0 @@
-# encoding: UTF-8
-DataMigrate::Data.define(version: 20180227115709)

--- a/test/fixtures/gobierto_attachments/attachments.yml
+++ b/test/fixtures/gobierto_attachments/attachments.yml
@@ -10,6 +10,7 @@ pdf_attachment:
   slug: pdf-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments
 
 pdf_collection_attachment:
   name: PDF Collection Attachment Name
@@ -51,6 +52,7 @@ xlsx_attachment:
   slug: xlsx-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments
 
 xlsx_attachment_event:
   name: XLSX Attachment Event
@@ -64,6 +66,7 @@ xlsx_attachment_event:
   slug: xlsx-attachment-event-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments
 
 attachment:
   name: Attachment Name
@@ -77,6 +80,7 @@ attachment:
   slug: attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments
 
 txt_pdf_attachment:
   name: TXT PDF Attachment Name
@@ -90,6 +94,7 @@ txt_pdf_attachment:
   slug: txt-pdf-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments
 
 santander_attachment:
   name: Santander Attachment
@@ -103,6 +108,7 @@ santander_attachment:
   slug: santander-attachment-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments_santander
 
 # Use real AWS url for testing purposes
 
@@ -118,6 +124,7 @@ pdf_attachment_uploaded:
   slug: pdf-attachment-aws-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments
 
 # Use real AWS url for testing purposes
 
@@ -133,3 +140,4 @@ png_attachment_uploaded:
   slug: png-attachment-aws-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  collection: site_attachments

--- a/test/fixtures/gobierto_common/collections.yml
+++ b/test/fixtures/gobierto_common/collections.yml
@@ -340,6 +340,97 @@ site_news:
   container: madrid (Site)
   item_type: GobiertoCms::News
 
+site_attachments:
+  site: madrid
+  title_translations: <%= {'en' => 'Site attachments', 'es' => 'Adjuntos del sitio' }.to_json %>
+  slug: site-attachments
+  container: madrid (Site)
+  item_type: GobiertoAttachments::Attachment
+
+site_pages_santander:
+  site: santander
+  title_translations: <%= {'en' => 'Site pages', 'es' => 'Páginas del sitio' }.to_json %>
+  slug: site-pages
+  container: santander (Site)
+  item_type: GobiertoCms::Page
+
+site_news_santander:
+  site: santander
+  title_translations: <%= {'en' => 'Site news', 'es' => 'Noticias del sitio' }.to_json %>
+  slug: site-news
+  container: santander (Site)
+  item_type: GobiertoCms::News
+
+site_attachments_santander:
+  site: santander
+  title_translations: <%= {'en' => 'Site attachments', 'es' => 'Adjuntos del sitio' }.to_json %>
+  slug: site-attachments
+  container: santander (Site)
+  item_type: GobiertoAttachments::Attachment
+
+site_pages_huesca:
+  site: huesca
+  title_translations: <%= {'en' => 'Site pages', 'es' => 'Páginas del sitio' }.to_json %>
+  slug: site-pages
+  container: huesca (Site)
+  item_type: GobiertoCms::Page
+
+site_news_huesca:
+  site: huesca
+  title_translations: <%= {'en' => 'Site news', 'es' => 'Noticias del sitio' }.to_json %>
+  slug: site-news
+  container: huesca (Site)
+  item_type: GobiertoCms::News
+
+site_attachments_huesca:
+  site: huesca
+  title_translations: <%= {'en' => 'Site attachments', 'es' => 'Adjuntos del sitio' }.to_json %>
+  slug: site-attachments
+  container: huesca (Site)
+  item_type: GobiertoAttachments::Attachment
+
+site_pages_cortegada:
+  site: cortegada
+  title_translations: <%= {'en' => 'Site pages', 'es' => 'Páginas del sitio' }.to_json %>
+  slug: site-pages
+  container: cortegada (Site)
+  item_type: GobiertoCms::Page
+
+site_news_cortegada:
+  site: cortegada
+  title_translations: <%= {'en' => 'Site news', 'es' => 'Noticias del sitio' }.to_json %>
+  slug: site-news
+  container: cortegada (Site)
+  item_type: GobiertoCms::News
+
+site_attachments_cortegada:
+  site: cortegada
+  title_translations: <%= {'en' => 'Site attachments', 'es' => 'Adjuntos del sitio' }.to_json %>
+  slug: site-attachments
+  container: cortegada (Site)
+  item_type: GobiertoAttachments::Attachment
+
+site_pages_wadus:
+  site: wadus
+  title_translations: <%= {'en' => 'Site pages', 'es' => 'Páginas del sitio' }.to_json %>
+  slug: site-pages
+  container: wadus (Site)
+  item_type: GobiertoCms::Page
+
+site_news_wadus:
+  site: wadus
+  title_translations: <%= {'en' => 'Site news', 'es' => 'Noticias del sitio' }.to_json %>
+  slug: site-news
+  container: wadus (Site)
+  item_type: GobiertoCms::News
+
+site_attachments_wadus:
+  site: wadus
+  title_translations: <%= {'en' => 'Site attachments', 'es' => 'Adjuntos del sitio' }.to_json %>
+  slug: site-attachments
+  container: wadus (Site)
+  item_type: GobiertoAttachments::Attachment
+
 ## /end
 
 santander_participation_docs:

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
@@ -150,6 +150,8 @@ module GobiertoAdmin
           }
         }
 
+        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:upload!).returns("http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf")
+
         post admin_attachments_api_attachments_path(payload)
 
         response_body = JSON.parse(response.body)
@@ -161,7 +163,7 @@ module GobiertoAdmin
 
         assert_equal "New attachment name", attachment["name"]
         assert_equal "new-pdf-attachment.pdf", attachment["file_name"]
-        assert_not_nil attachment["url"]
+        assert_equal "http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf", attachment["url"]
         assert_equal 1, attachment["current_version"]
       end
 
@@ -194,6 +196,8 @@ module GobiertoAdmin
           }
         }
 
+        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:upload!).returns("http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf")
+
         patch admin_attachments_api_attachment_path(pdf_attachment.id), params: payload
 
         # Check DB record was updated
@@ -202,6 +206,7 @@ module GobiertoAdmin
 
         assert_equal "Replace with new PDF file", db_pdf_attachment.name
         assert_nil db_pdf_attachment.description
+        assert_equal "http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf", db_pdf_attachment.url
         assert_equal "new-pdf-attachment.pdf", db_pdf_attachment.file_name
         assert_equal 2, db_pdf_attachment.current_version
 

--- a/test/models/gobierto_attachments/attachment_test.rb
+++ b/test/models/gobierto_attachments/attachment_test.rb
@@ -75,13 +75,16 @@ module GobiertoAttachments
     end
 
     def test_create_attachment
-      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf")
-
       new_attachment = Attachment.create!(
         site: site,
         name: "New attachment name",
         description: "New attachment description",
-        file: uploaded_new_pdf_file
+        file: uploaded_new_pdf_file,
+        file_name: "new-pdf-attachment.pdf",
+        file_digest: file_digest(uploaded_new_pdf_file),
+        file_size: uploaded_new_pdf_file.size,
+        url: "http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf",
+        current_version: 1
       )
 
       assert new_attachment.valid?
@@ -90,7 +93,6 @@ module GobiertoAttachments
       assert_equal "New attachment description", new_attachment.description
       assert_equal "new-pdf-attachment.pdf", new_attachment.file_name
       assert_equal file_digest(uploaded_new_pdf_file), new_attachment.file_digest
-      assert_equal "http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf", new_attachment.url
       assert_equal uploaded_new_pdf_file.size, new_attachment.file_size
 
       assert_equal 1, new_attachment.current_version
@@ -113,46 +115,6 @@ module GobiertoAttachments
       )
 
       refute new_attachment.valid?
-    end
-
-    def test_update_attachment
-      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf")
-
-      pdf_attachment.update_attributes!(
-        name: "(EDITED) PDF Attachment Name",
-        description: "(EDITED) Description of a PDF attachment",
-        file: uploaded_new_pdf_file
-      )
-
-      assert pdf_attachment.valid?
-
-      assert_equal 2, pdf_attachment.current_version
-      assert_equal 2, pdf_attachment.versions.size
-
-      assert_equal "(EDITED) PDF Attachment Name", pdf_attachment.name
-      assert_equal "(EDITED) Description of a PDF attachment", pdf_attachment.description
-      assert_equal "new-pdf-attachment.pdf", pdf_attachment.file_name
-      assert_equal file_digest(uploaded_new_pdf_file), pdf_attachment.file_digest
-      assert_equal "http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf", pdf_attachment.url
-      assert_equal uploaded_new_pdf_file.size, pdf_attachment.file_size
-    end
-
-    def test_update_attachment_file
-      ::GobiertoAdmin::FileUploadService.any_instance.stubs(:call).returns("http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf")
-
-      pdf_attachment.update_attributes!(file: uploaded_new_pdf_file)
-
-      assert_equal 2, pdf_attachment.current_version
-      assert_equal 2, pdf_attachment.versions.size
-
-      assert_equal "new-pdf-attachment.pdf", pdf_attachment.file_name
-      assert_equal uploaded_new_pdf_file.size, pdf_attachment.file_size
-    end
-
-    def test_update_attachment_when_file_is_duplicated
-      assert_raises ActiveRecord::RecordInvalid do
-        pdf_attachment.update_attributes!(file: uploaded_xlsx_file)
-      end
     end
 
     def test_update_attachment_metadata
@@ -212,6 +174,5 @@ module GobiertoAttachments
 
       refute process_attachment.public?
     end
-
   end
 end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -69,6 +69,25 @@ class SiteTest < ActiveSupport::TestCase
     refute Site.find_by_allowed_domain("foo")
   end
 
+  def test_site_attachments_collection_after_create
+    site = Site.new title: "Transparencia", name: "Albacete", domain: "albacete.gobierto.test",
+                    organization_name: "Albacete", organization_id: INE::Places::Place.find_by_slug("albacete").id
+
+    site.configuration_data = {
+      "links_markup" => %(<a href="http://madrid.es">Ayuntamiento de Madrid</a>),
+      "logo" => "http://www.madrid.es/assets/images/logo-madrid.png",
+      "modules" => %w(GobiertoBudgets GobiertoBudgetConsultations GobiertoPeople),
+      "locale" => "en",
+      "google_analytics_id" => "UA-000000-01"
+    }
+    site.save!
+
+    assert_equal 1, site.collections.count
+    collection = site.collections.first
+    assert_equal "GobiertoAttachments::Attachment", collection.item_type
+    assert_equal site, collection.container
+  end
+
   def test_seeder_called_after_create
     site = Site.new title: "Transparencia", name: "Albacete", domain: "albacete.gobierto.test",
                     organization_name: "Albacete", organization_id: INE::Places::Place.find_by_slug("albacete").id
@@ -81,6 +100,7 @@ class SiteTest < ActiveSupport::TestCase
       "google_analytics_id" => "UA-000000-01"
     }
     site.save!
+
     assert module_seeder_spy.has_been_called?
     assert module_site_seeder_spy.has_been_called?
     assert_equal ["GobiertoBudgets", site], module_seeder_spy.calls.first.args


### PR DESCRIPTION
Closes #1032

## :v: What does this PR do?

This PR refactos GobiertoAttachments API to use the attachments form object and forces it to use a collection ID.

This issue implies that all attachments will be linked to a collection. If the collection is not explicit, the attachment will belong to the attachments collection of the site.

I have run these scripts in staging and production:

1. Create attachments site collection:

```ruby
a = 0
Site.all.each do |site|
  c = site.collections.find_by(container_type: 'Site', container_id: site.id, item_type: "GobiertoAttachments::Attachment")
  if c.nil?
    a += 1
    site.collections.create!(container: site, item_type: "GobiertoAttachments::Attachment", slug: "site-attachments", title_translations: {"es"=>"Documentos del site"})
  end
end; 0
puts a
```

2. Associate attachments without collection to the site collection

```ruby
GobiertoAttachments::Attachment.where(collection_id: nil).find_each do |a|
  site = a.site
  c = site.collections.find_by(container_type: 'Site', container_id: site.id, item_type: "GobiertoAttachments::Attachment")
  a.update_column :collection_id, c.id
end
```

## :mag: How should this be manually tested?

After this PR no attachment should have an empty collection_id.

Also, deleting an attachment shouldn't cause now this Rollbar: https://rollbar.com/Populate/gobierto/items/1308/?item_page=0&item_count=100&#traceback

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No