### PR TITLE
473 avoid collections with archived containers

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_attachments/file_attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/file_attachments_controller.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
 
       def index
         @collections = current_site.collections.by_item_type('GobiertoAttachments::Attachment')
-        @file_attachments = ::GobiertoAttachments::Attachment.file_attachments_in_collections(current_site).sort_by_updated_at.limit(10)
+        @file_attachments = ::GobiertoAttachments::Attachment.in_collections(current_site).sort_by_updated_at.limit(10)
         @site_file_attachments = current_site.attachments.sort_by_updated_at
       end
 

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -8,7 +8,7 @@ module GobiertoAdmin
       def index
         @sections = current_site.sections
         @collections = current_site.collections.by_item_type(["GobiertoCms::Page", "GobiertoCms::News"])
-        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).sort_by_published_on.limit(10)
+        @pages = ::GobiertoCms::Page.in_collections(current_site).sort_by_published_on.limit(10)
       end
 
       def new

--- a/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/sections_controller.rb
@@ -21,11 +21,11 @@ module GobiertoAdmin
 
       def show
         @section = find_section
-        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).active.sort_by_updated_at.limit(15)
+        @pages = ::GobiertoCms::Page.in_collections(current_site).active.sort_by_updated_at.limit(15)
       end
 
       def pages
-        @pages = ::GobiertoCms::Page.pages_in_collections(current_site).active.sort_by_published_on.search(params[:query]).uniq
+        @pages = ::GobiertoCms::Page.in_collections(current_site).active.sort_by_published_on.search(params[:query]).uniq
 
         respond_to do |format|
           format.js { render layout: false }

--- a/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoAdmin
   module GobiertoCommon
     class CollectionsController < BaseController

--- a/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
@@ -2,6 +2,7 @@ module GobiertoAdmin
   module GobiertoCommon
     class CollectionsController < BaseController
       before_action :load_collection, only: [:show, :edit, :update]
+      before_action :check_container_presence, only: [:show, :edit, :update]
       before_action :redirect_to_custom_show, only: [:show]
 
       def show
@@ -150,6 +151,25 @@ module GobiertoAdmin
             redirect_to admin_participation_process_events_path(@collection.container) and return false
           end
         end
+      end
+
+      def check_container_presence
+        return if @collection.container.present?
+
+        redirect_path = case @collection.item_type
+                        when "GobiertoCms::News"
+                          admin_cms_pages_path
+                        when "GobiertoAttachments::Attachment"
+                          admin_attachments_file_attachments_path
+                        when "GobiertoCalendars::Event"
+                          admin_calendars_collections_path
+                        else
+                          admin_root_path
+                        end
+        redirect_to(
+          redirect_path,
+          alert: t("gobierto_admin.gobierto_common.collections.check_container_presence.container_not_found")
+        )
       end
     end
   end

--- a/app/controllers/gobierto_participation/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/attachments_controller.rb
@@ -7,7 +7,7 @@ module GobiertoParticipation
       @issues = find_issues
       @filtered_issue = find_issue if params[:issue_id]
       @attachments = if @filtered_issue
-                       GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @issue).page(params[:page])
+                       GobiertoAttachments::Attachment.in_collections_and_container(current_site, @issue).page(params[:page])
                      else
                        find_attachments.page(params[:page])
                      end
@@ -16,10 +16,10 @@ module GobiertoParticipation
     private
 
     def find_attachments
-      attachments = ::GobiertoAttachments::Attachment.attachments_in_collections_and_container_type(current_site, "GobiertoParticipation")
+      attachments = ::GobiertoAttachments::Attachment.in_collections_and_container_type(current_site, "GobiertoParticipation")
 
       if @filtered_issue
-        attachments = attachments.attachments_in_collections_and_container(current_site, @filtered_issue)
+        attachments = attachments.in_collections_and_container(current_site, @filtered_issue)
       end
 
       attachments

--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -32,7 +32,7 @@ module GobiertoParticipation
                     @container_events.past.sorted_backwards.page params[:page]
                   else
                     if @issue
-                      GobiertoCalendars::Event.events_in_collections_and_container(current_site, @issue).page(params[:page]).upcoming.sorted.page params[:page]
+                      GobiertoCalendars::Event.in_collections_and_container(current_site, @issue).published.page(params[:page]).upcoming.sorted.page params[:page]
                     else
                       @container_events.upcoming.sorted.page params[:page]
                     end
@@ -43,7 +43,7 @@ module GobiertoParticipation
     end
 
     def container_events
-      @container_events = GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation")
+      @container_events = GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published
     end
 
     def participation_events_scope

--- a/app/controllers/gobierto_participation/issues/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/issues/attachments_controller.rb
@@ -13,7 +13,7 @@ module GobiertoParticipation
       private
 
       def find_issue_attachments
-        ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @issue)
+        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, @issue)
       end
     end
   end

--- a/app/controllers/gobierto_participation/issues/events_controller.rb
+++ b/app/controllers/gobierto_participation/issues/events_controller.rb
@@ -25,7 +25,7 @@ module GobiertoParticipation
       private
 
       def find_participation_events
-        ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted
+        ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted
       end
 
       def find_event
@@ -33,8 +33,11 @@ module GobiertoParticipation
       end
 
       def set_events
-        @events = ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted.page params[:page]
-        @events = @events.events_in_collections_and_container(current_site, @issue) if @issue
+        @events = if @issue
+                    ::GobiertoCalendars::Event.in_collections_and_container(current_site, @issue).published.sorted.page params[:page] if @issue
+                  else
+                    ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted.page params[:page]
+                  end
 
         if params[:date]
           filter_events_by_date(params[:date])

--- a/app/controllers/gobierto_participation/processes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/processes/attachments_controller.rb
@@ -10,8 +10,8 @@ module GobiertoParticipation
         @filtered_issue = find_issue if params[:issue_id]
         @issue = find_issue if params[:issue_id]
         @attachments = if @issue
-                         GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @issue)
-                                                        .attachments_in_collections_and_container(current_site, current_process).page(params[:page])
+                         GobiertoAttachments::Attachment.in_collections_and_container(current_site, @issue)
+                                                        .in_collections_and_container(current_site, current_process).page(params[:page])
                        else
                          find_process_attachments
                        end
@@ -20,7 +20,7 @@ module GobiertoParticipation
       private
 
       def find_process_attachments
-        ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, current_process)
+        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, current_process)
       end
     end
   end

--- a/app/controllers/gobierto_participation/processes/events_controller.rb
+++ b/app/controllers/gobierto_participation/processes/events_controller.rb
@@ -28,15 +28,15 @@ module GobiertoParticipation
 
       def process_events_scope
         if valid_preview_token?
-          ::GobiertoCalendars::Event.events_in_collections_and_container_with_pending(
+          ::GobiertoCalendars::Event.in_collections_and_container(
             current_site,
             current_process
           ).sorted
         else
-          ::GobiertoCalendars::Event.events_in_collections_and_container(
+          ::GobiertoCalendars::Event.in_collections_and_container(
             current_site,
             current_process
-          ).sorted
+          ).published.sorted
         end
       end
 
@@ -46,7 +46,7 @@ module GobiertoParticipation
 
       def set_events
         @events = process_events_scope
-        @events = @events.events_in_collections_and_container(current_site, @issue) if @issue
+        @events = @events.in_collections_and_container(current_site, @issue).published if @issue
 
         @events = if params[:date]
                     filter_events_by_date(params[:date]).published

--- a/app/controllers/gobierto_participation/processes_controller.rb
+++ b/app/controllers/gobierto_participation/processes_controller.rb
@@ -26,7 +26,7 @@ module GobiertoParticipation
     end
 
     def find_process_events
-      ::GobiertoCalendars::Event.events_in_collections_and_container_with_pending(current_site, current_process).first(5)
+      ::GobiertoCalendars::Event.in_collections_and_container(current_site, current_process).first(5)
     end
 
     def current_process

--- a/app/controllers/gobierto_participation/scopes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/attachments_controller.rb
@@ -13,7 +13,7 @@ module GobiertoParticipation
       private
 
       def find_scope_attachments
-        ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(current_site, @scope)
+        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, @scope)
       end
     end
   end

--- a/app/controllers/gobierto_participation/scopes/events_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/events_controller.rb
@@ -25,7 +25,7 @@ module GobiertoParticipation
       private
 
       def find_participation_events
-        ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted
+        ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted
       end
 
       def find_event
@@ -33,8 +33,11 @@ module GobiertoParticipation
       end
 
       def set_events
-        @events = ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted.page params[:page]
-        @events = @events.events_in_collections_and_container(current_site, @scope) if @scope
+        @events = if @scope
+                    ::GobiertoCalendars::Event.in_collections_and_container(current_site, @scope).published.sorted.page params[:page]
+                  else
+                    ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted.page params[:page]
+                  end
 
         if params[:date]
           filter_events_by_date(params[:date])

--- a/app/controllers/gobierto_participation/welcome_controller.rb
+++ b/app/controllers/gobierto_participation/welcome_controller.rb
@@ -19,7 +19,7 @@ module GobiertoParticipation
     private
 
     def find_participation_events
-      ::GobiertoCalendars::Event.events_in_collections_and_container_type(current_site, "GobiertoParticipation").sorted.upcoming.limit(4)
+      ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted.upcoming.limit(4)
     end
 
     def find_participation_news

--- a/app/models/concerns/gobierto_common/collectionable.rb
+++ b/app/models/concerns/gobierto_common/collectionable.rb
@@ -5,6 +5,24 @@ module GobiertoCommon
     included do
       belongs_to :collection, class_name: "GobiertoCommon::Collection"
 
+      scope :in_collections, lambda { |site|
+        joins(Arel.sql("join collection_items on collection_items.item_id = #{ table_name }.id"))
+          .where("collection_items.item_type = ?", name)
+          .where(site: site)
+          .distinct
+      }
+
+      scope :in_collections_and_container_type, lambda { |site, container_type|
+        in_collections(site)
+          .where("collection_items.container_type = ?", container_type)
+      }
+
+      scope :in_collections_and_container, lambda { |site, container|
+        in_collections(site)
+          .where("collection_items.container_type = ?", container.class.name)
+          .where("collection_items.container_id = ?", container.id)
+      }
+
       def collection_container
         collection&.container
       end

--- a/app/models/concerns/gobierto_common/collectionable.rb
+++ b/app/models/concerns/gobierto_common/collectionable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCommon
   module Collectionable
     extend ActiveSupport::Concern

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -54,6 +54,8 @@ module GobiertoAttachments
     after_restore :set_slug
     belongs_to :collection, class_name: "GobiertoCommon::Collection"
 
+    has_many :collection_items, class_name: "GobiertoCommon::CollectionItem", as: :item
+
     scope :inverse_sorted, -> { order(id: :asc) }
     scope :sorted, -> { order(id: :desc) }
     scope :sort_by_updated_at, ->{ order(updated_at: :desc) }
@@ -70,21 +72,6 @@ module GobiertoAttachments
         "pdf": "pdf",
         "jpg": "image", "gif": "image", "bmp": "image", "jpeg": "image", "png": "image",
         "avi": "video", "mp4": "video", "wmv": "video", "mpg": "video", "mov": "video" }
-    end
-
-    def self.file_attachments_in_collections(site)
-      ids = GobiertoCommon::CollectionItem.attachments.map(&:item_id)
-      where(id: ids, site: site)
-    end
-
-    def self.attachments_in_collections_and_container_type(site, container_type)
-      ids = GobiertoCommon::CollectionItem.attachments.by_container_type(container_type).pluck(:item_id)
-      where(id: ids, site: site)
-    end
-
-    def self.attachments_in_collections_and_container(site, container)
-      ids = GobiertoCommon::CollectionItem.attachments.by_container(container).pluck(:item_id)
-      where(id: ids, site: site)
     end
 
     # Assumes file is opened and closed outside this function, since calling 'close'

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -79,20 +79,6 @@ module GobiertoCalendars
 
     enum state: { pending: 0, published: 1 }
 
-    def self.events_in_collections_and_container_type(site, container_type)
-      ids = GobiertoCommon::CollectionItem.events.by_container_type(container_type).pluck(:item_id)
-      where(id: ids, site: site).published
-    end
-
-    def self.events_in_collections_and_container(site, container)
-      events_in_collections_and_container_with_pending(site, container).published
-    end
-
-    def self.events_in_collections_and_container_with_pending(site, container)
-      ids = GobiertoCommon::CollectionItem.events.by_container(container).pluck(:item_id)
-      where(id: ids, site: site)
-    end
-
     def parameterize
       { container_slug: container.slug, slug: slug }
     end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -45,39 +45,24 @@ module GobiertoCms
     scope :sorted, -> { order(id: :desc) }
     scope :sort_by_published_on, -> { order(published_on: :desc) }
     scope :sort_by_updated_at, -> { order(updated_at: :desc) }
+    scope :news_in_collections, ->(site) {
+      joins(Arel.sql("join collection_items on collection_items.item_id = #{ self.table_name }.id"))
+        .where("collection_items.item_type = ?", "GobiertoCms::News")
+        .where(site: site)
+        .distinct
+    }
+    scope :news_in_collections_and_container_type, ->(site, container_type) {
+      news_in_collections(site)
+        .where("collection_items.container_type = ?", container_type)
+    }
+    scope :news_in_collections_and_container, ->(site, container) {
+      news_in_collections(site)
+        .where("collection_items.container_type = ?", container.class.name)
+        .where("collection_items.container_id = ?", container.id)
+    }
 
     def section
       GobiertoCms::SectionItem.find_by(item: self).try(:section)
-    end
-
-    # returns pages belonging to site pages collection
-    def self.pages_in_collections(site)
-      pages_ids = GobiertoCommon::CollectionItem.pages.pluck(:item_id)
-      where(id: pages_ids, site: site)
-    end
-
-    # returns news belonging to site news collection
-    def self.news_in_collections(site)
-      news_ids = GobiertoCommon::CollectionItem.news.pluck(:item_id)
-      where(id: news_ids, site: site)
-    end
-
-    # returns pages belonging to module pages collection
-    def self.pages_in_collections_and_container_type(site, container_type)
-      ids = GobiertoCommon::CollectionItem.pages.by_container_type(container_type).pluck(:item_id)
-      where(id: ids, site: site)
-    end
-
-    # returns news belonging to module news collection
-    def self.news_in_collections_and_container_type(site, container_type)
-      ids = GobiertoCommon::CollectionItem.news.by_container_type(container_type).pluck(:item_id)
-      where(id: ids, site: site)
-    end
-
-    # returns news belonging to process, issue, scope, etc.
-    def self.news_in_collections_and_container(site, container)
-      ids = GobiertoCommon::CollectionItem.news.by_container(container).pluck(:item_id)
-      where(id: ids, site: site)
     end
 
     def attributes_for_slug

--- a/app/views/gobierto_admin/gobierto_attachments/file_attachments/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_attachments/file_attachments/index.html.erb
@@ -51,6 +51,7 @@
 
       <tbody id="file_attachments_in_collection">
         <% @collections.each do |collection| %>
+          <% next unless collection.container.present? %>
           <tr id="collection-item-<%= collection.id %>">
             <td>
               <%= link_to edit_admin_common_collection_path(collection, item_type: 'Attachment'), class: 'open_remote_modal' do %>

--- a/app/views/gobierto_admin/gobierto_calendars/collections/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/collections/index.html.erb
@@ -49,6 +49,7 @@
 
       <tbody>
         <% @collections.each do |collection| %>
+          <% next unless collection.container.present? %>
           <tr>
             <td>
               <%= link_to edit_admin_common_collection_path(collection, item_type: 'Event'), class: 'open_remote_modal' do %>

--- a/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/index.html.erb
@@ -91,6 +91,7 @@
 
       <tbody>
         <% @collections.each do |collection| %>
+          <% next unless collection.container.present? %>
           <tr id="collection-item-<%= collection.id %>">
             <td>
               <%= link_to edit_admin_common_collection_path(collection, item_type: 'Page'), class: 'open_remote_modal' do %>

--- a/config/locales/gobierto_admin/gobierto_common/collections/controllers/collections/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/collections/controllers/collections/ca.yml
@@ -3,6 +3,8 @@ ca:
   gobierto_admin:
     gobierto_common:
       collections:
+        check_container_presence:
+          container_not_found: El recurs a què pertany la col·lecció no es troba
         create:
           success: La col·lecció s'ha creat correctament.
         update:

--- a/config/locales/gobierto_admin/gobierto_common/collections/controllers/collections/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/collections/controllers/collections/en.yml
@@ -3,6 +3,9 @@ en:
   gobierto_admin:
     gobierto_common:
       collections:
+        check_container_presence:
+          container_not_found: The resource the collection belongs to couldn't be
+            found
         create:
           success: Collection was successfully created.
         update:

--- a/config/locales/gobierto_admin/gobierto_common/collections/controllers/collections/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/collections/controllers/collections/es.yml
@@ -3,6 +3,8 @@ es:
   gobierto_admin:
     gobierto_common:
       collections:
+        check_container_presence:
+          container_not_found: El recurso al que pertenece la colección no se encuentra
         create:
           success: La colección se ha creado correctamente.
         update:

--- a/test/fixtures/gobierto_common/collections.yml
+++ b/test/fixtures/gobierto_common/collections.yml
@@ -115,6 +115,29 @@ dance_studio_group_ended_documents:
   container: dance_studio_group_ended (GobiertoParticipation::Process)
   item_type: GobiertoAttachments::Attachment
 
+# group_archived
+
+group_archived_news:
+  site: madrid
+  title_translations: <%= {'en' => 'News of archived group', 'es' => 'Noticias de grupo archivado' }.to_json %>
+  slug: group_archived-news
+  container: group_archived (GobiertoParticipation::Process)
+  item_type: GobiertoCms::News
+
+group_archived_calendar:
+  site: madrid
+  title_translations: <%= {'en' => 'Events of archived group', 'es' => 'Eventos de grupo archivado' }.to_json %>
+  slug: group_archived-calendar
+  container: group_archived (GobiertoParticipation::Process)
+  item_type: GobiertoCalendars::Event
+
+group_archived_documents:
+  site: madrid
+  title_translations: <%= {'en' => 'Documents of archived group', 'es' => 'Documentos de grupo archivado' }.to_json %>
+  slug: group_archived-documents
+  container: group_archived (GobiertoParticipation::Process)
+  item_type: GobiertoAttachments::Attachment
+
 # bowling_group_very_active
 
 bowling_group_very_active_news:

--- a/test/fixtures/gobierto_participation/processes.yml
+++ b/test/fixtures/gobierto_participation/processes.yml
@@ -65,6 +65,28 @@ bowling_group_very_active:
   issue: culture_term
   header_image_url: /assets/samples/process-b31e99553977f5da46a9f71d9c37a6ae90e8e3d7980363fa429f1c2a27c9f7ae.jpg
 
+group_archived:
+  site: madrid
+  title_translations: <%= {
+    'en' => 'Archived group',
+    'es' => 'Grupo archivado'
+  }.to_json %>
+  body_translations: <%= {
+    'en' => 'This group has been archived',
+    'es' => 'Este grupo ha sido archivado'
+  }.to_json %>
+  body_source_translations: <%= {
+    'en' => 'This group has been archived',
+    'es' => 'Este grupo ha sido archivado'
+  }.to_json %>
+  slug: grupo-archivado
+  process_type: <%= GobiertoParticipation::Process.process_types[:group_process] %>
+  visibility_level: <%= Site.visibility_levels['active'] %>
+  issue: culture_term
+  header_image_url: /assets/samples/process-b31e99553977f5da46a9f71d9c37a6ae90e8e3d7980363fa429f1c2a27c9f7ae.jpg
+  created_at: <%= 1.hour.ago %>
+  archived_at: <%= 1.second.ago %>
+
 # Processes
 
 sport_city_process:

--- a/test/integration/gobierto_admin/gobierto_attachments/file_attachment_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/file_attachment_index_test.rb
@@ -22,15 +22,24 @@ module GobiertoAdmin
         @collections ||= site.collections.where(item_type: "GobiertoAttachments::Attachment")
       end
 
+      def collections_with_container
+        @collections_with_container ||= collections.select { |collection| collection.container.present? }
+      end
+
+      def collection_with_archived_container
+        @collection_with_archived_container ||= gobierto_common_collections(:group_archived_documents)
+      end
+
       def test_attachments_index
         with_signed_in_admin(admin) do
           with_current_site(site) do
             visit @path
 
             within "#file_attachments_in_collection" do
-              assert has_selector?("tr", count: collections.size)
+              assert has_selector?("tr", count: collections_with_container.size)
+              refute has_link?(collection_with_archived_container.title.to_s)
 
-              collections.each do |collection|
+              collections_with_container.each do |collection|
                 assert has_selector?("tr#collection-item-#{collection.id}")
 
                 within "tr#collection-item-#{collection.id}" do

--- a/test/integration/gobierto_admin/gobierto_common/collections/edit_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/collections/edit_collection_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module Collections
+      class ShowCollectionTest < ActionDispatch::IntegrationTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def collection
+          @collection ||= gobierto_common_collections(:bowling_group_very_active_documents)
+        end
+
+        def collection_of_archived_container
+          @collection_of_archived_container ||= gobierto_common_collections(:group_archived_documents)
+        end
+
+        def archived_container
+          @archived_container ||= gobierto_participation_processes(:group_archived)
+        end
+
+        def test_edit_collection
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit edit_admin_common_collection_path(collection)
+
+              assert has_content?(collection.container.title)
+            end
+          end
+        end
+
+        def test_edit_collection_of_archived_container
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit edit_admin_common_collection_path(collection_of_archived_container)
+
+              assert has_content?("The resource the collection belongs to couldn't be found")
+              refute has_content?(archived_container.title)
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/collections/show_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/collections/show_collection_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module Collections
+      class ShowCollectionTest < ActionDispatch::IntegrationTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def collection
+          @collection ||= gobierto_common_collections(:bowling_group_very_active_documents)
+        end
+
+        def collection_of_archived_container
+          @collection_of_archived_container ||= gobierto_common_collections(:group_archived_documents)
+        end
+
+        def archived_container
+          @archived_container ||= gobierto_participation_processes(:group_archived)
+        end
+
+        def test_collection_show
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit admin_common_collection_path(collection)
+
+              assert has_content?(collection.container.title)
+            end
+          end
+        end
+
+        def test_collection_of_archived_container_show
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit admin_common_collection_path(collection_of_archived_container)
+
+              assert has_content?("The resource the collection belongs to couldn't be found")
+              refute has_content?(archived_container.title)
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
@@ -23,7 +23,7 @@ module GobiertoParticipation
     end
 
     def issue_attachments
-      @issue_attachments ||= ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(site, issue)
+      @issue_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container(site, issue)
     end
 
     def test_menu_subsections

--- a/test/integration/gobierto_participation/participation_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/participation_attachments_index_test.rb
@@ -17,7 +17,7 @@ module GobiertoParticipation
     end
 
     def participation_attachments
-      @participation_attachments ||= ::GobiertoAttachments::Attachment.attachments_in_collections_and_container_type(site, "GobiertoParticipation")
+      @participation_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container_type(site, "GobiertoParticipation")
     end
 
     def test_secondary_nav

--- a/test/integration/gobierto_participation/participation_events_index_test.rb
+++ b/test/integration/gobierto_participation/participation_events_index_test.rb
@@ -17,11 +17,11 @@ module GobiertoParticipation
     end
 
     def participation_current_events
-      @participation_current_events ||= ::GobiertoCalendars::Event.events_in_collections_and_container_type(site, "GobiertoParticipation").upcoming
+      @participation_current_events ||= ::GobiertoCalendars::Event.in_collections_and_container_type(site, "GobiertoParticipation").published.upcoming
     end
 
     def participation_past_events
-      @participation_past_events ||= ::GobiertoCalendars::Event.events_in_collections_and_container_type(site, "GobiertoParticipation").past
+      @participation_past_events ||= ::GobiertoCalendars::Event.in_collections_and_container_type(site, "GobiertoParticipation").published.past
     end
 
     def test_secondary_nav

--- a/test/integration/gobierto_participation/processes/process_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_attachments_index_test.rb
@@ -23,7 +23,7 @@ module GobiertoParticipation
     end
 
     def process_attachments
-      @process_attachments ||= ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(site, process)
+      @process_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container(site, process)
     end
 
     def test_breadcrumb_items

--- a/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
@@ -23,7 +23,7 @@ module GobiertoParticipation
     end
 
     def scope_attachments
-      @scope_attachments ||= ::GobiertoAttachments::Attachment.attachments_in_collections_and_container(site, scope)
+      @scope_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container(site, scope)
     end
 
     def test_menu_subsections


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/473


## :v: What does this PR do?
* Exclude collections belonging to archived or not present resources in index of CMS, Calendars and Documents
* Redirects to index of corresponding CMS, Calendars or Documents trying to access to a collection belonging to a not available resource
* Refactors some methods like `pages_in_collections`, `attachments_in_collections`, etc. under collectionable concern `in_collections`, optimizing the query and using scopes
 
## :mag: How should this be manually tested?

Visit admin and add documents, pages and events to a process. Review each index, and archive process .The documents, pages and events shouldn't appear and also the links to collections containing them shouldn't be available

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No