### PR TITLE
Fix link in flash message

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_attachments/file_attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/file_attachments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoAdmin
   module GobiertoAttachments
     class FileAttachmentsController < BaseController
@@ -5,7 +7,7 @@ module GobiertoAdmin
       before_action :load_collection, only: [:new, :edit, :create, :update, :destroy]
 
       def index
-        @collections = current_site.collections.by_item_type('GobiertoAttachments::Attachment')
+        @collections = current_site.collections.by_item_type("GobiertoAttachments::Attachment")
         @file_attachments = ::GobiertoAttachments::Attachment.file_attachments_in_collections(current_site).sort_by_updated_at.limit(10)
         @site_file_attachments = current_site.attachments.sort_by_updated_at
       end
@@ -34,7 +36,7 @@ module GobiertoAdmin
 
           redirect_to(
             edit_admin_attachments_file_attachment_path(@file_attachment_form.file_attachment.id, collection_id: collection_id),
-            notice: t(".success_html", link: gobierto_attachments_document_url(id: @file_attachment_form.slug, host: @file_attachment_form.site.domain))
+            notice: t(".success_html", link: gobierto_attachments_document_url(id: @file_attachment_form.file_attachment.id, host: @file_attachment_form.site.domain))
           )
         else
           render :edit

--- a/test/integration/gobierto_admin/gobierto_attachments/create_file_attachment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/create_file_attachment_test.rb
@@ -23,79 +23,76 @@ module GobiertoAdmin
       end
 
       def test_create_file_attachments_errors
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
-              click_link "Files"
-              assert has_selector?("h1", text: "Sport city")
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+            click_link "Files"
+            assert has_selector?("h1", text: "Sport city")
 
-              click_link "New"
-              assert has_selector?("h1", text: "Sport city")
-              click_button "Create"
-              assert has_alert?("File can't be blank")
-            end
+            click_link "New"
+            assert has_selector?("h1", text: "Sport city")
+            click_button "Create"
+            assert has_alert?("File can't be blank")
           end
         end
       end
 
       def test_create_file_attachments_with_name
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
 
-              click_link "Files"
+            click_link "Files"
 
-              assert has_selector?("h1", text: "Sport city")
+            assert has_selector?("h1", text: "Sport city")
 
-              click_link "New"
-              assert has_selector?("h1", text: "Sport city")
+            click_link "New"
+            assert has_selector?("h1", text: "Sport city")
 
-              fill_in "file_attachment_name", with: "My file_attachment"
-              fill_in "file_attachment_description", with: "My file_attachment description"
-              attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
+            fill_in "file_attachment_name", with: "My file_attachment"
+            fill_in "file_attachment_description", with: "My file_attachment description"
+            attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
 
-              with_stubbed_s3_file_upload do
-                click_button "Create"
-              end
-
-              assert has_message?("Attachment created successfully.")
-              file_attachment = ::GobiertoAttachments::Attachment.find_by(name: "My file_attachment",
-                                                                          description: "My file_attachment description")
-              activity = Activity.last
-              assert_equal file_attachment, activity.subject
-              assert_equal admin, activity.author
-              assert_equal site.id, activity.site_id
-              assert_equal "gobierto_attachments.attachment_created", activity.action
+            with_stubbed_s3_file_upload do
+              click_button "Create"
             end
+
+            assert has_message?("Attachment created successfully.")
+            file_attachment = ::GobiertoAttachments::Attachment.find_by(name: "My file_attachment",
+                                                                        description: "My file_attachment description")
+            activity = Activity.last
+            assert_equal file_attachment, activity.subject
+            assert_equal admin, activity.author
+            assert_equal site.id, activity.site_id
+            assert_equal "gobierto_attachments.attachment_created", activity.action
+
+            click_link "View the document"
+
+            assert has_content?("Documents for Sport city")
+            assert has_content?("My file_attachment")
           end
         end
       end
 
       def test_create_file_attachments_without_name
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
 
-              click_link "Files"
-              assert has_selector?("h1", text: "Sport city")
+            click_link "Files"
+            assert has_selector?("h1", text: "Sport city")
 
-              click_link "New"
-              assert has_selector?("h1", text: "Sport city")
+            click_link "New"
+            assert has_selector?("h1", text: "Sport city")
 
-              fill_in "file_attachment_description", with: "My file_attachment description"
-              attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
+            fill_in "file_attachment_description", with: "My file_attachment description"
+            attach_file("file_attachment_file", "test/fixtures/files/gobierto_attachments/attachment/pdf-collection-update-attachment.pdf")
 
-              with_stubbed_s3_file_upload do
-                click_button "Create"
-              end
-
-              assert has_message?("Attachment created successfully.")
-              file_attachment = ::GobiertoAttachments::Attachment.find_by(name: "pdf-collection-update-attachment.pdf",
-                                                                          description: "My file_attachment description")
+            with_stubbed_s3_file_upload do
+              click_button "Create"
             end
+
+            assert has_message?("Attachment created successfully.")
           end
         end
       end


### PR DESCRIPTION
Closes #2008 

## :v: What does this PR do?

This PR fixes the link to preview an attachment in the flash message.

## :mag: How should this be manually tested?

1. upload an attachment via the collection docs
2. check the link correctly redirects to the preview

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
