### PR TITLE
Attachments uniqueness

### DIFF
--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -27,7 +27,6 @@ module GobiertoAdmin
 
     validates :file, presence: true, unless: :persisted?
     validates :site, presence: true
-    validate :file_is_not_duplicated, if: -> { file.present? }
     validate :file_size_within_range, if: -> { file.present? }
     validates :collection, presence: true
 
@@ -150,15 +149,6 @@ module GobiertoAdmin
         attribute_name: :file,
         file: file
       ).upload!
-    end
-
-    def file_is_not_duplicated
-      attachment_hit = site.attachments.find_by(file_digest: file_attachment_class.file_digest(file))
-
-      if attachment_hit.present? && (!persisted? || (persisted? && id != attachment_hit.id))
-        errors.add(:file_digest,
-                   I18n.t("errors.messages.already_uploaded_html", url: admin_edit_attachment_path(attachment_hit)))
-      end
     end
 
     def file_size_within_range

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -37,15 +37,6 @@ module GobiertoAttachments
 
     validates :site, :url, presence: true
     validates :slug, uniqueness: { scope: :site_id }
-    # This validation is duplicated in FileAttachmentForm, but since it's still being used
-    # from the API, we can't remove it.
-    validates :file_digest, uniqueness: {
-      scope: :site_id,
-      message: -> (object, data) do
-        url = object.site.attachments.find_by!(file_digest: object.file_digest).url
-        "#{I18n.t("activerecord.messages.gobierto_attachments/attachment.already_uploaded")} #{url})."
-      end
-    }
 
     belongs_to :site
 
@@ -120,14 +111,8 @@ module GobiertoAttachments
 
     private
 
-    def unique_file_digest?
-      attachment_with_same_digest_id = site.attachments.where(file_digest: file_digest).pluck(:id).first
-      attachment_with_same_digest_id.nil? || (attachment_with_same_digest_id == id)
-    end
-
     def singular_route_key
       :gobierto_attachments_document
     end
-
   end
 end

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -23,13 +23,13 @@ module GobiertoAttachments
     default_scope { order(id: :desc) }
 
     has_paper_trail(
-      on:     [:create, :update, :destroy],
+      on: [:create, :update, :destroy],
       ignore: [:name, :file_size, :file_name, :description, :current_version]
     )
 
     algoliasearch_gobierto do
       attribute :site_id, :name, :description, :file_name, :url, :file_size
-      searchableAttributes ['name', 'description', 'file_name']
+      searchableAttributes %w(name description file_name)
       attributesForFaceting [:site_id]
     end
 
@@ -48,7 +48,7 @@ module GobiertoAttachments
 
     scope :inverse_sorted, -> { order(id: :asc) }
     scope :sorted, -> { order(id: :desc) }
-    scope :sort_by_updated_at, ->{ order(updated_at: :desc) }
+    scope :sort_by_updated_at, -> { order(updated_at: :desc) }
 
     def content_type
       MIME::Types.type_for(url).first.content_type

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -110,8 +110,6 @@ ca:
     format: "%{attribute} %{message}"
     messages:
       accepted: ha de ser acceptat
-      already_uploaded_html: has not been saved because it has already been uploaded
-        in the past. You can see it <a href="%{url}">here</a>.
       array_too_short:
         one: és massa curt (al menys %{count} element)
         other: és massa curt (al menys %{count} elements)

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -110,8 +110,6 @@ en:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
-      already_uploaded_html: has not been saved because it has already been uploaded
-        in the past. You can see it <a href="%{url}">here</a>.
       array_too_short:
         one: is too short (minimum at least %{count} element)
         other: is too short (minimum at least %{count} elements)

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -110,8 +110,6 @@ es:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
-      already_uploaded_html: no se ha guardado porque ya lo has subido en el pasado.
-        Puedes verlo <a href="%{url}">aquí</a>.
       array_too_short:
         one: es demasiado corto (al menos ${count} elemento)
         other: es demasiado corto (al menos ${count} elementos)

--- a/config/locales/gobierto_attachments/models/ca.yml
+++ b/config/locales/gobierto_attachments/models/ca.yml
@@ -12,7 +12,6 @@ ca:
         url: URL
     messages:
       gobierto_attachments/attachment:
-        already_uploaded: no és únic (ja està pujat a
         file_too_big: El fitxer excedeix la mida màxima
     models:
       gobierto_attachments/attachment: Adjunt

--- a/config/locales/gobierto_attachments/models/en.yml
+++ b/config/locales/gobierto_attachments/models/en.yml
@@ -12,7 +12,6 @@ en:
         url: URL
     messages:
       gobierto_attachments/attachment:
-        already_uploaded: not unique (already uploaded at
         file_too_big: File exceeds max size
     models:
       gobierto_attachments/attachment: Document

--- a/config/locales/gobierto_attachments/models/es.yml
+++ b/config/locales/gobierto_attachments/models/es.yml
@@ -12,7 +12,6 @@ es:
         url: URL
     messages:
       gobierto_attachments/attachment:
-        already_uploaded: no es único (ya está subido en
         file_too_big: El fichero excede el tamaño máximo
     models:
       gobierto_attachments/attachment: Documento

--- a/test/forms/gobierto_admin/gobierto_attachments/file_attachment_form_tests/create_test.rb
+++ b/test/forms/gobierto_admin/gobierto_attachments/file_attachment_form_tests/create_test.rb
@@ -67,15 +67,6 @@ module GobiertoAdmin
           assert_equal "logo-madrid.png", file_attachment.name
         end
 
-        def test_create_with_duplicated_file
-          form = ::GobiertoAdmin::FileAttachmentForm.new(
-            file_attachment_attributes.merge(file: existing_attachment_file)
-          )
-
-          refute form.save
-          assert form.errors.messages.include?(:file_digest)
-        end
-
         def test_create_when_file_too_big
           form = ::GobiertoAdmin::FileAttachmentForm.new(file_attachment_attributes)
 


### PR DESCRIPTION
Closes #2009 

## :v: What does this PR do?

This PR removes validations of file uniqueness to avoid problems described in #2009.

## :mag: How should this be manually tested?

Upload two times the same attachment in different collections.

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
