### PR TITLE
Disable Algolia for specific sites

### DIFF
--- a/app/models/concerns/gobierto_common/searchable.rb
+++ b/app/models/concerns/gobierto_common/searchable.rb
@@ -17,7 +17,7 @@ module GobiertoCommon
       end
 
       def self.trigger_reindex_job(record, remove)
-        return if record.nil?
+        return if record.nil? || (record.respond_to?(:site) && record.site.algolia_search_disabled?)
 
         GobiertoCommon::AlgoliaReindexJob.perform_later(record.class.name, record.id, remove)
       end
@@ -29,6 +29,7 @@ module GobiertoCommon
 
     def searchable_translated_attribute(translations_hash)
       return "" if translations_hash.nil?
+
       attribute_summary = translations_hash.values.join(" ").tr("\n\r", " ").gsub(/\s+/, " ")
       attribute_summary = strip_tags(attribute_summary)
       attribute_summary[0..9300]

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -194,6 +194,10 @@ class Site < ApplicationRecord
     url_helpers.send("#{configuration.home_page.underscore}_root_path")
   end
 
+  def algolia_search_disabled?
+    configuration.configuration_variables.fetch("algolia_search_disabled", false)
+  end
+
   private
 
   def site_configuration_attributes

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class Site < ApplicationRecord
 
-  RESERVED_SUBDOMAINS = %W(presupuestos hosted)
+  RESERVED_SUBDOMAINS = %w(presupuestos hosted).freeze
 
   has_many :activities
 
@@ -127,7 +129,7 @@ class Site < ApplicationRecord
 
   def gobierto_budgets_settings
     @gobierto_budgets_settings ||= if configuration.available_module?("GobiertoBudgets") && configuration.gobierto_budgets_enabled?
-                                    module_settings.find_by(module_name: "GobiertoBudgets")
+                                     module_settings.find_by(module_name: "GobiertoBudgets")
                                    end
   end
 
@@ -145,6 +147,7 @@ class Site < ApplicationRecord
 
   def settings_for_module(module_name)
     return unless respond_to?(method = "#{ module_name.underscore }_settings")
+
     send(method)
   end
 

--- a/test/models/gobierto_common/searchable_test.rb
+++ b/test/models/gobierto_common/searchable_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchableTest < ActiveSupport::TestCase
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def item
+    @item ||= gobierto_cms_pages(:site_news_1)
+  end
+
+  def test_trigger_reindex_job
+    # This mock sets the expectation of calling perform_later just once
+    GobiertoCommon::AlgoliaReindexJob.expects(:perform_later).returns(true)
+    item.class.trigger_reindex_job(item, false)
+
+    # The second time the reindex job is called doesn't call algolia reindex job
+    site.configuration.raw_configuration_variables = <<-YAML
+algolia_search_disabled: true
+    YAML
+    site.save
+    item.reload
+
+    item.class.trigger_reindex_job(item, false)
+  end
+
+end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -164,4 +164,21 @@ gobierto_people_default_filter_end_date:
     refute site.date_filter_configured?
   end
 
+  def test_algolia_search_disabled
+    refute site.algolia_search_disabled?
+
+    conf = site.configuration
+
+    conf.raw_configuration_variables = <<-YAML
+algolia_search_disabled: false
+    YAML
+    refute site.algolia_search_disabled?
+
+    conf.raw_configuration_variables = <<-YAML
+algolia_search_disabled: true
+    YAML
+
+    assert site.algolia_search_disabled?
+  end
+
 end


### PR DESCRIPTION
Closes #2001 

## :v: What does this PR do?

This PR allows an admin to disable the indexing of items for a given site using the custom variables.

## :mag: How should this be manually tested?

1. Disable search by setting `algolia_search_disabled: true`
2. Open the log
3. Save an item (i.e an event) and check no Algolia Job is executed

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

Yes, admin manual has been updated with the new setting: https://gobierto.readme.io/docs/administraci%C3%B3n-de-un-sitio#section-crear-y-personalizar-un-sitio

Once released, this setting should be activated in gencat production.