### PR TITLE
477 fix wrong slug counter increments

### DIFF
--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -19,7 +19,6 @@ module GobiertoCalendars
       :meta,
       :department_id,
       :interest_group_id,
-      :slug
     )
     attr_writer(
       :state,
@@ -97,6 +96,14 @@ module GobiertoCalendars
 
     def state
       @state ||= event.state
+    end
+
+    def slug=(value)
+      @slug = value.presence
+    end
+
+    def slug
+      @slug ||= event.slug
     end
 
     def notify?

--- a/test/forms/gobierto_calendars/event_form_test.rb
+++ b/test/forms/gobierto_calendars/event_form_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCalendars
+  class EventFormTest < ActiveSupport::TestCase
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def person
+      @person ||= gobierto_people_people(:richard)
+    end
+
+    def attendees
+      @attendees ||= gobierto_people_people(:nelson, :tamara, :juana).map { |attendee| EventAttendee.new(person: attendee) }
+    end
+
+    def calendar
+      gobierto_common_collections(:richard_calendar)
+    end
+
+    def existing_event
+      @existing_event ||= gobierto_calendars_events(:richard_published)
+    end
+
+    def valid_attributes
+      @valid_attributes ||= {
+        external_id: "wadus",
+        site_id: site.id,
+        person_id: person.id,
+        title_translations: { es: "Nuevo evento", en: "New event" },
+        description_translations: { es: "Descripción de nuevo evento", en: "New event description" },
+        description_source_translations: { es: "Descripción de nuevo evento", en: "New event description" },
+        starts_at: 1.day.from_now,
+        ends_at: 2.days.from_now,
+        notify: false,
+        attendees: attendees
+      }
+    end
+
+    def test_create_with_valid_attributes
+      form = EventForm.new(valid_attributes)
+      assert form.save
+
+      event = form.event
+      assert event.persisted?
+      assert event.slug.present?
+      event_attendees = event.attendees.map(&:person)
+      attendees.each do |attendee|
+        assert event_attendees.include? attendee.person
+      end
+    end
+
+    def test_update_with_valid_attributes
+      test_slug = "test-slug-wadus-event"
+      form = EventForm.new(valid_attributes.merge(slug: test_slug))
+      assert form.save
+
+      event = form.event
+      assert event.persisted?
+      assert_equal test_slug, event.slug
+    end
+
+    def test_update_not_including_slug
+      initial_slug = existing_event.slug
+      form = EventForm.new(valid_attributes.merge(id: existing_event.id))
+      assert form.save
+
+      event = form.event
+      assert event.persisted?
+      assert_equal initial_slug, event.slug
+    end
+
+    def test_update_with_blank_string_slug
+      initial_slug = existing_event.slug
+      ["", " "].each do |blank_string|
+        form = EventForm.new(valid_attributes.merge(id: existing_event.id, slug: blank_string))
+        assert form.save
+
+        event = form.event
+        assert event.persisted?
+        assert_equal initial_slug, event.slug
+      end
+    end
+  end
+end

--- a/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
+++ b/test/services/gobierto_people/google_calendar/calendar_integration_test.rb
@@ -244,6 +244,23 @@ module GobiertoPeople
         assert_equal "@ Event 2", event.title
       end
 
+      def test_sync_events_update_dont_affect_slug
+        calendar_service.sync!
+
+        event = richard.events.find_by external_id: "event2"
+        initial_slug = event.slug
+
+        (1..3).each do |i|
+          event.title = "Event 2 updated #{ i }"
+          event.save
+
+          calendar_service.sync!
+          event.reload
+
+          assert_equal initial_slug, event.slug
+        end
+      end
+
       def test_sync_events_removes_deleted_event_attributes
         calendar_service.sync!
 


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/477


## :v: What does this PR do?
Avoids errors importing or editing already existing events. There is a bug that causes recalculation of slug reimporting or updating events fom admin

## :mag: How should this be manually tested?

From admin edit an event, remove slug and click on update. The slug should remain the same.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No