### PR TITLE
Add algolia to gobierto citizens charters

### DIFF
--- a/app/javascript/lib/shared/modules/module-search.js
+++ b/app/javascript/lib/shared/modules/module-search.js
@@ -53,6 +53,10 @@ $(document).on('turbolinks:load', function() {
         } else {
           return I18n.t("layouts.search.budget_line_item_expense");
         }
+      case 'GobiertoCitizensCharters::Charter':
+        return I18n.t("layouts.search.charter");
+      case 'GobiertoCitizensCharters::Commitment':
+        return I18n.t("layouts.search.charter_commitment");
     }
   }
 

--- a/app/models/concerns/gobierto_common/searchable.rb
+++ b/app/models/concerns/gobierto_common/searchable.rb
@@ -27,6 +27,12 @@ module GobiertoCommon
       self.class.name
     end
 
+    def searchable_attribute(value)
+      return "" unless value.present?
+
+      strip_tags(value.tr("\n\r", " ").gsub(/\s+/, " "))[0..9300]
+    end
+
     def searchable_translated_attribute(translations_hash)
       return "" if translations_hash.nil?
 

--- a/app/models/gobierto_citizens_charters.rb
+++ b/app/models/gobierto_citizens_charters.rb
@@ -13,6 +13,10 @@ module GobiertoCitizensCharters
     [GobiertoCitizensCharters::Service, GobiertoCitizensCharters::Charter]
   end
 
+  def self.searchable_models
+    [GobiertoCitizensCharters::Charter, GobiertoCitizensCharters::Commitment]
+  end
+
   def self.module_submodules
     %w(services charters)
   end

--- a/app/models/gobierto_citizens_charters/charter.rb
+++ b/app/models/gobierto_citizens_charters/charter.rb
@@ -7,8 +7,15 @@ module GobiertoCitizensCharters
     acts_as_paranoid column: :archived_at
 
     include ActsAsParanoidAliases
-    include GobiertoCommon::UrlBuildable
     include GobiertoCommon::Sluggable
+    include GobiertoCommon::Searchable
+
+    algoliasearch_gobierto do
+      attribute :site_id, :updated_at, :title_en, :title_es, :title_ca, :searchable_custom_fields
+      searchableAttributes %w(title_en title_es title_ca searchable_custom_fields)
+      attributesForFaceting [:site_id]
+      add_attribute :resource_path, :class_name
+    end
 
     belongs_to :service, -> { with_archived }
     has_many :commitments, dependent: :destroy
@@ -18,7 +25,7 @@ module GobiertoCitizensCharters
 
     validates :slug, uniqueness: { scope: :service_id }
     translates :title
-    delegate :category, to: :service
+    delegate :category, :site_id, to: :service
 
     after_restore :set_slug
 
@@ -36,6 +43,21 @@ module GobiertoCitizensCharters
 
     def belongs_to_archived?
       service.archived?
+    end
+
+    def searchable_custom_fields
+      searchable_values = GobiertoCommon::CustomFieldRecord.searchable.for_item(self).map do |record|
+        if record.custom_field.has_localized_value?
+          searchable_translated_attribute(record.searchable_value)
+        else
+          searchable_attribute(record.searchable_value)
+        end
+      end
+      searchable_values.sort_by { |value| -value.length }.join(" ")[0..9300]
+    end
+
+    def resource_path
+      url_helpers.gobierto_citizens_charters_charter_url(slug: slug, host: service.site.domain)
     end
   end
 end

--- a/app/models/gobierto_citizens_charters/commitment.rb
+++ b/app/models/gobierto_citizens_charters/commitment.rb
@@ -7,8 +7,15 @@ module GobiertoCitizensCharters
     acts_as_paranoid column: :archived_at
 
     include ActsAsParanoidAliases
-    include GobiertoCommon::UrlBuildable
     include GobiertoCommon::Sluggable
+    include GobiertoCommon::Searchable
+
+    algoliasearch_gobierto do
+      attribute :site_id, :updated_at, :title_en, :title_es, :title_ca, :searchable_description
+      searchableAttributes %w(title_en title_es title_ca searchable_description)
+      attributesForFaceting [:site_id]
+      add_attribute :resource_path, :class_name
+    end
 
     belongs_to :charter, -> { with_archived }
     has_many :editions, dependent: :destroy
@@ -18,6 +25,7 @@ module GobiertoCitizensCharters
     validates :slug, uniqueness: { scope: :charter_id }
     translates :title
     translates :description
+    delegate :site_id, to: :charter
 
     after_restore :set_slug
 
@@ -35,6 +43,14 @@ module GobiertoCitizensCharters
 
     def belongs_to_archived?
       charter.archived?
+    end
+
+    def searchable_description
+      searchable_translated_attribute(description_translations)
+    end
+
+    def resource_path
+      url_helpers.gobierto_citizens_charters_charter_url(slug: charter.slug, host: charter.service.site.domain)
     end
   end
 end

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -32,6 +32,10 @@ module GobiertoCommon
       /paragraph/.match field_type
     end
 
+    def self.searchable_fields
+      [:localized_string, :string, :localized_paragraph, :paragraph]
+    end
+
     def has_options?
       /option/.match field_type
     end

--- a/app/models/gobierto_common/custom_field_record.rb
+++ b/app/models/gobierto_common/custom_field_record.rb
@@ -29,7 +29,10 @@ module GobiertoCommon
     validates :custom_field, presence: true
     validates :item, presence: true, type: true
 
-    delegate :value, :raw_value, :value=, to: :value_processor
+    scope :searchable, -> { joins(:custom_field).where(custom_fields: { field_type: CustomField.searchable_fields }) }
+    scope :for_item, ->(item) { where(item: item) }
+
+    delegate :value, :raw_value, :value=, :searchable_value, to: :value_processor
 
     def value_processor
       key = VALUE_PROCESSORS.has_key?(custom_field&.field_type&.to_sym) ? custom_field.field_type.to_sym : :default

--- a/app/models/gobierto_common/custom_field_value/base.rb
+++ b/app/models/gobierto_common/custom_field_value/base.rb
@@ -17,6 +17,10 @@ module GobiertoCommon
         raw_value
       end
 
+      def searchable_value
+        value
+      end
+
       def raw_value
         @raw_value ||= if custom_field && payload.present?
                          payload[custom_field.uid]

--- a/app/models/gobierto_common/custom_field_value/localized_text.rb
+++ b/app/models/gobierto_common/custom_field_value/localized_text.rb
@@ -6,6 +6,10 @@ module GobiertoCommon::CustomFieldValue
       raw_value[I18n.locale.to_s]
     end
 
+    def searchable_value
+      raw_value
+    end
+
     def raw_value
       super || {}
     end

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -94,6 +94,8 @@ ca:
     search:
       budget_line_item_expense: Partida pressupostària - Despesa
       budget_line_item_income: Partida pressupostària - Ingrés
+      charter: Carta de serveis
+      charter_commitment: Carta de serveis - Compromís
       contribution_item: Aportacions
       drag_drop_instructions: Arrossegueu i deixeu anar al costat esquerre per a col·locar
         aquesta pàgina al menú

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -89,6 +89,8 @@ en:
     search:
       budget_line_item_expense: Budget line - Expense
       budget_line_item_income: Budget line - Income
+      charter: Services charter
+      charter_commitment: Services charter - Commitment
       contribution_item: Contribution
       drag_drop_instructions: Drag and drop on the left side to place this page in
         the menu

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -94,6 +94,8 @@ es:
     search:
       budget_line_item_expense: Partida presupuestaria - Gasto
       budget_line_item_income: Partida presupuestaria - Ingreso
+      charter: Carta de servicios
+      charter_commitment: Carta de servicios - Compromiso
       contribution_item: Aportaciones
       drag_drop_instructions: Arrastre y suelte en la parte izquierda para colocar
         esta página en el menú


### PR DESCRIPTION
Related with https://github.com/PopulateTools/issues/issues/459


## :v: What does this PR do?

Includes `GobiertoCitizensCharters::Charter` and `GobiertoCitizensCharters::Commitment` in algolia 

## :mag: How should this be manually tested?

Visit a site with charters enabled and enter the name of a charter in the search box

## :eyes: Screenshots

### Before this PR
<img width="424" alt="screen shot 2018-11-13 at 18 49 38" src="https://user-images.githubusercontent.com/446459/48432535-e9d3e200-e774-11e8-8e6d-d430a6102acf.png">

### After this PR
<img width="474" alt="screen shot 2018-11-13 at 18 47 28" src="https://user-images.githubusercontent.com/446459/48432483-babd7080-e774-11e8-9f52-5ef86eb140a3.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No. Current documentation has been updated with missing information about changes required in `app/javascript/lib/shared/modules/module-search.js`
