### PR TITLE
459 charters small changes

### DIFF
--- a/app/javascript/gobierto_admin/modules/gobierto_citizens_charters_editions_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_citizens_charters_editions_controller.js
@@ -29,6 +29,16 @@ window.GobiertoAdmin.GobiertoCitizensChartersEditionsController = (function() {
       return this.editControl.val()
         ? parseFloat(this.editControl.val() || 0, 10)
         : "";
+    },
+
+    editTemplate: function(value, item) {
+      let $result = jsGrid.fields.number.prototype.editTemplate.call(this, value)
+
+      $result.on("click", function () {
+        $(this).select()
+      })
+
+      return $result
     }
   });
 

--- a/app/views/gobierto_citizens_charters/layouts/application.html.erb
+++ b/app/views/gobierto_citizens_charters/layouts/application.html.erb
@@ -1,6 +1,6 @@
 <% content_for :javascript_module_link do %>
   <!-- load module javascript specifics -->
-  <%= javascript_pack_tag 'plans', 'data-turbolinks-track': true %>
+  <%= javascript_pack_tag 'charters', 'data-turbolinks-track': true %>
 <% end %>
 
 <%= render template: "layouts/application" %>


### PR DESCRIPTION
## :v: What does this PR do?
* Fixes a bug loading for the first time the page of a charter, the pack loaded were `plans` instead of `charters` by mistake
* Makes content of numeric fields of charters editions jsGrid selected on click

## :mag: How should this be manually tested?

Go to home of charters and from there click on a charter with data. The sparkines should be displayed
From admin editions jsGrid click enable edition mode of a row and click on a cell with data. The content should be selected

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No