### PR TITLE
Fix custom name and description locale fallback

### DIFF
--- a/app/models/gobierto_budgets/category.rb
+++ b/app/models/gobierto_budgets/category.rb
@@ -17,11 +17,11 @@ module GobiertoBudgets
     end
 
     def name
-      custom_name_translations[I18n.locale.to_s] || default_name
+      custom_name_translations.try(:dig, I18n.locale.to_s) || default_name
     end
 
     def description
-      custom_description_translations[I18n.locale.to_s] || default_description
+      custom_description_translations.try(:dig, I18n.locale.to_s) || default_description
     end
 
     def self.default_name(area, kind, code)

--- a/app/models/gobierto_budgets/category.rb
+++ b/app/models/gobierto_budgets/category.rb
@@ -17,11 +17,11 @@ module GobiertoBudgets
     end
 
     def name
-      custom_name || default_name
+      custom_name_translations[I18n.locale.to_s] || default_name
     end
 
     def description
-      custom_description || default_description
+      custom_description_translations[I18n.locale.to_s] || default_description
     end
 
     def self.default_name(area, kind, code)

--- a/test/models/gobierto_budgets/budget_line_test.rb
+++ b/test/models/gobierto_budgets/budget_line_test.rb
@@ -54,12 +54,16 @@ module GobiertoBudgets
             .with(has_entries(budget_line_arguments_for_indexing))
             .returns("_shards" => { "failed" => 0 })
 
+      client.stubs(:search).returns({"hits" => {
+        "hits" => [
+          {"_source" => { "kind" => "expense", "code" => "1", "name" => "Despeses de personal" }}
+        ]
+      }})
+
       SearchEngine.stubs(client: client)
 
       algolia_index = mock
-
       algolia_index.expects(:add_object).with(budget_line.algolia_as_json)
-
       BudgetLine.stubs(algolia_index: algolia_index)
 
       budget_line.save
@@ -67,6 +71,12 @@ module GobiertoBudgets
 
     def test_save_fail
       client = mock
+
+      client.stubs(:search).returns({"hits" => {
+        "hits" => [
+          {"_source" => { "kind" => "expense", "code" => "1", "name" => "Despeses de personal" }}
+        ]
+      }})
 
       client.expects(:index)
             .with(has_entries(budget_line_arguments_for_indexing))
@@ -117,8 +127,8 @@ module GobiertoBudgets
         "description_es" => "Los gastos de personal son... (custom, translated)",
         "name_en"        => "Personal expenses (custom, translated)",
         "description_en" => "Personal expenses are... (custom, translated)",
-        "name_ca"        => "Gastos de personal (custom, translated)",
-        "description_ca" => "Los gastos de personal son... (custom, translated)"
+        "name_ca"        => "Despeses de personal",
+        "description_ca" => "Tot tipus de retribucions fixes i variables i indemnitzacions, en diners i en espècie, a satisfer per les entitats locals i els seus organismes autònoms al personal que hi presti els seus serveis. Cotitzacions obligatòries de les entitats locals i dels seus organismes autònoms als diferents règims de Seguretat Social del personal al seu servei. Prestacions socials, que comprenen tota classe de pensions i les remuneracions a concedir per raó de les càrregues familiars. Despeses de naturalesa social realitzades, en compliment d'acords i disposicions vigents, per les entitats locals i els seus organismes autònoms per al seu personal."
       }
 
       assert_equal expected_hash, budget_line.algolia_as_json

--- a/test/models/gobierto_budgets/category_test.rb
+++ b/test/models/gobierto_budgets/category_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoBudgets
+  class BudgetLineTest < ActiveSupport::TestCase
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def category
+      @category ||= gobierto_budgets_categories(:economic_1_g)
+    end
+
+    def test_name
+      I18n.locale = :es
+      assert_equal "Gastos de personal (custom, translated)", category.name
+      I18n.locale = :en
+      assert_equal "Personal expenses (custom, translated)", category.name
+      I18n.locale = :ca
+      assert_equal category.send(:default_name), category.name
+    end
+
+    def test_description
+      I18n.locale = :es
+      assert_equal "Los gastos de personal son... (custom, translated)", category.description
+      I18n.locale = :en
+      assert_equal "Personal expenses are... (custom, translated)", category.description
+      I18n.locale = :ca
+      assert_equal category.send(:default_description), category.description
+    end
+  end
+end


### PR DESCRIPTION
Bugfix

## :v: What does this PR do?

This PR fixes the fallback attribute when using customized names and descriptions in budget lines categories.

## :mag: How should this be manually tested?

Go to SantFeliu and check the names and descriptions of the budget categories correspond with the current locale.

## :eyes: Screenshots

### Before this PR

![screen shot 2018-11-15 at 13 11 13](https://user-images.githubusercontent.com/17616/48552151-f7ee4380-e8d7-11e8-888a-c5e502f82107.png)

### After this PR

![screen shot 2018-11-15 at 13 11 23](https://user-images.githubusercontent.com/17616/48552164-fde42480-e8d7-11e8-9cf4-1a3d186fc5d9.png)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No