### PR TITLE
2021 measurements add value and objective

### DIFF
--- a/app/helpers/gobierto_citizens_charters/application_helper.rb
+++ b/app/helpers/gobierto_citizens_charters/application_helper.rb
@@ -12,5 +12,9 @@ module GobiertoCitizensCharters
         helpers.number_with_precision(number, precision: 1, strip_insignificant_zeros: true, delimiter: t("number.format.delimiter"))
       end
     end
+
+    def format_percentage(number)
+      helpers.number_to_percentage(number, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true)
+    end
   end
 end

--- a/app/helpers/gobierto_citizens_charters/application_helper.rb
+++ b/app/helpers/gobierto_citizens_charters/application_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GobiertoCitizensCharters
+  module ApplicationHelper
+    def format_value(number, other_num = nil, absolute_value = false)
+      return nil if number.blank?
+      number = number.abs if absolute_value
+
+      if [number, other_num].compact.any? { |n| n.abs > 1_000_000 }
+        "#{helpers.number_with_precision(number.to_f / 1_000_000.to_f, precision: 1, strip_insignificant_zeros: true, delimiter: t("number.format.delimiter"))} M"
+      else
+        helpers.number_with_precision(number, precision: 1, strip_insignificant_zeros: true, delimiter: t("number.format.delimiter"))
+      end
+    end
+  end
+end

--- a/app/models/gobierto_citizens_charters/edition.rb
+++ b/app/models/gobierto_citizens_charters/edition.rb
@@ -8,6 +8,7 @@ module GobiertoCitizensCharters
 
     include ActsAsParanoidAliases
 
+    SIGNIFICATIVE_DECIMALS = 1
     PERIOD_INTERVAL_DATA = {
       year: ->(date) { { year: date.year } },
       quarter: ->(date) { { year: date.year, quarter: (date.month / 4) + 1 } },
@@ -34,6 +35,10 @@ module GobiertoCitizensCharters
       return nil if percentage.blank? && [value, max_value].any?(&:blank?)
 
       percentage || 100 * (value / max_value)
+    end
+
+    def has_values?
+      [value, max_value].all?(&:present?) && (percentage.blank? || percentage.round(SIGNIFICATIVE_DECIMALS) == (100 * (value / max_value)).round(SIGNIFICATIVE_DECIMALS))
     end
 
     def front_period_interval

--- a/app/views/gobierto_citizens_charters/charters/index.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/index.html.erb
@@ -30,7 +30,7 @@
           <div class="box-inner">
             <div class="box-results top left">
               <div class="results-title"><%= t(".global_progress") %></div>
-              <div class="results-value"><%= number_to_percentage(@resources_root.progress, precision: 1, strip_insignificant_zeros: true) %></div>
+              <div class="results-value"><%= format_percentage(@resources_root.progress) %></div>
             </div>
             <div class="box-contents bottom right">
               <%= t(".period") %>
@@ -49,7 +49,7 @@
             <% if charter.progress.present? %>
               <div class="box-results bottom left">
                 <div class="results-title"><%= t(".progress") %></div>
-                <div class="results-value"><%= number_to_percentage(charter.progress, precision: 1, strip_insignificant_zeros: true) %></div>
+                <div class="results-value"><%= format_percentage(charter.progress) %></div>
               </div>
             <% end %>
             <div class="box-contents bottom right"><%= t(".commitments", count: charter.commitments.count) %></div>

--- a/app/views/gobierto_citizens_charters/charters/show.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/show.html.erb
@@ -75,10 +75,17 @@
           <div class="m_b_2"><%= edition.commitment.description %></div>
           <div>
             <div class="charter-number m_b_1">
-              <p> <%= number_to_percentage(edition.proportion, precision: 1, strip_insignificant_zeros: true) %> </p>
+              <p> <%= number_to_percentage(edition.proportion, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) %> </p>
               <div id="sparkline-<%= edition.id %>" class="sparkline"></div>
             </div>
             <small class="charter-text--muted"><%= edition.commitment.title %></small>
+            <% if edition.has_values? %>
+              <div>
+                <%= "#{ t(".value") }: #{ number_to_human(edition.value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+                /
+                <%= "#{ t(".max_value") }: #{ number_to_human(edition.max_value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/gobierto_citizens_charters/charters/show.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/show.html.erb
@@ -82,9 +82,9 @@
             <% if edition.has_values? %>
               <div>
                 <small class="charter-text--muted">
-                  <%= "#{ t(".value") }: #{ number_to_human(edition.value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+                  <%= "#{ t(".value") }: #{ format_value(edition.value, edition.max_value) }" %>
                   /
-                  <%= "#{ t(".max_value") }: #{ number_to_human(edition.max_value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+                  <%= "#{ t(".max_value") }: #{ format_value(edition.max_value, edition.value) }" %>
                 </small>
               </div>
             <% end %>

--- a/app/views/gobierto_citizens_charters/charters/show.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/show.html.erb
@@ -81,9 +81,11 @@
             <small class="charter-text--muted"><%= edition.commitment.title %></small>
             <% if edition.has_values? %>
               <div>
-                <%= "#{ t(".value") }: #{ number_to_human(edition.value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
-                /
-                <%= "#{ t(".max_value") }: #{ number_to_human(edition.max_value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+                <small class="charter-text--muted">
+                  <%= "#{ t(".value") }: #{ number_to_human(edition.value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+                  /
+                  <%= "#{ t(".max_value") }: #{ number_to_human(edition.max_value, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) }" %>
+                </small>
               </div>
             <% end %>
           </div>

--- a/app/views/gobierto_citizens_charters/charters/show.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/show.html.erb
@@ -28,7 +28,7 @@
         <% if @charter.progress.present? %>
           <div class="subheader-title"><%= t(".global_progress") %></div>
           <div class="subheader-number m_v_2">
-            <p><%= number_to_percentage(@charter.progress, precision: 1, strip_insignificant_zeros: true) %></p>
+            <p><%= format_percentage(@charter.progress) %></p>
             <div id="sparkline-GLOBAL" class="sparkline"></div>
           </div>
         <% end %>
@@ -37,7 +37,7 @@
           <div class="subheader-title subheader-title--muted m_b_3">
             <%= t(
               "gobierto_citizens_charters.shared.evolution.#{ @progress_evolution < 0 ? "negative" : "positive" }",
-              progress: number_to_percentage(@progress_evolution, precision: 1, strip_insignificant_zeros: true)
+              progress: format_percentage(@progress_evolution)
               ) %>
           </div>
         <% end %>
@@ -75,7 +75,7 @@
           <div class="m_b_2"><%= edition.commitment.description %></div>
           <div>
             <div class="charter-number m_b_1">
-              <p> <%= number_to_percentage(edition.proportion, precision: GobiertoCitizensCharters::Edition::SIGNIFICATIVE_DECIMALS, strip_insignificant_zeros: true) %> </p>
+              <p><%= format_percentage(edition.proportion) %></p>
               <div id="sparkline-<%= edition.id %>" class="sparkline"></div>
             </div>
             <small class="charter-text--muted"><%= edition.commitment.title %></small>

--- a/config/locales/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_citizens_charters/views/ca.yml
@@ -23,8 +23,10 @@ ca:
         about: Sobre aquesta carta
         editions_details: Detall dels compromisos
         global_progress: Complim els compromisos d'aquesta carta al
+        max_value: Objectiu
         see_all: Veure la carta completa
         see_all_subtitle: Missió, Visió, Serveis, Unitat responsable...
+        value: Arribat
     layouts:
       application:
         citizens_charters: Cartes de Servei

--- a/config/locales/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_citizens_charters/views/en.yml
@@ -23,8 +23,10 @@ en:
         about: About this charter
         editions_details: Detail of the commitments
         global_progress: We fulfill the commitments of this charter to
+        max_value: Goal
         see_all: See the full charter
         see_all_subtitle: Mission, Vision, Services, Responsible Unit...
+        value: Reached
     layouts:
       application:
         citizens_charters: Services Charters

--- a/config/locales/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_citizens_charters/views/es.yml
@@ -23,8 +23,10 @@ es:
         about: Acerca de esta carta
         editions_details: Detalle de los compromisos
         global_progress: Cumplimos los compromisos de esta carta al
+        max_value: Objectivo
         see_all: Ver la carta completa
         see_all_subtitle: Misión, Visión, Servicios, Unidad responsable...
+        value: Alcanzado
     layouts:
       application:
         citizens_charters: Cartas de Servicios

--- a/config/locales/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_citizens_charters/views/es.yml
@@ -23,7 +23,7 @@ es:
         about: Acerca de esta carta
         editions_details: Detalle de los compromisos
         global_progress: Cumplimos los compromisos de esta carta al
-        max_value: Objectivo
+        max_value: Objetivo
         see_all: Ver la carta completa
         see_all_subtitle: Misión, Visión, Servicios, Unidad responsable...
         value: Alcanzado

--- a/test/fixtures/gobierto_citizens_charters/commitments.yml
+++ b/test/fixtures/gobierto_citizens_charters/commitments.yml
@@ -15,3 +15,51 @@ devices_operation:
   visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
   created_at: 2018-09-11 00:02:00
   updated_at: 2018-09-11 00:02:00
+
+equipment_maintenance:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "Equipment maintenance budget (€)", "es" => "Mantenimiento de equipos (€)" }.to_json %>
+  description_translations:  <%= { "en" => "At least 1.2M € euros will be allocated to expenses for maintenance and acquisition of medical equipment", "es" => "Se destinará al menos 1,2M € euros a gastos de mantenimiento y adquisición de equipos médicos"}.to_json %>
+
+families_activities:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "% of scores greater or equal than 7", "es" => "% de puntuaciones iguales o superiores a 7"}.to_json %>
+  description_translations: <%= { "en" => "90% of families will value the activities assigned to them with a score equal to or greater than 7", "es" => "El 90% de las familias valorará las actividades destinadas a ellas con una puntuación igual o superior a 7" }.to_json %>
+
+identification_card:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "Staff correctly identified by day", "es" => "Personal correctamente identificado por día" }.to_json %>
+  description_translations:  <%= { "en" => "All the staff that provide the different services of the Day Care Service will carry in a visible place the corresponding identification card", "es" => "Todo el personal que presta los diferentes servicios del Centro de Día llevará en lugar visible la correspondiente tarjeta de identificación"}.to_json %>
+
+adequate_menus:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "Adequate menus by day", "es" => "Menús adecuados por día" }.to_json %>
+  description_translations:  <%= { "en" => "The menus of all Day Centers are nutritionally adequate and are signed by a medical professional or nutritionist", "es" => "Los menús de todos los Centros de Día son nutricionalmente adecuados y son firmados por un profesional de la medicina o nutricionista"}.to_json %>
+
+average_response_time:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "Average response time (days)", "es" => "Tiempo medio de respuesta (days)" }.to_json %>
+  description_translations:  <%= { "en" => "The average response time of suggestions, claims and congratulations will be 30 calendar days from its presentation", "es" => "El tiempo medio de contestación de las sugerencias, reclamaciones y felicitaciones será de 30 días naturales desde su presentación"}.to_json %>
+
+published_service_schedule:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "Service provided on schedule", "es" => "Servicio prestado en horario" }.to_json %>
+  description_translations:  <%= { "en" => "The service is provided at a convenient time to the needs of the users and their families", "es" => "El servicio se presta en un horario conveniente a las necesidades de las personas usuarias y sus familias"}.to_json %>
+
+draft_service_schedule:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["draft"] %>
+  title_translations: <%= { "en" => "Draft service provided on schedule", "es" => "Servicio en borrador prestado en horario" }.to_json %>
+  description_translations:  <%= { "en" => "A draft service is provided at a convenient time to the needs of the users and their families", "es" => "Un sevicio en borrador se presta en un horario conveniente a las necesidades de las personas usuarias y sus familias"}.to_json %>
+
+old_service_schedule:
+  charter: day_care_service_charter
+  visibility_level: <%= GobiertoCitizensCharters::Commitment.visibility_levels["active"] %>
+  title_translations: <%= { "en" => "Old service provided on schedule", "es" => "Servicio antiguo prestado en horario" }.to_json %>
+  description_translations:  <%= { "en" => "An old service is provided on schedule", "es" => "Un servicio antiguo cumple el horario de atención"}.to_json %>

--- a/test/fixtures/gobierto_citizens_charters/editions.yml
+++ b/test/fixtures/gobierto_citizens_charters/editions.yml
@@ -2,7 +2,7 @@ call_center_service_level_2014:
   commitment: call_center_service_level
   period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
   period: 2014-01-01
-  percentage: 0.999
+  percentage: 111.1
   max_value: 90
   value: 100
   created_at: 2018-09-12 00:02:00
@@ -21,8 +21,9 @@ call_center_service_level_2016:
   commitment: call_center_service_level
   period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
   period: 2016-01-01
-  max_value: 95
-  value: 95.1
+  percentage: 66.667
+  max_value: 400
+  value: 200
   created_at: 2018-09-12 00:02:00
   updated_at: 2018-09-12 00:02:00
 

--- a/test/fixtures/gobierto_citizens_charters/editions.yml
+++ b/test/fixtures/gobierto_citizens_charters/editions.yml
@@ -44,3 +44,67 @@ call_center_service_level_2018:
   value:
   created_at: 2018-09-12 00:02:00
   updated_at: 2018-09-12 00:02:00
+
+equipment_maintenance_2018:
+  commitment: equipment_maintenance
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  value: 500000
+  max_value: 1200000
+
+families_activities_2018:
+  commitment: families_activities
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  value: 76.666
+  max_value: 90.0
+
+identification_card_2018:
+  commitment: identification_card
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  percentage: 33.333
+  value: 99.9
+  max_value: 300
+
+old_service_schedule_2010:
+  commitment: old_service_schedule
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2010-09-12
+  percentage: 50
+  value: 150
+  max_value: 300
+
+adequate_menus_2018:
+  commitment: adequate_menus
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  percentage: 66.666
+  value: 15
+  max_value: 30
+
+average_response_time_2018:
+  commitment: average_response_time
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  percentage: 66.666
+
+draft_service_schedule_2018:
+  commitment: draft_service_schedule
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  percentage: 100
+
+published_service_schedule_2018:
+  commitment: published_service_schedule
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  percentage: 100
+
+adequate_menus_2017:
+  commitment: adequate_menus
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2017-09-12
+  percentage: 100
+  value: 30
+  max_value: 30

--- a/test/integration/gobierto_citizens_charters/show_charter_test.rb
+++ b/test/integration/gobierto_citizens_charters/show_charter_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCitizensCharters
+  class ShowCharterTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = gobierto_citizens_charters_charter_path(slug: charter.slug)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def charter
+      @charter ||= gobierto_citizens_charters_charters(:day_care_service_charter)
+    end
+
+    def edition_with_large_values
+      @edition_with_large_values ||= gobierto_citizens_charters_editions(:equipment_maintenance_2018)
+    end
+    alias edition_without_other_editions edition_with_large_values
+
+    def edition_with_decimal_values
+      @edition_with_decimal_values ||= gobierto_citizens_charters_editions(:families_activities_2018)
+    end
+
+    def edition_with_percentage_and_compatible_values
+      @edition_with_percentage_and_compatible_values ||= gobierto_citizens_charters_editions(:identification_card_2018)
+    end
+
+    def edition_with_percentage_and_not_compatible_values
+      @edition_with_percentage_and_not_compatible_values ||= gobierto_citizens_charters_editions(:adequate_menus_2018)
+    end
+    alias edition_with_other_editions edition_with_percentage_and_not_compatible_values
+
+    def edition_with_decimal_percentage
+      @edition_with_decimal_percentage ||= gobierto_citizens_charters_editions(:average_response_time_2018)
+    end
+
+    def edition_with_integer_percentage
+      @edition_with_integer_percentage ||= gobierto_citizens_charters_editions(:published_service_schedule_2018)
+    end
+
+    def edition_with_draft_commitment
+      @edition_with_draft_commitment ||= gobierto_citizens_charters_editions(:draft_service_schedule_2018)
+    end
+
+    def visible_latest_period_editions
+      [edition_with_large_values,
+       edition_with_decimal_values,
+       edition_with_percentage_and_compatible_values,
+       edition_with_percentage_and_not_compatible_values,
+       edition_with_integer_percentage,
+       edition_with_decimal_percentage]
+    end
+
+    def edition_of_old_period
+      @edition_of_old_period ||= gobierto_citizens_charters_editions(:old_service_schedule_2010)
+    end
+
+    def test_show_last_edition
+      with_current_site(site) do
+        visit @path
+        within "div.dropdown div.dropdown-inner", match: :first do
+          assert has_content? "Data corresponding to #{ visible_latest_period_editions.first.front_period_params[:period] }"
+        end
+        visible_latest_period_editions.each do |edition|
+          within "div.charter", text: edition.commitment.description do
+            assert has_content? edition.commitment.title
+          end
+        end
+
+        refute has_content? edition_of_old_period.commitment.description
+        refute has_content? edition_with_draft_commitment.commitment.description
+      end
+    end
+
+    def test_change_edition
+      old_period_year = edition_of_old_period.front_period_params[:period]
+      with_current_site(site) do
+        visit @path
+        click_link "Data corresponding to #{ old_period_year }"
+        within "div.dropdown div.dropdown-inner", match: :first do
+          assert has_content? "Data corresponding to #{ old_period_year }"
+        end
+        assert has_content? edition_of_old_period.commitment.description
+        visible_latest_period_editions.each do |edition|
+          refute has_content? edition.commitment.description
+        end
+      end
+    end
+
+    def test_sparkline_presence
+      with_current_site(site) do
+        with_javascript do
+          visit @path
+          within "#sparkline-#{ edition_without_other_editions.id }" do
+            refute has_css? "svg"
+          end
+
+          within "#sparkline-#{ edition_with_other_editions.id }" do
+            assert has_css? "svg"
+          end
+        end
+      end
+    end
+
+    def test_global_progress
+      proportion = visible_latest_period_editions.map(&:proportion).compact
+      global_progress = proportion.sum / proportion.count
+      with_current_site(site) do
+        visit @path
+        within "div.charter-subheader", text: "We fulfill the commitments of this charter to" do
+          assert has_content? "#{ global_progress.round(1) }%"
+        end
+      end
+    end
+
+    def test_progress_with_large_values
+      with_current_site(site) do
+        visit @path
+        within "div.charter", text: edition_with_large_values.commitment.description do
+          assert has_content? "Reached: 0.5 M"
+          assert has_content? "Goal: 1.2 M"
+        end
+
+        edition_with_large_values.update_attribute(:max_value, 500_000)
+        visit @path
+        within "div.charter", text: edition_with_large_values.commitment.description do
+          assert has_content? "Reached: 500,000"
+          assert has_content? "Goal: 500,000"
+        end
+      end
+    end
+
+    def test_progress_with_decimal_values
+      with_current_site(site) do
+        visit @path
+        within "div.charter", text: edition_with_decimal_values.commitment.description do
+          assert has_content? "Reached: 76.7"
+          assert has_content? "Goal: 90"
+        end
+      end
+    end
+
+    def test_progress_with_percentage_and_compatible_values
+      with_current_site(site) do
+        visit @path
+        within "div.charter", text: edition_with_percentage_and_compatible_values.commitment.description do
+          within "div.charter-number" do
+            assert has_content? "33.3%"
+          end
+          assert has_content? "Reached: 99.9"
+          assert has_content? "Goal: 300"
+        end
+      end
+    end
+
+    def test_progress_with_percentage_and_not_compatible_values
+      with_current_site(site) do
+        visit @path
+        within "div.charter", text: edition_with_percentage_and_not_compatible_values.commitment.description do
+          within "div.charter-number" do
+            assert has_content? "66.7%"
+          end
+          refute has_content? "Reached"
+          refute has_content? "Goal"
+        end
+      end
+    end
+
+    def test_progress_with_decimal_percentage_round
+      with_current_site(site) do
+        visit @path
+        within "div.charter", text: edition_with_decimal_percentage.commitment.description do
+          within "div.charter-number" do
+            assert has_content? "66.7%"
+          end
+          refute has_content? "Reached"
+          refute has_content? "Goal"
+        end
+      end
+    end
+
+    def test_progress_with_integer_percentage
+      with_current_site(site) do
+        visit @path
+        within "div.charter", text: edition_with_integer_percentage.commitment.description do
+          within "div.charter-number" do
+            assert has_content? "100%"
+          end
+          refute has_content? "Reached"
+          refute has_content? "Goal"
+        end
+      end
+    end
+  end
+end

--- a/test/models/gobierto_citizens_charters/edition_test.rb
+++ b/test/models/gobierto_citizens_charters/edition_test.rb
@@ -12,8 +12,12 @@ module GobiertoCitizensCharters
       @edition_with_values ||= gobierto_citizens_charters_editions(:call_center_service_level_2015)
     end
 
-    def edition_with_percentage
-      @edition_with_percentage ||= gobierto_citizens_charters_editions(:call_center_service_level_2014)
+    def edition_with_percentage_and_values_matching
+      @edition_with_percentage_and_values_matching ||= gobierto_citizens_charters_editions(:call_center_service_level_2014)
+    end
+
+    def edition_with_percentage_and_values_not_matching
+      @edition_with_percentage_and_values_not_matching ||= gobierto_citizens_charters_editions(:call_center_service_level_2016)
     end
 
     def test_valid
@@ -42,9 +46,17 @@ module GobiertoCitizensCharters
     end
 
     def test_proportion
-      assert_equal 0.999, edition_with_percentage.proportion
+      assert_equal 111.1, edition_with_percentage_and_values_matching.proportion
+      assert_equal 66.667, edition_with_percentage_and_values_not_matching.proportion
       assert_equal 111, edition_with_values.proportion
       assert_nil edition.proportion
+    end
+
+    def test_has_value?
+      refute edition.has_values?
+      assert edition_with_values.has_values?
+      assert edition_with_percentage_and_values_matching.has_values?
+      refute edition_with_percentage_and_values_not_matching.has_values?
     end
   end
 end


### PR DESCRIPTION
Closes #2021


## :v: What does this PR do?
* Displays reached value and goal on measurements edition values if the values are present and compatible with the percentage or percentage is not set (the percentage has priority over other values)

## :mag: How should this be manually tested?

Visit show page of a charter on an edition with value and objective set

## :eyes: Screenshots

### Before this PR
<img width="1267" alt="screen shot 2018-11-16 at 19 45 45" src="https://user-images.githubusercontent.com/446459/48640872-4125bc80-e9d8-11e8-9f01-f270496f2b7f.png">

### After this PR
<img width="1267" alt="screen shot 2018-11-16 at 19 44 40" src="https://user-images.githubusercontent.com/446459/48640876-46830700-e9d8-11e8-84bd-68958c16007b.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
