### PR TITLE
Move display categories option from services to charters section in settings

### DIFF
--- a/app/controllers/gobierto_citizens_charters/application_controller.rb
+++ b/app/controllers/gobierto_citizens_charters/application_controller.rb
@@ -13,7 +13,7 @@ class GobiertoCitizensCharters::ApplicationController < ApplicationController
   end
 
   def services_home_enabled?
-    services_enabled? && current_site.gobierto_citizens_charters_settings&.enable_services_home
+    current_site.gobierto_citizens_charters_settings&.enable_services_home
   end
 
   private

--- a/app/views/gobierto_admin/gobierto_citizens_charters/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_citizens_charters/configuration/settings/edit.html.erb
@@ -36,13 +36,6 @@
                 <%= t(".enable_services")  %>
               <% end %>
             </div>
-            <div class="option">
-              <%= f.check_box :enable_services_home %>
-              <%= f.label :enable_services_home do %>
-                <span></span>
-                <%= t(".enable_services_home")  %>
-              <% end %>
-            </div>
           </div>
         </div>
       </div>
@@ -55,6 +48,13 @@
               <%= f.label :enable_charters do %>
                 <span></span>
                 <%= t(".enable_charters")  %>
+              <% end %>
+            </div>
+            <div class="option">
+              <%= f.check_box :enable_services_home %>
+              <%= f.label :enable_services_home do %>
+                <span></span>
+                <%= t(".enable_services_home")  %>
               <% end %>
             </div>
           </div>

--- a/test/fixtures/gobierto_citizens_charters/editions.yml
+++ b/test/fixtures/gobierto_citizens_charters/editions.yml
@@ -43,3 +43,11 @@ call_center_service_level_2018:
   value:
   created_at: 2018-09-12 00:02:00
   updated_at: 2018-09-12 00:02:00
+
+devices_operation_2018:
+  commitment: devices_operation
+  period_interval: <%= GobiertoCitizensCharters::Edition.period_intervals["year"] %>
+  period: 2018-09-12
+  percentage: 99.666
+  created_at: 2018-09-12 00:02:00
+  updated_at: 2018-09-12 00:02:00

--- a/test/integration/gobierto_admin/gobierto_attachments/file_attachment_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/file_attachment_index_test.rb
@@ -37,7 +37,7 @@ module GobiertoAdmin
 
             within "#file_attachments_in_collection" do
               assert has_selector?("tr", count: collections_with_container.size)
-              refute has_link?(collection_with_archived_container.title.to_s)
+              assert has_no_link?(collection_with_archived_container.title.to_s)
 
               collections_with_container.each do |collection|
                 assert has_selector?("tr#collection-item-#{collection.id}")

--- a/test/integration/gobierto_admin/gobierto_common/collections/edit_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/collections/edit_collection_test.rb
@@ -43,7 +43,7 @@ module GobiertoAdmin
               visit edit_admin_common_collection_path(collection_of_archived_container)
 
               assert has_content?("The resource the collection belongs to couldn't be found")
-              refute has_content?(archived_container.title)
+              assert has_no_content?(archived_container.title)
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/collections/show_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/collections/show_collection_test.rb
@@ -43,7 +43,7 @@ module GobiertoAdmin
               visit admin_common_collection_path(collection_of_archived_container)
 
               assert has_content?("The resource the collection belongs to couldn't be found")
-              refute has_content?(archived_container.title)
+              assert has_no_content?(archived_container.title)
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_plans/plans/plan_data_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/plan_data_test.rb
@@ -78,7 +78,7 @@ module GobiertoAdmin
               end
 
               assert_match "Invalid data entered", page.driver.browser.modal_message
-              refute has_content? "Test Plan Node"
+              assert has_no_content? "Test Plan Node"
             end
           end
         end

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -98,7 +98,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
 
         click_button "Send"
 
-        refute has_content? subscription_ack_message
+        assert has_no_content?(subscription_ack_message)
       end
     end
   end
@@ -143,7 +143,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
 
         click_button "Follow"
 
-        refute has_content? subscription_ack_message
+        assert has_no_content?(subscription_ack_message)
       end
     end
   end

--- a/test/integration/gobierto_citizens_charters/home_page_test.rb
+++ b/test/integration/gobierto_citizens_charters/home_page_test.rb
@@ -66,7 +66,7 @@ module GobiertoCitizensCharters
         end
 
         charters.each do |charter|
-          refute has_content? charter.title
+          assert has_no_content? charter.title
         end
       end
     end
@@ -84,7 +84,7 @@ module GobiertoCitizensCharters
         end
 
         charters.each do |charter|
-          refute has_content? charter.title
+          assert has_no_content? charter.title
         end
       end
     end

--- a/test/integration/gobierto_citizens_charters/home_page_test.rb
+++ b/test/integration/gobierto_citizens_charters/home_page_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCitizensCharters
+  class HomePageTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = gobierto_citizens_charters_root_path
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def services
+      @services ||= site.services
+    end
+
+    def charters
+      @charters ||= site.charters
+    end
+
+    def test_home_page_with_display_categories_setting_disabled
+      site.settings_for_module("GobiertoCitizensCharters").enable_services_home = false
+      site.settings_for_module("GobiertoCitizensCharters").save
+
+      with_current_site(site) do
+        visit @path
+
+        assert has_content?("Global compliance")
+        assert has_css?(".charters-box-container")
+
+        within "div.charters-box--lead div.results-value" do
+          assert has_content? "99.7%"
+        end
+
+        charters.each do |charter|
+          within "#charter-#{ charter.id }" do
+            assert has_content? charter.title
+          end
+        end
+      end
+    end
+
+    def test_home_page_with_display_categories_setting_enabled
+      site.settings_for_module("GobiertoCitizensCharters").enable_services_home = true
+      site.settings_for_module("GobiertoCitizensCharters").save
+
+      with_current_site(site) do
+        visit @path
+        assert has_content?("Services")
+        services.each do |service|
+          assert has_content? service.title
+        end
+
+        charters.each do |charter|
+          refute has_content? charter.title
+        end
+      end
+    end
+
+    def test_home_page_with_display_categories_setting_enabled_and_services_disabled
+      site.settings_for_module("GobiertoCitizensCharters").enable_services_home = true
+      site.settings_for_module("GobiertoCitizensCharters").disable_services = true
+      site.settings_for_module("GobiertoCitizensCharters").save
+
+      with_current_site(site) do
+        visit @path
+        assert has_content?("Services")
+        services.each do |service|
+          assert has_content? service.title
+        end
+
+        charters.each do |charter|
+          refute has_content? charter.title
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_citizens_charters/show_charter_test.rb
+++ b/test/integration/gobierto_citizens_charters/show_charter_test.rb
@@ -72,8 +72,8 @@ module GobiertoCitizensCharters
           end
         end
 
-        refute has_content? edition_of_old_period.commitment.description
-        refute has_content? edition_with_draft_commitment.commitment.description
+        assert has_no_content? edition_of_old_period.commitment.description
+        assert has_no_content? edition_with_draft_commitment.commitment.description
       end
     end
 
@@ -87,7 +87,7 @@ module GobiertoCitizensCharters
         end
         assert has_content? edition_of_old_period.commitment.description
         visible_latest_period_editions.each do |edition|
-          refute has_content? edition.commitment.description
+          assert has_no_content? edition.commitment.description
         end
       end
     end
@@ -97,7 +97,7 @@ module GobiertoCitizensCharters
         with_javascript do
           visit @path
           within "#sparkline-#{ edition_without_other_editions.id }" do
-            refute has_css? "svg"
+            assert has_no_css? "svg"
           end
 
           within "#sparkline-#{ edition_with_other_editions.id }" do
@@ -165,8 +165,8 @@ module GobiertoCitizensCharters
           within "div.charter-number" do
             assert has_content? "66.7%"
           end
-          refute has_content? "Reached"
-          refute has_content? "Goal"
+          assert has_no_content? "Reached"
+          assert has_no_content? "Goal"
         end
       end
     end
@@ -178,8 +178,8 @@ module GobiertoCitizensCharters
           within "div.charter-number" do
             assert has_content? "66.7%"
           end
-          refute has_content? "Reached"
-          refute has_content? "Goal"
+          assert has_no_content? "Reached"
+          assert has_no_content? "Goal"
         end
       end
     end
@@ -191,7 +191,7 @@ module GobiertoCitizensCharters
           within "div.charter-number" do
             assert has_content? "100%"
           end
-          refute has_content? "Reached"
+          assert has_no_content? "Reached"
           refute has_content? "Goal"
         end
       end

--- a/test/integration/gobierto_cms/visit_pages_collection_test.rb
+++ b/test/integration/gobierto_cms/visit_pages_collection_test.rb
@@ -50,7 +50,7 @@ module GobiertoCms
         end
 
         collection_hidden_pages.each do |page|
-          refute has_link?(page.title)
+          assert has_no_link?(page.title)
         end
 
         collection_page = collection_public_pages.first

--- a/test/integration/gobierto_cms/visit_section_test.rb
+++ b/test/integration/gobierto_cms/visit_section_test.rb
@@ -47,8 +47,8 @@ module GobiertoCms
           assert has_link?(page.title)
         end
 
-        refute has_link?(section_archived_page.title)
-        refute has_link?(section_draft_page.title)
+        assert has_no_link?(section_archived_page.title)
+        assert has_no_link?(section_draft_page.title)
 
         click_link section_page.title
 
@@ -111,7 +111,7 @@ module GobiertoCms
         end
 
         hidden_children_pages.each do |page|
-          refute has_link?(page.title)
+          assert has_no_link?(page.title)
         end
       end
     end

--- a/test/integration/gobierto_participation/processes/process_contribution_containers_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contribution_containers_index_test.rb
@@ -100,7 +100,7 @@ module GobiertoParticipation
 
         assert_equal process_contribution_containers.active.size, all(".themed").size
 
-        refute has_content? draft_container.title
+        assert has_no_content? draft_container.title
 
         within contribution_container_wrapper(current_container) do
           assert has_content? 'What can we do to improve the bowling group?'

--- a/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contributions/permission_levels_test.rb
@@ -69,7 +69,7 @@ module GobiertoParticipation
             visit container_path verified_level_contribution_container
             assert has_link? 'Have an idea!', href: new_participation_path(verified_level_contribution_container)
             page.find("a", text: "Have an idea!").trigger("click")
-            refute page.has_content? "WRITE YOUR IDEA CONCISE"
+            assert has_no_content? "WRITE YOUR IDEA CONCISE"
           end
         end
 

--- a/test/integration/gobierto_people/departments/index_test.rb
+++ b/test/integration/gobierto_people/departments/index_test.rb
@@ -47,7 +47,7 @@ YAML
           visit gobierto_people_departments_path
 
           assert has_link? justice_department.name
-          refute has_link? culture_department.name
+          assert has_no_link? culture_department.name
         end
       end
 

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -85,7 +85,7 @@ YAML
 
           within departments_sidebar do
             assert has_link? justice_department.name
-            refute has_link? culture_department.name
+            assert has_no_link? culture_department.name
           end
         end
       end

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -102,7 +102,7 @@ YAML
 
         within ".people-summary" do
           assert has_content? richard.name
-          refute has_content? tamara.name # hide people without events
+          assert has_no_content? tamara.name # hide people without events
         end
       end
     end

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -146,7 +146,7 @@ module GobiertoPlans
             within "section.level_2.cat_1" do
               within "ul.action-line--list" do
                 find("h3", text: actions.first.name).click
-                refute has_selector?("thead", count: 1)
+                assert has_no_selector?("thead", count: 1)
               end
             end
           end

--- a/test/integration/search_box_test.rb
+++ b/test/integration/search_box_test.rb
@@ -27,7 +27,7 @@ class SearchBoxTest < ActionDispatch::IntegrationTest
 
     with_current_site(site) do
       visit gobierto_people_root_path
-      refute has_selector?("#gobierto_search")
+      assert has_no_selector?("#gobierto_search")
 
       visit gobierto_budgets_root_path
       assert has_selector?(".search-box_input") # GobiertoBudgets search is shown instead


### PR DESCRIPTION
## :v: What does this PR do?

Moves "display categories in module home page" option from services to charters section in module settings

## :mag: How should this be manually tested?
Go to admin/citizens_charters/configuration/settings/edit path

## :eyes: Screenshots

### Before this PR
<img width="759" alt="screen shot 2018-11-17 at 10 15 07" src="https://user-images.githubusercontent.com/446459/48659461-f21c6d80-ea51-11e8-87e1-306c388160df.png">

### After this PR
<img width="771" alt="screen shot 2018-11-17 at 10 14 46" src="https://user-images.githubusercontent.com/446459/48659466-f779b800-ea51-11e8-8eb3-dc0b422e01d3.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No