### PR TITLE
Remove unused content_for breadcrumb_current_item

### DIFF
--- a/app/views/gobierto_budgets/budget_lines/index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/index.html.erb
@@ -1,11 +1,5 @@
 <% title t('.title', year: @year) %>
 
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.budget'), gobierto_budgets_budget_lines_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last, kind: GobiertoBudgets::BudgetLine::INCOME, area_name: GobiertoBudgets::EconomicArea.area_name, level: 1) %>
-  </h1>
-<% end %>
-
 <div class="column">
 	<%= render partial: 'gobierto_budgets/budgets/year_breadcrumb' %>
   <%= render partial: 'gobierto_budgets/budget_lines/explorer' %>

--- a/app/views/gobierto_budgets/budgets/guide.html.erb
+++ b/app/views/gobierto_budgets/budgets/guide.html.erb
@@ -1,12 +1,6 @@
 <% description t('.description') %>
 <% title t('.title') %>
 
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.guide'), gobierto_budgets_budgets_guide_path %>
-  </h1>
-<% end %>
-
 <div class="column">
 
   <main class="content">

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -1,11 +1,5 @@
 <% title t('.title', year: @year) %>
 
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.summary'), gobierto_budgets_budgets_path %>
-  </h1>
-<% end %>
-
 <% content_for :body_attributes do %>
   <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{GobiertoBudgets::SearchEngineConfiguration::Year.last}"} %>
 <% end %>

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -1,11 +1,5 @@
 <% title t('.header') %>
 
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.elaboration'), gobierto_budgets_budgets_elaboration_path %>
-  </h1>
-<% end %>
-
 <% content_for :body_attributes do %>
   <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{Date.today.year + 1}"} %>
 <% end %>

--- a/app/views/gobierto_budgets/budgets_execution/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_execution/index.html.erb
@@ -3,12 +3,6 @@
   set_meta_tags description: t('.description', place: current_site.organization_name, year: @year)
 %>
 
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.execution'), gobierto_budgets_budgets_execution_path(year: GobiertoBudgets::SearchEngineConfiguration::Year.last) %>
-  </h1>
-<% end %>
-
 <div class="column">
   <div class="block">
     <div class="pure-g header_block_inline">

--- a/app/views/gobierto_cms/pages/show.html.erb
+++ b/app/views/gobierto_cms/pages/show.html.erb
@@ -1,14 +1,4 @@
 <% title(@page.title) %>
 <% description(truncate(strip_tags(@page.body), length: 100)) %>
 
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <% if @section %>
-      <%= link_to @section.title, gobierto_cms_section_path(@section.slug) %>
-    <% else %>
-      <%= @collection.title %>
-    <% end %>
-  </strong>
-<% end %>
-
 <%= render @page.template %>

--- a/app/views/gobierto_participation/issues/activities/index.html.erb
+++ b/app/views/gobierto_participation/issues/activities/index.html.erb
@@ -1,17 +1,3 @@
-<% if @issue %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @issue.name, gobierto_participation_issue_path(@issue.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/issues/attachments/index.html.erb
+++ b/app/views/gobierto_participation/issues/attachments/index.html.erb
@@ -1,17 +1,3 @@
-<% if @issue %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @issue.name, gobierto_participation_issue_path(@issue.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/issues/events/index.html.erb
+++ b/app/views/gobierto_participation/issues/events/index.html.erb
@@ -1,17 +1,3 @@
-<% if @issue %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @issue.name, gobierto_participation_issue_path(@issue.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class="gradient-bg">
   <div class="column">
 

--- a/app/views/gobierto_participation/issues/events/show.html.erb
+++ b/app/views/gobierto_participation/issues/events/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_participation.shared.agenda'), gobierto_participation_issue_events_path %>
-  </h1>
-<% end %>
-
 <% content_for :subscribable_button do %>
   <%= render 'user/subscriptions/subscribable_button', subscribable: @event %>
 <% end %>

--- a/app/views/gobierto_participation/issues/index.html.erb
+++ b/app/views/gobierto_participation/issues/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
-  </strong>
-<% end %>
-
 <% content_for(:current_submodule_link) do %>
   <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
 <% end %>

--- a/app/views/gobierto_participation/issues/show.html.erb
+++ b/app/views/gobierto_participation/issues/show.html.erb
@@ -1,15 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <%= link_to t('gobierto_participation.layouts.menu_subsections.issues'), gobierto_participation_issues_path %>
-  </strong>
-
-  <span role="separator">/</span>
-
-  <h1>
-    <%= link_to @issue.name, gobierto_participation_issue_path(@issue.slug) %>
-  </h1>
-<% end %>
-
 <% content_for(:current_submodule_link) do %>
   <%= link_to @issue.name, gobierto_participation_issue_path(@issue.slug) %>
 <% end %>

--- a/app/views/gobierto_participation/layouts/application.html.erb
+++ b/app/views/gobierto_participation/layouts/application.html.erb
@@ -9,18 +9,6 @@
 <% end %>
 
 <% unless try(:current_process).nil? %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-    </h1>
-  <% end %>
-
   <% content_for :subscribable_button do %>
     <%= render 'user/subscriptions/subscribable_button', subscribable: current_process %>
   <% end %>

--- a/app/views/gobierto_participation/processes/activities/index.html.erb
+++ b/app/views/gobierto_participation/processes/activities/index.html.erb
@@ -1,17 +1,3 @@
-<% if current_process %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/processes/attachments/index.html.erb
+++ b/app/views/gobierto_participation/processes/attachments/index.html.erb
@@ -1,17 +1,3 @@
-<% if try(:current_process).present? %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/processes/attachments/templates/_attachment.html.erb
+++ b/app/views/gobierto_participation/processes/attachments/templates/_attachment.html.erb
@@ -1,17 +1,3 @@
-<% if @current_process %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @current_process.title, gobierto_participation_process_path(@current_process.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/processes/contribution_containers/index.html.erb
+++ b/app/views/gobierto_participation/processes/contribution_containers/index.html.erb
@@ -1,17 +1,3 @@
-<% if current_process %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class="gradient-bg">
   <div class="column">
 

--- a/app/views/gobierto_participation/processes/events/index.html.erb
+++ b/app/views/gobierto_participation/processes/events/index.html.erb
@@ -1,17 +1,3 @@
-<% if try(:current_process).present? %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class="gradient-bg">
   <div class="column">
 

--- a/app/views/gobierto_participation/processes/events/show.html.erb
+++ b/app/views/gobierto_participation/processes/events/show.html.erb
@@ -1,17 +1,3 @@
-<% if try(:current_process).present? %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class="gradient-bg">
   <div class="column">
 

--- a/app/views/gobierto_participation/processes/index.html.erb
+++ b/app/views/gobierto_participation/processes/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
-  </strong>
-<% end %>
-
 <% content_for(:current_submodule_link) do %>
   <%= link_to t('gobierto_participation.layouts.menu_subsections.processes'), gobierto_participation_processes_path %>
 <% end %>

--- a/app/views/gobierto_participation/processes/polls/index.html.erb
+++ b/app/views/gobierto_participation/processes/polls/index.html.erb
@@ -1,15 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <%= link_to t("gobierto_participation.layouts.menu_subsections.processes"), gobierto_participation_processes_path %>
-  </strong>
-
-  <span role="separator">/</span>
-
-  <h1>
-    <%= link_to current_process.title, gobierto_participation_process_path(current_process.slug) %>
-  </h1>
-<% end %>
-
 <div class="gradient-bg">
   <div class="column">
 

--- a/app/views/gobierto_participation/scopes/activities/index.html.erb
+++ b/app/views/gobierto_participation/scopes/activities/index.html.erb
@@ -1,17 +1,3 @@
-<% if @scope %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.scopes'), gobierto_participation_scopes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @scope.name, gobierto_participation_scope_path(@scope.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/scopes/attachments/index.html.erb
+++ b/app/views/gobierto_participation/scopes/attachments/index.html.erb
@@ -1,17 +1,3 @@
-<% if @scope %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.scopes'), gobierto_participation_scopes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @scope.name, gobierto_participation_scope_path(@scope.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class='gradient-bg'>
   <div class='column'>
     <div class='pure-g'>

--- a/app/views/gobierto_participation/scopes/events/index.html.erb
+++ b/app/views/gobierto_participation/scopes/events/index.html.erb
@@ -1,17 +1,3 @@
-<% if @scope %>
-  <% content_for :breadcrumb_current_item do %>
-    <strong>
-      <%= link_to t('gobierto_participation.layouts.menu_subsections.scopes'), gobierto_participation_scopes_path %>
-    </strong>
-
-    <span role="separator">/</span>
-
-    <h1>
-      <%= link_to @scope.name, gobierto_participation_scope_path(@scope.slug) %>
-    </h1>
-  <% end %>
-<% end %>
-
 <div class="gradient-bg">
   <div class="column">
 

--- a/app/views/gobierto_participation/scopes/events/show.html.erb
+++ b/app/views/gobierto_participation/scopes/events/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_participation.shared.agenda'), gobierto_participation_scope_events_path %>
-  </h1>
-<% end %>
-
 <% content_for :subscribable_button do %>
   <%= render 'user/subscriptions/subscribable_button', subscribable: @event %>
 <% end %>

--- a/app/views/gobierto_participation/scopes/index.html.erb
+++ b/app/views/gobierto_participation/scopes/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <%= link_to t('gobierto_participation.layouts.menu_subsections.scopes'), gobierto_participation_scopes_path %>
-  </strong>
-<% end %>
-
 <% content_for(:current_submodule_link) do %>
   <%= link_to t('gobierto_participation.layouts.menu_subsections.scopes'), gobierto_participation_scopes_path %>
 <% end %>

--- a/app/views/gobierto_participation/scopes/show.html.erb
+++ b/app/views/gobierto_participation/scopes/show.html.erb
@@ -1,15 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <strong>
-    <%= link_to t('gobierto_participation.layouts.menu_subsections.scopes'), gobierto_participation_scopes_path %>
-  </strong>
-
-  <span role="separator">/</span>
-
-  <h1>
-    <%= link_to @scope.name, gobierto_participation_scope_path(@scope.slug) %>
-  </h1>
-<% end %>
-
 <% content_for(:current_submodule_link) do %>
   <%= link_to @scope.name, gobierto_participation_scope_path(@scope.slug) %>
 <% end %>

--- a/app/views/gobierto_people/departments/index.html.erb
+++ b/app/views/gobierto_people/departments/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("gobierto_people.layouts.menu_subsections.departments"), gobierto_people_departments_path %>
-  </h1>
-<% end %>
-
 <h2><%= t("gobierto_people.layouts.menu_subsections.departments") %> </h2>
 
 <%= render partial: "department", collection: @departments %>

--- a/app/views/gobierto_people/departments/show.html.erb
+++ b/app/views/gobierto_people/departments/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("gobierto_people.layouts.menu_subsections.departments"), gobierto_people_departments_path %>
-  </h1>
-<% end %>
-
 <h2><%= @department.name %> </h2>
 
 <h2><%= "#{ @department_stats[:total_people_with_attendances] } #{ t(".people_with_events") }" %></h2>

--- a/app/views/gobierto_people/interest_groups/index.html.erb
+++ b/app/views/gobierto_people/interest_groups/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("gobierto_people.layouts.menu_subsections.interest_groups"), gobierto_people_interest_groups_path %>
-  </h1>
-<% end %>
-
 <h2><%= t("gobierto_people.layouts.menu_subsections.interest_groups") %> </h2>
 
 <%= render partial: "interest_group", collection: @interest_groups %>

--- a/app/views/gobierto_people/interest_groups/show.html.erb
+++ b/app/views/gobierto_people/interest_groups/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("gobierto_people.layouts.menu_subsections.interest_groups"), gobierto_people_interest_groups_path %>
-  </h1>
-<% end %>
-
 <h2><%= @interest_group.name %> </h2>
 <h2><%= "#{ @total_events } #{ t(".events") }" %></h2>
 

--- a/app/views/gobierto_people/people/_content_for_breadcrumb.html.erb
+++ b/app/views/gobierto_people/people/_content_for_breadcrumb.html.erb
@@ -1,5 +1,0 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.people'), gobierto_people_people_path %>
-  </h1>
-<% end %>

--- a/app/views/gobierto_people/people/_index.html.erb
+++ b/app/views/gobierto_people/people/_index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.people'), gobierto_people_people_path %>
-  </h1>
-<% end %>
-
 <div class="column">
 
   <div class="block">

--- a/app/views/gobierto_people/people/person_bio/show.html.erb
+++ b/app/views/gobierto_people/people/person_bio/show.html.erb
@@ -1,5 +1,4 @@
 <% description @person.bio %>
-<%= render "gobierto_people/people/content_for_breadcrumb" %>
 
 <div class="person_header">
 

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -2,8 +2,6 @@
   <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
-<%= render "gobierto_people/people/content_for_breadcrumb" %>
-
 <div class="person_header">
   <h2><%= title t(".title", person_name: @person.name) %></h2>
 </div>

--- a/app/views/gobierto_people/people/person_events/show.html.erb
+++ b/app/views/gobierto_people/people/person_events/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.agendas'), gobierto_people_events_path %>
-  </h1>
-<% end %>
-
 <% content_for :subscribable_button do %>
   <%= render 'user/subscriptions/subscribable_button', subscribable: @event %>
 <% end %>

--- a/app/views/gobierto_people/people/person_post_tags/show.html.erb
+++ b/app/views/gobierto_people/people/person_post_tags/show.html.erb
@@ -1,5 +1,3 @@
-<%= render "gobierto_people/people/content_for_breadcrumb" %>
-
 <h3 class="center">
   <%= title t("gobierto_people.people.person_posts.index.title", person_name: @person.name, person_charge: @person.charge) %>
 </h3>

--- a/app/views/gobierto_people/people/person_posts/index.html.erb
+++ b/app/views/gobierto_people/people/person_posts/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "gobierto_people/people/content_for_breadcrumb" %>
-
 <h3 class="blog_header">
   <%= title t(".title", person_name: @person.name, person_charge: @person.charge) %>
 </h3>

--- a/app/views/gobierto_people/people/person_posts/show.html.erb
+++ b/app/views/gobierto_people/people/person_posts/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path %>
-  </h1>
-<% end %>
-
 <div class="blog_header">
   <%= t(".title", person_name: @person.name, person_charge: @person.charge) %>
 </div>

--- a/app/views/gobierto_people/people/person_statements/index.html.erb
+++ b/app/views/gobierto_people/people/person_statements/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "gobierto_people/people/content_for_breadcrumb" %>
-
 <div class="pure-g">
 
   <div class="pure-u-1 pure-u-md-7-24"></div>

--- a/app/views/gobierto_people/people/person_statements/show.html.erb
+++ b/app/views/gobierto_people/people/person_statements/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.statements'), gobierto_people_statements_path %>
-  </h1>
-<% end %>
-
 <div class="person_header">
   <h2><%= title t(".title", person_name: @person.name) %></h2>
 </div>

--- a/app/views/gobierto_people/people/show.html.erb
+++ b/app/views/gobierto_people/people/show.html.erb
@@ -1,7 +1,5 @@
 <% description(@person.bio) %>
 
-<%= render "gobierto_people/people/content_for_breadcrumb" %>
-
 <% content_for :subscribable_button do %>
   <%= render 'user/subscriptions/subscribable_button', subscribable: @person %>
 <% end %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.agendas'), gobierto_people_events_path %>
-  </h1>
-<% end %>
-
 <div class="column">
 
   <div class="block">

--- a/app/views/gobierto_people/person_post_tags/show.html.erb
+++ b/app/views/gobierto_people/person_post_tags/show.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path %>
-  </h1>
-<% end %>
-
 <div class="column">
 
   <h1>

--- a/app/views/gobierto_people/person_posts/index.html.erb
+++ b/app/views/gobierto_people/person_posts/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.blogs'), gobierto_people_posts_path %>
-  </h1>
-<% end %>
-
 <div class="column pure-g">
 
   <div class="pure-u-1 pure-u-md-7-24">

--- a/app/views/gobierto_people/person_statements/index.html.erb
+++ b/app/views/gobierto_people/person_statements/index.html.erb
@@ -1,10 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_people.layouts.menu_subsections.statements'), gobierto_people_statements_path %>
-  </h1>
-<% end %>
-
-
 <div class="column pure-g">
 
   <div class="pure-u-1 pure-u-md-7-24">

--- a/app/views/sandbox/indicators-ita.html.erb
+++ b/app/views/sandbox/indicators-ita.html.erb
@@ -1,11 +1,5 @@
 <% title t('.title', year: @year) %>
 
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t('gobierto_budgets.layouts.menu_subsections.summary'), gobierto_budgets_budgets_path %>
-  </h1>
-<% end %>
-
 <% content_for :body_attributes do %>
   <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{Date.today.year}"} %>
 <% end %>

--- a/app/views/user/notifications/index.html.erb
+++ b/app/views/user/notifications/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("user.layouts.menu_subsections.notifications"), user_notifications_path %>
-  </h1>
-<% end %>
-
 <div class="column">
 
   <div class="block">

--- a/app/views/user/settings/show.html.erb
+++ b/app/views/user/settings/show.html.erb
@@ -1,12 +1,6 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("user.layouts.menu_subsections.admin"), user_settings_path %>
-  </h1>
-<% end %>
-
 <div class="column">
 
-	<div class="block">
+  <div class="block">
     <h2><%= t('.title') %></h2>
 	</div>
 

--- a/app/views/user/subscriptions/index.html.erb
+++ b/app/views/user/subscriptions/index.html.erb
@@ -1,9 +1,3 @@
-<% content_for :breadcrumb_current_item do %>
-  <h1>
-    <%= link_to t("user.layouts.menu_subsections.alerts"), user_subscriptions_path %>
-  </h1>
-<% end %>
-
 <div class="column">
   <%= form_for(@user_subscription_preferences_form, as: :user_subscription_preferences, url: :user_subscription_preferences, method: :patch) do |f| %>
     <div class="block">

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -508,7 +508,6 @@ ca:
       application:
         budgets: Pressupostos
       menu_subsections:
-        budget: Pressupost
         data: Dades
         elaboration: Elaboració
         execution: Execució
@@ -516,7 +515,6 @@ ca:
         indicators: Indicadors
         providers: Proveïdors i Factures
         receipt: Rebut
-        summary: Resum
     providers:
       index:
         all_invoices: Totes les factures

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -486,7 +486,6 @@ en:
       application:
         budgets: Budgets
       menu_subsections:
-        budget: Budget
         data: Data
         elaboration: Elaboration
         execution: Execution
@@ -494,7 +493,6 @@ en:
         indicators: Indicators
         providers: Providers and Invoices
         receipt: Receipt
-        summary: Summary
     providers:
       index:
         all_invoices: All the invoices

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -501,7 +501,6 @@ es:
       application:
         budgets: Presupuestos
       menu_subsections:
-        budget: Presupuesto
         data: Datos
         elaboration: Elaboración
         execution: Ejecución
@@ -509,7 +508,6 @@ es:
         indicators: Indicadores
         providers: Proveedores y Facturas
         receipt: Recibo
-        summary: Resumen
     providers:
       index:
         all_invoices: Todas las facturas


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

Removes an unused piece of code, specifically the `content_for :breadcrumb_current_item` block.

## :mag: How should this be manually tested?

Nothing should change between staging and production sites given that the code wasn't in use.

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No