### PR TITLE
Use same markup as news for activities list

### DIFF
--- a/app/assets/stylesheets/comp-content.scss
+++ b/app/assets/stylesheets/comp-content.scss
@@ -16,7 +16,8 @@
   }
 }
 
-.news_teaser {
+.news_teaser,
+.activities_teaser {
   margin: 0 0 4em 0;
 
   h3 {
@@ -32,7 +33,8 @@
 }
 
 .news_teaser,
-.news_article {
+.news_article,
+.activities_teaser {
   .meta {
     font-size: $f7;
     opacity: 0.5;

--- a/app/assets/stylesheets/theme-participation.scss
+++ b/app/assets/stylesheets/theme-participation.scss
@@ -924,6 +924,17 @@ $lighter_black: rgba($color_headers, 0.7);
     }
   }
 
+  /* Activities */
+  .activities_teaser {
+    h3 {
+      font-weight: 600;
+
+      a {
+        color: $green;
+      }
+    }
+  }
+
   /* Theme list */
   .slim_headline {
     color: $black;

--- a/app/views/gobierto_participation/activities/index.html.erb
+++ b/app/views/gobierto_participation/activities/index.html.erb
@@ -23,15 +23,13 @@
       </div>
 
       <div class='pure-u-1 pure-u-lg-2-3'>
-        <div class="activity_feed">
-          <% if @activities.any? %>
-            <% @activities.each do |activity| %>
-              <%= render 'gobierto_participation/shared/activities/activity_teaser', { activity: activity } %>
-            <% end %>
-          <% else %>
-            <%= t("gobierto_participation.shared.no_activities") %>
+        <% if @activities.any? %>
+          <% @activities.each do |activity| %>
+            <%= render 'gobierto_participation/shared/activities/activity_teaser', { activity: activity } %>
           <% end %>
-        </div>
+        <% else %>
+          <%= t("gobierto_participation.shared.no_activities") %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/gobierto_participation/shared/activities/_activity_teaser.html.erb
+++ b/app/views/gobierto_participation/shared/activities/_activity_teaser.html.erb
@@ -1,9 +1,11 @@
-<div class="activity_item">
-  <h2>
+<div class="activities_teaser">
+  <h3>
     <%= link_to_if activity.active?, activity.translated_action, activity.subject.to_url(host: current_site.domain) do %>
       <%= activity.translated_action %>
       <span class="secondary"><%= activity.subject_name %></span>
     <% end %>
-  </h2>
-  <div class="date"><%= l(activity.created_at.to_date, format: :short) %></div>
+  </h3>
+  <div class="meta">
+    <time><%= time_ago_in_words(activity.created_at) %></time>
+  </div>
 </div>


### PR DESCRIPTION
Closes #2041

## :v: What does this PR do?

Fixes markup of participation activities index using the same markup the news index page have

## :mag: How should this be manually tested?
Visit http://madrid.gobify.net/participacion/actividad
 
## :eyes: Screenshots

### Before this PR
<img width="1229" alt="screen shot 2018-11-23 at 17 10 30" src="https://user-images.githubusercontent.com/446459/48952526-ca8e3f00-ef42-11e8-8501-0b5ee2f24d2e.png">


### After this PR
<img width="1263" alt="screen shot 2018-11-23 at 17 09 16" src="https://user-images.githubusercontent.com/446459/48952534-d1b54d00-ef42-11e8-9d4c-9fd73f7ba669.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No