### PR TITLE
1995 delete process stage pages when archived

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_participation/processes/process_stages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_participation/processes/process_stages_controller.rb
@@ -62,7 +62,7 @@ module GobiertoAdmin
           @process_stage = find_process_stage
 
           respond_to do |format|
-            if @process_stage.destroy
+            if !@process_stage.active && @process_stage.destroy
               format.js { flash.now[:notice] = t(".success") }
             else
               format.js { flash.now[:alert] = t(".default") }

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -27,7 +27,7 @@ module GobiertoParticipation
     belongs_to :site
     has_vocabulary :issues
     has_vocabulary :scopes
-    has_many :stages, -> { sorted }, dependent: :delete_all, class_name: "GobiertoParticipation::ProcessStage", autosave: true
+    has_many :stages, -> { sorted }, dependent: :destroy, class_name: "GobiertoParticipation::ProcessStage", autosave: true
     has_many :published_stages, -> { published.sorted }, class_name: "GobiertoParticipation::ProcessStage"
     has_many :polls
     has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"

--- a/app/models/gobierto_participation/process_stage.rb
+++ b/app/models/gobierto_participation/process_stage.rb
@@ -8,8 +8,6 @@ module GobiertoParticipation
     include GobiertoCommon::Sluggable
     include GobiertoCommon::UrlBuildable
 
-    before_destroy :check_stage_active
-
     belongs_to :process
     has_one :process_stage_page, class_name: "GobiertoParticipation::ProcessStagePage", dependent: :destroy
 
@@ -112,12 +110,6 @@ module GobiertoParticipation
     end
 
     private
-
-    def check_stage_active
-      return true unless active?
-      false
-      throw(:abort)
-    end
 
     def singular_route_key
       if information?

--- a/test/integration/gobierto_admin/gobierto_participation/processes/archive_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/archive_process_test.rb
@@ -22,17 +22,26 @@ module GobiertoAdmin
         @process ||= gobierto_participation_processes(:sport_city_process)
       end
 
+      def process_stage_page
+        @process_stage_page ||= gobierto_participation_process_stage_pages(:sport_process_information_stage_page)
+      end
+
       def test_archive_restore_process
         with_javascript do
           with_signed_in_admin(admin) do
             with_current_site(site) do
               visit @path
 
+              process_stage_page_id = process_stage_page.id
+              assert ::GobiertoParticipation::ProcessStagePage.where(id: process_stage_page_id).exists?
+
               within "#process-item-#{process.id}" do
                 find("a[data-method='delete']").click
               end
 
               assert has_message?("The process has been archived correctly")
+
+              refute ::GobiertoParticipation::ProcessStagePage.where(id: process_stage_page_id).exists?
 
               click_on "Archived elements"
 


### PR DESCRIPTION
Closes #1995


## :v: What does this PR do?
Use `dependent: :destroy` on stages association of `GobiertoParticipation::Process` and removes a callback on stages preventing their destruction when active. Also adds a check in admin stages controller to avoid deletion of active stages.

## :mag: How should this be manually tested?
Follow the steps described in the related issue

## :eyes: Screenshots

### Before this PR
![1995_before](https://user-images.githubusercontent.com/446459/48966748-b7797e80-efd7-11e8-9433-7f975c26d947.gif)
![1995_before_2](https://user-images.githubusercontent.com/446459/48966758-d7a93d80-efd7-11e8-80c6-870edf6f0e92.gif)

### After this PR
![1995_after](https://user-images.githubusercontent.com/446459/48966766-e2fc6900-efd7-11e8-99f4-a2658c304200.gif)
![1995_after_2](https://user-images.githubusercontent.com/446459/48966782-f7d8fc80-efd7-11e8-8ab6-d8d63c6385f7.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No