### PR TITLE
2030 percentages format in budgets

### DIFF
--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -4,10 +4,13 @@ module GobiertoBudgets
       include GobiertoBudgets::ApplicationHelper
 
       caches_action :total_budget, :total_budget_execution, :population, :total_budget_per_inhabitant,
-                    :budget, :budget_execution, :budget_per_inhabitant, :budget_percentage_over_total, :debt
+                    :budget_execution, :budget_percentage_over_total, :debt
 
       caches_action(
         :lines,
+        :budget_per_inhabitant,
+        :budget,
+
         cache_path: proc { |c| "#{c.request.url}?locale=#{I18n.locale}" }
       )
 

--- a/app/helpers/gobierto_budgets/application_helper.rb
+++ b/app/helpers/gobierto_budgets/application_helper.rb
@@ -51,7 +51,15 @@ module GobiertoBudgets
     end
 
     def percentage_of_total(value, total)
-      number_with_precision((value.to_f / total.to_f) * 100, precision: 2) + '%'
+      percentage_fraction_format(value.to_f / total.to_f)
+    end
+
+    def percentage_fraction_format(fraction)
+      number_with_precision(fraction * 100, precision: 2) + '%'
+    end
+
+    def percentage_format(percentage)
+      number_with_precision(percentage, precision: 2) + '%'
     end
 
     def budget_line_denomination(area_name, code, kind, capped = -1)

--- a/app/javascript/lib/visualizations/modules/bubbles.js
+++ b/app/javascript/lib/visualizations/modules/bubbles.js
@@ -195,11 +195,11 @@ export class VisBubbles {
       return d > 0 ? I18n.t('gobierto_common.visualizations.main_budget_levels_tooltip_up') : I18n.t('gobierto_common.visualizations.main_budget_levels_tooltip_down');
     }
     function perInhabitantTooltipStr(d) {
-      return d ? '<div class="clear_b">' + accounting.formatMoney(d, "€", 0, ".", ",") + ' ' + I18n.t('gobierto_common.visualizations.main_budget_levels_per_inhabitant') + '</div>' : '';
+      return d ? '<div class="clear_b">' + accounting.formatMoney(d, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + ' ' + I18n.t('gobierto_common.visualizations.main_budget_levels_per_inhabitant') + '</div>' : '';
     }
 
     this.tooltip.html('<div class="line-name"><strong>' + d.name + '</strong></div> \
-                       <div>' + accounting.formatMoney(d.value, "€", 0, ".", ",") + '</div> \
+                       <div>' + accounting.formatMoney(d.value, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + '</div> \
                        ' + perInhabitantTooltipStr(d.per_inhabitant) + ' \
                        <div class="line-pct">' + getString(d.pct_diff) + ' ' + accounting.formatNumber(d.pct_diff, 1) + ' %</span> ' + I18n.t('gobierto_common.visualizations.main_budget_levels_tooltip_article') + ' ' + (d.year - 1) + '</div>');
   }

--- a/app/javascript/lib/visualizations/modules/lineas_tabla.js
+++ b/app/javascript/lib/visualizations/modules/lineas_tabla.js
@@ -263,7 +263,7 @@ export class VisLineasJ {
       this.yAxis
           .scale(this.yScale)
           .tickValues(this._tickValues(this.yScale))
-          .tickFormat(function(d) { return accounting.formatMoney(d, "€", 0, ".", ","); })
+          .tickFormat(function(d) { return accounting.formatMoney(d, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")); })
           .tickSize(-(this.width - (this.margin.right + this.margin.left - 20)));
 
 
@@ -396,7 +396,7 @@ export class VisLineasJ {
                   return value.name == d.name;
                 })
                 d.value = newValue[0].value
-                return d.value != null ? accounting.formatMoney(d.value) : '-- €';
+                return d.value != null ? accounting.formatMoney(d.value, "€", 2, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) : '-- €';
               })
               .transition()
               .duration(self.duration)
@@ -584,7 +584,7 @@ export class VisLineasJ {
                   classed = this._normalize(dataChartFiltered[0].name)
 
                 } else if (column == 'value') {
-                  value = dataChartFiltered[0][column] != null ? accounting.formatMoney(dataChartFiltered[0][column]) : '-- €'
+                  value = dataChartFiltered[0][column] != null ? accounting.formatMoney(dataChartFiltered[0][column], "€", 2, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) : '-- €'
                   classed = 'value right ' + this._normalize(dataChartFiltered[0].name)
                 } else if (column == 'dif') {
                   if (dataChartFiltered[0][column] != null) {

--- a/app/javascript/lib/visualizations/modules/lineas_tabla.js
+++ b/app/javascript/lib/visualizations/modules/lineas_tabla.js
@@ -413,7 +413,7 @@ export class VisLineasJ {
                 })
                 d.dif = newValue[0].dif
                 if (d.dif != null) {
-                  return d.dif <= 0 ? d.dif + ' %' : '+' + d.dif + ' %';
+                  return d.dif <= 0 ? d.dif.toLocaleString(I18n.locale) + ' %' : '+' + d.dif.toLocaleString(I18n.locale) + ' %';
                 } else {
                   return '-- %'
                 }
@@ -588,7 +588,7 @@ export class VisLineasJ {
                   classed = 'value right ' + this._normalize(dataChartFiltered[0].name)
                 } else if (column == 'dif') {
                   if (dataChartFiltered[0][column] != null) {
-                    value = dataChartFiltered[0][column] > 0 ? '+' +dataChartFiltered[0][column] + ' %' : dataChartFiltered[0][column] + ' %'
+                    value = dataChartFiltered[0][column] > 0 ? '+' +dataChartFiltered[0][column].toLocaleString(I18n.locale) + ' %' : dataChartFiltered[0][column].toLocaleString(I18n.locale) + ' %'
                   } else {
                     value = '--%'
                   }

--- a/app/javascript/lib/visualizations/modules/lines_execution.js
+++ b/app/javascript/lib/visualizations/modules/lines_execution.js
@@ -387,12 +387,12 @@ export class VisLinesExecution {
       .style('top', (y + 40) + 'px');
 
     var tooltipHtml = '<div class="line-name"><strong>' + d['name_' + this.localeFallback] + '</strong></div>' +
-                      '<div class="line-name">' + I18n.t('gobierto_common.visualizations.tooltip_budgeted')  + ': ' + accounting.formatMoney(d.budget, "€", 0, ".", ",") + '</div>';
+                      '<div class="line-name">' + I18n.t('gobierto_common.visualizations.tooltip_budgeted')  + ': ' + accounting.formatMoney(d.budget, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + '</div>';
 
     if(d.budget_updated !== null)
-      tooltipHtml += '<div class="line-name">' + I18n.t('gobierto_common.visualizations.tooltip_budgeted_updated')  + ': ' + accounting.formatMoney(d.budget_updated, "€", 0, ".", ",") + '</div>';
+      tooltipHtml += '<div class="line-name">' + I18n.t('gobierto_common.visualizations.tooltip_budgeted_updated')  + ': ' + accounting.formatMoney(d.budget_updated, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + '</div>';
 
-    tooltipHtml += '<div class="line-name">' + I18n.t('gobierto_common.visualizations.tooltip_executed_amount')  + ': ' + accounting.formatMoney(d.executed, "€", 0, ".", ",") + '</div>';
+    tooltipHtml += '<div class="line-name">' + I18n.t('gobierto_common.visualizations.tooltip_executed_amount')  + ': ' + accounting.formatMoney(d.executed, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + '</div>';
 
     tooltipHtml += '<div>' + I18n.t('gobierto_common.visualizations.tooltip') + ' ' + this.pctFormat(d.pct_executed) + ' %</div>';
 

--- a/app/javascript/lib/visualizations/modules/treemap.js
+++ b/app/javascript/lib/visualizations/modules/treemap.js
@@ -66,10 +66,10 @@ export class VisTreemap {
         }.bind(this))
         .attr("title", function(d){
           function totalBudgetTooltipStr(str) {
-            return "<br>" + accounting.formatMoney(str, "€", 0, '.');
+            return "<br>" + accounting.formatMoney(str, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator"));
           }
           function perInhabitantTooltipStr(str) {
-            return str ? "<br>" + accounting.formatMoney(str, "€", 0, ',') + " /" + I18n.t("gobierto_common.visualizations.inhabitant_short") : "";
+            return str ? "<br>" + accounting.formatMoney(str, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + " /" + I18n.t("gobierto_common.visualizations.inhabitant_short") : "";
           }
           return "<strong>" + d.data.name + "</strong>" + totalBudgetTooltipStr(d.data.budget) + perInhabitantTooltipStr(d.data.budget_per_inhabitant);
         }.bind(this))
@@ -86,9 +86,9 @@ export class VisTreemap {
         .html(function(d) {
           function getBudgetAmount(d) {
             if (d.data.budget_per_inhabitant) {
-              return accounting.formatMoney(d.data.budget_per_inhabitant, "€", 0) + "/" + I18n.t("gobierto_common.visualizations.inhabitant_short");
+              return accounting.formatMoney(d.data.budget_per_inhabitant, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator")) + "/" + I18n.t("gobierto_common.visualizations.inhabitant_short");
             } else {
-              return accounting.formatMoney(d.data.budget, "€", 0);
+              return accounting.formatMoney(d.data.budget, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator"));
             }
           }
           if(d.children) {

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -191,7 +191,7 @@
               <% @budget_line_descendants.each do |budget_line| %>
                 <tr>
                   <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
-                  <td class="qty"><%= number_with_precision(budget_line.percentage_compared_with(@budget_line.amount) * 100, precision: 2) + '%' %></td>
+                  <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                   <td class="amount"><%= format_currency(budget_line.amount) %></td>
                 </tr>
               <% end %>
@@ -210,7 +210,7 @@
             <% @budget_line_composition.each do |budget_line| %>
               <tr>
                 <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
-                <td class="qty"><%= number_with_precision(budget_line.percentage_compared_with(@budget_line.amount) * 100, precision: 2) + '%' %></td>
+                <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                 <td class="amount"><%= format_currency(budget_line.amount) %></td>
               </tr>
             <% end %>

--- a/app/views/gobierto_budgets/budgets/_sub_budget_line.html.erb
+++ b/app/views/gobierto_budgets/budgets/_sub_budget_line.html.erb
@@ -1,6 +1,6 @@
 <td><%= link_to sub_budget_line.name, gobierto_budgets_budget_line_path(sub_budget_line.to_param) %></td>
 <td style="<%= class_if("border-radius: 0 0 0 4px", last_item) %>" class="qty big_qty <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><%= number_to_currency sub_budget_line.amount, precision:0 %></td>
-<td class="qty <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><%= sub_budget_line.percentage_of_total %> %</td>
+<td class="qty <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><%= percentage_format(sub_budget_line.percentage_of_total) %></td>
 <% unless controller_name == 'budgets_elaboration' %>
   <td class="bar <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><div class="bar" style="width:<%= sub_budget_line.percentage_of_total %>%"></div></td>
 <% end %>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -84,7 +84,7 @@
           <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.inhabitants_tooltip') %>" data-box="population">
             <div class="inner">
               <h3><%= t('.inhabitants') %></h3>
-              <div class="metric"><%= number_with_precision @site_stats.latest_available(:population, @year)[:value], precision: 0, delimiter: '.' %></div>
+              <div class="metric"><%= number_with_delimiter @site_stats.latest_available(:population, @year)[:value] %></div>
               <% if @site_stats.latest_available(:population, @year)[:year] != @year %>
                 <div class="explanation">
                   <%= t('.data_of_year', year: @site_stats.latest_available(:population, @year)[:year]) %>

--- a/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
+++ b/app/views/gobierto_budgets/featured_budget_lines/gobierto_site_template.html.erb
@@ -11,20 +11,20 @@
   <% if @population %>
     <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
                                         data-widget-type="per_person"
-                                        data-widget-data-url="<%= gobierto_budgets_api_data_budget_per_inhabitant_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                                        data-widget-data-url="<%= gobierto_budgets_api_data_budget_per_inhabitant_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, locale: I18n.locale, format: :json) %>"
                                         title="<%= t('.per_person') %>">
     </div>
   <% end %>
 
   <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template"
                              data-widget-type="budget"
-                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(organization_id: current_site.organization_id, year: @year, kind: @kind, code: @code.parameterize, area: @area_name, locale: I18n.locale, format: :json) %>"
                              title="<%= t('.total') %>">
   </div>
 
   <div class="pure-u-1 pure-u-md-1-6" data-widget-template="#widget-template-small"
                              data-widget-type="budget"
-                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(organization_id: current_site.organization_id, year: (@year - 1), kind: @kind, code: @code.parameterize, area: @area_name, format: :json) %>"
+                             data-widget-data-url="<%= gobierto_budgets_api_data_budget_path(organization_id: current_site.organization_id, year: (@year - 1), kind: @kind, code: @code.parameterize, area: @area_name, locale: I18n.locale, format: :json) %>"
                              title="<%= t('.last_year') %>">
   </div>
 </div>

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -246,7 +246,7 @@ en:
         in_total: Total
         income: Income
         inhabitants: Inhabitants
-        inhabitants_tooltip: Number of inhabitantes
+        inhabitants_tooltip: Number of inhabitants
         less: less
         level_1_category: Level 1 category
         level_2_category: Level 2 category


### PR DESCRIPTION
Closes #2030


## :v: What does this PR do?
Uses the same locale configuration to format percentages and currencies in budgets module.

## :mag: How should this be manually tested?
Visit budgets index and check that all the numeric data uses the same characters for decimal delimiter and thousands separator in each locale

## :eyes: Screenshots

### Before this PR
EN:
<img width="687" alt="screen shot 2018-11-25 at 16 07 51" src="https://user-images.githubusercontent.com/446459/48980826-4e286700-f0ce-11e8-862a-8e561b2ccc40.png">
<img width="743" alt="screen shot 2018-11-25 at 16 08 30" src="https://user-images.githubusercontent.com/446459/48980827-4e286700-f0ce-11e8-93d8-2c2a02fd77cf.png">
<img width="494" alt="screen shot 2018-11-25 at 16 27 28" src="https://user-images.githubusercontent.com/446459/48980894-1a017600-f0cf-11e8-94aa-93255e1d8fba.png">
<img width="719" alt="screen shot 2018-11-25 at 16 08 52" src="https://user-images.githubusercontent.com/446459/48980828-4e286700-f0ce-11e8-8c58-2d257cc7f804.png">

ES:
<img width="691" alt="screen shot 2018-11-25 at 16 24 46" src="https://user-images.githubusercontent.com/446459/48980900-31d8fa00-f0cf-11e8-9d40-b24769c7527a.png">
<img width="721" alt="screen shot 2018-11-25 at 16 25 46" src="https://user-images.githubusercontent.com/446459/48980901-31d8fa00-f0cf-11e8-816c-36dd671adb79.png">
<img width="508" alt="screen shot 2018-11-25 at 16 26 23" src="https://user-images.githubusercontent.com/446459/48980902-32719080-f0cf-11e8-83ba-5cfdd4e53324.png">
<img width="694" alt="screen shot 2018-11-25 at 16 26 32" src="https://user-images.githubusercontent.com/446459/48980903-32719080-f0cf-11e8-8705-8b1853a1ae68.png">



### After this PR
EN:
<img width="688" alt="screen shot 2018-11-25 at 16 12 22" src="https://user-images.githubusercontent.com/446459/48980829-4e286700-f0ce-11e8-80db-1d161f59b5c7.png">
<img width="740" alt="screen shot 2018-11-25 at 16 13 02" src="https://user-images.githubusercontent.com/446459/48980830-4ec0fd80-f0ce-11e8-9a09-72013c672b26.png">

<img width="1146" alt="screen shot 2018-11-25 at 17 27 09" src="https://user-images.githubusercontent.com/446459/48981651-b11efb80-f0d8-11e8-962c-790bf7fe5584.png">


<img width="706" alt="screen shot 2018-11-25 at 16 17 09" src="https://user-images.githubusercontent.com/446459/48980831-4ec0fd80-f0ce-11e8-86e1-900f0f225a1a.png">

ES:
<img width="691" alt="screen shot 2018-11-25 at 16 31 34" src="https://user-images.githubusercontent.com/446459/48980953-d22f1e80-f0cf-11e8-8f46-18f1f86a0b1c.png">
<img width="719" alt="screen shot 2018-11-25 at 16 31 48" src="https://user-images.githubusercontent.com/446459/48980954-d2c7b500-f0cf-11e8-8a47-7a951abb4d43.png">

<img width="1144" alt="screen shot 2018-11-25 at 17 26 43" src="https://user-images.githubusercontent.com/446459/48981647-a6646680-f0d8-11e8-9ef8-abf52ffb6c09.png">


<img width="702" alt="screen shot 2018-11-25 at 16 32 16" src="https://user-images.githubusercontent.com/446459/48980956-d2c7b500-f0cf-11e8-87b2-2595432a9f67.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No