### PR TITLE
Tag log domain

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:domain, :request_id]
+  config.log_tags = [:host, :request_id]
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = true
@@ -17,12 +19,12 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -51,6 +53,9 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [:domain, :request_id]
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:domain, :request_id]
+  config.log_tags = [:host, :request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -75,7 +75,6 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-  config.log_tags = [:domain, :uuid]
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  config.log_tags = [:domain, :request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -75,6 +75,7 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+  config.log_tags = [:domain, :uuid]
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  config.log_tags = [:domain, :request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:domain, :request_id]
+  config.log_tags = [:host, :request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Improvement

## :v: What does this PR do?

This PR adds the current request domain to the log, so requests can be filtered for a given site.

## :mag: How should this be manually tested?

Check the log, you should see something like:


```
I, [2018-11-26T10:25:20.781432 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered gobierto_budgets/layouts/_navigation.sub.html.erb (5.2ms)
I, [2018-11-26T10:25:20.781913 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered gobierto_people/layouts/_navigation.main.html.erb (0.2ms)
I, [2018-11-26T10:25:20.793357 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered gobierto_people/layouts/_navigation.sub.html.erb (11.2ms)
I, [2018-11-26T10:25:20.793979 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered gobierto_observatory/layouts/_navigation.main.html.erb (0.3ms)
I, [2018-11-26T10:25:20.795077 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered gobierto_observatory/layouts/_navigation.sub.html.erb (0.8ms)
I, [2018-11-26T10:25:20.795423 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered layouts/_hamburger_mobile.html.erb (22.8ms)
I, [2018-11-26T10:25:20.795536 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered layouts/_header.html.erb (59.0ms)
I, [2018-11-26T10:25:20.795768 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered user/shared/_flash_messages.html.erb (0.1ms)
I, [2018-11-26T10:25:20.797821 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered user/subscriptions/_subscribable_box.html.erb (1.3ms)
I, [2018-11-26T10:25:20.798038 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered layouts/_footer.html.erb (2.1ms)
I, [2018-11-26T10:25:20.798347 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered layouts/_analytics_footer_site.html.erb (0.1ms)
I, [2018-11-26T10:25:20.798440 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered layouts/_gobierto_footer.html.erb (0.3ms)
I, [2018-11-26T10:25:20.798517 #1536]  INFO -- : [gobiernoabierto.getafe.es] [1e047b87-6918-44e9-afcc-471954082710]   Rendered inline template (68.8ms)
```


