### PR TITLE
Add admin site activities for GobiertoCitizensCharters module

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/api/editions_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/api/editions_controller.rb
@@ -22,9 +22,9 @@ module GobiertoAdmin
 
         def destroy
           find_charter
-          @edition = @charter.editions.find(params[:id])
+          @edition_form = EditionForm.new(id: params[:id], site_id: current_site.id, charter_id: @charter.id, admin_id: current_admin.id)
 
-          if @edition.really_destroy!
+          if @edition_form.really_destroy!
             render json: { message: "destroyed" }
           else
             render json: { error: "Record couldn't be destroyed" }, status: 400

--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/api/editions_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/api/editions_controller.rb
@@ -37,6 +37,7 @@ module GobiertoAdmin
           find_charter
           extra_params[:site_id] = current_site.id
           extra_params[:charter_id] = @charter.id
+          extra_params[:admin_id] = current_admin.id
 
           @edition_form = EditionForm.new(edition_params.merge(extra_params))
           if @edition_form.save

--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/charters/commitments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/charters/commitments_controller.rb
@@ -59,9 +59,10 @@ module GobiertoAdmin
 
         def destroy
           load_commitment
-          charter = commitment.charter
+          charter = @commitment.charter
+          @commitment_form = CommitmentForm.new(id: @commitment.id, site_id: current_site.id, charter_id: charter.id, admin_id: current_admin.id)
 
-          if @charter.destroy
+          if @commitment_form.destroy
             redirect_to admin_citizens_charters_charter_commitments_path(charter), notice: t(".success")
           else
             redirect_to admin_citizens_charters_charter_commitments_path(charter), alert: t(".destroy_failed")

--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/charters/commitments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/charters/commitments_controller.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
         end
 
         def create
-          @commitment_form = CommitmentForm.new(commitment_params.merge(site_id: current_site.id, charter_id: @charter.id))
+          @commitment_form = CommitmentForm.new(commitment_params.merge(site_id: current_site.id, charter_id: @charter.id, admin_id: current_admin.id))
 
           if @commitment_form.save
             redirect_to(
@@ -44,7 +44,7 @@ module GobiertoAdmin
         def update
           load_commitment
 
-          @commitment_form = CommitmentForm.new(commitment_params.merge(id: params[:id], site_id: current_site.id, charter_id: @commitment.charter.id))
+          @commitment_form = CommitmentForm.new(commitment_params.merge(id: params[:id], site_id: current_site.id, charter_id: @commitment.charter.id, admin_id: current_admin.id))
 
           if @commitment_form.save
             redirect_to(

--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/charters_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/charters_controller.rb
@@ -27,7 +27,7 @@ module GobiertoAdmin
       end
 
       def create
-        @charter_form = CharterForm.new(charter_params.merge(site_id: current_site.id))
+        @charter_form = CharterForm.new(charter_params.merge(site_id: current_site.id, admin_id: current_admin.id))
 
         @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(site_id: current_site.id, item: @charter_form.resource)
         @custom_fields_form.custom_field_records = custom_params
@@ -47,7 +47,7 @@ module GobiertoAdmin
       def update
         load_charter
 
-        @charter_form = CharterForm.new(charter_params.merge(id: params[:id], site_id: current_site.id))
+        @charter_form = CharterForm.new(charter_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id))
         @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(site_id: current_site.id, item: @charter)
         @custom_fields_form.custom_field_records = custom_params
 

--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/charters_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/charters_controller.rb
@@ -10,7 +10,7 @@ module GobiertoAdmin
 
       def new
         @charter_form = CharterForm.new(
-          charters_relation.new.attributes.except(*ignored_charter_attributes).merge(site_id: current_site.id)
+          ::GobiertoCitizensCharters::Charter.new.attributes.except(*ignored_charter_attributes).merge(site_id: current_site.id)
         )
         @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(site_id: current_site.id, item: @charter_form.resource)
         render(:new_modal, layout: false) && return if request.xhr?

--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/services_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/services_controller.rb
@@ -27,7 +27,7 @@ module GobiertoAdmin
       end
 
       def create
-        @service_form = ServiceForm.new(service_params.merge(site_id: current_site.id))
+        @service_form = ServiceForm.new(service_params.merge(site_id: current_site.id, admin_id: current_admin.id))
         @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(site_id: current_site.id, item: @service_form.resource)
         @custom_fields_form.custom_field_records = custom_params
 
@@ -46,7 +46,7 @@ module GobiertoAdmin
       def update
         load_service
 
-        @service_form = ServiceForm.new(service_params.merge(id: params[:id], site_id: current_site.id))
+        @service_form = ServiceForm.new(service_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id))
         @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(site_id: current_site.id, item: @service)
         @custom_fields_form.custom_field_records = custom_params
 

--- a/app/extensions/gobierto_common/trackable_grouped_attributes.rb
+++ b/app/extensions/gobierto_common/trackable_grouped_attributes.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module TrackableGroupedAttributes
+    module ClassMethods
+      attr_reader :trackable, :publisher, :subject
+
+      def notify_changed(*attribute_names, **opts)
+        changed_attributes_to_notify.push(*attribute_names)
+        if opts[:as].present?
+          attributes_notification_alias[opts[:as]] = attribute_names
+        end
+      end
+
+      def trackable_on(trackable)
+        @trackable = trackable
+      end
+
+      def use_publisher(publisher)
+        @publisher = publisher
+      end
+
+      def use_trackable_subject(subject)
+        @subject = subject
+      end
+
+      private
+
+      def changed_attributes_to_notify
+        @changed_attributes_to_notify ||= []
+      end
+
+      def attributes_notification_alias
+        @attributes_notification_alias ||= {}
+      end
+    end
+
+    def self.prepended(base)
+      base.extend(ClassMethods)
+
+      base.class_eval do
+        extend ActiveModel::Callbacks
+        define_model_callbacks :save, only: [:before, :after]
+        before_save :store_changes
+        define_model_callbacks :destroy, only: [:after]
+        after_destroy :store_changes
+      end
+    end
+
+    def save
+      perform_notifications if super
+    end
+
+    def destroy
+      perform_notifications if super
+    end
+
+    def really_destroy!
+      perform_notifications if super
+    end
+
+    def notify?
+      return super if defined?(super)
+
+      true
+    end
+
+    def trackable
+      @trackable ||= send(self.class.trackable)
+    end
+
+    def publisher
+      @publisher ||= self.class.publisher || Publishers::Trackable
+    end
+
+    def subject
+      @subject ||= self.class.subject.present? ? send(self.class.subject) : trackable
+    end
+
+    private
+
+    def perform_notifications
+      unless notify?
+        Rails.logger.debug("Skipping notifications for #{trackable.class.name} #{trackable.id}")
+        return true
+      end
+
+      if new_record?
+        publish_created
+      elsif destroyed?
+        publish_destroyed
+      elsif archived?
+        publish_archived
+      else
+        notifiable_list.each do |notifiable_name|
+          publish_changed(notifiable_name)
+        end
+      end
+
+      true
+    end
+
+    protected
+
+    def notifiable_list
+      ungrouped_notifiable_attributes = self.class.send(:changed_attributes_to_notify) & Array(@changed)
+      notifiable_list = ungrouped_notifiable_attributes - attributes_notification_alias.values.flatten
+      attributes_notification_alias.each do |alias_name, notifiable_attributes|
+        notifiable_list << alias_name if (Array(@changed) & notifiable_attributes).any?
+      end
+      notifiable_list
+    end
+
+    def attributes_notification_alias
+      @attributes_notification_alias ||= self.class.send(:attributes_notification_alias)
+    end
+
+    def publish_changed(attribute_name)
+      broadcast_event("#{ event_prefix }#{ attribute_name }_changed") if changed?(attribute_name)
+    end
+
+    def publish_created
+      broadcast_event("#{ event_prefix }created")
+    end
+
+    def publish_archived
+      broadcast_event("#{ event_prefix }archived")
+    end
+
+    def publish_destroyed
+      broadcast_event("#{ event_prefix }deleted")
+    end
+
+    def broadcast_event(event_name)
+      Rails.logger.debug("Broadcasting event \"#{event_name}\" with payload: #{event_payload}")
+      publisher.broadcast_event(event_name, event_payload)
+    end
+
+    def event_payload
+      { gid: subject.to_gid, site_id: trackable.site_id, admin_id: (trackable.admin_id if trackable.respond_to?(:admin_id)) }
+    end
+
+    def event_prefix
+      @event_prefix ||= if subject != trackable
+                          trackable.class.name.demodulize.tableize + "_"
+                        else
+                          ""
+                        end
+    end
+
+    def store_changes
+      @changed = trackable.changed.map(&:to_sym)
+      @persisted = trackable.persisted?
+      @new_record = trackable.new_record?
+      @archived = trackable.try(:archived?)
+
+      true
+    end
+
+    def changed?(notifiable_name)
+      Array(@changed).include?(notifiable_name.to_sym) ||
+        attributes_notification_alias[notifiable_name].present? && (Array(@changed) & attributes_notification_alias[notifiable_name]).present?
+    end
+
+    def new_record?
+      @new_record
+    end
+
+    def destroyed?
+      !@persisted && !@new_record
+    end
+
+    def archived?
+      @archived
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_citizens_charters/base_form.rb
+++ b/app/forms/gobierto_admin/gobierto_citizens_charters/base_form.rb
@@ -5,7 +5,7 @@ module GobiertoAdmin
     class BaseForm < ::BaseForm
       class NotImplementedError < StandardError; end
 
-      attr_accessor :id, :site_id
+      attr_accessor :id, :site_id, :admin_id
       attr_writer(
         :visibility_level
       )
@@ -43,6 +43,7 @@ module GobiertoAdmin
         @resource = resource.tap do |attributes|
           attributes.assign_attributes(visibility_level: visibility_level) if attributes.has_attribute? :visibility_level
           attributes.assign_attributes(attributes_assignments) if respond_to? :attributes_assignments
+          attributes.admin_id = admin_id
         end
 
         return @resource if @resource.save

--- a/app/forms/gobierto_admin/gobierto_citizens_charters/base_form.rb
+++ b/app/forms/gobierto_admin/gobierto_citizens_charters/base_form.rb
@@ -33,6 +33,14 @@ module GobiertoAdmin
         @site ||= Site.find_by(id: site_id)
       end
 
+      def destroy
+        destroy_resource
+      end
+
+      def really_destroy!
+        really_destroy_resource
+      end
+
       def available_visibility_levels
         resources_relation.try(:visibility_levels)
       end
@@ -50,6 +58,20 @@ module GobiertoAdmin
 
         promote_errors(@resource.errors)
         false
+      end
+
+      def destroy_resource
+        resource.admin_id = admin_id
+        run_callbacks(:destroy) do
+          resource.destroy
+        end
+      end
+
+      def really_destroy_resource
+        resource.admin_id = admin_id
+        run_callbacks(:destroy) do
+          resource.really_destroy!
+        end
       end
 
       def resources_relation

--- a/app/forms/gobierto_admin/gobierto_citizens_charters/charter_form.rb
+++ b/app/forms/gobierto_admin/gobierto_citizens_charters/charter_form.rb
@@ -12,6 +12,11 @@ module GobiertoAdmin
       validates :service, presence: true
       validates :title_translations, translated_attribute_presence: true
 
+      trackable_on :resource
+      notify_changed :visibility_level, :title_translations
+      notify_changed :title_translations, as: :charter_attribute
+      use_publisher Publishers::AdminGobiertoCitizensChartersActivity
+
       def available_services
         services_relation.order(Arel.sql("title_translations->'#{I18n.locale}' ASC"))
       end

--- a/app/forms/gobierto_admin/gobierto_citizens_charters/commitment_form.rb
+++ b/app/forms/gobierto_admin/gobierto_citizens_charters/commitment_form.rb
@@ -13,6 +13,12 @@ module GobiertoAdmin
       validates :charter, presence: true
       validates :title_translations, translated_attribute_presence: true
 
+      trackable_on :resource
+      notify_changed :visibility_level
+      notify_changed :title_translations, :description_translations, as: :commitment_attribute
+      use_publisher Publishers::AdminGobiertoCitizensChartersActivity
+      use_trackable_subject :charter
+
       def attributes_assignments
         {
           title_translations: title_translations,

--- a/app/forms/gobierto_admin/gobierto_citizens_charters/edition_form.rb
+++ b/app/forms/gobierto_admin/gobierto_citizens_charters/edition_form.rb
@@ -18,6 +18,11 @@ module GobiertoAdmin
       validates :value, :max_value, presence: true, if: ->(object) { object.percentage.blank? }
       validate :period_uniqueness
 
+      trackable_on :resource
+      notify_changed :commitment_id, :percentage, :value, :max_value, as: :edition_attribute
+      use_publisher Publishers::AdminGobiertoCitizensChartersActivity
+      use_trackable_subject :charter
+
       def attributes_assignments
         {
           commitment_id: commitment_id,

--- a/app/forms/gobierto_admin/gobierto_citizens_charters/service_form.rb
+++ b/app/forms/gobierto_admin/gobierto_citizens_charters/service_form.rb
@@ -12,6 +12,11 @@ module GobiertoAdmin
       validates :category, presence: true
       validates :title_translations, translated_attribute_presence: true
 
+      trackable_on :resource
+      notify_changed :visibility_level, :title_translations
+      notify_changed :title_translations, as: :service_attribute
+      use_publisher Publishers::AdminGobiertoCitizensChartersActivity
+
       def available_categories
         categories_relation
       end

--- a/app/models/gobierto_citizens_charters/charter.rb
+++ b/app/models/gobierto_citizens_charters/charter.rb
@@ -17,6 +17,8 @@ module GobiertoCitizensCharters
       add_attribute :resource_path, :class_name
     end
 
+    attr_accessor :admin_id
+
     belongs_to :service, -> { with_archived }
     has_many :commitments, dependent: :destroy
     has_many :editions, through: :commitments, class_name: "GobiertoCitizensCharters::Edition"

--- a/app/models/gobierto_citizens_charters/commitment.rb
+++ b/app/models/gobierto_citizens_charters/commitment.rb
@@ -17,6 +17,8 @@ module GobiertoCitizensCharters
       add_attribute :resource_path, :class_name
     end
 
+    attr_accessor :admin_id
+
     belongs_to :charter, -> { with_archived }
     has_many :editions, dependent: :destroy
 

--- a/app/models/gobierto_citizens_charters/edition.rb
+++ b/app/models/gobierto_citizens_charters/edition.rb
@@ -26,6 +26,7 @@ module GobiertoCitizensCharters
     attr_accessor :admin_id
 
     belongs_to :commitment, -> { with_archived }
+    delegate :site_id, :charter, to: :commitment
 
     enum period_interval: PERIOD_INTERVAL_DATA.keys
 

--- a/app/models/gobierto_citizens_charters/edition.rb
+++ b/app/models/gobierto_citizens_charters/edition.rb
@@ -23,6 +23,8 @@ module GobiertoCitizensCharters
       week: "s"
     }.freeze
 
+    attr_accessor :admin_id
+
     belongs_to :commitment, -> { with_archived }
 
     enum period_interval: PERIOD_INTERVAL_DATA.keys

--- a/app/models/gobierto_citizens_charters/service.rb
+++ b/app/models/gobierto_citizens_charters/service.rb
@@ -11,6 +11,8 @@ module GobiertoCitizensCharters
     include GobiertoCommon::Sluggable
     include GobiertoCommon::HasVocabulary
 
+    attr_accessor :admin_id
+
     belongs_to :site
     has_many :charters, dependent: :destroy
     has_many :commitments, through: :charters, class_name: "GobiertoCitizensCharters::Commitment"

--- a/app/publishers/admin_gobierto_citizens_charters_activity.rb
+++ b/app/publishers/admin_gobierto_citizens_charters_activity.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Publishers
+  class AdminGobiertoCitizensChartersActivity
+    include Publisher
+
+    self.pub_sub_namespace = "activities/admin_gobierto_citizens_charters"
+  end
+end

--- a/app/subscribers/admin_gobierto_citizens_charters_activity.rb
+++ b/app/subscribers/admin_gobierto_citizens_charters_activity.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class AdminGobiertoCitizensChartersActivity < ::Subscribers::Base
+
+    def editions_edition_attribute_changed(event)
+      create_activity_from_event(event, "edition_updated")
+    end
+
+    def editions_created(event)
+      create_activity_from_event(event, "edition_created")
+    end
+
+    def editions_deleted(event)
+      create_activity_from_event(event, "edition_deleted")
+    end
+
+    def commitments_commitment_attribute_changed(event)
+      create_activity_from_event(event, "commitment_updated")
+    end
+
+    def commitments_visibility_level_changed(event)
+      create_activity_from_event(event, "commitment_published")
+    end
+
+    def commitments_created(event)
+      create_activity_from_event(event, "commitment_created")
+    end
+
+    def commitments_archived(event)
+      create_activity_from_event(event, "commitment_archived")
+    end
+
+    def charter_attribute_changed(event)
+      create_activity_from_event(event, "updated")
+    end
+
+    def service_attribute_changed(event)
+      create_activity_from_event(event, "updated")
+    end
+
+    def visibility_level_changed(event)
+      create_activity_from_event(event, "published")
+    end
+
+    def created(event)
+      create_activity_from_event(event, "created")
+    end
+
+    def archived(event)
+      create_activity_from_event(event, "archived")
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      subject = GlobalID::Locator.locate event.payload[:gid]
+
+      return unless subject.class.parent == GobiertoCitizensCharters
+
+      author = GobiertoAdmin::Admin.find_by id: event.payload[:admin_id]
+      # When the author is nil, we can asume the action has been performed by an integration
+      return unless author.present?
+
+      action = subject.class.name.underscore.tr("/", ".") + "." + action
+
+      Activity.create! subject: subject,
+                       author: author,
+                       subject_ip: author.last_sign_in_ip,
+                       action: action,
+                       admin_activity: true,
+                       site_id: event.payload[:site_id]
+    end
+  end
+end

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -28,6 +28,7 @@ Subscribers::GobiertoPlansPlanTypeActivity.attach_to("activities/gobierto_plans_
 Subscribers::UserActivity.attach_to("activities/users")
 Subscribers::SiteActivity.attach_to("activities/sites")
 Subscribers::AdminGobiertoCalendarsActivity.attach_to("activities/admin_gobierto_calendars")
+Subscribers::AdminGobiertoCitizensChartersActivity.attach_to("activities/admin_gobierto_citizens_charters")
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|

--- a/config/locales/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_citizens_charters/views/ca.yml
@@ -27,6 +27,20 @@ ca:
         see_all: Veure la carta completa
         see_all_subtitle: Missió, Visió, Serveis, Unitat responsable...
         value: Arribat
+    events:
+      gobierto_citizens_charters_charter_commitment_archived: Compromisos arxivats
+      gobierto_citizens_charters_charter_commitment_created: Compromisos creats
+      gobierto_citizens_charters_charter_commitment_published: Compromisos publicats
+      gobierto_citizens_charters_charter_commitment_updated: Compromisos actualitzats
+      gobierto_citizens_charters_charter_created: Carta creada
+      gobierto_citizens_charters_charter_edition_created: Mesuraments creades
+      gobierto_citizens_charters_charter_edition_deleted: Mesuraments eliminades
+      gobierto_citizens_charters_charter_edition_updated: Mesuraments actualitzades
+      gobierto_citizens_charters_charter_published: Carta publicada
+      gobierto_citizens_charters_charter_updated: Carta actualitzada
+      gobierto_citizens_charters_service_created: Servei creat
+      gobierto_citizens_charters_service_published: Servei publicat
+      gobierto_citizens_charters_service_updated: Servei actualitzat
     layouts:
       application:
         citizens_charters: Cartes de Servei

--- a/config/locales/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_citizens_charters/views/en.yml
@@ -27,6 +27,20 @@ en:
         see_all: See the full charter
         see_all_subtitle: Mission, Vision, Services, Responsible Unit...
         value: Reached
+    events:
+      gobierto_citizens_charters_charter_commitment_archived: Commitments archived
+      gobierto_citizens_charters_charter_commitment_created: Commitments created
+      gobierto_citizens_charters_charter_commitment_published: Commitments published
+      gobierto_citizens_charters_charter_commitment_updated: Commitments updated
+      gobierto_citizens_charters_charter_created: Charter created
+      gobierto_citizens_charters_charter_edition_created: Measurements created
+      gobierto_citizens_charters_charter_edition_deleted: Measurements deleted
+      gobierto_citizens_charters_charter_edition_updated: Measurements updated
+      gobierto_citizens_charters_charter_published: Charter published
+      gobierto_citizens_charters_charter_updated: Charter updated
+      gobierto_citizens_charters_service_created: Service created
+      gobierto_citizens_charters_service_published: Service published
+      gobierto_citizens_charters_service_updated: Service updated
     layouts:
       application:
         citizens_charters: Services Charters

--- a/config/locales/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_citizens_charters/views/es.yml
@@ -27,6 +27,20 @@ es:
         see_all: Ver la carta completa
         see_all_subtitle: Misión, Visión, Servicios, Unidad responsable...
         value: Alcanzado
+    events:
+      gobierto_citizens_charters_charter_commitment_archived: Compromisos archivados
+      gobierto_citizens_charters_charter_commitment_created: Compromisos creados
+      gobierto_citizens_charters_charter_commitment_published: Compromisos publicados
+      gobierto_citizens_charters_charter_commitment_updated: Compromisos actualizados
+      gobierto_citizens_charters_charter_created: Carta creada
+      gobierto_citizens_charters_charter_edition_created: Mediciones creadas
+      gobierto_citizens_charters_charter_edition_deleted: Mediciones borradas
+      gobierto_citizens_charters_charter_edition_updated: Mediciones actualizadas
+      gobierto_citizens_charters_charter_published: Carta publicada
+      gobierto_citizens_charters_charter_updated: Carta actualizada
+      gobierto_citizens_charters_service_created: Servicio creado
+      gobierto_citizens_charters_service_published: Servicio publicado
+      gobierto_citizens_charters_service_updated: Servicio actualizado
     layouts:
       application:
         citizens_charters: Cartas de Servicios

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/charters_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/charters_index_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Charters
+      class ChartersIndexTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_charters_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charters
+          @charters ||= site.charters
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
+        end
+
+        def test_charters_index
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "table tbody" do
+                assert has_selector?("tr", count: charters.size)
+
+                charters.each do |charter|
+                  assert has_selector?("tr#charter-item-#{ charter.id }")
+
+                  within "tr#charter-item-#{ charter.id }" do
+                    assert has_link?(charter.title)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/create_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/create_charter_test.rb
@@ -4,11 +4,11 @@ require "test_helper"
 
 module GobiertoAdmin
   module GobiertoCitizensCharters
-    module Services
-      class CreateServiceTest < ActionDispatch::IntegrationTest
+    module Charters
+      class CreateCharterTest < ActionDispatch::IntegrationTest
         def setup
           super
-          @path = new_admin_citizens_charters_service_path
+          @path = new_admin_citizens_charters_charter_path
         end
 
         def admin
@@ -33,7 +33,7 @@ module GobiertoAdmin
           end
         end
 
-        def test_create_service_errors
+        def test_create_charter_errors
           with_javascript do
             with_signed_in_admin(admin) do
               with_current_site(site) do
@@ -41,24 +41,24 @@ module GobiertoAdmin
 
                 click_button "Create"
 
-                assert has_alert?("can't be blank")
+                assert has_alert?("Title can't be blank")
               end
             end
           end
         end
 
-        def test_create_service
+        def test_create_charter
           with_javascript do
             with_signed_in_admin(admin) do
               with_current_site(site) do
                 visit @path
 
-                fill_in "service_title_translations_en", with: "Big service"
+                fill_in "charter_title_translations_en", with: "Dependent people"
 
                 click_link "ES"
-                fill_in "service_title_translations_es", with: "Gran servicio"
+                fill_in "charter_title_translations_es", with: "Personas dependientes"
 
-                select "Culture", from: "service_category_id"
+                select "Teleassistance", from: "charter_service_id"
 
                 within ".widget_save" do
                   find("label", text: "Published").click
@@ -66,27 +66,30 @@ module GobiertoAdmin
 
                 click_button "Create"
 
-                assert has_message?("The service has been correctly created.")
+                assert has_message?("The charter has been correctly created.")
 
-                click_link "Big service"
+                new_charter = ::GobiertoCitizensCharters::Charter.last
+                within "#charter-item-#{ new_charter.id }" do
+                  find("i.fa-edit").click
+                end
 
-                assert has_select?("service_category_id", with_selected: "Culture")
+                assert has_select?("charter_service_id", with_selected: "Teleassistance")
 
-                assert has_field?("service_title_translations_en", with: "Big service")
+                assert has_field?("charter_title_translations_en", with: "Dependent people")
 
                 click_link "ES"
 
-                assert has_field?("service_title_translations_es", with: "Gran servicio")
+                assert has_field?("charter_title_translations_es", with: "Personas dependientes")
               end
             end
           end
 
           activity = Activity.last
-          new_service = ::GobiertoCitizensCharters::Service.last
-          assert_equal new_service, activity.subject
+          new_charter = ::GobiertoCitizensCharters::Charter.last
+          assert_equal new_charter, activity.subject
           assert_equal admin, activity.author
           assert_equal site.id, activity.site_id
-          assert_equal "gobierto_citizens_charters.service.created", activity.action
+          assert_equal "gobierto_citizens_charters.charter.created", activity.action
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/delete_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/delete_charter_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCitizensCharters
+  module GobiertoAdmin
+    class DeleteCharterTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = admin_citizens_charters_charters_path
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def charter
+        @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+      def test_delete_charter
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "#charter-item-#{charter.id}" do
+              find("a[data-method='delete']").click
+            end
+
+            assert has_message?("The charter has been correctly archived")
+
+            refute site.charters.exists?(id: charter.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/update_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/update_charter_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCitizensCharters
+  module GobiertoAdmin
+    class UpdateServiceTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = edit_admin_citizens_charters_charter_path(charter)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def charter
+        @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+      def test_update_charter
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              fill_in "charter_title_translations_en", with: "Teleassistance charter updated"
+              select "Day care service", from: "charter_service_id"
+
+              click_button "Update"
+
+              assert has_message?("The charter has been correctly updated.")
+
+              visit @path
+
+              assert has_field? "charter_title_translations_en", with: "Teleassistance charter updated"
+              assert has_select? "charter_service_id", with_selected: "Day care service"
+            end
+          end
+        end
+
+        activity = Activity.last
+        assert_equal charter, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.charter.updated", activity.action
+      end
+
+      def test_update_draft_charter
+        charter.update_attribute(:visibility_level, :draft)
+
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              assert_no_difference "Activity.count" do
+                visit @path
+
+                fill_in "charter_title_translations_en", with: "Teleassistance charter updated"
+                select "Day care service", from: "charter_service_id"
+
+                click_button "Update"
+
+                assert has_message?("The charter has been correctly updated.")
+
+                visit @path
+
+                assert has_field? "charter_title_translations_en", with: "Teleassistance charter updated"
+                assert has_select? "charter_service_id", with_selected: "Day care service"
+              end
+            end
+          end
+        end
+      end
+
+      def test_publish_draft_charter
+        charter.update_attribute(:visibility_level, :draft)
+
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within ".widget_save" do
+                find("label", text: "Published").click
+              end
+
+              click_button "Update"
+
+              assert has_message?("The charter has been correctly updated.")
+
+              visit @path
+
+              assert has_field? "charter_title_translations_en", with: charter.title_en
+              click_link "ES"
+              assert has_field? "charter_title_translations_es", with: charter.title_es
+            end
+          end
+        end
+
+        activity = Activity.last
+        assert_equal charter, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.charter.published", activity.action
+      end
+
+      def test_update_charter_error
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              fill_in "charter_title_translations_en", with: ""
+              click_link "ES"
+              fill_in "charter_title_translations_es", with: ""
+
+              click_button "Update"
+
+              assert has_alert?("can't be blank")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/commitments_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/commitments_index_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Commitments
+      class CommitmentsIndexTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_charter_commitments_path(charter)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+        end
+
+        def commitments
+          @commitments ||= charter.commitments
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
+        end
+
+        def test_commitments_index
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "table tbody" do
+                assert has_selector?("tr", count: commitments.size)
+
+                commitments.each do |commitment|
+                  assert has_selector?("tr#commitment-item-#{commitment.id}")
+
+                  within "tr#commitment-item-#{commitment.id}" do
+                    assert has_link?(commitment.title)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/create_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/create_commitment_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Commitments
+      class CreateCommitmentTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = new_admin_citizens_charters_charter_commitment_path(charter)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
+          end
+        end
+
+        def test_create_commitment_errors
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                click_button "Create"
+
+                assert has_alert?("can't be blank")
+              end
+            end
+          end
+        end
+
+        def test_create_commitment
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                fill_in "commitment_title_translations_en", with: "Internet availability"
+                fill_in "commitment_description_translations_en", with: "There must be at least a device connected to Internet"
+
+                click_link "ES"
+                fill_in "commitment_title_translations_es", with: "Disponibilidad de Internet"
+                fill_in "commitment_description_translations_es", with: "Debe haber al menos un dispositivo conectado a Internet"
+
+                within ".widget_save" do
+                  find("label", text: "Published").click
+                end
+
+                click_button "Create"
+
+                assert has_message?("The commitment has been correctly created.")
+
+                new_commitment = ::GobiertoCitizensCharters::Commitment.last
+
+                assert_equal charter.id, new_commitment.charter_id
+
+                within "#commitment-item-#{ new_commitment.id }" do
+                  find("i.fa-edit").click
+                end
+
+                assert has_field?("commitment_title_translations_en", with: "Internet availability")
+                assert has_field?("commitment_description_translations_en", with: "There must be at least a device connected to Internet")
+                click_link "ES"
+                assert has_field?("commitment_title_translations_es", with: "Disponibilidad de Internet")
+                assert has_field?("commitment_description_translations_es", with: "Debe haber al menos un dispositivo conectado a Internet")
+              end
+            end
+          end
+
+          activity = Activity.last
+          assert_equal charter, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.charter.commitment_created", activity.action
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCitizensCharters
+  module GobiertoAdmin
+    class DeleteCommitmentTest < ActionDispatch::IntegrationTest
+
+      def setup
+        super
+        @path = admin_citizens_charters_charter_commitments_path(charter)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def charter
+        @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+      end
+
+      def commitment
+        @commitment ||= gobierto_citizens_charters_commitments(:devices_operation)
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+      def test_delete_commitment
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            within "#commitment-item-#{commitment.id}" do
+              find("a[data-method='delete']").click
+            end
+
+            assert has_message?("The commitment has been correctly deleted")
+
+            refute site.commitments.exists?(id: commitment.id)
+          end
+        end
+
+        activity = Activity.last
+        assert_equal charter, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.charter.commitment_archived", activity.action
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCitizensCharters
+  module GobiertoAdmin
+    class UpdateServiceTest < ActionDispatch::IntegrationTest
+      def setup
+        super
+        @path = edit_admin_citizens_charters_charter_commitment_path(charter, commitment)
+        @draft_commitment_path = edit_admin_citizens_charters_charter_commitment_path(charter, draft_commitment)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def unauthorized_admin
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def charter
+        @charter ||= gobierto_citizens_charters_charters(:day_care_service_charter)
+      end
+
+      def commitment
+        @commitment ||= gobierto_citizens_charters_commitments(:average_response_time)
+      end
+
+      def draft_commitment
+        @draft_commitment ||= gobierto_citizens_charters_commitments(:draft_service_schedule)
+      end
+
+      def test_permissions
+        with_signed_in_admin(unauthorized_admin) do
+          with_current_site(site) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+      end
+
+      def test_update_commitment
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              fill_in "commitment_title_translations_en", with: "Commitment updated"
+              fill_in "commitment_description_translations_en", with: "Commitment updated description"
+              click_link "ES"
+              fill_in "commitment_title_translations_es", with: "Compromiso actualizado"
+              fill_in "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+
+              click_button "Update"
+
+              assert has_message?("The commitment has been correctly updated.")
+
+              visit @path
+
+              assert has_field? "commitment_title_translations_en", with: "Commitment updated"
+              assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
+              click_link "ES"
+              assert has_field? "commitment_title_translations_es", with: "Compromiso actualizado"
+              assert has_field? "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+            end
+          end
+        end
+
+        activity = Activity.last
+        assert_equal charter, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.charter.commitment_updated", activity.action
+      end
+
+      def test_update_draft_commitment
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              assert_no_difference "Activity.count" do
+                visit @draft_commitment_path
+
+                fill_in "commitment_title_translations_en", with: "Commitment updated"
+                fill_in "commitment_description_translations_en", with: "Commitment updated description"
+                click_link "ES"
+                fill_in "commitment_title_translations_es", with: "Compromiso actualizado"
+                fill_in "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+
+                click_button "Update"
+
+                assert has_message?("The commitment has been correctly updated.")
+
+                visit @draft_commitment_path
+
+                assert has_field? "commitment_title_translations_en", with: "Commitment updated"
+                assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
+                click_link "ES"
+                assert has_field? "commitment_title_translations_es", with: "Compromiso actualizado"
+                assert has_field? "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+              end
+            end
+          end
+        end
+      end
+
+      def test_publish_draft_commitment
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @draft_commitment_path
+
+              within ".widget_save" do
+                find("label", text: "Published").click
+              end
+
+              click_button "Update"
+
+              assert has_message?("The commitment has been correctly updated.")
+
+              visit @draft_commitment_path
+
+              assert has_field? "commitment_title_translations_en", with: draft_commitment.title_en
+              assert has_field? "commitment_description_translations_en", with: draft_commitment.description_en
+              click_link "ES"
+              assert has_field? "commitment_title_translations_es", with: draft_commitment.title_es
+              assert has_field? "commitment_description_translations_es", with: draft_commitment.description_es
+            end
+          end
+        end
+
+        activity = Activity.last
+        assert_equal charter, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.charter.commitment_published", activity.action
+      end
+
+      def test_update_commitment_error
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              fill_in "commitment_title_translations_en", with: ""
+              fill_in "commitment_description_translations_en", with: ""
+              click_link "ES"
+              fill_in "commitment_title_translations_es", with: ""
+              fill_in "commitment_description_translations_es", with: ""
+
+              click_button "Update"
+
+              assert has_alert?("can't be blank")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/update_service_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/update_service_test.rb
@@ -60,6 +60,76 @@ module GobiertoCitizensCharters
             end
           end
         end
+
+        activity = Activity.last
+        assert_equal service, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.service.updated", activity.action
+      end
+
+      def test_update_draft_service
+        service.update_attribute(:visibility_level, :draft)
+
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              assert_no_difference "Activity.count" do
+                visit @path
+
+                click_link service.title
+                within "form.edit_service" do
+                  fill_in "service_title_translations_en", with: "Teleassistance updated"
+                  select "Culture", from: "service_category_id"
+
+                  click_button "Update"
+                end
+
+                assert has_message?("The service has been correctly updated.")
+
+                click_link service.title
+
+                assert has_field? "service_title_translations_en", with: "Teleassistance updated"
+                assert has_select? "service_category_id", with_selected: "Culture"
+              end
+            end
+          end
+        end
+      end
+
+      def test_publish_draft_service
+        service.update_attribute(:visibility_level, :draft)
+
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              click_link service.title
+              within "form.edit_service" do
+                within ".widget_save" do
+                  find("label", text: "Published").click
+                end
+
+                click_button "Update"
+              end
+
+              assert has_message?("The service has been correctly updated.")
+
+              click_link service.title
+
+              assert has_field? "service_title_translations_en", with: service.title_en
+              click_link "ES"
+              assert has_field? "service_title_translations_es", with: service.title_es
+            end
+          end
+        end
+
+        activity = Activity.last
+        assert_equal service, activity.subject
+        assert_equal admin, activity.author
+        assert_equal site.id, activity.site_id
+        assert_equal "gobierto_citizens_charters.service.published", activity.action
       end
 
       def test_update_service_error

--- a/test/pub_sub/subscribers/admin_gobierto_citizens_charters_activity_test.rb
+++ b/test/pub_sub/subscribers/admin_gobierto_citizens_charters_activity_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Subscribers::AdminGobiertoCitizensChartersActivityTest < ActiveSupport::TestCase
+  class Event < OpenStruct; end
+
+  IP = "1.2.3.4"
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def subject
+    @subject ||= Subscribers::AdminGobiertoCitizensChartersActivity.new("activities/admin_gobierto_citizens_charters")
+  end
+
+  def service
+    @service ||= gobierto_citizens_charters_services(:teleassistance)
+  end
+
+  def charter
+    @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+  end
+
+  def admin
+    @admin ||= gobierto_admin_admins(:tony)
+  end
+
+  def ip_address
+    @ip_address ||= IPAddr.new("1.2.3.4")
+  end
+
+  def payload(subject)
+    { gid: subject.to_gid, site_id: site.id, admin_id: admin.id }
+  end
+
+  def test_editions_edition_attribute_changed_event_handling
+    assert_difference "Activity.count" do
+      subject.editions_edition_attribute_changed Event.new(name: "edition_updated", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.edition_updated", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_editions_created_event_handling
+    assert_difference "Activity.count" do
+      subject.editions_created Event.new(name: "edition_created", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.edition_created", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_editions_deleted_event_handling
+    assert_difference "Activity.count" do
+      subject.editions_deleted Event.new(name: "edition_deleted", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.edition_deleted", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_commitments_commitment_attribute_changed_event_handling
+    assert_difference "Activity.count" do
+      subject.commitments_commitment_attribute_changed Event.new(name: "commitment_updated", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.commitment_updated", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_commitments_visibility_level_changed_event_handling
+    assert_difference "Activity.count" do
+      subject.commitments_visibility_level_changed Event.new(name: "commitment_published", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.commitment_published", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_commitments_created_event_handling
+    assert_difference "Activity.count" do
+      subject.commitments_created Event.new(name: "commitment_created", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.commitment_created", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_commitments_archived_event_handling
+    assert_difference "Activity.count" do
+      subject.commitments_archived Event.new(name: "commitment_archived", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.commitment_archived", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_charter_attribute_changed_event_handling
+    assert_difference "Activity.count" do
+      subject.charter_attribute_changed Event.new(name: "updated", payload: payload(charter))
+    end
+
+    activity = Activity.last
+    assert_equal charter, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.charter.updated", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_service_attribute_changed_event_handling
+    assert_difference "Activity.count" do
+      subject.service_attribute_changed Event.new(name: "updated", payload: payload(service))
+    end
+
+    activity = Activity.last
+    assert_equal service, activity.subject
+    assert_equal admin, activity.author
+    assert_equal "gobierto_citizens_charters.service.updated", activity.action
+    assert activity.admin_activity
+    assert_equal site.id, activity.site_id
+  end
+
+  def test_visibility_level_changed_event_handling
+    assert_difference "Activity.count", 2 do
+      subject.visibility_level_changed Event.new(name: "published", payload: payload(charter))
+
+      activity = Activity.last
+      assert_equal charter, activity.subject
+      assert_equal admin, activity.author
+      assert_equal "gobierto_citizens_charters.charter.published", activity.action
+      assert activity.admin_activity
+      assert_equal site.id, activity.site_id
+
+      subject.visibility_level_changed Event.new(name: "published", payload: payload(service))
+
+      activity = Activity.last
+      assert_equal service, activity.subject
+      assert_equal admin, activity.author
+      assert_equal "gobierto_citizens_charters.service.published", activity.action
+      assert activity.admin_activity
+      assert_equal site.id, activity.site_id
+    end
+  end
+
+  def test_created_event_handling
+    assert_difference "Activity.count", 2 do
+      subject.created Event.new(name: "created", payload: payload(charter))
+
+      activity = Activity.last
+      assert_equal charter, activity.subject
+      assert_equal admin, activity.author
+      assert_equal "gobierto_citizens_charters.charter.created", activity.action
+      assert activity.admin_activity
+      assert_equal site.id, activity.site_id
+
+      subject.created Event.new(name: "created", payload: payload(service))
+
+      activity = Activity.last
+      assert_equal service, activity.subject
+      assert_equal admin, activity.author
+      assert_equal "gobierto_citizens_charters.service.created", activity.action
+      assert activity.admin_activity
+      assert_equal site.id, activity.site_id
+    end
+  end
+
+  def test_archived_event_handling
+    assert_difference "Activity.count", 2 do
+      subject.archived Event.new(name: "archived", payload: payload(charter))
+
+      activity = Activity.last
+      assert_equal charter, activity.subject
+      assert_equal admin, activity.author
+      assert_equal "gobierto_citizens_charters.charter.archived", activity.action
+      assert activity.admin_activity
+      assert_equal site.id, activity.site_id
+
+      subject.archived Event.new(name: "archived", payload: payload(service))
+
+      activity = Activity.last
+      assert_equal service, activity.subject
+      assert_equal admin, activity.author
+      assert_equal "gobierto_citizens_charters.service.archived", activity.action
+      assert activity.admin_activity
+      assert_equal site.id, activity.site_id
+    end
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?
* Creates an extension to track changes in models allowing to set the payload subject and group changes of a set of attributes under a common event. In this way the number of events and activities generated can be reduced. Changes in draft objects do not generate activities.
* Configures activities for creation, edition and publication of services and charters and activities for creation, edition, deletion and publication (in the case of commitments) of editions and commitments under the charter.
* Adds integration tests for admin management of services, charters and commitments and tests for subscriber

## :mag: How should this be manually tested?
Go to admin and generate activities for module

## :eyes: Screenshots

![site_activities_charters](https://user-images.githubusercontent.com/446459/49014283-e92d4980-f17f-11e8-85f0-5540562dc6b1.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
