### PR TITLE
484 custom fields order

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -11,7 +11,8 @@ module GobiertoAdmin
           set_class_name
 
           @class_human_name = @class_name.constantize.model_name.human(count: 2)
-          @custom_fields = current_site.custom_fields.where(class_name: @class_name).sorted
+          @localized_custom_fields = current_site.custom_fields.where(class_name: @class_name).localized.sorted
+          @not_localized_custom_fields = current_site.custom_fields.where(class_name: @class_name).not_localized.sorted
         end
 
         def new

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/sort_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/sort_controller.rb
@@ -8,7 +8,11 @@ module GobiertoAdmin
         private
 
         def collection
-          @collection ||= current_site.custom_fields.where(class_name: params[:module_resource_name].tr("-", "/").camelize)
+          @collection ||= begin
+                            return current_site.custom_fields.none unless ["localized", "not_localized"].any?(params[:localized])
+
+                            current_site.custom_fields.where(class_name: params[:module_resource_name].tr("-", "/").camelize).send(params[:localized])
+                          end
         end
       end
     end

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
       validates :site, presence: true
 
       def available_custom_fields
-        site.custom_fields.where(class_name: item.class.name)
+        site.custom_fields.sorted.where(class_name: item.class.name)
       end
 
       def custom_field_records

--- a/app/javascript/gobierto_admin/modules/sortable_component.js
+++ b/app/javascript/gobierto_admin/modules/sortable_component.js
@@ -4,18 +4,19 @@ window.GobiertoAdmin.SortableComponent = (function() {
   function SortableComponent() {}
 
   SortableComponent.prototype.list = function(options) {
-    _handleSortableList(options.wrapper, options.placeholder);
+    let positionOffset = options.hasOwnProperty("positionOffset") ? options.positionOffset : 0
+    _handleSortableList(options.wrapper, options.placeholder, positionOffset);
   };
 
-  function _handleSortableList(wrapper, placeholder) {
+  function _handleSortableList(wrapper, placeholder, positionOffset) {
     $(wrapper).sortable({
       items: '.list_item',
       handle: '.custom_handle',
       forcePlaceholderSize: true,
       placeholder: placeholder,
       update: function() {
-        _refreshPositions(wrapper);
-        _requestUpdate(wrapper, _buildPositions(wrapper));
+        _refreshPositions(wrapper, positionOffset);
+        _requestUpdate(wrapper, _buildPositions(wrapper, positionOffset));
       },
       helper: _fixWidthHelper
     });
@@ -28,19 +29,19 @@ window.GobiertoAdmin.SortableComponent = (function() {
     return ui;
   }
 
-  function _refreshPositions(wrapper) {
+  function _refreshPositions(wrapper, positionOffset) {
     $(wrapper).find(".list_item").each(function(index) {
-      $(this).attr("data-pos", index + 1);
+      $(this).attr("data-pos", positionOffset + index + 1);
     });
   }
 
-  function _buildPositions(wrapper) {
+  function _buildPositions(wrapper, positionOffset) {
     var positions = [];
 
     $(wrapper).find(".list_item").each(function(index) {
       positions.push({
         id: $(this).data("id"),
-        position: index + 1
+        position: positionOffset + index + 1
       });
     });
 

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -18,6 +18,8 @@ module GobiertoCommon
                        image: 7 }
 
     scope :sorted, -> { order(position: :asc) }
+    scope :localized, -> { where(field_type: [:localized_string, :localized_paragraph]) }
+    scope :not_localized, -> { where.not(field_type: [:localized_string, :localized_paragraph]) }
 
     translates :name
 

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
@@ -66,8 +66,13 @@
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
     window.GobiertoAdmin.sortable_component.list({
-      wrapper: "div[data-behavior=sortable]",
+      wrapper: "div[data-behavior=sortable-localized]",
       placeholder: '<div class="list_item">&nbsp;&nbsp;</div>'
+    });
+    window.GobiertoAdmin.sortable_component.list({
+      wrapper: "div[data-behavior=sortable-not-localized]",
+      placeholder: '<div class="list_item">&nbsp;&nbsp;</div>',
+      positionOffset: <%= @localized_custom_fields.maximum(:position) || 0 %>
     });
   <% end %>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
@@ -6,8 +6,9 @@
 
 <h1><%= t(".title") %></h1>
 
-<div data-behavior="sortable" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name]) %>">
-  <% @custom_fields.each do |custom_field| %>
+<h3><%= t(".localized_custom_fields") %></h3>
+<div data-behavior="sortable-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "localized") %>">
+  <% @localized_custom_fields.each do |custom_field| %>
     <div class="list_item with_mandatory_option" id="item-<%= custom_field.id %>" data-id="<%= custom_field.id %>" c>
       <i class="sort-handler fa fa-bars tipsit custom_handle"></i>
       <label class="main"><%= custom_field.name %></label>
@@ -30,7 +31,31 @@
     </div>
   <% end %>
 </div>
+<h3><%= t(".not_localized_custom_fields") %></h3>
+<div data-behavior="sortable-not-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "not_localized") %>">
+  <% @not_localized_custom_fields.each do |custom_field| %>
+    <div class="list_item with_mandatory_option" id="item-<%= custom_field.id %>" data-id="<%= custom_field.id %>" c>
+      <i class="sort-handler fa fa-bars tipsit custom_handle"></i>
+      <label class="main"><%= custom_field.name %></label>
 
+      <div class="tools">
+        <%= link_to edit_admin_common_custom_fields_custom_field_path(custom_field),
+          title: t("views.edit"),
+          class: "tipsit" do %>
+          <i class="fa fa-edit"></i>
+        <% end %>
+
+        <%= link_to admin_common_custom_fields_custom_field_path(custom_field),
+          title: t("views.delete"),
+          method: :delete,
+          class: "tipsit",
+          data: { confirm: t("views.delete_confirm") } do %>
+          <i class="fa fa-trash"></i>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>
 <div class="m_2">
   <%= link_to new_admin_common_custom_fields_module_resource_custom_field_path(params[:module_resource_name]) do %>
     <i class="fa fa-plus-circle"></i>

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
@@ -11,7 +11,9 @@ ca:
             confirm: Estàs segur?
             crop: Retallar
           index:
+            localized_custom_fields: Camps traduïbles
             new: Afegir nou camp
+            not_localized_custom_fields: Camps no traduïbles
             title: Camps personalitzats
           new:
             title: Nou camp

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
@@ -11,7 +11,9 @@ en:
             confirm: Are you sure?
             crop: Crop
           index:
+            localized_custom_fields: Translatable fields
             new: Add new field
+            not_localized_custom_fields: Non-translatable fields
             title: Custom fields
           new:
             title: New field

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
@@ -11,7 +11,9 @@ es:
             confirm: "¿Estás seguro?"
             crop: Recortar
           index:
+            localized_custom_fields: Campos traducibles
             new: Añadir nuevo campo
+            not_localized_custom_fields: Campos no traducibles
             title: Campos personalizados
           new:
             title: Nuevo campo


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/484


## :v: What does this PR do?

* Splits custom fields index in 2 sections, one for translatable custom fields and other for not translatable custom fields
* Manages order of items for each list
* Uses the order to display custom fields in edition form of resources with custom fields defined, showing ordered translatable fields in the first place, and then the not translatable fields also ordered.

## :mag: How should this be manually tested?
Visit index of charters custom fields and reorder elements `/admin/custom_fields/module_resources/gobierto_citizens_charters-charter`. The order changes  should appear in the edit form of a charter

## :eyes: Screenshots

### Before this PR

![484_before](https://user-images.githubusercontent.com/446459/49029137-34595380-f1a4-11e8-9e76-19ee7a25eb9e.gif)


### After this PR

![484_after](https://user-images.githubusercontent.com/446459/49028863-ab421c80-f1a3-11e8-8c6a-7aa1a7ad6b61.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
