### PR TITLE
501 attachment image

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,19 +54,26 @@ module ApplicationHelper
   end
 
   def filetype_icon(attachment)
-    extension = if attachment.class == String
-                  attachment.split(".").last
-                else
-                  attachment.extension
-                end
-
-    fontawesome_filetype = if ::GobiertoAttachments::Attachment.extension_fontawesome_matching.has_key?(extension.to_sym)
-                             "-" + ::GobiertoAttachments::Attachment.extension_fontawesome_matching[extension.to_sym]
+    extension = attachment_extension(attachment)
+    fontawesome_filetype = if ::GobiertoAttachments::Attachment.extension_fontawesome_matching.has_key?(extension)
+                             "-" + ::GobiertoAttachments::Attachment.extension_fontawesome_matching[extension]
                            else
                              ""
                            end
     html = "<i class='fa fa-file" + fontawesome_filetype + "-o'></i>"
     html.html_safe
+  end
+
+  def image_extension?(attachment)
+    ::GobiertoAttachments::Attachment.extension_fontawesome_matching[attachment_extension(attachment)] == "image"
+  end
+
+  def attachment_extension(attachment)
+    if attachment.class == String
+      attachment.split(".").last
+    else
+      attachment.extension
+    end.to_sym
   end
 
   def current_parameters_with_year(year)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,11 +4,11 @@ module ApplicationHelper
 
   def body_css_classes
     classes = []
-    classes.push current_module == 'gobierto_participation' ?  'gobierto_participation theme-participation' : current_module
+    classes.push current_module == "gobierto_participation" ? "gobierto_participation theme-participation" : current_module
     classes.push controller_name
     classes.push action_name
     classes.push "#{controller_name}_#{action_name}"
-    classes.push "#{controller_path}_#{action_name}".gsub("/", "_")
+    classes.push "#{controller_path}_#{action_name}".tr("/", "_")
     classes.join(" ")
   end
 
@@ -35,7 +35,7 @@ module ApplicationHelper
   end
 
   def privacy_policy_page_link
-    if current_site && current_site.configuration.privacy_page?
+    if current_site&.configuration&.privacy_page?
       link_to t("layouts.accept_privacy_policy_signup"), gobierto_cms_page_or_news_path(current_site.configuration.privacy_page)
     end
   end
@@ -86,7 +86,7 @@ module ApplicationHelper
     answerable_polls_by_user = answerable_polls.detect { |p| p.answerable_by?(current_user) } if current_user
 
     if current_user
-      if poll && poll.answerable_by?(current_user)
+      if poll&.answerable_by?(current_user)
         poll
       elsif answerable_polls_by_user
         answerable_polls_by_user
@@ -116,7 +116,7 @@ module ApplicationHelper
 
   def whom(entity_name)
     if I18n.locale == :ca
-      if /\A[aeiou]/i =~ entity_name
+      if /\A[aeiou]/i.match? entity_name
         " l'#{entity_name}"
       else
         # TODO: define a setting with the genre of the entity
@@ -147,12 +147,12 @@ module ApplicationHelper
 
     stripped_text = html_text.dup
 
-    if (options[:headers] == false)
-      stripped_text.gsub!(/<h\d(.*?)>/, "<p>")  # header opening
-      stripped_text.gsub!(/<\\h\d>/, "</p>")    # header closing
+    if options[:headers] == false
+      stripped_text.gsub!(/<h\d(.*?)>/, "<p>") # header opening
+      stripped_text.gsub!(/<\\h\d>/, "</p>") # header closing
     end
 
-    stripped_text.gsub!(/<img(.*?)>/, "") if (options[:images] == false)
+    stripped_text.gsub!(/<img(.*?)>/, "") if options[:images] == false
 
     truncate_html(stripped_text, options)
   end

--- a/app/views/gobierto_admin/gobierto_attachments/file_attachments/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_attachments/file_attachments/_form.html.erb
@@ -5,7 +5,11 @@
     <div class='pure-u-1 pure-u-md-16-24'>
       <div class='form_item file_field avatar_file_field'>
         <% if f.object.url.present? %>
-          <%= filetype_icon(f.object.url) %>
+          <% if image_extension?(f.object.url) %>
+            <%= image_tag f.object.url %>
+          <% else %>
+            <%= filetype_icon(f.object.url) %>
+          <% end %>
         <% end %>
         <%= label_tag "file_attachment[file]" do %>
           <%= t('.file_constraints') %>


### PR DESCRIPTION
Closes #501


## :v: What does this PR do?
Displays image in attachments form if attachment extension corresponds to an image

## :mag: How should this be manually tested?
Go to documents section of a process and upload images and other documents

## :eyes: Screenshots

### Before this PR
![501_before](https://user-images.githubusercontent.com/446459/49077225-0d9a2c00-f23b-11e8-8167-1b086c1493d9.gif)

### After this PR
![501_after](https://user-images.githubusercontent.com/446459/49077238-1559d080-f23b-11e8-808f-86f0ede08561.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
