### PR TITLE
457 issues and scopes collections

### DIFF
--- a/app/controllers/gobierto_participation/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/attachments_controller.rb
@@ -6,23 +6,17 @@ module GobiertoParticipation
       @issue = find_issue if params[:issue_id]
       @issues = find_issues
       @filtered_issue = find_issue if params[:issue_id]
-      @attachments = if @filtered_issue
-                       GobiertoAttachments::Attachment.in_collections_and_container(current_site, @issue).page(params[:page])
-                     else
-                       find_attachments.page(params[:page])
-                     end
+      @attachments = find_attachments.page(params[:page])
     end
 
     private
 
     def find_attachments
-      attachments = ::GobiertoAttachments::Attachment.in_collections_and_container_type(current_site, "GobiertoParticipation")
-
       if @filtered_issue
-        attachments = attachments.in_collections_and_container(current_site, @filtered_issue)
+        @issue.attachments
+      else
+        ::GobiertoAttachments::Attachment.in_collections_and_container_type(current_site, "GobiertoParticipation")
       end
-
-      attachments
     end
   end
 end

--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -32,7 +32,7 @@ module GobiertoParticipation
                     @container_events.past.sorted_backwards.page params[:page]
                   else
                     if @issue
-                      GobiertoCalendars::Event.in_collections_and_container(current_site, @issue).published.page(params[:page]).upcoming.sorted.page params[:page]
+                      @issue.events.published.page(params[:page]).upcoming.sorted.page params[:page]
                     else
                       @container_events.upcoming.sorted.page params[:page]
                     end

--- a/app/controllers/gobierto_participation/filtered_events_controller.rb
+++ b/app/controllers/gobierto_participation/filtered_events_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module GobiertoParticipation
+  class FilteredEventsController < GobiertoParticipation::ApplicationController
+
+    include ::PreviewTokenHelper
+
+    def show
+      @event = find_event
+
+      set_events
+    end
+
+    def index
+      @issues = find_issues
+      @scopes = find_scopes
+
+      set_events
+
+      respond_to do |format|
+        format.html
+        format.js
+      end
+    end
+
+    private
+
+    def find_event
+      base_relation.find_by_slug!(params[:id])
+    end
+
+    def base_relation
+      @base_relation ||= if valid_preview_token?
+                           GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation")
+                         else
+                           GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published
+                         end
+    end
+
+    def set_events
+      @events = base_relation.sorted.page params[:page]
+
+      if params[:date]
+        filter_events_by_date(params[:date])
+      elsif @past_events
+        @events = @events.past.sorted_backwards
+      elsif @events.upcoming.empty?
+        @no_upcoming_events = true
+        @events = @events.past.sorted_backwards
+      else
+        @events = @events.upcoming.sorted
+      end
+    end
+
+    def filter_events_by_date(date)
+      @filtering_date = Date.parse(date)
+      @events = @events.by_date(@filtering_date)
+      @events = (@filtering_date >= Time.now ? @events.sorted : @events.sorted_backwards)
+    rescue ArgumentError
+      @events
+    end
+  end
+end

--- a/app/controllers/gobierto_participation/issues/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/issues/attachments_controller.rb
@@ -13,7 +13,7 @@ module GobiertoParticipation
       private
 
       def find_issue_attachments
-        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, @issue)
+        @issue.attachments
       end
     end
   end

--- a/app/controllers/gobierto_participation/issues/events_controller.rb
+++ b/app/controllers/gobierto_participation/issues/events_controller.rb
@@ -2,65 +2,17 @@
 
 module GobiertoParticipation
   module Issues
-    class EventsController < GobiertoParticipation::ApplicationController
-      include ::PreviewTokenHelper
-
-      def show
-        @event = find_event
-
-        set_events
-      end
-
-      def index
-        @issue = find_issue
-
-        set_events
-
-        respond_to do |format|
-          format.html
-          format.js
-        end
-      end
+    class EventsController < GobiertoParticipation::FilteredEventsController
 
       private
 
-      def find_participation_events
-        ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted
-      end
-
-      def find_event
-        find_participation_events.find_by_slug!(params[:id])
-      end
-
-      def set_events
-        @events = if @issue
-                    ::GobiertoCalendars::Event.in_collections_and_container(current_site, @issue).published.sorted.page params[:page] if @issue
-                  else
-                    ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted.page params[:page]
-                  end
-
-        if params[:date]
-          filter_events_by_date(params[:date])
-        else
-          if @past_events
-            @events = @events.past.sorted_backwards
-          else
-            if @events.upcoming.empty?
-              @no_upcoming_events = true
-              @events = @events.past.sorted_backwards
-            else
-              @events = @events.upcoming.sorted
-            end
-          end
-        end
-      end
-
-      def filter_events_by_date(date)
-        @filtering_date = Date.parse(date)
-        @events = @events.by_date(@filtering_date)
-        @events = (@filtering_date >= Time.now ? @events.sorted : @events.sorted_backwards)
-      rescue ArgumentError
-        @events
+      def base_relation
+        @issue = find_issue
+        @base_relation ||= if valid_preview_token?
+                             @issue.events
+                           else
+                             @issue.events.published
+                           end
       end
     end
   end

--- a/app/controllers/gobierto_participation/news_controller.rb
+++ b/app/controllers/gobierto_participation/news_controller.rb
@@ -24,8 +24,10 @@ module GobiertoParticipation
     end
 
     def participation_module_news
-      if (container = @issue || @scope)
-        ::GobiertoCms::Page.news_in_collections_and_container(current_site, container)
+      if @issue
+        @issue.news
+      elsif @scope
+        @scope.news
       else
         ::GobiertoCms::Page.news_in_collections_and_container_type(current_site, "GobiertoParticipation")
       end

--- a/app/controllers/gobierto_participation/processes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/processes/attachments_controller.rb
@@ -19,7 +19,7 @@ module GobiertoParticipation
       private
 
       def find_process_attachments
-        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, current_process)
+        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, current_process).page(params[:page])
       end
     end
   end

--- a/app/controllers/gobierto_participation/processes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/processes/attachments_controller.rb
@@ -10,8 +10,7 @@ module GobiertoParticipation
         @filtered_issue = find_issue if params[:issue_id]
         @issue = find_issue if params[:issue_id]
         @attachments = if @issue
-                         GobiertoAttachments::Attachment.in_collections_and_container(current_site, @issue)
-                                                        .in_collections_and_container(current_site, current_process).page(params[:page])
+                         @issue.attachments.in_collections_and_container(current_site, current_process).page(params[:page])
                        else
                          find_process_attachments
                        end

--- a/app/controllers/gobierto_participation/processes/events_controller.rb
+++ b/app/controllers/gobierto_participation/processes/events_controller.rb
@@ -46,7 +46,7 @@ module GobiertoParticipation
 
       def set_events
         @events = process_events_scope
-        @events = @events.in_collections_and_container(current_site, @issue).published if @issue
+        @events = ProcessCollectionDecorator.new(@events).with_issue(@issue).published if @issue
 
         @events = if params[:date]
                     filter_events_by_date(params[:date]).published

--- a/app/controllers/gobierto_participation/scopes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/attachments_controller.rb
@@ -13,7 +13,7 @@ module GobiertoParticipation
       private
 
       def find_scope_attachments
-        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, @scope)
+        @scope.attachments
       end
     end
   end

--- a/app/controllers/gobierto_participation/scopes/events_controller.rb
+++ b/app/controllers/gobierto_participation/scopes/events_controller.rb
@@ -2,65 +2,17 @@
 
 module GobiertoParticipation
   module Scopes
-    class EventsController < GobiertoParticipation::ApplicationController
-      include ::PreviewTokenHelper
-
-      def show
-        @event = find_event
-
-        set_events
-      end
-
-      def index
-        @scope = find_scope
-
-        set_events
-
-        respond_to do |format|
-          format.html
-          format.js
-        end
-      end
+    class EventsController < GobiertoParticipation::FilteredEventsController
 
       private
 
-      def find_participation_events
-        ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted
-      end
-
-      def find_event
-        find_participation_events.find_by_slug!(params[:id])
-      end
-
-      def set_events
-        @events = if @scope
-                    ::GobiertoCalendars::Event.in_collections_and_container(current_site, @scope).published.sorted.page params[:page]
-                  else
-                    ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted.page params[:page]
-                  end
-
-        if params[:date]
-          filter_events_by_date(params[:date])
-        else
-          if @past_events
-            @events = @events.past.sorted_backwards
-          else
-            if @events.upcoming.empty?
-              @no_upcoming_events = true
-              @events = @events.past.sorted_backwards
-            else
-              @events = @events.upcoming.sorted
-            end
-          end
-        end
-      end
-
-      def filter_events_by_date(date)
-        @filtering_date = Date.parse(date)
-        @events = @events.by_date(@filtering_date)
-        @events = (@filtering_date >= Time.now ? @events.sorted : @events.sorted_backwards)
-      rescue ArgumentError
-        @events
+      def base_relation
+        @scope = find_scope
+        @base_relation ||= if valid_preview_token?
+                             @scope.events
+                           else
+                             @scope.events.published
+                           end
       end
     end
   end

--- a/app/decorators/gobierto_participation/process_collection_decorator.rb
+++ b/app/decorators/gobierto_participation/process_collection_decorator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module GobiertoParticipation
+  class ProcessCollectionDecorator < BaseDecorator
+    def initialize(klass, opts = {})
+      @class = klass
+      @item_type = opts[:item_type] || @class.name
+    end
+
+    def with_issue(issue)
+      with_term(issue, :issue)
+    end
+
+    def with_scope(scope)
+      with_term(scope, :scope)
+    end
+
+    private
+
+    def with_term(term, vocabulary_association_name)
+      return @class.none unless term.is_a? term_class
+
+      item_type_scope = case @item_type
+                        when "GobiertoCms::News"
+                          :news_in_collections_and_container_type
+                        else
+                          :in_collections_and_container_type
+                        end
+
+      @class.send(item_type_scope, term.site, process_class.name)
+            .joins(
+              Arel.sql(
+                <<-SQL
+                  JOIN #{ process_class.table_name } ON #{ process_class.table_name }.id = #{ item_class.table_name }.container_id
+                  JOIN #{ term_class.table_name } ON #{ term_class.table_name }.id = #{ process_class.table_name }.#{ vocabulary_association_name.to_s.foreign_key }
+                  JOIN #{ vocabulary_class.table_name } ON #{ vocabulary_class.table_name }.id = #{ term_class.table_name }.vocabulary_id
+                SQL
+              )
+            )
+            .where(vocabularies: { id: process_class.send("#{ vocabulary_association_name.to_s.pluralize }_vocabulary_id", term.site) })
+            .where(terms: { id: term.id })
+    end
+
+    def process_class
+      GobiertoParticipation::Process
+    end
+
+    def item_class
+      GobiertoCommon::CollectionItem
+    end
+
+    def term_class
+      GobiertoCommon::Term
+    end
+
+    def vocabulary_class
+      GobiertoCommon::Vocabulary
+    end
+  end
+end

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -21,6 +21,8 @@ module GobiertoCommon
 
     translates :name, :description
 
+    delegate :site, to: :vocabulary
+
     def attributes_for_slug
       [vocabulary_name, name]
     end

--- a/test/fixtures_archive/gobierto_common/collection_items/madrid/pages.yml
+++ b/test/fixtures_archive/gobierto_common/collection_items/madrid/pages.yml
@@ -137,11 +137,11 @@ notice_2_on_site:
   item_type: 'GobiertoCms::News'
   container: gender_violence_process (GobiertoParticipation::Process)
 
-notice_2_on_site:
+notice_2_on_process:
   collection: gender_violence_process_news
   item: notice_2
   item_type: 'GobiertoCms::News'
-  container: madrid (Site)
+  container: gender_violence_process (GobiertoParticipation::Process)
 
 notice_2_on_participation:
   collection: gender_violence_process_news

--- a/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
@@ -209,6 +209,25 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_update_process_issue
+        old_issue = gobierto_common_terms(:women_term)
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit gobierto_participation_issue_attachments_path(old_issue) do
+              assert has_content? gobierto_attachments_attachments(:pdf_collection_attachment).description
+            end
+            visit edit_admin_participation_process_path(process)
+
+            select "Economy", from: "process_issue_id"
+            click_button "Update"
+
+            visit gobierto_participation_issue_attachments_path(old_issue) do
+              refute has_content? gobierto_attachments_attachments(:pdf_collection_attachment).description
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
@@ -12,6 +12,14 @@ module GobiertoParticipation
       @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
+    def other_issue
+      @other_issue ||= gobierto_common_terms(:economy_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
+    end
+
     def issue_attachments_path
       @issue_attachments_path ||= gobierto_participation_issue_attachments_path(
         issue_id: issue.slug
@@ -23,7 +31,7 @@ module GobiertoParticipation
     end
 
     def issue_attachments
-      @issue_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container(site, issue)
+      @issue_attachments ||= issue.attachments
     end
 
     def test_menu_subsections
@@ -58,6 +66,19 @@ module GobiertoParticipation
 
         assert has_link? "XLSX Attachment Event"
         assert has_link? "PDF Collection Attachment Name"
+      end
+    end
+
+    def test_update_process_issue_attachments_index
+      participation_process.update_attribute(:issue_id, other_issue.id)
+
+      with_current_site(site) do
+        visit issue_attachments_path
+
+        assert_equal issue_attachments.size, all(".news_teaser").size
+
+        refute has_link? "XLSX Attachment Event"
+        refute has_link? "PDF Collection Attachment Name"
       end
     end
   end

--- a/test/integration/gobierto_participation/issues/issue_events_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_events_index_test.rb
@@ -12,6 +12,14 @@ module GobiertoParticipation
       @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
+    def other_issue
+      @other_issue ||= gobierto_common_terms(:economy_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
+    end
+
     def issue_events_path
       @issue_events_path ||= gobierto_participation_issue_events_path(
         issue_id: issue.slug
@@ -65,6 +73,16 @@ module GobiertoParticipation
           assert has_content? "Intensive reading club in english"
           assert has_content? "Intensive reading club in english description"
         end
+      end
+    end
+
+    def test_update_process_issue_events_index
+      participation_process.update_attribute(:issue_id, other_issue.id)
+
+      with_current_site(site) do
+        visit issue_events_path
+
+        assert has_content? "No related events"
       end
     end
   end

--- a/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
@@ -12,6 +12,14 @@ module GobiertoParticipation
       @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
+    def other_issue
+      @other_issue ||= gobierto_common_terms(:economy_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
+    end
+
     def issue_pages_path
       @issue_pages_path ||= gobierto_participation_news_index_path(
         issue_id: issue.slug
@@ -23,7 +31,7 @@ module GobiertoParticipation
     end
 
     def issue_news
-      @issue_news ||= GobiertoCms::Page.news_in_collections_and_container(site, issue).sorted
+      @issue_news ||= issue.news
     end
 
     def test_menu_subsections
@@ -54,10 +62,23 @@ module GobiertoParticipation
       with_current_site(site) do
         visit issue_pages_path
 
-        assert_equal issue_news.size, all(".news_teaser").size
+        assert_equal issue_news.active.size, all(".news_teaser").size
 
         assert has_link? "Notice 1 title"
         assert has_link? "Notice 2 title"
+      end
+    end
+
+    def test_update_process_issue_pages_index
+      participation_process.update_attribute(:issue_id, other_issue.id)
+
+      with_current_site(site) do
+        visit issue_pages_path
+
+        assert_equal issue_news.active.size, all(".news_teaser").size
+
+        refute has_link? "Notice 1 title"
+        refute has_link? "Notice 2 title"
       end
     end
   end

--- a/test/integration/gobierto_participation/issues/issue_show_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_show_test.rb
@@ -21,6 +21,14 @@ module GobiertoParticipation
       @issue ||= ProcessTermDecorator.new(gobierto_common_terms(:women_term))
     end
 
+    def other_issue
+      @other_issue ||= gobierto_common_terms(:economy_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
+    end
+
     def processes
       @processes ||= site.processes.process.where(issue: issue).active
     end
@@ -170,7 +178,27 @@ module GobiertoParticipation
       with_current_site(site) do
         visit @path
 
+        within "div#processes" do
+          assert has_content? participation_process.title
+        end
+
         assert_equal processes.size, all("div#processes/div").size
+      end
+    end
+
+    def test_update_process_issue_show
+      participation_process.update_attribute(:issue_id, other_issue.id)
+
+      with_current_site(site) do
+        visit @path
+
+        within "div#processes" do
+          refute has_content? participation_process.title
+        end
+
+        assert has_content? "No related news"
+        assert has_content? "No related events"
+        assert has_content? "No related updates"
       end
     end
   end

--- a/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
@@ -12,6 +12,14 @@ module GobiertoParticipation
       @scope ||= ProcessTermDecorator.new(gobierto_common_terms(:old_town_term))
     end
 
+    def other_scope
+      @other_scope ||= gobierto_common_terms(:center_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
+    end
+
     def scope_attachments_path
       @scope_attachments_path ||= gobierto_participation_scope_attachments_path(
         scope_id: scope.slug
@@ -23,7 +31,7 @@ module GobiertoParticipation
     end
 
     def scope_attachments
-      @scope_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container(site, scope)
+      @scope_attachments ||= scope.attachments
     end
 
     def test_menu_subsections
@@ -58,6 +66,19 @@ module GobiertoParticipation
 
         assert has_link? "XLSX Attachment Event"
         assert has_link? "PDF Collection Attachment Name"
+      end
+    end
+
+    def test_update_process_scope_attachments_index
+      participation_process.update_attribute(:scope_id, other_scope.id)
+
+      with_current_site(site) do
+        visit scope_attachments_path
+
+        assert_equal scope_attachments.size, all(".news_teaser").size
+
+        refute has_link? "XLSX Attachment Event"
+        refute has_link? "PDF Collection Attachment Name"
       end
     end
   end

--- a/test/integration/gobierto_participation/scopes/scope_events_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_events_index_test.rb
@@ -12,6 +12,14 @@ module GobiertoParticipation
       @scope ||= ProcessTermDecorator.new(gobierto_common_terms(:old_town_term))
     end
 
+    def other_scope
+      @other_scope ||= gobierto_common_terms(:center_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
+    end
+
     def scope_events_path
       @scope_events_path ||= gobierto_participation_scope_events_path(
         scope_id: scope.slug
@@ -65,6 +73,16 @@ module GobiertoParticipation
           assert has_content? "Intensive reading club in english"
           assert has_content? "Intensive reading club in english description"
         end
+      end
+    end
+
+    def test_update_process_scope_events_index
+      participation_process.update_attribute(:scope_id, other_scope.id)
+
+      with_current_site(site) do
+        visit scope_events_path
+
+        assert has_content? "No related events"
       end
     end
   end

--- a/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
@@ -9,7 +9,15 @@ module GobiertoParticipation
     end
 
     def scope
-      @scope ||= gobierto_common_terms(:old_town_term)
+      @scope ||= ProcessTermDecorator.new(gobierto_common_terms(:old_town_term))
+    end
+
+    def other_scope
+      @other_scope ||= gobierto_common_terms(:center_term)
+    end
+
+    def participation_process
+      @participation_process ||= gobierto_participation_processes(:gender_violence_process)
     end
 
     def scope_pages_path
@@ -23,7 +31,7 @@ module GobiertoParticipation
     end
 
     def scope_news
-      @scope_news ||= GobiertoCms::Page.news_in_collections_and_container(site, scope).sorted
+      @scope_news ||= scope.news
     end
 
     def test_menu_subsections
@@ -54,7 +62,27 @@ module GobiertoParticipation
       with_current_site(site) do
         visit scope_pages_path
 
-        assert_equal scope_news.size, all(".news_teaser").size
+        assert_equal scope_news.active.size, all(".news_teaser").size
+
+        assert has_link? "Notice 1 title"
+        assert has_link? "Notice 2 title"
+        assert has_link? "Themes in the site"
+
+        assert has_content? "News for Old town"
+      end
+    end
+
+    def test_update_process_scope_pages_index
+      participation_process.update_attribute(:scope_id, other_scope.id)
+
+      with_current_site(site) do
+        visit scope_pages_path
+
+        assert_equal scope_news.active.size, all(".news_teaser").size
+
+        refute has_link? "Notice 1 title"
+        refute has_link? "Notice 2 title"
+        assert has_link? "Themes in the site"
 
         assert has_content? "News for Old town"
       end


### PR DESCRIPTION
Closes #457


## :v: What does this PR do?
Refactors collections to get events, attachments and news related with issues or scopes using a query joining with processes. Before this PR `GobiertoCommon::CollectionItem` with container_type `GobiertoCommon::Term` was being used to get the resources: with this PR the collections of processes are used directly to get the resources, no callbacks required.

## :mag: How should this be manually tested?
1. From admin go to a process with scope and issue set and publish some resources.
2. In front go to scope and issue pages and check that the resources are present
3. Change scope and issue of process
4. In front he resources should not appear in the old issue and scope but in the new ones

## :eyes: Screenshots

### Before this PR
![457_before](https://user-images.githubusercontent.com/446459/49146397-608ae680-f302-11e8-92dd-5f0cbedb79d5.gif)

### After this PR
![457_after](https://user-images.githubusercontent.com/446459/49146464-7e584b80-f302-11e8-988a-00f3938ba724.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No