### PR TITLE
Display all validation error messages in custom_sessions_controller

### DIFF
--- a/app/controllers/user/custom_sessions_controller.rb
+++ b/app/controllers/user/custom_sessions_controller.rb
@@ -20,10 +20,10 @@ class User::CustomSessionsController < User::BaseController
   end
 
   def auth_callback
-    create
+    create(false)
   end
 
-  def create
+  def create(invalid_messages = true)
     set_user_session_forms
 
     if @user_session_forms.values.any?(&:save)
@@ -37,8 +37,8 @@ class User::CustomSessionsController < User::BaseController
       ) and return
 
     else
-      if @user_session_forms.values.any? { |session_form| session_form.respond_to?(:email) && session_form.errors.added?(:email, :taken) }
-        flash[:alert] = t('user.custom_sessions.create.email_taken')
+      if invalid_messages && (errors_form = @user_session_forms.values.find { |session_form| session_form.errors.any? }).present?
+        flash[:alert] = errors_form.errors.full_messages.to_sentence
       end
 
       @strategy_name, @user_session_form = @user_session_forms.find do |key, form|

--- a/config/locales/user/controllers/custom_sessions/ca.yml
+++ b/config/locales/user/controllers/custom_sessions/ca.yml
@@ -3,7 +3,6 @@ ca:
   user:
     custom_sessions:
       create:
-        email_taken: El correu-e ja està en ús
         invalid_data: Les dades rebudes no són vàlids. No s'ha pogut crear la sessió
         not_confirmed: Revisa el teu correu-e i fes click en l'enllaç de confirmació
           per poder accedir al servei

--- a/config/locales/user/controllers/custom_sessions/en.yml
+++ b/config/locales/user/controllers/custom_sessions/en.yml
@@ -3,7 +3,6 @@ en:
   user:
     custom_sessions:
       create:
-        email_taken: That email is already registered
         invalid_data: Invalid data received. The session could not be created
         not_confirmed: Please check your inbox and follow the confirmation link to
           access the service

--- a/config/locales/user/controllers/custom_sessions/es.yml
+++ b/config/locales/user/controllers/custom_sessions/es.yml
@@ -3,7 +3,6 @@ es:
   user:
     custom_sessions:
       create:
-        email_taken: El email ya está en uso
         invalid_data: Los datos recibidos no son válidos, no se ha podido crear la
           sesión
         not_confirmed: Revisa tu correo-e y haz click en el enlace de confirmación


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/498


## :v: What does this PR do?
Displays validation error messages when custom_sessions_controller can't create a user

## :mag: How should this be manually tested?

Register with a custom auth provider. An email already taken or blank should generate a validation error alert

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
