### PR TITLE
505 custom census integration

### DIFF
--- a/app/models/user/verification/census_verification.rb
+++ b/app/models/user/verification/census_verification.rb
@@ -1,8 +1,14 @@
 class User::Verification::CensusVerification < User::Verification
   default_scope -> { where(verification_type: "census") }
 
+  attr_writer :census_repository_class, :custom_params
+
   def verification_type
     "census"
+  end
+
+  def census_repository_class
+    @census_repository_class ||= CensusRepository
   end
 
   def document_number
@@ -37,13 +43,19 @@ class User::Verification::CensusVerification < User::Verification
     end
   end
 
+  def custom_params
+    @custom_params ||= {}
+  end
+
   private
 
   def census_repository
-    @census_repository ||= CensusRepository.new(
-      site_id: site_id,
-      document_number: document_number,
-      date_of_birth: date_of_birth
+    @census_repository ||= census_repository_class.new(
+      custom_params.merge(
+        site_id: site_id,
+        document_number: document_number,
+        date_of_birth: date_of_birth
+      )
     )
   end
 end

--- a/app/models/user/verification/id_number.rb
+++ b/app/models/user/verification/id_number.rb
@@ -16,6 +16,14 @@ class User::Verification::IdNumber < User::Verification
     valid? if encryption_key.present?
   end
 
+  def document_type=(document_type)
+    verification_data["document_type"] = document_type
+  end
+
+  def document_type
+    verification_data["document_type"]
+  end
+
   def encryption_key
     verification_data['encryption_key']
   end


### PR DESCRIPTION
Related with https://github.com/PopulateTools/issues/issues/505

## :v: What does this PR do?

* Adds a document_type parameter to `User::Verification::IdNumber` to be stored in verification_data. This can be required for further validations
* Allows `User::Verification::CensusVerification` to create instances with a custom census repository class and custom arguments to call it.

## :mag: How should this be manually tested?

It's expected to be used from a custom auth provider

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
