### PR TITLE
505 custom census integration

### DIFF
--- a/app/controllers/user/census_verifications_controller.rb
+++ b/app/controllers/user/census_verifications_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User::CensusVerificationsController < User::BaseController
   before_action :authenticate_user!
   before_action(only: [:new, :create]) { require_not_verified_user_in(current_site) }
@@ -29,11 +31,11 @@ class User::CensusVerificationsController < User::BaseController
 
     if @user_verification_form.save && @user_verification_form.user.census_verified?
       redirect_to(
-        @user_verification_form.referrer_url.present? ?  @user_verification_form.referrer_url : user_settings_path,
-        notice: t('.notice')
+        @user_verification_form.referrer_url.present? ? @user_verification_form.referrer_url : user_settings_path,
+        notice: t(".notice")
       )
     else
-      flash.now[:alert] = t('.error')
+      flash.now[:alert] = t(".error")
       render :new
     end
   end

--- a/app/controllers/user/census_verifications_controller.rb
+++ b/app/controllers/user/census_verifications_controller.rb
@@ -3,7 +3,7 @@ class User::CensusVerificationsController < User::BaseController
   before_action(only: [:new, :create]) { require_not_verified_user_in(current_site) }
 
   def new
-    @user_verification_form = User::CensusVerificationForm.new(
+    @user_verification_form = census_verification_form_class.new(
       site_id: current_site.id, referrer_url: request.referrer,
       date_of_birth_year: current_user.date_of_birth.year,
       date_of_birth_month: current_user.date_of_birth.month,
@@ -16,7 +16,7 @@ class User::CensusVerificationsController < User::BaseController
   end
 
   def create
-    @user_verification_form = User::CensusVerificationForm.new(
+    @user_verification_form = census_verification_form_class.new(
       user_verification_params.except(*ignored_user_verification_params).merge(
         date_of_birth_year: user_verification_params["date_of_birth(1i)"],
         date_of_birth_month: user_verification_params["date_of_birth(2i)"],
@@ -46,5 +46,17 @@ class User::CensusVerificationsController < User::BaseController
 
   def ignored_user_verification_params
     ["date_of_birth(1i)", "date_of_birth(2i)", "date_of_birth(3i)"]
+  end
+
+  def census_verification_form_class
+    @census_verification_form_class ||= custom_census_verification_form_class.presence || User::CensusVerificationForm
+  end
+
+  def custom_census_verification_form_class
+    return unless auth_modules_present?
+
+    if (name = current_site.configuration.auth_modules_data.map(&:census_verification_form).compact.first).present?
+      User.const_get(name)
+    end
   end
 end

--- a/app/models/user/verification/census_verification.rb
+++ b/app/models/user/verification/census_verification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User::Verification::CensusVerification < User::Verification
   default_scope -> { where(verification_type: "census") }
 

--- a/app/models/user/verification/id_number.rb
+++ b/app/models/user/verification/id_number.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_dependency 'asymmetric_encryptor'
+require_dependency "asymmetric_encryptor"
 
 class User::Verification::IdNumber < User::Verification
   before_save :encrypt_id_number
 
   validate :encryption_values_must_be_present
 
-  attr_accessor :id_number
+  attr_reader :id_number
 
-  default_scope -> { where(verification_type: 'id_number') }
+  default_scope -> { where(verification_type: "id_number") }
 
   def id_number=(id_number)
     @id_number = id_number
@@ -25,20 +25,20 @@ class User::Verification::IdNumber < User::Verification
   end
 
   def encryption_key
-    verification_data['encryption_key']
+    verification_data["encryption_key"]
   end
 
   def encryption_key=(encryption_key)
-    verification_data['encryption_key'] = encryption_key
+    verification_data["encryption_key"] = encryption_key
     valid? if id_number.present?
   end
 
   def encrypted_id_number
-    verification_data['encrypted_id_number'] ||= encrypt_id_number
+    verification_data["encrypted_id_number"] ||= encrypt_id_number
   end
 
   def encrypted_id_number=(encrypted_id_number)
-    verification_data['encrypted_id_number'] = encrypted_id_number
+    verification_data["encrypted_id_number"] = encrypted_id_number
   end
 
   def encryption_values_must_be_present


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/505


## :v: What does this PR do?


## :mag: How should this be manually tested?

Enable an auth provider with a custom census verification form implemented.

To enable it, if the custom census verification form is named `CustomCensusVerificationForm` in `config/application.yml` at the auth_module corresponding section add:
```
      census_verification_form: CustomCensusVerificationForm
```

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [x] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Updated in wiki
