### PR TITLE
Allows to configure staging and production cache with memcache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,8 +53,9 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:host, :request_id]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  if ENV["GOBIERTO_CACHE_TYPE"] == "mem_cache_store"
+    config.cache_store = :mem_cache_store, ENV["GOBIERTO_CACHE_MEMCACHE_HOST"]
+  end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -52,8 +52,9 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:host, :request_id]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  if ENV["GOBIERTO_CACHE_TYPE"] == "mem_cache_store"
+    config.cache_store = :mem_cache_store, ENV["GOBIERTO_CACHE_MEMCACHE_HOST"]
+  end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
## :v: What does this PR do?

This PR allows to parameterize staging and production cache storages to use memcache with custom hosts. All the configuration is provided using env variables.

## :mag: How should this be manually tested?

With the variables set, check the cache storage is Memcached.

## :eyes: Screenshots

No

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

Yes, changes introduced in the Server deployment and the environment vars sections.