### PR TITLE
Participation queries refactor

### DIFF
--- a/app/controllers/gobierto_participation/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/attachments_controller.rb
@@ -15,7 +15,7 @@ module GobiertoParticipation
       if @filtered_issue
         @issue.attachments
       else
-        ::GobiertoAttachments::Attachment.in_collections_and_container_type(current_site, "GobiertoParticipation")
+        ProcessCollectionDecorator.new(current_site.attachments).in_participation_module
       end
     end
   end

--- a/app/controllers/gobierto_participation/events_controller.rb
+++ b/app/controllers/gobierto_participation/events_controller.rb
@@ -43,7 +43,7 @@ module GobiertoParticipation
     end
 
     def container_events
-      @container_events = GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published
+      @container_events = ProcessCollectionDecorator.new(current_site.events).in_participation_module.published
     end
 
     def participation_events_scope

--- a/app/controllers/gobierto_participation/filtered_events_controller.rb
+++ b/app/controllers/gobierto_participation/filtered_events_controller.rb
@@ -31,9 +31,9 @@ module GobiertoParticipation
 
     def base_relation
       @base_relation ||= if valid_preview_token?
-                           GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation")
+                           ProcessCollectionDecorator.new(current_site.events).in_participation_module
                          else
-                           GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published
+                           ProcessCollectionDecorator.new(current_site.events).in_participation_module.published
                          end
     end
 

--- a/app/controllers/gobierto_participation/news_controller.rb
+++ b/app/controllers/gobierto_participation/news_controller.rb
@@ -29,7 +29,7 @@ module GobiertoParticipation
       elsif @scope
         @scope.news
       else
-        ::GobiertoCms::Page.news_in_collections_and_container_type(current_site, "GobiertoParticipation")
+        ProcessCollectionDecorator.new(current_site.pages, item_type: "GobiertoCms::News").in_participation_module.active
       end
     end
   end

--- a/app/controllers/gobierto_participation/processes/attachments_controller.rb
+++ b/app/controllers/gobierto_participation/processes/attachments_controller.rb
@@ -10,7 +10,7 @@ module GobiertoParticipation
         @filtered_issue = find_issue if params[:issue_id]
         @issue = find_issue if params[:issue_id]
         @attachments = if @issue
-                         @issue.attachments.in_collections_and_container(current_site, current_process).page(params[:page])
+                         @issue.attachments.in_process(current_process).page(params[:page])
                        else
                          find_process_attachments
                        end
@@ -19,7 +19,7 @@ module GobiertoParticipation
       private
 
       def find_process_attachments
-        ::GobiertoAttachments::Attachment.in_collections_and_container(current_site, current_process).page(params[:page])
+        current_process.attachments.page(params[:page])
       end
     end
   end

--- a/app/controllers/gobierto_participation/processes/events_controller.rb
+++ b/app/controllers/gobierto_participation/processes/events_controller.rb
@@ -28,15 +28,9 @@ module GobiertoParticipation
 
       def process_events_scope
         if valid_preview_token?
-          ::GobiertoCalendars::Event.in_collections_and_container(
-            current_site,
-            current_process
-          ).sorted
+          current_process.events.sorted
         else
-          ::GobiertoCalendars::Event.in_collections_and_container(
-            current_site,
-            current_process
-          ).published.sorted
+          current_process.events.sorted.published
         end
       end
 
@@ -46,7 +40,7 @@ module GobiertoParticipation
 
       def set_events
         @events = process_events_scope
-        @events = ProcessCollectionDecorator.new(@events).with_issue(@issue).published if @issue
+        @events = @events.with_term(@issue) if @issue
 
         @events = if params[:date]
                     filter_events_by_date(params[:date]).published

--- a/app/controllers/gobierto_participation/processes_controller.rb
+++ b/app/controllers/gobierto_participation/processes_controller.rb
@@ -22,11 +22,11 @@ module GobiertoParticipation
     private
 
     def find_process_news
-      current_process.news.sort_by(&:created_at).reverse.first(5)
+      current_process.news.sort_by_published_on.first(5)
     end
 
     def find_process_events
-      ::GobiertoCalendars::Event.in_collections_and_container(current_site, current_process).first(5)
+      current_process.events.published.first(5)
     end
 
     def current_process

--- a/app/controllers/gobierto_participation/welcome_controller.rb
+++ b/app/controllers/gobierto_participation/welcome_controller.rb
@@ -19,11 +19,11 @@ module GobiertoParticipation
     private
 
     def find_participation_events
-      ::GobiertoCalendars::Event.in_collections_and_container_type(current_site, "GobiertoParticipation").published.sorted.upcoming.limit(4)
+      ProcessCollectionDecorator.new(current_site.events).in_participation_module.published.sorted.upcoming.limit(4)
     end
 
     def find_participation_news
-      ::GobiertoCms::Page.news_in_collections_and_container_type(current_site, "GobiertoParticipation").active.sorted.limit(5)
+      ProcessCollectionDecorator.new(current_site.pages, item_type: "GobiertoCms::News").in_participation_module.active.sorted.limit(5)
     end
 
     def find_participation_activities

--- a/app/decorators/gobierto_attachments/attachment_decorator.rb
+++ b/app/decorators/gobierto_attachments/attachment_decorator.rb
@@ -17,7 +17,7 @@ module GobiertoAttachments
 
     def initialize(attachment, context = nil, item_type = nil)
       @object = attachment
-      @context = context || attachment.collection.try(:container_type)
+      @context = context || attachment.collection.try(:container) ? attachment.collection.container_type : nil
       @item_type = item_type || attachment.collection.try(:item_type) || 'attachment'
       @layout_configuration ||= OpenStruct.new(CONTEXT_CONFIGURATION[@context] || CONTEXT_CONFIGURATION[:default])
     end

--- a/app/decorators/gobierto_participation/process_term_decorator.rb
+++ b/app/decorators/gobierto_participation/process_term_decorator.rb
@@ -35,15 +35,15 @@ module GobiertoParticipation
     end
 
     def events
-      ProcessCollectionDecorator.new(::GobiertoCalendars::Event).send("with_#{ association_with_processes }", object)
+      ProcessCollectionDecorator.new(::GobiertoCalendars::Event).with_term(object)
     end
 
     def attachments
-      ProcessCollectionDecorator.new(::GobiertoAttachments::Attachment).send("with_#{ association_with_processes }", object)
+      ProcessCollectionDecorator.new(::GobiertoAttachments::Attachment).with_term(object)
     end
 
     def news
-      ProcessCollectionDecorator.new(::GobiertoCms::Page, item_type: "GobiertoCms::News").send("with_#{ association_with_processes }", object)
+      ProcessCollectionDecorator.new(::GobiertoCms::Page, item_type: "GobiertoCms::News").with_term(object)
     end
 
     def processes

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -152,7 +152,7 @@ module GobiertoParticipation
       end
 
       # News
-      news_collection =  site.collections.find_by(container: self, item_type: "GobiertoCms::News")
+      news_collection = site.collections.find_by(container: self, item_type: "GobiertoCms::News")
       if news_collection
         site.pages.where(collection: news_collection).destroy_all
         news_collection.destroy

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -65,6 +65,18 @@ module GobiertoParticipation
       find_collection_of_items("GobiertoAttachments::Attachment")
     end
 
+    def events
+      ProcessCollectionDecorator.new(site.events).in_process(self)
+    end
+
+    def attachments
+      ProcessCollectionDecorator.new(site.attachments).in_process(self)
+    end
+
+    def news
+      ProcessCollectionDecorator.new(site.pages, item_type: "GobiertoCms::News").in_process(self)
+    end
+
     def current_stage
       published_stages.find_by(active: true)
     end

--- a/app/models/gobierto_participation/process.rb
+++ b/app/models/gobierto_participation/process.rb
@@ -41,6 +41,7 @@ module GobiertoParticipation
     scope :sorted, -> { order(id: :desc) }
 
     after_create :create_collections
+    after_destroy :delete_collections
     after_restore :set_slug
 
     alias public? active?
@@ -133,6 +134,29 @@ module GobiertoParticipation
       site.collections.create! container: self, item_type: "GobiertoAttachments::Attachment", slug: "attachment-#{slug}", title: title
       # News
       site.collections.create! container: self, item_type: "GobiertoCms::News", slug: "news-#{slug}", title: title
+    end
+
+    def delete_collections
+      # Events
+      events_collection = site.collections.find_by(container: self, item_type: "GobiertoCalendars::Event")
+      if events_collection
+        site.events.where(collection: events_collection).destroy_all
+        events_collection.destroy
+      end
+
+      # Attachments
+      attachments_collection = site.collections.find_by(container: self, item_type: "GobiertoAttachments::Attachment")
+      if attachments_collection
+        site.attachments.where(collection: attachments_collection).destroy_all
+        attachments_collection.destroy
+      end
+
+      # News
+      news_collection =  site.collections.find_by(container: self, item_type: "GobiertoCms::News")
+      if news_collection
+        site.pages.where(collection: news_collection).destroy_all
+        news_collection.destroy
+      end
     end
 
     def attributes_for_slug

--- a/test/decorators/gobierto_participation/process_collection_decorator_test.rb
+++ b/test/decorators/gobierto_participation/process_collection_decorator_test.rb
@@ -95,7 +95,6 @@ module GobiertoParticipation
         refute_includes news_decorator.in_participation_module, resource
         assert_includes news_decorator.in_participation_module(with_archived: true), resource
       end
-
     end
 
     def test_resources_of_draft_process

--- a/test/decorators/gobierto_participation/process_collection_decorator_test.rb
+++ b/test/decorators/gobierto_participation/process_collection_decorator_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoParticipation
+  class ProcessCollectionDecoratorTest < ActiveSupport::TestCase
+
+    def site
+      sites(:madrid)
+    end
+
+    def participation_process
+      @participation_process = gobierto_participation_processes :gender_violence_process
+    end
+
+    def participation_group
+      @participation_group = gobierto_participation_processes :bowling_group_very_active
+    end
+
+    def issue
+      @issue ||= gobierto_common_terms(:women_term)
+    end
+
+    def scope
+      @scope ||= gobierto_common_terms(:old_town_term)
+    end
+
+    def participation_events
+      site.events.joins(:collection).where(collections: { container_type: ["GobiertoParticipation", "GobiertoParticipation::Process"] })
+    end
+
+    def participation_pages
+      site.pages.joins(:collection).where(collections: { container_type: ["GobiertoParticipation", "GobiertoParticipation::Process"] })
+    end
+
+    def participation_news
+      site.pages.joins(:collection).where(collections: { container_type: ["GobiertoParticipation", "GobiertoParticipation::Process"], item_type: "GobiertoCms::News" })
+    end
+
+    def participation_attachments
+      site.attachments.joins(:collection).where(collections: { container_type: ["GobiertoParticipation", "GobiertoParticipation::Process"] })
+    end
+
+    def events_decorator
+      ProcessCollectionDecorator.new(site.events)
+    end
+
+    def attachments_decorator
+      ProcessCollectionDecorator.new(site.attachments)
+    end
+
+    def news_decorator
+      ProcessCollectionDecorator.new(site.pages, item_type: "GobiertoCms::News")
+    end
+
+    def test_events_in_participation_module
+      participation_events.each do |event|
+        assert_includes events_decorator.in_participation_module, event
+      end
+    end
+
+    def test_resources_of_deleted_process
+      participation_process.destroy
+
+      participation_events.where(collections: { container: participation_process }).each do |resource|
+        refute_includes events_decorator.in_participation_module, resource
+        assert_includes events_decorator.in_participation_module(with_archived: true), resource
+      end
+
+      participation_attachments.where(collections: { container: participation_process }).each do |resource|
+        refute_includes attachments_decorator.in_participation_module, resource
+        assert_includes attachments_decorator.in_participation_module(with_archived: true), resource
+      end
+
+      participation_news.where(collections: { container: participation_process }).each do |resource|
+        refute_includes news_decorator.in_participation_module, resource
+        assert_includes news_decorator.in_participation_module(with_archived: true), resource
+      end
+    end
+
+    def test_resources_of_draft_process
+      participation_process.draft!
+
+      participation_events.where(collections: { container: participation_process }).each do |resource|
+        refute_includes events_decorator.in_participation_module, resource
+        assert_includes events_decorator.in_participation_module(with_draft: true), resource
+      end
+
+      participation_attachments.where(collections: { container: participation_process }).each do |resource|
+        refute_includes attachments_decorator.in_participation_module, resource
+        assert_includes attachments_decorator.in_participation_module(with_draft: true), resource
+      end
+
+      participation_news.where(collections: { container: participation_process }).each do |resource|
+        refute_includes news_decorator.in_participation_module, resource
+        assert_includes news_decorator.in_participation_module(with_draft: true), resource
+      end
+    end
+
+    def test_resources_with_term
+      participation_events.where(collections: { container: participation_process }).each do |resource|
+        assert_includes events_decorator.with_term(issue), resource
+        assert_includes events_decorator.with_term(scope), resource
+      end
+
+      participation_process.update_attributes(scope_id: nil, issue_id: nil)
+
+      participation_events.where(collections: { container: participation_process }).each do |resource|
+        refute_includes events_decorator.with_term(issue), resource
+        refute_includes events_decorator.with_term(scope), resource
+      end
+    end
+
+    def test_in_process
+      assert_equal events_decorator.in_process(participation_process), participation_events.where(collections: { container: participation_process })
+      assert_equal attachments_decorator.in_process(participation_process), participation_attachments.where(collections: { container: participation_process })
+      assert_equal news_decorator.in_process(participation_process), participation_news.where(collections: { container: participation_process })
+    end
+  end
+end

--- a/test/decorators/gobierto_participation/process_collection_decorator_test.rb
+++ b/test/decorators/gobierto_participation/process_collection_decorator_test.rb
@@ -78,6 +78,26 @@ module GobiertoParticipation
       end
     end
 
+    def test_resource_of_deleted_process_without_callbacks
+      participation_process.update_column(:archived_at, 1.hour.ago)
+
+      participation_events.where(collections: { container: participation_process }).each do |resource|
+        refute_includes events_decorator.in_participation_module, resource
+        assert_includes events_decorator.in_participation_module(with_archived: true), resource
+      end
+
+      participation_attachments.where(collections: { container: participation_process }).each do |resource|
+        refute_includes attachments_decorator.in_participation_module, resource
+        assert_includes attachments_decorator.in_participation_module(with_archived: true), resource
+      end
+
+      participation_news.where(collections: { container: participation_process }).each do |resource|
+        refute_includes news_decorator.in_participation_module, resource
+        assert_includes news_decorator.in_participation_module(with_archived: true), resource
+      end
+
+    end
+
     def test_resources_of_draft_process
       participation_process.draft!
 

--- a/test/fixtures/gobierto_attachments/attachments.yml
+++ b/test/fixtures/gobierto_attachments/attachments.yml
@@ -94,7 +94,7 @@ xlsx_attachment_event:
   slug: xlsx-attachment-event-slug
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
-  collection: site_attachments
+  collection: gender_violence_process_documents
 
 attachment:
   name: Attachment Name

--- a/test/integration/gobierto_participation/participation_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/participation_attachments_index_test.rb
@@ -17,7 +17,7 @@ module GobiertoParticipation
     end
 
     def participation_attachments
-      @participation_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container_type(site, "GobiertoParticipation")
+      @participation_attachments ||= GobiertoParticipation::ProcessCollectionDecorator.new(site.attachments).in_participation_module
     end
 
     def test_secondary_nav
@@ -44,6 +44,7 @@ module GobiertoParticipation
         assert has_link? "PDF Collection On Participation"
         assert has_link? "XLSX Attachment Event"
         assert has_link? "PDF Collection Attachment Name"
+        assert has_link? "PDF Collection On Process"
       end
     end
   end

--- a/test/integration/gobierto_participation/participation_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/participation_attachments_index_test.rb
@@ -20,6 +20,10 @@ module GobiertoParticipation
       @participation_attachments ||= GobiertoParticipation::ProcessCollectionDecorator.new(site.attachments).in_participation_module
     end
 
+    def participation_process
+      @participation_process ||= gobierto_participation_processes :bowling_group_very_active
+    end
+
     def test_secondary_nav
       with_current_site(site) do
         visit participation_attachments_path
@@ -45,6 +49,40 @@ module GobiertoParticipation
         assert has_link? "XLSX Attachment Event"
         assert has_link? "PDF Collection Attachment Name"
         assert has_link? "PDF Collection On Process"
+      end
+    end
+
+    def test_participation_process_draft
+      participation_process.draft!
+
+      with_current_site(site) do
+        visit participation_attachments_path
+
+        assert_equal participation_attachments.size, all(".news_teaser").size
+
+        assert has_no_content? "See all documents"
+
+        assert has_link? "PDF Collection On Participation"
+        assert has_link? "XLSX Attachment Event"
+        assert has_link? "PDF Collection Attachment Name"
+        assert has_no_content? "PDF Collection On Process"
+      end
+    end
+
+    def test_participation_process_archived
+      participation_process.destroy
+
+      with_current_site(site) do
+        visit participation_attachments_path
+
+        assert_equal participation_attachments.size, all(".news_teaser").size
+
+        assert has_no_content? "See all documents"
+
+        assert has_link? "PDF Collection On Participation"
+        assert has_link? "XLSX Attachment Event"
+        assert has_link? "PDF Collection Attachment Name"
+        assert has_no_content? "PDF Collection On Process"
       end
     end
   end

--- a/test/integration/gobierto_participation/participation_events_index_test.rb
+++ b/test/integration/gobierto_participation/participation_events_index_test.rb
@@ -20,6 +20,10 @@ module GobiertoParticipation
       @participation_current_events ||= ProcessCollectionDecorator.new(site.events).in_participation_module.published.upcoming
     end
 
+    def participation_process
+      @participation_process ||= gobierto_participation_processes :gender_violence_process
+    end
+
     def participation_past_events
       @participation_past_events ||= ProcessCollectionDecorator.new(site.events).in_participation_module.published.past
     end
@@ -76,6 +80,26 @@ module GobiertoParticipation
         assert has_link? "Intensive reading club in english"
         assert has_link? "View all events"
         assert has_link? "View past events"
+      end
+    end
+
+    def test_participation_process_draft
+      participation_process.draft!
+
+      with_current_site(site) do
+        visit participation_events_path
+
+        assert has_no_content? "Swimming lessons for elders"
+      end
+    end
+
+    def test_participation_process_archived
+      participation_process.destroy
+
+      with_current_site(site) do
+        visit participation_events_path
+
+        assert has_no_content? "Swimming lessons for elders"
       end
     end
   end

--- a/test/integration/gobierto_participation/participation_events_index_test.rb
+++ b/test/integration/gobierto_participation/participation_events_index_test.rb
@@ -17,11 +17,11 @@ module GobiertoParticipation
     end
 
     def participation_current_events
-      @participation_current_events ||= ::GobiertoCalendars::Event.in_collections_and_container_type(site, "GobiertoParticipation").published.upcoming
+      @participation_current_events ||= ProcessCollectionDecorator.new(site.events).in_participation_module.published.upcoming
     end
 
     def participation_past_events
-      @participation_past_events ||= ::GobiertoCalendars::Event.in_collections_and_container_type(site, "GobiertoParticipation").published.past
+      @participation_past_events ||= ProcessCollectionDecorator.new(site.events).in_participation_module.published.past
     end
 
     def test_secondary_nav

--- a/test/integration/gobierto_participation/processes/process_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/processes/process_attachments_index_test.rb
@@ -23,7 +23,7 @@ module GobiertoParticipation
     end
 
     def process_attachments
-      @process_attachments ||= ::GobiertoAttachments::Attachment.in_collections_and_container(site, process)
+      @process_attachments ||= process.attachments
     end
 
     def test_breadcrumb_items


### PR DESCRIPTION
Closes #1973


## :v: What does this PR do?

* Refactors `ProcessCollectionDecorator` to use `collections` instead of `collection_items` in the query. In this way, events, attachments and news can be hidden from the main controller if they belongs to a process deleted or in draft status
* Adds a callback to remove collections and archive their belonging resources when a process is archived
* Avoids errors trying to show an attachment belonging to a not available container

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR
![1973_before](https://user-images.githubusercontent.com/446459/49344076-ff9d3e80-f672-11e8-90d0-ac993251e8ae.gif)

### After this PR
![1973_after](https://user-images.githubusercontent.com/446459/49344082-1774c280-f673-11e8-812b-2b0e839d21c9.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
