### PR TITLE
Fix charters tests namespaces

### DIFF
--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/delete_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/delete_charter_test.rb
@@ -2,52 +2,54 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class DeleteCharterTest < ActionDispatch::IntegrationTest
-      def setup
-        super
-        @path = admin_citizens_charters_charters_path
-      end
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Charters
+      class DeleteCharterTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_charters_path
+        end
 
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
 
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
 
-      def site
-        @site ||= sites(:madrid)
-      end
+        def site
+          @site ||= sites(:madrid)
+        end
 
-      def charter
-        @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
-      end
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+        end
 
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
           end
         end
-      end
 
-      def test_delete_charter
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        def test_delete_charter
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            within "#charter-item-#{charter.id}" do
-              find("a[data-method='delete']").click
+              within "#charter-item-#{charter.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("The charter has been correctly archived")
+
+              refute site.charters.exists?(id: charter.id)
             end
-
-            assert has_message?("The charter has been correctly archived")
-
-            refute site.charters.exists?(id: charter.id)
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/update_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/update_charter_test.rb
@@ -2,75 +2,45 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class UpdateServiceTest < ActionDispatch::IntegrationTest
-      def setup
-        super
-        @path = edit_admin_citizens_charters_charter_path(charter)
-      end
-
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
-
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
-
-      def site
-        @site ||= sites(:madrid)
-      end
-
-      def charter
-        @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
-      end
-
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
-          end
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Charters
+      class UpdateCharterTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = edit_admin_citizens_charters_charter_path(charter)
         end
-      end
 
-      def test_update_charter
-        with_javascript do
-          with_signed_in_admin(admin) do
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
             with_current_site(site) do
               visit @path
-
-              fill_in "charter_title_translations_en", with: "Teleassistance charter updated"
-              select "Day care service", from: "charter_service_id"
-
-              click_button "Update"
-
-              assert has_message?("The charter has been correctly updated.")
-
-              visit @path
-
-              assert has_field? "charter_title_translations_en", with: "Teleassistance charter updated"
-              assert has_select? "charter_service_id", with_selected: "Day care service"
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
             end
           end
         end
 
-        activity = Activity.last
-        assert_equal charter, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.charter.updated", activity.action
-      end
-
-      def test_update_draft_charter
-        charter.update_attribute(:visibility_level, :draft)
-
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              assert_no_difference "Activity.count" do
+        def test_update_charter
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
                 visit @path
 
                 fill_in "charter_title_translations_en", with: "Teleassistance charter updated"
@@ -87,54 +57,86 @@ module GobiertoCitizensCharters
               end
             end
           end
+
+          activity = Activity.last
+          assert_equal charter, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.charter.updated", activity.action
         end
-      end
 
-      def test_publish_draft_charter
-        charter.update_attribute(:visibility_level, :draft)
+        def test_update_draft_charter
+          charter.update_attribute(:visibility_level, :draft)
 
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                assert_no_difference "Activity.count" do
+                  visit @path
 
-              within ".widget_save" do
-                find("label", text: "Published").click
+                  fill_in "charter_title_translations_en", with: "Teleassistance charter updated"
+                  select "Day care service", from: "charter_service_id"
+
+                  click_button "Update"
+
+                  assert has_message?("The charter has been correctly updated.")
+
+                  visit @path
+
+                  assert has_field? "charter_title_translations_en", with: "Teleassistance charter updated"
+                  assert has_select? "charter_service_id", with_selected: "Day care service"
+                end
               end
-
-              click_button "Update"
-
-              assert has_message?("The charter has been correctly updated.")
-
-              visit @path
-
-              assert has_field? "charter_title_translations_en", with: charter.title_en
-              click_link "ES"
-              assert has_field? "charter_title_translations_es", with: charter.title_es
             end
           end
         end
 
-        activity = Activity.last
-        assert_equal charter, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.charter.published", activity.action
-      end
+        def test_publish_draft_charter
+          charter.update_attribute(:visibility_level, :draft)
 
-      def test_update_charter_error
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
 
-              fill_in "charter_title_translations_en", with: ""
-              click_link "ES"
-              fill_in "charter_title_translations_es", with: ""
+                within ".widget_save" do
+                  find("label", text: "Published").click
+                end
 
-              click_button "Update"
+                click_button "Update"
 
-              assert has_alert?("can't be blank")
+                assert has_message?("The charter has been correctly updated.")
+
+                visit @path
+
+                assert has_field? "charter_title_translations_en", with: charter.title_en
+                click_link "ES"
+                assert has_field? "charter_title_translations_es", with: charter.title_es
+              end
+            end
+          end
+
+          activity = Activity.last
+          assert_equal charter, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.charter.published", activity.action
+        end
+
+        def test_update_charter_error
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                fill_in "charter_title_translations_en", with: ""
+                click_link "ES"
+                fill_in "charter_title_translations_es", with: ""
+
+                click_button "Update"
+
+                assert has_alert?("can't be blank")
+              end
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
@@ -2,65 +2,66 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class DeleteCommitmentTest < ActionDispatch::IntegrationTest
-
-      def setup
-        super
-        @path = admin_citizens_charters_charter_commitments_path(charter)
-      end
-
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
-
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
-
-      def site
-        @site ||= sites(:madrid)
-      end
-
-      def charter
-        @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
-      end
-
-      def commitment
-        @commitment ||= gobierto_citizens_charters_commitments(:devices_operation)
-      end
-
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
-          end
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Commitments
+      class DeleteCommitmentTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_charter_commitments_path(charter)
         end
-      end
 
-      def test_delete_commitment
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
 
-            within "#commitment-item-#{commitment.id}" do
-              find("a[data-method='delete']").click
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+        end
+
+        def commitment
+          @commitment ||= gobierto_citizens_charters_commitments(:devices_operation)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
             end
-
-            assert has_message?("The commitment has been correctly deleted")
-
-            refute site.commitments.exists?(id: commitment.id)
           end
         end
 
-        activity = Activity.last
-        assert_equal charter, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.charter.commitment_archived", activity.action
+        def test_delete_commitment
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "#commitment-item-#{commitment.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("The commitment has been correctly deleted")
+
+              refute site.commitments.exists?(id: commitment.id)
+            end
+          end
+
+          activity = Activity.last
+          assert_equal charter, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.charter.commitment_archived", activity.action
+        end
       end
     end
   end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
@@ -2,89 +2,55 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class UpdateServiceTest < ActionDispatch::IntegrationTest
-      def setup
-        super
-        @path = edit_admin_citizens_charters_charter_commitment_path(charter, commitment)
-        @draft_commitment_path = edit_admin_citizens_charters_charter_commitment_path(charter, draft_commitment)
-      end
-
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
-
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
-
-      def site
-        @site ||= sites(:madrid)
-      end
-
-      def charter
-        @charter ||= gobierto_citizens_charters_charters(:day_care_service_charter)
-      end
-
-      def commitment
-        @commitment ||= gobierto_citizens_charters_commitments(:average_response_time)
-      end
-
-      def draft_commitment
-        @draft_commitment ||= gobierto_citizens_charters_commitments(:draft_service_schedule)
-      end
-
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
-          end
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Commitments
+      class UpdateServiceTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = edit_admin_citizens_charters_charter_commitment_path(charter, commitment)
+          @draft_commitment_path = edit_admin_citizens_charters_charter_commitment_path(charter, draft_commitment)
         end
-      end
 
-      def test_update_commitment
-        with_javascript do
-          with_signed_in_admin(admin) do
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:day_care_service_charter)
+        end
+
+        def commitment
+          @commitment ||= gobierto_citizens_charters_commitments(:average_response_time)
+        end
+
+        def draft_commitment
+          @draft_commitment ||= gobierto_citizens_charters_commitments(:draft_service_schedule)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
             with_current_site(site) do
               visit @path
-
-              fill_in "commitment_title_translations_en", with: "Commitment updated"
-              fill_in "commitment_description_translations_en", with: "Commitment updated description"
-              click_link "ES"
-              fill_in "commitment_title_translations_es", with: "Compromiso actualizado"
-              fill_in "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
-
-              click_button "Update"
-
-              assert has_message?("The commitment has been correctly updated.")
-
-              visit @path
-
-              assert has_field? "commitment_title_translations_en", with: "Commitment updated"
-              assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
-              click_link "ES"
-              assert has_field? "commitment_title_translations_es", with: "Compromiso actualizado"
-              assert has_field? "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
             end
           end
         end
 
-        activity = Activity.last
-        assert_equal charter, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.charter.commitment_updated", activity.action
-      end
-
-      def test_update_draft_commitment
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              assert_no_difference "Activity.count" do
-                visit @draft_commitment_path
+        def test_update_commitment
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
 
                 fill_in "commitment_title_translations_en", with: "Commitment updated"
                 fill_in "commitment_description_translations_en", with: "Commitment updated description"
@@ -96,7 +62,7 @@ module GobiertoCitizensCharters
 
                 assert has_message?("The commitment has been correctly updated.")
 
-                visit @draft_commitment_path
+                visit @path
 
                 assert has_field? "commitment_title_translations_en", with: "Commitment updated"
                 assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
@@ -106,56 +72,92 @@ module GobiertoCitizensCharters
               end
             end
           end
+
+          activity = Activity.last
+          assert_equal charter, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.charter.commitment_updated", activity.action
         end
-      end
 
-      def test_publish_draft_commitment
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @draft_commitment_path
+        def test_update_draft_commitment
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                assert_no_difference "Activity.count" do
+                  visit @draft_commitment_path
 
-              within ".widget_save" do
-                find("label", text: "Published").click
+                  fill_in "commitment_title_translations_en", with: "Commitment updated"
+                  fill_in "commitment_description_translations_en", with: "Commitment updated description"
+                  click_link "ES"
+                  fill_in "commitment_title_translations_es", with: "Compromiso actualizado"
+                  fill_in "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+
+                  click_button "Update"
+
+                  assert has_message?("The commitment has been correctly updated.")
+
+                  visit @draft_commitment_path
+
+                  assert has_field? "commitment_title_translations_en", with: "Commitment updated"
+                  assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
+                  click_link "ES"
+                  assert has_field? "commitment_title_translations_es", with: "Compromiso actualizado"
+                  assert has_field? "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
+                end
               end
-
-              click_button "Update"
-
-              assert has_message?("The commitment has been correctly updated.")
-
-              visit @draft_commitment_path
-
-              assert has_field? "commitment_title_translations_en", with: draft_commitment.title_en
-              assert has_field? "commitment_description_translations_en", with: draft_commitment.description_en
-              click_link "ES"
-              assert has_field? "commitment_title_translations_es", with: draft_commitment.title_es
-              assert has_field? "commitment_description_translations_es", with: draft_commitment.description_es
             end
           end
         end
 
-        activity = Activity.last
-        assert_equal charter, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.charter.commitment_published", activity.action
-      end
+        def test_publish_draft_commitment
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @draft_commitment_path
 
-      def test_update_commitment_error
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+                within ".widget_save" do
+                  find("label", text: "Published").click
+                end
 
-              fill_in "commitment_title_translations_en", with: ""
-              fill_in "commitment_description_translations_en", with: ""
-              click_link "ES"
-              fill_in "commitment_title_translations_es", with: ""
-              fill_in "commitment_description_translations_es", with: ""
+                click_button "Update"
 
-              click_button "Update"
+                assert has_message?("The commitment has been correctly updated.")
 
-              assert has_alert?("can't be blank")
+                visit @draft_commitment_path
+
+                assert has_field? "commitment_title_translations_en", with: draft_commitment.title_en
+                assert has_field? "commitment_description_translations_en", with: draft_commitment.description_en
+                click_link "ES"
+                assert has_field? "commitment_title_translations_es", with: draft_commitment.title_es
+                assert has_field? "commitment_description_translations_es", with: draft_commitment.description_es
+              end
+            end
+          end
+
+          activity = Activity.last
+          assert_equal charter, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.charter.commitment_published", activity.action
+        end
+
+        def test_update_commitment_error
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                fill_in "commitment_title_translations_en", with: ""
+                fill_in "commitment_description_translations_en", with: ""
+                click_link "ES"
+                fill_in "commitment_title_translations_es", with: ""
+                fill_in "commitment_description_translations_es", with: ""
+
+                click_button "Update"
+
+                assert has_alert?("can't be blank")
+              end
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/delete_service_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/delete_service_test.rb
@@ -2,53 +2,54 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class DeleteServiceTest < ActionDispatch::IntegrationTest
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Services
+      class DeleteServiceTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_services_path
+        end
 
-      def setup
-        super
-        @path = admin_citizens_charters_services_path
-      end
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
 
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
 
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
+        def site
+          @site ||= sites(:madrid)
+        end
 
-      def site
-        @site ||= sites(:madrid)
-      end
+        def service
+          @service ||= gobierto_citizens_charters_services(:teleassistance)
+        end
 
-      def service
-        @service ||= gobierto_citizens_charters_services(:teleassistance)
-      end
-
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
           end
         end
-      end
 
-      def test_delete_service
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        def test_delete_service
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            within "#service-item-#{service.id}" do
-              find("a[data-method='delete']").click
+              within "#service-item-#{service.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("The service has been correctly archived")
+
+              refute site.services.exists?(id: service.id)
             end
-
-            assert has_message?("The service has been correctly archived")
-
-            refute site.services.exists?(id: service.id)
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/services_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/services_index_test.rb
@@ -2,54 +2,55 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class ServicesIndexTest < ActionDispatch::IntegrationTest
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Services
+      class ServicesIndexTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_services_path
+        end
 
-      def setup
-        super
-        @path = admin_citizens_charters_services_path
-      end
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
 
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
 
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
+        def site
+          @site ||= sites(:madrid)
+        end
 
-      def site
-        @site ||= sites(:madrid)
-      end
+        def services
+          @services ||= site.services
+        end
 
-      def services
-        @services ||= site.services
-      end
-
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
+            with_current_site(site) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
+            end
           end
         end
-      end
 
-      def test_services_index
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit @path
+        def test_services_index
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
 
-            within "table tbody" do
-              assert has_selector?("tr", count: services.size)
+              within "table tbody" do
+                assert has_selector?("tr", count: services.size)
 
-              services.each do |service|
-                assert has_selector?("tr#service-item-#{service.id}")
+                services.each do |service|
+                  assert has_selector?("tr#service-item-#{service.id}")
 
-                within "tr#service-item-#{service.id}" do
-                  assert has_link?(service.title)
+                  within "tr#service-item-#{service.id}" do
+                    assert has_link?(service.title)
+                  end
                 end
               end
             end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/update_service_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/update_service_test.rb
@@ -2,82 +2,49 @@
 
 require "test_helper"
 
-module GobiertoCitizensCharters
-  module GobiertoAdmin
-    class UpdateServiceTest < ActionDispatch::IntegrationTest
-      def setup
-        super
-        @path = admin_citizens_charters_services_path
-      end
-
-      def admin
-        @admin ||= gobierto_admin_admins(:nick)
-      end
-
-      def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:steve)
-      end
-
-      def site
-        @site ||= sites(:madrid)
-      end
-
-      def service
-        @service ||= gobierto_citizens_charters_services(:teleassistance)
-      end
-
-      def test_permissions
-        with_signed_in_admin(unauthorized_admin) do
-          with_current_site(site) do
-            visit @path
-            assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
-          end
+module GobiertoAdmin
+  module GobiertoCitizensCharters
+    module Services
+      class UpdateServiceTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_citizens_charters_services_path
         end
-      end
 
-      def test_update_service
-        with_javascript do
-          with_signed_in_admin(admin) do
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def service
+          @service ||= gobierto_citizens_charters_services(:teleassistance)
+        end
+
+        def test_permissions
+          with_signed_in_admin(unauthorized_admin) do
             with_current_site(site) do
               visit @path
-
-              click_link service.title
-
-              within "form.edit_service" do
-                fill_in "service_title_translations_en", with: "Teleassistance updated"
-                select "Culture", from: "service_category_id"
-
-                click_button "Update"
-              end
-
-              assert has_message?("The service has been correctly updated.")
-
-              click_link service.title
-
-              assert has_field? "service_title_translations_en", with: "Teleassistance updated"
-              assert has_select? "service_category_id", with_selected: "Culture"
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal admin_root_path, current_path
             end
           end
         end
 
-        activity = Activity.last
-        assert_equal service, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.service.updated", activity.action
-      end
-
-      def test_update_draft_service
-        service.update_attribute(:visibility_level, :draft)
-
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              assert_no_difference "Activity.count" do
+        def test_update_service
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
                 visit @path
 
                 click_link service.title
+
                 within "form.edit_service" do
                   fill_in "service_title_translations_en", with: "Teleassistance updated"
                   select "Culture", from: "service_category_id"
@@ -94,62 +61,97 @@ module GobiertoCitizensCharters
               end
             end
           end
+
+          activity = Activity.last
+          assert_equal service, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.service.updated", activity.action
         end
-      end
 
-      def test_publish_draft_service
-        service.update_attribute(:visibility_level, :draft)
+        def test_update_draft_service
+          service.update_attribute(:visibility_level, :draft)
 
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                assert_no_difference "Activity.count" do
+                  visit @path
 
-              click_link service.title
-              within "form.edit_service" do
-                within ".widget_save" do
-                  find("label", text: "Published").click
+                  click_link service.title
+                  within "form.edit_service" do
+                    fill_in "service_title_translations_en", with: "Teleassistance updated"
+                    select "Culture", from: "service_category_id"
+
+                    click_button "Update"
+                  end
+
+                  assert has_message?("The service has been correctly updated.")
+
+                  click_link service.title
+
+                  assert has_field? "service_title_translations_en", with: "Teleassistance updated"
+                  assert has_select? "service_category_id", with_selected: "Culture"
                 end
-
-                click_button "Update"
               end
-
-              assert has_message?("The service has been correctly updated.")
-
-              click_link service.title
-
-              assert has_field? "service_title_translations_en", with: service.title_en
-              click_link "ES"
-              assert has_field? "service_title_translations_es", with: service.title_es
             end
           end
         end
 
-        activity = Activity.last
-        assert_equal service, activity.subject
-        assert_equal admin, activity.author
-        assert_equal site.id, activity.site_id
-        assert_equal "gobierto_citizens_charters.service.published", activity.action
-      end
+        def test_publish_draft_service
+          service.update_attribute(:visibility_level, :draft)
 
-      def test_update_service_error
-        with_javascript do
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit @path
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
 
-              click_link service.title
+                click_link service.title
+                within "form.edit_service" do
+                  within ".widget_save" do
+                    find("label", text: "Published").click
+                  end
 
-              within "form.edit_service" do
-                fill_in "service_title_translations_en", with: ""
+                  click_button "Update"
+                end
+
+                assert has_message?("The service has been correctly updated.")
+
+                click_link service.title
+
+                assert has_field? "service_title_translations_en", with: service.title_en
                 click_link "ES"
-                fill_in "service_title_translations_es", with: ""
-                select "Culture", from: "service_category_id"
-
-                click_button "Update"
+                assert has_field? "service_title_translations_es", with: service.title_es
               end
+            end
+          end
 
-              assert has_alert?("Title can't be blank")
+          activity = Activity.last
+          assert_equal service, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_citizens_charters.service.published", activity.action
+        end
+
+        def test_update_service_error
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                click_link service.title
+
+                within "form.edit_service" do
+                  fill_in "service_title_translations_en", with: ""
+                  click_link "ES"
+                  fill_in "service_title_translations_es", with: ""
+                  select "Culture", from: "service_category_id"
+
+                  click_button "Update"
+                end
+
+                assert has_alert?("Title can't be blank")
+              end
             end
           end
         end


### PR DESCRIPTION
## :v: What does this PR do?
Fix namespaces of integration tests on admin for gobierto citizens charters module

## :mag: How should this be manually tested?
Only tests are changed with this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No