### PR TITLE
Calendars performance

### DIFF
--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -35,7 +35,7 @@ module GobiertoPeople
       @events = GobiertoCalendars::Event.by_site(current_site).
         person_events.
         published.
-        includes(:locations).
+        includes(:collection, :locations).
         page params[:page]
       @events = @events.by_person_category(@person_category) if @person_category
       @events = @events.by_person_party(@person_party) if @person_party

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -7,12 +7,13 @@ module GobiertoPeople
     before_action :check_active_submodules
 
     def index
-      @political_groups = get_political_groups
-
       set_events
+      render_404 and return if params[:page].present? && @events.empty?
+
       set_calendar_events
       set_people
       set_present_groups_with_published_activities
+      @political_groups = get_political_groups
 
       respond_to do |format|
         format.html

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -31,7 +31,11 @@ module GobiertoPeople
     end
 
     def set_events
-      @events = GobiertoCalendars::Event.by_site(current_site).person_events.published.page params[:page]
+      @events = GobiertoCalendars::Event.by_site(current_site).
+        person_events.
+        published.
+        includes(:locations).
+        page params[:page]
       @events = @events.by_person_category(@person_category) if @person_category
       @events = @events.by_person_party(@person_party) if @person_party
 

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -28,7 +28,11 @@ module GobiertoPeople
     end
 
     def set_events
-      events = GobiertoCalendars::Event.by_site(current_site).person_events.by_person_party(Person.parties[:government]).limit(10)
+      events = GobiertoCalendars::Event.by_site(current_site).
+        person_events.
+        by_person_party(Person.parties[:government]).
+        includes(:locations).
+        limit(10)
       @events = events.upcoming.sorted
       if @events.empty?
         @no_upcoming_events = true

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -28,12 +28,11 @@ module GobiertoPeople
     end
 
     def set_events
-      @events = GobiertoCalendars::Event.by_site(current_site).person_events.by_person_party(Person.parties[:government]).limit(10)
-
-      @events = @events.upcoming.sorted
+      events = GobiertoCalendars::Event.by_site(current_site).person_events.by_person_party(Person.parties[:government]).limit(10)
+      @events = events.upcoming.sorted
       if @events.empty?
         @no_upcoming_events = true
-        @events = @events.past.sorted_backwards
+        @events = events.past.sorted_backwards
       end
     end
 

--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -31,7 +31,7 @@ module GobiertoPeople
       events = GobiertoCalendars::Event.by_site(current_site).
         person_events.
         by_person_party(Person.parties[:government]).
-        includes(:locations).
+        includes(:collection, :locations).
         limit(10)
       @events = events.upcoming.sorted
       if @events.empty?

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -61,13 +61,15 @@ module GobiertoCalendars
     scope :by_site, ->(site) { where(site_id: site.id) }
 
     scope :by_person_category, ->(category) do
-      collection_ids = ::GobiertoPeople::Person.where(category: category).map { |p| p.events_collection.id }
-      where(collection_id: collection_ids)
+      joins("INNER JOIN #{GobiertoPeople::Person.table_name} ON
+        collection_items.container_id = #{GobiertoPeople::Person.table_name}.id AND
+        #{GobiertoPeople::Person.table_name}.category = #{category}")
     end
 
     scope :by_person_party, ->(party) do
-      collection_ids = ::GobiertoPeople::Person.where(party: party).map { |p| p.events_collection.id }
-      where(collection_id: collection_ids)
+      joins("INNER JOIN #{GobiertoPeople::Person.table_name} ON
+        collection_items.container_id = #{GobiertoPeople::Person.table_name}.id AND
+        #{GobiertoPeople::Person.table_name}.party = #{party}")
     end
 
     scope :person_events, -> do

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -60,15 +60,29 @@ module GobiertoCalendars
     scope :by_site, ->(site) { where(site_id: site.id) }
 
     scope :by_person_category, ->(category) do
+      category_value = if category.is_a?(String)
+                         GobiertoPeople::Person.categories[category]
+                       else
+                         category
+                       end
+      raise "Invalid category #{category}" if category_value.blank?
+
       joins("INNER JOIN #{GobiertoPeople::Person.table_name} ON
         collection_items.container_id = #{GobiertoPeople::Person.table_name}.id AND
-        #{GobiertoPeople::Person.table_name}.category = #{category}")
+        #{GobiertoPeople::Person.table_name}.category = #{category_value}")
     end
 
     scope :by_person_party, ->(party) do
+      party_value = if party.is_a?(String)
+                      GobiertoPeople::Person.parties[party]
+                    else
+                      party
+                    end
+      raise "Invalid party #{party}" if party_value.blank?
+
       joins("INNER JOIN #{GobiertoPeople::Person.table_name} ON
         collection_items.container_id = #{GobiertoPeople::Person.table_name}.id AND
-        #{GobiertoPeople::Person.table_name}.party = #{party}")
+        #{GobiertoPeople::Person.table_name}.party = #{party_value}")
     end
 
     scope :person_events, -> do

--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -23,7 +23,6 @@ module GobiertoCalendars
     validates :site, :collection, presence: true
     validates :slug, uniqueness: { scope: :site_id }
 
-
     translates :title, :description
 
     metadata_attributes :type

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -74,6 +74,13 @@ module GobiertoPeople
       end
     end
 
+    def test_person_events_index_invalid_pagination
+      with_current_site(site) do
+        visit gobierto_people_events_path(page: 10)
+        assert_equal 404, page.status_code
+      end
+    end
+
     def test_person_events_index_pagination
       government_member.events.destroy_all
 

--- a/test/models/gobierto_calendars/event_test.rb
+++ b/test/models/gobierto_calendars/event_test.rb
@@ -72,29 +72,23 @@ module GobiertoCalendars
 
       assert_includes subject, event
 
-      assert event_site == past_event.site
+      assert_equal event_site, past_event.site
       assert_includes subject, past_event
     end
 
-    # TODO
     def test_by_person_category_scope
       person_category = ::GobiertoPeople::Person.categories[person.category]
-      subject = subject_class.by_person_category(person_category)
+      subject = subject_class.person_events.by_person_category(person_category)
 
       assert_includes subject, event
-
-      assert person_category == ::GobiertoPeople::Person.categories[person.category]
       assert_includes subject, past_event
     end
 
-    # TODO
     def test_by_person_party_scope
       person_party = ::GobiertoPeople::Person.parties[person.party]
-      subject = subject_class.by_person_party(person_party)
+      subject = subject_class.person_events.by_person_party(person_party)
 
       assert_includes subject, event
-
-      assert person_party == ::GobiertoPeople::Person.parties[person.party]
       assert_includes subject, past_event
     end
 


### PR DESCRIPTION
## :v: What does this PR do?

This PR reduces many N+1 queries in calendars

For example, this page /agendas/ included 728 queries. Now uses just 26 queries. Other sites and pages have been also possitively affected by queries and by load time.

## :mag: How should this be manually tested?

Check calendar modules still work.

## :eyes: Screenshots

No


## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No