### PR TITLE
Force email downcase

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,4 +52,10 @@ class User < ApplicationRecord
     now.year - date_of_birth.year - ((now.month > date_of_birth.month || (now.month == date_of_birth.month && now.day >= date_of_birth.day)) ? 0 : 1)
   end
 
+  def email=(value)
+    if value.present?
+      super(value.downcase)
+    end
+  end
+
 end

--- a/test/integration/user/registration_test.rb
+++ b/test/integration/user/registration_test.rb
@@ -91,6 +91,18 @@ class User::RegistrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_registration_with_email_capitalized
+    with_current_site(site) do
+      visit @registration_path
+
+      fill_in :user_registration_email, with: user.email.upcase
+
+      click_on "Let's go"
+
+      assert has_message?("That email is already registered. Try login in or recovering your password")
+    end
+  end
+
   def test_registration_with_registered_user_in_other_site
     with_current_site(other_site) do
       visit @registration_path

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -63,6 +63,12 @@ class UserTest < ActiveSupport::TestCase
     assert other_madrid_user.errors.include? :email
   end
 
+  def test_email_unique_capitalized
+    new_user = User.new email: user.email.upcase, site: user.site
+    refute new_user.valid?
+    assert new_user.errors[:email].present?
+  end
+
   def test_valid
     assert user.valid?
   end


### PR DESCRIPTION
Closes #2066 

## :v: What does this PR do?

This PR forces user emails to be stored downcased to allow the validation in the database to check the address properly.

## :mag: How should this be manually tested?

Try to register in a site with an email you already know is being used but replacing some chars with capitalized letters.

## :eyes: Screenshots

No

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
