### PR TITLE
Optimize attendees query

### DIFF
--- a/app/controllers/gobierto_people/departments_controller.rb
+++ b/app/controllers/gobierto_people/departments_controller.rb
@@ -32,11 +32,11 @@ module GobiertoPeople
 
     def show
       @department = site_departments.find_by_slug!(params[:id])
-      people = QueryWithEvents.new(source: @department.people.active.with_event_attendances,
+      people = QueryWithEvents.new(source: @department.people.active.with_event_attendances(current_site),
                                    start_date: filter_start_date,
                                    end_date: filter_end_date)
 
-      interest_groups = QueryWithEvents.new(source: @department.events,
+      interest_groups = QueryWithEvents.new(source: @department.events.published,
                                             start_date: filter_start_date,
                                             end_date: filter_end_date)
       @department_stats = {

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -37,7 +37,7 @@ module GobiertoPeople
 
     scope :sorted, -> { order(position: :asc, created_at: :desc) }
     scope :by_site, ->(site) { where(site_id: site.id) }
-    scope :with_event_attendances, -> { where(id: ::GobiertoCalendars::EventAttendee.pluck(:person_id)) }
+    scope :with_event_attendances, ->(site) { where(id: site.event_attendances.pluck(:person_id).uniq) }
     enum visibility_level: { draft: 0, active: 1 }
     alias public? active?
     enum category: { politician: 0, executive: 1 }

--- a/test/queries/gobierto_people/query_with_events.rb
+++ b/test/queries/gobierto_people/query_with_events.rb
@@ -49,7 +49,7 @@ module GobiertoPeople
     end
 
     def people_with_events_in_department_source
-      justice_department.people.with_event_attendances
+      justice_department.people.with_event_attendances(site)
     end
 
     def test_query


### PR DESCRIPTION
## :v: What does this PR do?

- Optmizes query of event attendees by providing an unique list of person id's
- Scopes the ids in the current_site
- Fixes this Rollbar https://rollbar.com/Populate/gobierto/items/1345/

## :mag: How should this be manually tested?

Department pages should work as before

## :eyes: Screenshots

No

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No