### PR TITLE
Budgets elaboration fixes

### DIFF
--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -8,6 +8,7 @@ module GobiertoBudgets
       @year = options.fetch(:year).to_i
       @data = { debt: {}, population: {} }
       @empty_population = !has_available?(:population)
+      @empty_debt = !has_available?(:debt)
     end
 
     def budgets_data_updated_at
@@ -31,6 +32,10 @@ module GobiertoBudgets
 
     def has_available_population_data?
       !@empty_population
+    end
+
+    def has_available_debt_data?
+      !@empty_debt
     end
 
     def total_budget_per_inhabitant(year = nil)

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -86,23 +86,41 @@
               <% end %>
             </div>
           </div>
+        <% else %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip', of_the_organization_name: @site.determined_organization_name(:of_the)) %>" data-box="debt">
+            <div class="inner">
+              <h3><%= t('gobierto_budgets.budgets_elaboration.index.net_savings') %></h3>
+              <div class="metric"><%= format_currency @site_stats.net_savings %></div>
+              <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :net_savings) %> vs <%= @year - 1 %></div>
+            </div>
+          </div>
         <% end %>
 
-        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip', of_the_organization_name: @site.determined_organization_name(:of_the)) %>" data-box="debt">
-          <div class="inner">
-            <h3><%= t('.debt') %></h3>
-            <% if (debt = @site_stats.latest_available(:debt, @year)[:value]) %>
-              <div class="metric"><%= format_currency @site_stats.latest_available(:debt, @year)[:value] %></div>
-              <% if @site_stats.latest_available(:debt, @year)[:year] != @year %>
-                <div class="explanation">
-                  <%= t('.at_years_end', year: @site_stats.latest_available(:debt, @year)[:year])%>
-                </div>
+        <% if @site_stats.has_available_debt_data? %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip', of_the_organization_name: @site.determined_organization_name(:of_the)) %>" data-box="debt">
+            <div class="inner">
+              <h3><%= t('.debt') %></h3>
+              <% if (debt = @site_stats.latest_available(:debt, @year)[:value]) %>
+                <div class="metric"><%= format_currency @site_stats.latest_available(:debt, @year)[:value] %></div>
+                <% if @site_stats.latest_available(:debt, @year)[:year] != @year %>
+                  <div class="explanation">
+                    <%= t('.at_years_end', year: @site_stats.latest_available(:debt, @year)[:year])%>
+                  </div>
+                <% end %>
+              <% else %>
+                <div class="metric"><span class="not_av"><%= t('.not_available_short') %></span></div>
               <% end %>
-            <% else %>
-              <div class="metric"><span class="not_av"><%= t('.not_available_short') %></span></div>
-            <% end %>
+            </div>
           </div>
-        </div>
+        <% else %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip', of_the_organization_name: @site.determined_organization_name(:of_the)) %>" data-box="debt">
+            <div class="inner">
+              <h3><%= t('gobierto_budgets.budgets_elaboration.index.auto_funding') %></h3>
+              <div class="metric"><%= format_currency @site_stats.auto_funding %></div>
+              <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :auto_funding) %> vs <%= @year - 1 %></div>
+            </div>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -19,14 +19,16 @@
 
   <div class="pure-g metric_boxes">
 
-    <div id="metric_box_1" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant_tooltip') %>">
-      <!--  metric_box should be flexbox -->
-      <div class="inner">
-        <h3><%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant') %></h3>
-        <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant %></div>
-        <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_budget_per_inhabitant) %> vs <%= @year - 1 %></div>
+    <% if @site_stats.has_available_population_data? %>
+      <div id="metric_box_1" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant_tooltip') %>">
+        <!--  metric_box should be flexbox -->
+        <div class="inner">
+          <h3><%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant') %></h3>
+          <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant %></div>
+          <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_budget_per_inhabitant) %> vs <%= @year - 1 %></div>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <div id="metric_box_2" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.total_expenses_tooltip') %>">
       <div class="inner">
@@ -44,13 +46,15 @@
       </div>
     </div>
 
-    <div id="metric_box_4" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.debt_level_tooltip') %>">
-      <div class="inner">
-        <h3><%= t('gobierto_budgets.budgets_elaboration.index.debt_level') %></h3>
-        <div class="metric"><%= format_currency @site_stats.debt_level %></div>
-        <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :debt_level) %> vs <%= @year - 1 %></div>
+    <% if @site_stats.has_available_debt_data? %>
+      <div id="metric_box_4" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.debt_level_tooltip') %>">
+        <div class="inner">
+          <h3><%= t('gobierto_budgets.budgets_elaboration.index.debt_level') %></h3>
+          <div class="metric"><%= format_currency @site_stats.debt_level %></div>
+          <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :debt_level) %> vs <%= @year - 1 %></div>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <div id="metric_box_5" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.auto_funding_tooltip') %>">
       <div class="inner">

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -1,7 +1,7 @@
 <% title t('.header') %>
 
 <% content_for :body_attributes do %>
-  <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{Date.today.year + 1}"} %>
+  <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{GobiertoBudgets::SearchEngineConfiguration::Year.last + 1}"} %>
 <% end %>
 
 <div class="column">

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -56,30 +56,32 @@
     <%= render 'data_block' %>
   </div>
 
-  <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
-    <div class=" pure-u-1 pure-u-md-1-2 block" >
-      <h2><%= t('.at_a_glance') %></h2>
+  <% if budgets_comparison_context_table_enabled %>
+    <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+      <div class=" pure-u-1 pure-u-md-1-2 block" >
+        <h2><%= t('.at_a_glance') %></h2>
 
-      <div id="lines_chart"></div>
-    </div>
+        <div id="lines_chart"></div>
+      </div>
 
-    <div class="pure-u-1 pure-u-md-1-2 block">
-      <h2><%= t('.context') %></h2>
+      <div class="pure-u-1 pure-u-md-1-2 block">
+        <h2><%= t('.context') %></h2>
 
-      <div id="lines_tooltip"></div>
-      <div class="help">
-        <%= link_to t('.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], target: '_blank', title: t('.note_about_the_data_title'), class: 'tipsit' %>
+        <div id="lines_tooltip"></div>
+        <div class="help">
+          <%= link_to t('.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], target: '_blank', title: t('.note_about_the_data_title'), class: 'tipsit' %>
+        </div>
+      </div>
+
+      <div class="pure-u-1">
+        <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
+          <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'per_person', include_next_year: true, format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
+          <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'total_budget', include_next_year: true, format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
+
+          </div>
       </div>
     </div>
-
-    <div class="pure-u-1">
-      <div class="filter m_v_2" role="tablist" aria-label="<%= t('.visualize') %>">
-        <%= link_to t('.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'per_person', include_next_year: true, format: :json), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person', 'aria-controls' => 'lines_chart_wrapper' %>
-        <%= link_to t('.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_path(organization_id: current_site.organization_id, year: @year, what: 'total_budget', include_next_year: true, format: :json), "line-widget-type" => "total_budget" }, role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
-
-        </div>
-    </div>
-  </div>
+  <% end %>
 
   <div class="separator"></div>
 


### PR DESCRIPTION
This PR fixes a few things on elaborations section and on data cards.

## :v: What does this PR do?

- [ ] a D3 issue with the timeline bubbles has been fixed in elaboration page
- [ ] if there's no debt all data cards related with debt are hidden
- [ ] if there's no population all data cards related with population are hidden
- [ ] in the elaboration section, only the comparison line chart is displayed if the option is enabled
- [ ] in the main section if there are no debt or population cards new cards are displayed: net savings and autofinancing ability.

## :mag: How should this be manually tested?

Check these things in a site with elaboration enabled

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
