### PR TITLE
Remove populate data from Gobierto Budgets module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,4 +123,5 @@ group :development do
   gem "listen"
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "foreman"
+  gem "rb-readline"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 8b5f4f2ac096032d9e847734227c258e2a57f62d
+  revision: 4ce285d351320b9ccde85b3b9f5e39aac41a6808
   specs:
     gobierto_data (0.0.1)
       actionpack (>= 5.0.0.1)
@@ -10,7 +10,6 @@ GIT
       elasticsearch-extensions (~> 0.0.27)
       ine-places (~> 0.3.0)
       oj (~> 3.5, >= 3.5.0)
-      sequel (~> 5.8, >= 5.8.0)
 
 GIT
   remote: https://github.com/ferblape/webpacker.git
@@ -78,7 +77,7 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    algoliasearch (1.24.0)
+    algoliasearch (1.25.2)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     algoliasearch-rails (1.20.6)
@@ -87,13 +86,13 @@ GEM
     ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
-    aws-sdk (2.11.205)
-      aws-sdk-resources (= 2.11.205)
-    aws-sdk-core (2.11.205)
+    aws-sdk (2.11.212)
+      aws-sdk-resources (= 2.11.212)
+    aws-sdk-core (2.11.212)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.205)
-      aws-sdk-core (= 2.11.205)
+    aws-sdk-resources (2.11.212)
+      aws-sdk-core (= 2.11.212)
     aws-ses (0.6.0)
       builder
       mail (> 2.2.5)
@@ -148,7 +147,6 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (0.7.0)
     elasticsearch (6.1.0)
       elasticsearch-api (= 6.1.0)
       elasticsearch-transport (= 6.1.0)
@@ -170,17 +168,16 @@ GEM
     execjs (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.10.0)
     flight-for-rails (1.5.1)
       jquery-rails (>= 2.1.4)
       rails (>= 3.1.0)
-    foreman (0.64.0)
-      dotenv (~> 0.7.0)
-      thor (>= 0.13.6)
+    foreman (0.85.0)
+      thor (~> 0.19.1)
     geocoder (1.5.1)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
-    google-api-client (0.28.0)
+    google-api-client (0.28.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.10.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -197,12 +194,12 @@ GEM
       signet (~> 0.7)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashdiff (0.3.7)
-    highline (2.0.0)
+    hashdiff (0.3.8)
+    highline (2.0.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    httpi (2.4.3)
+    httpi (2.4.4)
       rack
       socksify
     i18n (1.5.3)
@@ -287,7 +284,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.2)
+    mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -302,7 +299,7 @@ GEM
     minitest-stub_any_instance (1.0.2)
     mocha (1.8.0)
       metaclass (~> 0.0.1)
-    msgpack (1.2.4)
+    msgpack (1.2.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4.1)
@@ -314,7 +311,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     ntlm-http (0.1.1)
-    oj (3.6.10)
+    oj (3.7.8)
     os (1.0.0)
     paper_trail (10.1.0)
       activerecord (>= 4.2, < 6.0)
@@ -369,8 +366,9 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rb-readline (0.5.5)
     redcarpet (3.4.0)
     redis (4.1.0)
     ref (2.0.0)
@@ -405,7 +403,7 @@ GEM
       activesupport (>= 4.2.5)
     rubyntlm (0.6.2)
     safe_yaml (1.0.4)
-    sass (3.5.6)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -424,7 +422,6 @@ GEM
       nokogiri (>= 1.4.0)
       nori (~> 2.4)
       wasabi (~> 3.4)
-    sequel (5.12.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -463,9 +460,9 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
-    thor (0.20.3)
+    thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.8)
+    tilt (2.0.9)
     timecop (0.9.1)
     truncate_html (0.9.3)
     turbolinks (5.2.0)
@@ -555,6 +552,7 @@ DEPENDENCIES
   puma
   rails (~> 5.2.1)
   rails-html-sanitizer
+  rb-readline
   redcarpet
   redis (~> 4.0)
   responders
@@ -579,4 +577,4 @@ DEPENDENCIES
   webpacker (~> 3.0)!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/controllers/gobierto_budgets/providers_controller.rb
+++ b/app/controllers/gobierto_budgets/providers_controller.rb
@@ -1,11 +1,27 @@
+# frozen_string_literal: true
+
 class GobiertoBudgets::ProvidersController < GobiertoBudgets::ApplicationController
 
   before_action :check_setting_enabled
 
   def index
-    @year = Date.today.year
-    site_stats = GobiertoBudgets::SiteStats.new(site: @site, year: @year)
-    @budgets_data_updated_at = site_stats.providers_data_updated_at
+    respond_to do |format|
+      format.html do
+        @year = Date.today.year
+        site_stats = GobiertoBudgets::SiteStats.new(site: @site, year: @year)
+        @budgets_data_updated_at = site_stats.providers_data_updated_at
+      end
+      format.csv do
+        render csv: GobiertoBudgets::Data::Invoices.dump_csv({
+          location_id: current_site.organization_id,
+          limit: params[:limit],
+          sort_desc_by: params[:sort_desc_by],
+          sort_asc_by: params[:sort_asc_by],
+          date_date_range: params[:date_date_range],
+          except_columns: params[:except_columns]
+        }), filename: 'invoices.csv'
+      end
+    end
   end
 
   private

--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -10,14 +10,20 @@ window.GobiertoBudgets.InvoicesController = (function() {
   function InvoicesController() {}
 
   // Global variables
-  var data, ndx, _r, _tabledata, _empty, _chartdata = {}, $tableHTML = {};
+  var data, ndx, _r, _tabledata, _empty, dataEndpoint, _chartdata = {}, $tableHTML = {};
 
   InvoicesController.prototype.show = function() {
     $tableHTML = $("#providers-table");
 
+    if(window.populateData.endpoint === ""){
+      dataEndpoint = "/presupuestos/proveedores-facturas.csv"
+    } else {
+      dataEndpoint = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv'
+    }
+
     let municipalityId = window.populateData.municipalityId;
-    let maxYearUrl = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv?filter_by_location_id='+municipalityId+'&sort_desc_by=date&limit=1';
-    let minYearUrl = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv?filter_by_location_id='+municipalityId+'&sort_asc_by=date&limit=1';
+    let maxYearUrl = dataEndpoint + '?filter_by_location_id='+municipalityId+'&sort_desc_by=date&limit=1';
+    let minYearUrl = dataEndpoint + '?filter_by_location_id='+municipalityId+'&sort_asc_by=date&limit=1';
 
     // Get the dates
     let getYear = function (url) {
@@ -100,7 +106,7 @@ window.GobiertoBudgets.InvoicesController = (function() {
     }
 
     var municipalityId = window.populateData.municipalityId;
-    var url = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv?filter_by_location_id='+municipalityId+'&date_date_range='+dateRange+'&sort_asc_by=date&except_columns=_id,invoice_id,payment_date,location_id,province_id,autonomous_region_id';
+    var url = dataEndpoint + '?filter_by_location_id='+municipalityId+'&date_date_range='+dateRange+'&sort_asc_by=date&except_columns=_id,invoice_id,payment_date,location_id,province_id,autonomous_region_id';
 
     // Show spinner
     $(".js-toggle-overlay").addClass('is-active');

--- a/app/models/gobierto_budgets/data/invoices.rb
+++ b/app/models/gobierto_budgets/data/invoices.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module GobiertoBudgets
+  module Data
+    class Invoices
+      def self.dump_csv(options)
+        sort = if options[:sort_desc_by]
+                 [{ options[:sort_desc_by].to_sym => { order: "desc"} }]
+               elsif options[:sort_asc_by]
+                 [{ options[:sort_asc_by].to_sym => { order: "asc" } }]
+               end
+        remove_columns = options[:except_columns].present? ? options[:except_columns].split(",") : []
+        limit = options[:limit] || 10_000
+
+        query_filters = [{ term: { location_id: options[:location_id] }}]
+        if options[:date_date_range]
+          # 20181028-20190128
+          gte,lte = options[:date_date_range].split('-')
+          query_filters.push({ range: {
+            date: {
+              gte: gte,
+              lte: lte,
+              format: 'yyyyMMdd'
+            }
+          }})
+        end
+
+        query = {
+          sort: sort,
+          query: {
+            filtered: {
+              filter: {
+                bool: {
+                  must: query_filters
+                }
+              }
+            }
+          },
+          size: limit
+        }
+
+        response = SearchEngine.client.search index: SearchEngineConfiguration::Invoice.index, type: GobiertoBudgets::SearchEngineConfiguration::Invoice.type, body: query
+        response = response['hits']['hits'].map{ |h| h['_source'] }
+        parsed_response = if remove_columns.any?
+          response.map do |result|
+            result.except(*remove_columns)
+          end
+        else
+          response
+        end
+
+        data = CSV.generate do |csv|
+          csv << parsed_response.first.keys if parsed_response.first.present?
+          parsed_response.each do |hash|
+            csv << hash.values
+          end
+        end
+
+        return data
+      end
+    end
+  end
+end

--- a/app/models/gobierto_budgets/search_engine_configuration/invoice.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/invoice.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module GobiertoBudgets
+  module SearchEngineConfiguration
+    class Invoice
+      def self.all_indices
+        [index]
+      end
+
+      def self.index
+        GobiertoData::GobiertoBudgets::ES_INDEX_INVOICES
+      end
+
+      def self.type
+        GobiertoData::GobiertoBudgets::INVOICE_TYPE
+      end
+    end
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

Currently we were using Populate Data to provided providers and invoices information, but this had a few limitations and it wasn't very useful as PD dataset.

This PR removes that dependency. For the moment it does the fallback to a new controller API if populate data endpoint is not set.

From here we should migrate the data from the customers to Gobierto ES get rid of this check in the JS controller:

```
    if(window.populateData.endpoint === ""){
      dataEndpoint = "/presupuestos/proveedores-facturas.csv"
    } else {
      dataEndpoint = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv'
    }
```

## :mag: How should this be manually tested?

Easy:

- go to a site in our staging and providers and invoices should work as before
- go to a Gobierto installation without the endpoint configured, and the javascript visualizations should fetch from our internal API.
