### PR TITLE
Small issues

### DIFF
--- a/app/models/gobierto_common/custom_field_value/localized_text.rb
+++ b/app/models/gobierto_common/custom_field_value/localized_text.rb
@@ -3,7 +3,12 @@
 module GobiertoCommon::CustomFieldValue
   class LocalizedText < Base
     def value
-      raw_value[I18n.locale.to_s]
+      value = raw_value[I18n.locale.to_s] || raw_value[I18n.default_locale.to_s]
+      return value if value.present?
+      I18n.available_locales.each do |locale|
+        value = raw_value[locale.to_s]
+        return value if value.present?
+      end
     end
 
     def searchable_value

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,6 +79,11 @@ module Gobierto
     config.action_view.field_error_proc = proc { |html_tag, _instance| html_tag }
 
     config.time_zone = "Madrid"
+
+    # if Gobierto runs in a root path, assets should use that path too
+    if ENV["GOBIERTO_ROOT_URL_PATH"].present?
+      Rails.application.config.relative_url_root = ENV["GOBIERTO_ROOT_URL_PATH"]
+    end
   end
 end
 

--- a/test/models/gobierto_common/custom_field_record_test.rb
+++ b/test/models/gobierto_common/custom_field_record_test.rb
@@ -83,4 +83,13 @@ class GobiertoCommon::CustomFieldRecordTest < ActiveSupport::TestCase
     refute subject.valid?
     assert_not_nil subject.errors[:item]
   end
+
+  def test_localized_string_fallback_value
+    subject = GobiertoCommon::CustomFieldRecord.new
+    subject.custom_field = custom_field_localized_string
+    subject.value = { es: "test_es", en: "test_en" }
+
+    I18n.locale = :ca
+    assert_equal "test_en", subject.value
+  end
 end


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes:

- [ ] Assets path should include the `GOBIERTO_ROOT_URL_PATH` value if set
- [ ] Helper that renders custom field values should fallback locales as we do in other parts of Gobierto

## :mag: How should this be manually tested?

- In a site with a custom root url check the assets prepend the path (checked)
- In a site with custom fields check the value is fallback (checked)
