### PR TITLE
Allow overwrite budgets guide with a CMS page

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_budgets/options_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_budgets/options_controller.rb
@@ -5,11 +5,13 @@ module GobiertoAdmin
       before_action { module_allowed!(current_admin, 'GobiertoBudgets') }
 
       def index
+        @available_pages = get_available_pages
         @options_form = GobiertoAdmin::GobiertoBudgets::OptionsForm.new(site: current_site)
         @services_config = get_services_config
       end
 
       def update
+        @available_pages = get_available_pages
         @services_config = get_services_config
         @options_form = GobiertoAdmin::GobiertoBudgets::OptionsForm.new(gobierto_budgets_params.merge(site: current_site))
         if @options_form.save
@@ -32,13 +34,17 @@ module GobiertoAdmin
       def gobierto_budgets_params
         params.require(:gobierto_budgets_options).permit(:elaboration_enabled, :budget_lines_feedback_enabled, :feedback_emails, :receipt_enabled, :receipt_configuration,
                                                          :comparison_tool_enabled, :comparison_context_table_enabled, :comparison_show_widget, :comparison_compare_municipalities_enabled,
-                                                         :providers_enabled, :indicators_enabled, comparison_compare_municipalities: [])
+                                                         :providers_enabled, :indicators_enabled, :budgets_guide_page,
+                                                         comparison_compare_municipalities: [])
       end
 
       def get_services_config
         OpenStruct.new(APP_CONFIG["services"])
       end
 
+      def get_available_pages
+        @site.pages.active.sorted
+      end
     end
   end
 end

--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -25,6 +25,9 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
   def guide
     @year = GobiertoBudgets::SearchEngineConfiguration::Year.last
     @site_stats = GobiertoBudgets::SiteStats.new site: @site, year: @year
+    if current_site.gobierto_budgets_settings && current_site.gobierto_budgets_settings.settings["budgets_guide_page"]
+      @page = GobiertoCms::Page.find_by id: current_site.gobierto_budgets_settings.settings["budgets_guide_page"]
+    end
   end
 
   private

--- a/app/forms/gobierto_admin/gobierto_budgets/options_form.rb
+++ b/app/forms/gobierto_admin/gobierto_budgets/options_form.rb
@@ -17,7 +17,8 @@ module GobiertoAdmin
         :comparison_compare_municipalities,
         :comparison_show_widget,
         :providers_enabled,
-        :indicators_enabled
+        :indicators_enabled,
+        :budgets_guide_page
       )
 
       validates :site, presence: true
@@ -111,6 +112,10 @@ module GobiertoAdmin
         indicators_enabled == true || indicators_enabled == '1'
       end
 
+      def budgets_guide_page
+        @budgets_guide_page ||= site.gobierto_budgets_settings && site.gobierto_budgets_settings.settings["budgets_guide_page"]
+      end
+
       def save
         save_options if valid?
       end
@@ -129,6 +134,7 @@ module GobiertoAdmin
         settings[:comparison_show_widget] = comparison_show_widget? ? comparison_show_widget : nil
         settings[:budgets_providers_enabled] = providers_enabled if providers_enabled?
         settings[:budgets_indicators_enabled] = indicators_enabled if indicators_enabled?
+        settings[:budgets_guide_page] = budgets_guide_page
 
         if site.gobierto_budgets_settings.nil?
           GobiertoModuleSettings.create! site: site, module_name: "GobiertoBudgets", settings: settings

--- a/app/views/gobierto_admin/gobierto_budgets/options/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_budgets/options/index.html.erb
@@ -141,6 +141,11 @@
           <% end %>
         </div>
 
+        <div class="option">
+          <%= f.label :budgets_guide_page %>
+          <%= f.select :budgets_guide_page, @available_pages.map{ |p| [p.title, p.id] }, { include_blank: true } %>
+        </div>
+
       </div>
     </div>
   </div>
@@ -155,7 +160,7 @@
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
     window.GobiertoAdmin.gobierto_budgets_controller.options({
-    municipalities_suggestion_url: '<%= @services_config.municipalities_suggestions_endpoint %>'
+      municipalities_suggestion_url: '<%= @services_config.municipalities_suggestions_endpoint %>'
     });
   <% end %>
 <% end %>

--- a/app/views/gobierto_budgets/budgets/guide.html.erb
+++ b/app/views/gobierto_budgets/budgets/guide.html.erb
@@ -1,274 +1,294 @@
-<% description t('.description') %>
-<% title t('.title') %>
+<% if @page %>
+  <% description @page.title %>
+  <% title @page.title %>
 
-<div class="column">
+  <div class="column">
 
-  <main class="content">
-    <header class="gradient-bg">
+    <main class="content">
       <div class="inner">
-        <h1><%= t('.title') %></h1>
-        <p><%= t('.description') %></p>
-
-        <ul>
-          <li><a href="#como-se-lee"><%= t('.how_to_read') %></a></li>
-          <li><a href="#tipos-de-ingreso"><%= t('.income') %></a></li>
-          <li><a href="#tipos-de-gasto"><%= t('.expenses') %></a></li>
-          <li><a href="#deuda-viva"><%= t('.debt') %></a></li>
-          <li><a href="#ejecucion-presupuestaria"><%= t('.execution') %></a></li>
-        </ul>
-      </div>
-    </header>
-
-
-    <article class="inner">
-      <%= image_tag 'illustrations/presupuestos.jpg', class: 'pure-img', id: 'image1' %>
-
-      <ol>
-        <li><%= t('.intro_p1') %></li>
-        <li><%= t('.intro_p2') %></li>
-      </ol>
-
-      <div class="note">
-        <p><%= t('.intro_p3') %></p>
+        <h1><%= @page.title %></h1>
       </div>
 
-      <h2 id="como-se-lee"><%= t('.how_to_read') %></h2>
-      <p><%= t('.how_to_read_p1_html') %></p>
 
-      <h3><%= t('.income') %></h3>
-      <p><%= t('.income_p1') %></p>
+      <article class="inner">
+        <%== @page.body %>
+      </article>
+    </main>
+  </div>
 
-      <div class="number">
-        <p><%= t('.income_p2', year: @year) %></p>
-        <div><%= format_currency @site_stats.total_budget %></div>
-      </div>
+<% else %>
+  <% description t('.description') %>
+  <% title t('.title') %>
 
-      <h3><%= t('.expenses') %></h3>
-      <p><%= t('.expenses_how') %></p>
+  <div class="column">
 
-      <div class="number">
-        <p><%= t('.expenses_per_inhabitant') %></p>
-        <div><%= format_currency @site_stats.total_budget_per_inhabitant %>/hab</div>
-      </div>
+    <main class="content">
+      <header class="gradient-bg">
+        <div class="inner">
+          <h1><%= t('.title') %></h1>
+          <p><%= t('.description') %></p>
 
-      <hr class="separator_responsive" />
-
-      <blockquote>
-        <h4><%= t('.classification') %></h4>
-        <p><%= t('.classification_p1') %></p>
-
-        <div class="share" data-share>
-          <a data-share-network="facebook" data-track-event="Social Share|Click Facebook|Header"><i class="fa fa-facebook"></i></a>
-          <a data-share-network="twitter" data-track-event="Social Share|Click Twitter|Header"><i class="fa fa-twitter"></i></a>
+          <ul>
+            <li><a href="#como-se-lee"><%= t('.how_to_read') %></a></li>
+            <li><a href="#tipos-de-ingreso"><%= t('.income') %></a></li>
+            <li><a href="#tipos-de-gasto"><%= t('.expenses') %></a></li>
+            <li><a href="#deuda-viva"><%= t('.debt') %></a></li>
+            <li><a href="#ejecucion-presupuestaria"><%= t('.execution') %></a></li>
+          </ul>
         </div>
-      </blockquote>
+      </header>
 
-      <hr class="separator_responsive" />
 
-      <h2 id="tipos-de-ingreso"><%= t('.types_income') %></h2>
+      <article class="inner">
+        <%= image_tag 'illustrations/presupuestos.jpg', class: 'pure-img', id: 'image1' %>
 
-      <figure>
-        <%= image_tag 'samples/park.jpg', class: 'pure-img', id: 'image2' %>
-        <figcaption>Parque Cedeira (Oporto) <br /> João M. Gil.</figcaption>
-      </figure>
+        <ol>
+          <li><%= t('.intro_p1') %></li>
+          <li><%= t('.intro_p2') %></li>
+        </ol>
 
-      <p><%= t('.types_income_p1') %></p>
-
-      <p><%= t('.types_income_p2') %></p>
-
-      <p><%= t('.types_income_p3') %></p>
-
-      <h4><%= t('.types_income') %></h4>
-      <ol>
-        <li><a href="#ingresos-corrientes"><%= t('.regular_income') %></a></li>
-        <li><a href="#ingresos-de-capital"><%= t('.capital_income') %></a></li>
-        <li><a href="#ingresos-financieros"><%= t('.financial_income') %></a></li>
-      </ol>
-
-      <hr class="separator_responsive quarter" />
-
-      <h3 id="ingresos-corrientes"><small>1</small> <%= t('.regular_income') %></h3>
-      <p><%= t('.regular_income_p1') %></p>
-
-      <dl>
-        <div>
-          <dt><a href="/presupuestos/partidas/1/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 1, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_1_desc') %></dd>
+        <div class="note">
+          <p><%= t('.intro_p3') %></p>
         </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/2/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 2, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_2_desc') %></dd>
+
+        <h2 id="como-se-lee"><%= t('.how_to_read') %></h2>
+        <p><%= t('.how_to_read_p1_html') %></p>
+
+        <h3><%= t('.income') %></h3>
+        <p><%= t('.income_p1') %></p>
+
+        <div class="number">
+          <p><%= t('.income_p2', year: @year) %></p>
+          <div><%= format_currency @site_stats.total_budget %></div>
         </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/4/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 4, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_4_desc') %></dd>
+
+        <h3><%= t('.expenses') %></h3>
+        <p><%= t('.expenses_how') %></p>
+
+        <div class="number">
+          <p><%= t('.expenses_per_inhabitant') %></p>
+          <div><%= format_currency @site_stats.total_budget_per_inhabitant %>/hab</div>
         </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/3/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 3, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_3_desc') %></dd>
+
+        <hr class="separator_responsive" />
+
+        <blockquote>
+          <h4><%= t('.classification') %></h4>
+          <p><%= t('.classification_p1') %></p>
+
+          <div class="share" data-share>
+            <a data-share-network="facebook" data-track-event="Social Share|Click Facebook|Header"><i class="fa fa-facebook"></i></a>
+            <a data-share-network="twitter" data-track-event="Social Share|Click Twitter|Header"><i class="fa fa-twitter"></i></a>
+          </div>
+        </blockquote>
+
+        <hr class="separator_responsive" />
+
+        <h2 id="tipos-de-ingreso"><%= t('.types_income') %></h2>
+
+        <figure>
+          <%= image_tag 'samples/park.jpg', class: 'pure-img', id: 'image2' %>
+          <figcaption>Parque Cedeira (Oporto) <br /> João M. Gil.</figcaption>
+        </figure>
+
+        <p><%= t('.types_income_p1') %></p>
+
+        <p><%= t('.types_income_p2') %></p>
+
+        <p><%= t('.types_income_p3') %></p>
+
+        <h4><%= t('.types_income') %></h4>
+        <ol>
+          <li><a href="#ingresos-corrientes"><%= t('.regular_income') %></a></li>
+          <li><a href="#ingresos-de-capital"><%= t('.capital_income') %></a></li>
+          <li><a href="#ingresos-financieros"><%= t('.financial_income') %></a></li>
+        </ol>
+
+        <hr class="separator_responsive quarter" />
+
+        <h3 id="ingresos-corrientes"><small>1</small> <%= t('.regular_income') %></h3>
+        <p><%= t('.regular_income_p1') %></p>
+
+        <dl>
+          <div>
+            <dt><a href="/presupuestos/partidas/1/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 1, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_1_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/2/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 2, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_2_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/4/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 4, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_4_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/3/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 3, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_3_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/5/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 5, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_5_desc') %></dd>
+          </div>
+        </dl>
+
+        <h3 id="ingresos-de-capital"><small>2</small> <%= t('.capital_income') %></h3>
+        <p><%= t('.capital_income_p1') %></p>
+
+        <dl>
+          <div>
+            <dt><a href="/presupuestos/partidas/6/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 6, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_6_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/7/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 7, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_7_desc') %></dd>
+          </div>
+        </dl>
+
+        <h3 id="ingresos-financieros"><small>3</small> <%= t('.financial_income') %></h3>
+        <p><%= t('.financial_income_p1') %></p>
+
+        <dl>
+          <div>
+            <dt><a href="/presupuestos/partidas/8/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 8, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_8_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/9/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 9, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
+            <dd><%= t('.income_9_desc') %></dd>
+          </div>
+        </dl>
+
+        <hr class="separator_responsive" />
+
+        <h2 id="tipos-de-gasto"><%= t('.expenses_types') %></h2>
+
+        <figure>
+          <%= image_tag 'samples/metro.jpg', class: 'pure-img', id: 'image3' %>
+          <figcaption>Mar de Cristal (Madrid) <br /> Daniel Erler.</figcaption>
+        </figure>
+
+        <p><%= t('.expenses_types_p1') %></p>
+
+        <h4><%= t('.expenses_types') %></h4>
+        <ol>
+          <li><a href="#gasto-funcional"><%= t('.functional') %></a></li>
+          <li><a href="#gasto-economico"><%= t('.economic') %></a></li>
+        </ol>
+
+        <hr class="separator_responsive quarter" />
+
+        <h3 id="gasto-funcional"><small>1</small> <%= t('.functional') %></h3>
+        <p><%= t('.functional_p1') %></p>
+        <p><%= t('.functional_p2') %></p>
+
+        <dl>
+          <div>
+            <dt><a href="/presupuestos/partidas/0/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 0, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_functional_0_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/1/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 1, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_functional_1_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/2/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 2, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_functional_2_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/3/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 3, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_functional_3_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/4/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 4, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_functional_4_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/9/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 9, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_functional_9_desc') %></dd>
+          </div>
+        </dl>
+
+        <h3 id="gasto-economico"><small>2</small> <%= t('.economic') %></h3>
+
+        <p><%= t('.economic_p1') %></p>
+
+        <p><%= t('.economic_p2') %></p>
+
+        <dl>
+          <div>
+            <dt><a href="/presupuestos/partidas/1/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 1, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_1_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/2/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 2, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_2_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/3/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 3, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_3_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/4/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 4, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_4_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/5/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 5, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_5_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/6/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 6, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_6_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/7/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 7, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_7_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/8/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 8, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_8_desc') %></dd>
+          </div>
+          <div>
+            <dt><a href="/presupuestos/partidas/9/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 9, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
+            <dd><%= t('.expense_economic_9_desc') %></dd>
+          </div>
+        </dl>
+
+        <hr class="separator_responsive" />
+
+        <h2 id="deuda-viva"><%= t('.how_much_debt') %></h2>
+
+        <figure>
+          <%= image_tag 'samples/retiro.jpg', class: 'pure-img', id: 'image4' %>
+          <figcaption>El Retiro (Madrid) <br /> Rimbaud Grégoire.</figcaption>
+        </figure>
+
+        <p><%= t('.how_much_debt_p1') %></p>
+
+        <p><%= t('.how_much_debt_p2') %></p>
+
+        <div class="note">
+          <p><%= t('.how_much_debt_p3') %></p>
         </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/5/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 5, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_5_desc') %></dd>
+
+        <hr class="separator_responsive" />
+
+        <h2 id="ejecucion-presupuestaria"><%= t('.budget_execution') %></h2>
+
+        <p><%= t('.budget_execution_p1_html', year: @year) %></p>
+
+        <div class="note">
+          <p><%= t('.budget_execution_p2') %></p>
         </div>
-      </dl>
 
-      <h3 id="ingresos-de-capital"><small>2</small> <%= t('.capital_income') %></h3>
-      <p><%= t('.capital_income_p1') %></p>
-
-      <dl>
-        <div>
-          <dt><a href="/presupuestos/partidas/6/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 6, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_6_desc') %></dd>
+        <div class="sources note">
+          <h4><%= t('.sources') %></h4>
+          <p><%= t('.sources_p1_html') %></p>
         </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/7/<%= @year %>/economic/I"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 7, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_7_desc') %></dd>
-        </div>
-      </dl>
 
-      <h3 id="ingresos-financieros"><small>3</small> <%= t('.financial_income') %></h3>
-      <p><%= t('.financial_income_p1') %></p>
+      </article>
+    </main>
 
-      <dl>
-        <div>
-          <dt><a href="/presupuestos/partidas/8/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 8, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_8_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/9/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 9, kind: GobiertoBudgets::BudgetLine::INCOME).name %></a></dt>
-          <dd><%= t('.income_9_desc') %></dd>
-        </div>
-      </dl>
-
-      <hr class="separator_responsive" />
-
-      <h2 id="tipos-de-gasto"><%= t('.expenses_types') %></h2>
-
-      <figure>
-        <%= image_tag 'samples/metro.jpg', class: 'pure-img', id: 'image3' %>
-        <figcaption>Mar de Cristal (Madrid) <br /> Daniel Erler.</figcaption>
-      </figure>
-
-      <p><%= t('.expenses_types_p1') %></p>
-
-      <h4><%= t('.expenses_types') %></h4>
-      <ol>
-        <li><a href="#gasto-funcional"><%= t('.functional') %></a></li>
-        <li><a href="#gasto-economico"><%= t('.economic') %></a></li>
-      </ol>
-
-      <hr class="separator_responsive quarter" />
-
-      <h3 id="gasto-funcional"><small>1</small> <%= t('.functional') %></h3>
-      <p><%= t('.functional_p1') %></p>
-      <p><%= t('.functional_p2') %></p>
-
-      <dl>
-        <div>
-          <dt><a href="/presupuestos/partidas/0/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 0, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_functional_0_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/1/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 1, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_functional_1_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/2/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 2, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_functional_2_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/3/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 3, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_functional_3_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/4/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 4, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_functional_4_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/9/<%= @year %>/functional/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::FunctionalArea.area_name, code: 9, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_functional_9_desc') %></dd>
-        </div>
-      </dl>
-
-      <h3 id="gasto-economico"><small>2</small> <%= t('.economic') %></h3>
-
-      <p><%= t('.economic_p1') %></p>
-
-      <p><%= t('.economic_p2') %></p>
-
-      <dl>
-        <div>
-          <dt><a href="/presupuestos/partidas/1/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 1, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_1_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/2/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 2, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_2_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/3/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 3, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_3_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/4/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 4, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_4_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/5/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 5, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_5_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/6/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 6, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_6_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/7/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 7, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_7_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/8/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 8, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_8_desc') %></dd>
-        </div>
-        <div>
-          <dt><a href="/presupuestos/partidas/9/<%= @year %>/economic/G"><%= GobiertoBudgets::Category.new(site: current_site, area_name: GobiertoBudgets::EconomicArea.area_name, code: 9, kind: GobiertoBudgets::BudgetLine::EXPENSE).name %></a></dt>
-          <dd><%= t('.expense_economic_9_desc') %></dd>
-        </div>
-      </dl>
-
-      <hr class="separator_responsive" />
-
-      <h2 id="deuda-viva"><%= t('.how_much_debt') %></h2>
-
-      <figure>
-        <%= image_tag 'samples/retiro.jpg', class: 'pure-img', id: 'image4' %>
-        <figcaption>El Retiro (Madrid) <br /> Rimbaud Grégoire.</figcaption>
-      </figure>
-
-      <p><%= t('.how_much_debt_p1') %></p>
-
-      <p><%= t('.how_much_debt_p2') %></p>
-
-      <div class="note">
-        <p><%= t('.how_much_debt_p3') %></p>
-      </div>
-
-      <hr class="separator_responsive" />
-
-      <h2 id="ejecucion-presupuestaria"><%= t('.budget_execution') %></h2>
-
-      <p><%= t('.budget_execution_p1_html', year: @year) %></p>
-
-      <div class="note">
-        <p><%= t('.budget_execution_p2') %></p>
-      </div>
-
-      <div class="sources note">
-        <h4><%= t('.sources') %></h4>
-        <p><%= t('.sources_p1_html') %></p>
-      </div>
-
-    </article>
-  </main>
-
-</div>
+  </div>
+<% end %>

--- a/config/locales/gobierto_admin/gobierto_budgets/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/models/ca.yml
@@ -3,6 +3,8 @@ ca:
   activemodel:
     attributes:
       gobierto_admin/gobierto_budgets/options_form:
+        budgets_guide_page: Pàgina de la guia de pressupostos (si no selecciones niguna
+          se mostrarà el text per defecte)
         comparison_compare_municipalities: Mostrar municipis específics
         comparison_context_table_enabled: Mostrar taula de contexte
         comparison_show_widget: Mostrar widget comparació

--- a/config/locales/gobierto_admin/gobierto_budgets/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/models/en.yml
@@ -3,6 +3,7 @@ en:
   activemodel:
     attributes:
       gobierto_admin/gobierto_budgets/options_form:
+        budgets_guide_page: Budgets guide page
         comparison_compare_municipalities: Show specific municipalities
         comparison_context_table_enabled: Show context table
         comparison_show_widget: Show comparison widget

--- a/config/locales/gobierto_admin/gobierto_budgets/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_budgets/models/es.yml
@@ -3,6 +3,8 @@ es:
   activemodel:
     attributes:
       gobierto_admin/gobierto_budgets/options_form:
+        budgets_guide_page: Página guía de presupuestos (si no se selecciona ninguna
+          se mostrará el texto por defecto)
         comparison_compare_municipalities: Mostrar municipios específicos
         comparison_context_table_enabled: Mostrar tabla de contexto
         comparison_show_widget: Mostrar widget comparación

--- a/test/forms/gobierto_admin/gobierto_budgets/options_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_budgets/options_form_test.rb
@@ -10,6 +10,10 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def page
+        @page ||= gobierto_cms_pages(:site_news_1)
+      end
+
       def receipt_configuration
         @receipt_configuration ||= <<-JSON
 {
@@ -50,7 +54,8 @@ JSON
           comparison_context_table_enabled: '1',
           comparison_compare_municipalities: [28065, 28001],
           comparison_show_widget: '1',
-          providers_enabled: '1'
+          providers_enabled: '1',
+          budgets_guide_page: page.id
         )
       end
 
@@ -64,7 +69,7 @@ JSON
           comparison_context_table_enabled: '1',
           comparison_compare_municipalities: [28065, 28001],
           comparison_show_widget: '1',
-          providers_enabled: '1'
+          providers_enabled: '1',
         )
       end
 
@@ -103,6 +108,7 @@ JSON
         assert site.gobierto_budgets_settings.settings["budgets_receipt_enabled"]
         assert_equal receipt_configuration, site.gobierto_budgets_settings.settings["budgets_receipt_configuration"]
         assert site.gobierto_budgets_settings.settings["budgets_providers_enabled"]
+        assert site.gobierto_budgets_settings.settings["budgets_guide_page"]
       end
 
       def test_save_valid_form_feedback_disabled
@@ -114,6 +120,7 @@ JSON
         refute site.gobierto_budgets_settings.settings["budget_lines_feedback_enabled"]
         assert site.gobierto_budgets_settings.settings["budgets_receipt_enabled"]
         assert site.gobierto_budgets_settings.settings["budgets_providers_enabled"]
+        refute site.gobierto_budgets_settings.settings["budgets_guide_page"]
       end
 
       def test_error_messages_with_invalid_attributes

--- a/test/integration/gobierto_admin/gobierto_budgets/options_test.rb
+++ b/test/integration/gobierto_admin/gobierto_budgets/options_test.rb
@@ -18,6 +18,10 @@ module GobiertoAdmin
         @admin ||= gobierto_admin_admins(:nick)
       end
 
+      def cms_page
+        @cms_page ||= gobierto_cms_pages(:about_site)
+      end
+
       def test_enable_options
         with_javascript do
           with_signed_in_admin(admin) do
@@ -42,6 +46,7 @@ module GobiertoAdmin
               find("#gobierto_budgets_options_comparison_context_table_enabled", visible: false).trigger(:click)
               find("#gobierto_budgets_options_comparison_tool_enabled", visible: false).trigger(:click)
               find("#gobierto_budgets_options_indicators_enabled", visible: false).trigger(:click)
+              select cms_page.title, from: "gobierto_budgets_options_budgets_guide_page"
 
               click_button "Save"
 
@@ -54,6 +59,7 @@ module GobiertoAdmin
               refute find("#gobierto_budgets_options_comparison_tool_enabled", visible: false).checked?
               refute find("#gobierto_budgets_options_comparison_context_table_enabled", visible: false).checked?
               assert find("#gobierto_budgets_options_indicators_enabled", visible: false).checked?
+              assert has_field?("gobierto_budgets_options_budgets_guide_page", with: cms_page.id)
             end
           end
         end

--- a/test/integration/gobierto_budgets/guide_test.rb
+++ b/test/integration/gobierto_budgets/guide_test.rb
@@ -16,6 +16,10 @@ class GobiertoBudgets::GuideTest < ActionDispatch::IntegrationTest
     @organization_site ||= sites(:organization_wadus)
   end
 
+  def cms_page
+    @cms_page ||= gobierto_cms_pages(:about_site)
+  end
+
   def last_year
     GobiertoBudgets::SearchEngineConfiguration::Year.last
   end
@@ -26,6 +30,17 @@ class GobiertoBudgets::GuideTest < ActionDispatch::IntegrationTest
 
       assert has_content?("How a municipal budget works")
       assert has_content?("In #{last_year} were entered...")
+    end
+  end
+
+  def test_overwrite_page
+    placed_site.gobierto_budgets_settings.settings["budgets_guide_page"] = cms_page.id
+    placed_site.gobierto_budgets_settings.save!
+
+    with_current_site(placed_site) do
+      visit @path
+
+      assert has_content?("About site")
     end
   end
 end


### PR DESCRIPTION
## :v: What does this PR do?

This PR allows to select a page from the CMS to be rendered as the text of the budgets guide.

## :mag: How should this be manually tested?

1. Update the option with a cms page
2. Check in the frontend that the page content is displayed instead of the guide content

## :eyes: Screenshots

### Before this PR

![screen shot 2019-01-30 at 09 47 53](https://user-images.githubusercontent.com/17616/51969210-23fb7880-2474-11e9-9167-2078b42aaa25.png)

### After this PR

![screen shot 2019-01-30 at 09 48 25](https://user-images.githubusercontent.com/17616/51969247-37a6df00-2474-11e9-8598-d4d2778eff71.png)


## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

- [x] significant changes in some feature? Yes, the documentation of the budgets module has been updated with this option
