### PR TITLE
Fixes in elaboration and other parts of budgets

### DIFF
--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -101,7 +101,7 @@ module GobiertoBudgets
       @autonomy_id = place ? place.province.autonomous_region_id.to_i : nil
       @level = self.class.get_level(code)
       @parent_code = self.class.get_parent_code(code)
-      @amount_per_inhabitant = (amount / population).round(2)
+      @amount_per_inhabitant = population ? (amount / population).round(2) : nil
     end
 
     def population

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -38,9 +38,9 @@ module GobiertoBudgets
       !@empty_debt
     end
 
-    def total_budget_per_inhabitant(year = nil)
+    def total_budget_per_inhabitant(year = nil, kind = GobiertoBudgets::BudgetLine::EXPENSE)
       year ||= @year
-      BudgetTotal.budgeted_for(@site.organization_id, year, BudgetLine::EXPENSE).to_f / (population(year) || population(year - 1) || population(year - 2)).to_f
+      BudgetTotal.budgeted_for(@site.organization_id, year, kind).to_f / (population(year) || population(year - 1) || population(year - 2)).to_f
     end
 
     def total_income_budget(year = nil)
@@ -58,9 +58,9 @@ module GobiertoBudgets
       BudgetTotal.budgeted_for(@site.organization_id, year, BudgetLine::INCOME).to_f / (population(year) || population(year - 1) || population(year - 2)).to_f
     end
 
-    def total_budget(year = nil)
+    def total_budget(year = nil, kind = GobiertoBudgets::BudgetLine::EXPENSE)
       year ||= @year
-      BudgetTotal.budgeted_for(@site.organization_id, year)
+      BudgetTotal.budgeted_for(@site.organization_id, year, kind)
     end
     alias total_budget_planned total_budget
 

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -113,14 +113,11 @@ module GobiertoBudgets
       return 0 if total_income == 0
 
       total_expense = 0
-      (1..4).each do |code|
+      (1..5).each do |code|
         total_expense += get_expense_budget_line(year, code)
       end
 
-      value = (total_income - total_expense + get_expense_budget_line(year, 9))
-
-      return nil if value == 0
-      ((value / total_income) * 100).round(2)
+      return (total_income - total_expense - get_expense_budget_line(year, 9)).round(2)
     end
 
     def debt_level(year = nil)
@@ -192,6 +189,12 @@ module GobiertoBudgets
                return nil if v1.nil? || v2.nil?
                ((v1.to_f - v2.to_f) / v2.to_f) * 100
       end
+      total_income = 0
+      (1..5).each do |code|
+        total_income += get_income_budget_line(year, code)
+      end
+      return 0 if total_income == 0
+
 
       if diff < 0
         direction = I18n.t("gobierto_budgets.budgets.index.less")
@@ -273,7 +276,7 @@ module GobiertoBudgets
     end
 
     def get_income_budget_line(year, code)
-      kind = BudgetLine::INCOME
+      kind = GobiertoBudgets::BudgetLine::INCOME
       id = [@site.organization_id, year, code, kind].join("/")
       index = GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast
       type = GobiertoBudgets::EconomicArea.area_name
@@ -285,9 +288,9 @@ module GobiertoBudgets
     end
 
     def get_expense_budget_line(year, code)
-      kind = BudgetLine::EXPENSE
+      kind = GobiertoBudgets::BudgetLine::EXPENSE
       id = [@site.organization_id, year, code, kind].join("/")
-      index = SearchEngineConfiguration::BudgetLine.index_forecast
+      index = GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast
       type = GobiertoBudgets::EconomicArea.area_name
 
       result = GobiertoBudgets::SearchEngine.client.get index: index, type: type, id: id

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -87,7 +87,7 @@
             </div>
           </div>
         <% else %>
-          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip', of_the_organization_name: @site.determined_organization_name(:of_the)) %>" data-box="debt">
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.net_savings_tooltip') %>" data-box="debt">
             <div class="inner">
               <h3><%= t('gobierto_budgets.budgets_elaboration.index.net_savings') %></h3>
               <div class="metric"><%= format_currency @site_stats.net_savings %></div>
@@ -113,10 +113,10 @@
             </div>
           </div>
         <% else %>
-          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.debt_tooltip', of_the_organization_name: @site.determined_organization_name(:of_the)) %>" data-box="debt">
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.auto_funding_tooltip') %>" data-box="debt">
             <div class="inner">
               <h3><%= t('gobierto_budgets.budgets_elaboration.index.auto_funding') %></h3>
-              <div class="metric"><%= format_currency @site_stats.auto_funding %></div>
+              <div class="metric"><%= @site_stats.auto_funding %> %</div>
               <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :auto_funding) %> vs <%= @year - 1 %></div>
             </div>
           </div>

--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -20,23 +20,42 @@
   <div class="pure-g metric_boxes">
 
     <% if @site_stats.has_available_population_data? %>
-      <div id="metric_box_1" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant_tooltip') %>">
-        <!--  metric_box should be flexbox -->
+      <% if @kind == GobiertoBudgets::BudgetLine::EXPENSE %>
+        <div id="metric_box_1" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant_tooltip') %>">
+          <div class="inner">
+            <h3><%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant') %></h3>
+            <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant(@year, @kind) %></div>
+            <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_income_budget_per_inhabitant) %> vs <%= @year - 1 %></div>
+          </div>
+        </div>
+      <% else %>
+        <div id="metric_box_1" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.income_per_inhabitant_tooltip') %>">
+          <div class="inner">
+            <h3><%= t('gobierto_budgets.budgets_elaboration.index.income_per_inhabitant') %></h3>
+            <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant(@year, @kind) %></div>
+            <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_expenses) %> vs <%= @year - 1 %></div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <% if @kind == GobiertoBudgets::BudgetLine::EXPENSE %>
+      <div id="metric_box_2" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.total_expenses_tooltip') %>">
         <div class="inner">
-          <h3><%= t('gobierto_budgets.budgets_elaboration.index.expenses_per_inhabitant') %></h3>
-          <div class="metric"><%= format_currency @site_stats.total_budget_per_inhabitant %></div>
-          <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_budget_per_inhabitant) %> vs <%= @year - 1 %></div>
+          <h3><%= t('gobierto_budgets.budgets_elaboration.index.total_expenses') %></h3>
+          <div class="metric"><%= format_currency @site_stats.total_budget(@year, @kind) %></div>
+          <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_budget) %> vs <%= @year - 1 %></div>
+        </div>
+      </div>
+    <% else %>
+      <div id="metric_box_2" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.total_income_tooltip') %>">
+        <div class="inner">
+          <h3><%= t('gobierto_budgets.budgets_elaboration.index.total_income') %></h3>
+          <div class="metric"><%= format_currency @site_stats.total_budget(@year, @kind) %></div>
+          <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_income_budget) %> vs <%= @year - 1 %></div>
         </div>
       </div>
     <% end %>
-
-    <div id="metric_box_2" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.total_expenses_tooltip') %>">
-      <div class="inner">
-        <h3><%= t('gobierto_budgets.budgets_elaboration.index.total_expenses') %></h3>
-        <div class="metric"><%= format_currency @site_stats.total_budget %></div>
-        <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :total_budget) %> vs <%= @year - 1 %></div>
-      </div>
-    </div>
 
     <div id="metric_box_3" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.net_savings_tooltip') %>">
       <div class="inner">

--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -59,7 +59,7 @@
     <div id="metric_box_5" class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('gobierto_budgets.budgets_elaboration.index.auto_funding_tooltip') %>">
       <div class="inner">
         <h3><%= t('gobierto_budgets.budgets_elaboration.index.auto_funding') %></h3>
-        <div class="metric"><%= format_currency @site_stats.auto_funding %></div>
+        <div class="metric"><%= @site_stats.auto_funding %> %</div>
         <div class="diff"><%= @site_stats.percentage_difference(year1: @year, year2: @year - 1, variable1: :auto_funding) %> vs <%= @year - 1 %></div>
       </div>
     </div>

--- a/app/views/gobierto_budgets/exports/_index.html.erb
+++ b/app/views/gobierto_budgets/exports/_index.html.erb
@@ -1,4 +1,4 @@
-<div class="pure-g data_block" id="section-people">
+<div class="pure-g data_block" id="section-budgets">
 
   <div class="pure-u-1 pure-u-md-7-24">
     <h2><%= t("gobierto_budgets.exports.budget_lines_title") %></h2>
@@ -25,7 +25,7 @@
 </div>
 
 <% if budgets_providers_active? %>
-  <div class="pure-g data_block" id="section-people">
+  <div class="pure-g data_block" id="section-budgets-providers">
 
     <div class="pure-u-1 pure-u-md-7-24">
       <h2><%= t("gobierto_budgets.exports.invoices_title") %></h2>

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -261,6 +261,8 @@ ca:
         header: Pressupostos
         in_total: En total
         income: Ingressos
+        income_per_inhabitant: Ingressos per habitant
+        income_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
         inhabitants: Habitants
         inhabitants_tooltip: Nombre d’habitants
         less: menys
@@ -339,6 +341,8 @@ ca:
         explore_the_detail: Explora el detall
         header: Elaboració del pressupost
         in_total: En total
+        income_per_inhabitant: Ingressos per habitant
+        income_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
         main_budget_levels_timeline: Compara despeses i ingressos any per any
         main_budget_lines: Els principals ingressos i despeses %{from_your_organization_name}
         main_budget_lines_expense: Despeses
@@ -359,6 +363,8 @@ ca:
         proposal: Proposta
         total_expenses: Despesa total
         total_expenses_tooltip: Pressupost inicial
+        total_income: Ingrés total
+        total_income_tooltip: Pressupost inicial d'ingressos
         visualize: Visualitza la despesa per habitant o total
     budgets_execution:
       execution_table:

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -245,6 +245,8 @@ en:
         header: Budgets
         in_total: Total
         income: Income
+        income_per_inhabitant: Income per inhabitant
+        income_per_inhabitant_tooltip: Starting budget divided by the inhabitants
         inhabitants: Inhabitants
         inhabitants_tooltip: Number of inhabitants
         less: less
@@ -322,6 +324,8 @@ en:
         explore_the_detail: Explore the details
         header: Budgets elaboration
         in_total: Total
+        income_per_inhabitant: Income per inhabitant
+        income_per_inhabitant_tooltip: Starting budget divided by the inhabitants
         main_budget_levels_timeline: Compare income and expenses year by year
         main_budget_lines: Main income and expenses %{from_your_organization_name}
         main_budget_lines_expense: Expense
@@ -340,6 +344,8 @@ en:
         proposal: Proposal
         total_expenses: Total expenses
         total_expenses_tooltip: Starting budget
+        total_income: Total income
+        total_income_tooltip: Starting budget
         visualize: Visualize expenses per inhabitant
     budgets_execution:
       execution_table:

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -243,13 +243,16 @@ es:
           intro: Así va la ejecución del presupuesto municipal.
           last_update: 'Última actualización: %{date}.'
           title: Ejecución
-        expenses: Gastos
+        expenses: Ingresos
         expenses_per_inhabitant: Gasto por habitante
         expenses_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
           de habitantes
         header: Presupuestos
         in_total: En total
         income: Ingresos
+        income_per_inhabitant: Ingreso por habitante
+        income_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
+          de habitantes
         inhabitants: Habitantes
         inhabitants_tooltip: Número de habitantes
         less: menos
@@ -330,6 +333,9 @@ es:
         explore_the_detail: Explora el detalle
         header: Elaboración del presupuesto
         in_total: En total
+        income_per_inhabitant: Ingreso por habitante
+        income_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
+          de habitantes
         main_budget_levels_timeline: Compara gastos e ingresos año por año
         main_budget_lines: Los principales ingresos y gastos %{from_your_organization_name}
         main_budget_lines_expense: Gastos
@@ -338,8 +344,7 @@ es:
         metric_boxes_data_description: Así cambiará el presupuesto de cara al próximo
           ejercicio
         net_savings: Ahorro neto
-        net_savings_tooltip: Ingresos corrientes menos gastos corrientes y gastos
-          financieros
+        net_savings_tooltip: Capacidad que tiene la entidad de hacer frente
         next_year_proposal: Propuesta para el %{year}
         no_data: No hay datos para esta clasificación
         note_about_the_data: Nota sobre los datos
@@ -351,6 +356,8 @@ es:
         proposal: Propuesta
         total_expenses: Gasto total
         total_expenses_tooltip: Presupuesto inicial
+        total_income: Ingreso total
+        total_income_tooltip: Presupuesto inicial
         visualize: Visualiza los gastos por habitante o el total
     budgets_execution:
       execution_table:

--- a/lib/tasks/gobierto_budgets/algolia_indices.rake
+++ b/lib/tasks/gobierto_budgets/algolia_indices.rake
@@ -6,7 +6,6 @@ namespace :gobierto_budgets do
     task :reindex, [:site_domain, :year] => [:environment] do |_t, args|
       site = Site.find_by!(domain: args[:site_domain])
       year = args[:year].to_i
-      ine_code = site.place.id
       organization_id = site.organization_id
 
       puts "== Reindexing records for site #{site.domain}=="


### PR DESCRIPTION
## :v: What does this PR do?

- In elaboration, income and expenses tabs update the data block to show total income and total expenses
- Fixes net savings calculations
- Fixes the tooltips of net savings and autofinancing 
- Budget lines work even when population is not available
- Fixes a duplicated ID in the export data section
