### PR TITLE
584 include people activities

### DIFF
--- a/app/controllers/concerns/gobierto_people/filter_by_activities_helper.rb
+++ b/app/controllers/concerns/gobierto_people/filter_by_activities_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  module FilterByActivitiesHelper
+    extend ActiveSupport::Concern
+
+    private
+
+    def filter_by_activities(source:, start_date: nil, end_date: nil)
+      return source if start_date.blank? && end_date.blank?
+
+      source.select do |item|
+        events = item.events.published
+        gifts = item.gifts
+        trips = item.trips
+        invitations = item.invitations
+
+        if start_date.present?
+          events = events.where("starts_at >= ?", start_date)
+          gifts = gifts.where("date >= ?", start_date)
+          trips = trips.where("start_date >= ?", start_date)
+          invitations = invitations.where("start_date >= ?", start_date)
+        end
+
+        if end_date.present?
+          events = events.where("ends_at <= ?", end_date)
+          gifts = gifts.where("date <= ?", end_date)
+          trips = trips.where("end_date <= ?", end_date)
+          invitations = invitations.where("end_date <= ?", end_date)
+        end
+        events.exists? || gifts.exists? || trips.exists? || invitations.exists?
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_people/departments/people_controller.rb
+++ b/app/controllers/gobierto_people/departments/people_controller.rb
@@ -7,6 +7,7 @@ module GobiertoPeople
       layout "gobierto_people/layouts/departments"
 
       include DatesRangeHelper
+      include FilterByActivitiesHelper
 
       def index
         @people = QueryWithActivities.new(
@@ -26,27 +27,11 @@ module GobiertoPeople
       private
 
       def filter_sidebar_departments
-        @sidebar_departments = @sidebar_departments.select do |department|
-          events = department.events.published
-          gifts = department.gifts
-          trips = department.trips
-          invitations = department.invitations
-
-          if filter_start_date.present?
-            events = events.where("starts_at >= ?", filter_start_date)
-            gifts = gifts.where("date >= ?", filter_start_date)
-            trips = trips.where("start_date >= ?", filter_start_date)
-            invitations = invitations.where("start_date >= ?", filter_start_date)
-          end
-
-          if filter_end_date.present?
-            events = events.where("ends_at <= ?", filter_end_date)
-            gifts = gifts.where("date <= ?", filter_end_date)
-            trips = trips.where("end_date <= ?", filter_end_date)
-            invitations = invitations.where("end_date <= ?", filter_end_date)
-          end
-          events.exists? || gifts.exists? || trips.exists? || invitations.exists?
-        end
+        @sidebar_departments = filter_by_activities(
+          source: @sidebar_departments,
+          start_date: filter_start_date,
+          end_date: filter_end_date
+        )
       end
     end
   end

--- a/app/controllers/gobierto_people/departments/people_controller.rb
+++ b/app/controllers/gobierto_people/departments/people_controller.rb
@@ -18,17 +18,36 @@ module GobiertoPeople
 
         @sidebar_departments = current_site.departments
 
-        if current_site.date_filter_configured?
-          @sidebar_departments = QueryWithEvents.new(
-            source: @sidebar_departments,
-            start_date: filter_start_date,
-            end_date: filter_end_date
-          )
-        end
+        filter_sidebar_departments if current_site.date_filter_configured?
 
         render "gobierto_people/people/index"
       end
 
+      private
+
+      def filter_sidebar_departments
+        @sidebar_departments = @sidebar_departments.select do |department|
+          events = department.events.published
+          gifts = department.gifts
+          trips = department.trips
+          invitations = department.invitations
+
+          if filter_start_date.present?
+            events = events.where("starts_at >= ?", filter_start_date)
+            gifts = gifts.where("date >= ?", filter_start_date)
+            trips = trips.where("start_date >= ?", filter_start_date)
+            invitations = invitations.where("start_date >= ?", filter_start_date)
+          end
+
+          if filter_end_date.present?
+            events = events.where("ends_at <= ?", filter_end_date)
+            gifts = gifts.where("date <= ?", filter_end_date)
+            trips = trips.where("end_date <= ?", filter_end_date)
+            invitations = invitations.where("end_date <= ?", filter_end_date)
+          end
+          events.exists? || gifts.exists? || trips.exists? || invitations.exists?
+        end
+      end
     end
   end
 end

--- a/app/controllers/gobierto_people/departments/people_controller.rb
+++ b/app/controllers/gobierto_people/departments/people_controller.rb
@@ -9,10 +9,11 @@ module GobiertoPeople
       include DatesRangeHelper
 
       def index
-        @people = QueryWithEvents.new(
+        @people = QueryWithActivities.new(
           source: current_department.people.active,
           start_date: filter_start_date,
-          end_date: filter_end_date
+          end_date: filter_end_date,
+          include_joins: { events: :attending_events, gifts: :received_gifts, invitations: :invitations, trips: :trips }
         ).sorted
 
         @sidebar_departments = current_site.departments

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -103,10 +103,11 @@ module GobiertoPeople
       @people = current_site.people.active.sorted
 
       if current_site.date_filter_configured?
-        @people = QueryWithEvents.new(
+        @people = QueryWithActivities.new(
           source: @people,
           start_date: filter_start_date,
-          end_date: filter_end_date
+          end_date: filter_end_date,
+          include_joins: { events: :attending_events, gifts: :received_gifts, invitations: :invitations, trips: :trips }
         ).sorted
       end
 

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
     include PreviewTokenHelper
     include PeopleClassificationHelper
     include DatesRangeHelper
+    include FilterByActivitiesHelper
 
     layout :resolve_layout
 
@@ -129,7 +130,7 @@ module GobiertoPeople
     end
 
     def set_departments
-      @sidebar_departments = QueryWithEvents.new(
+      @sidebar_departments = filter_by_activities(
         source: current_site.departments,
         start_date: filter_start_date,
         end_date: filter_end_date

--- a/app/models/gobierto_people/department.rb
+++ b/app/models/gobierto_people/department.rb
@@ -43,8 +43,11 @@ module GobiertoPeople
 
     def people
       site.people
-          .joins(attending_person_events: :event)
-          .where("gc_events.department_id = ?", id)
+          .left_outer_joins(attending_person_events: :event)
+          .left_outer_joins(:trips)
+          .left_outer_joins(:invitations)
+          .left_outer_joins(:received_gifts)
+          .where("gc_events.department_id = :id or gp_trips.department_id = :id or gp_invitations.department_id = :id or gp_gifts.department_id = :id", id: id)
           .distinct
     end
 

--- a/app/queries/gobierto_people/query_with_activities.rb
+++ b/app/queries/gobierto_people/query_with_activities.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module GobiertoPeople
+  class QueryWithActivities
+    attr_reader :relation
+
+    def method_missing(*args, &block)
+      relation.send(*args, &block)
+    end
+
+    def initialize(params = {})
+      @relation = params[:source]
+      @joins = params[:include_joins] || {}
+      @joins.each do |_, join_name|
+        add_join(join_name)
+      end
+      add_interval_conditions(params[:start_date], params[:end_date])
+      params[:not_null]&.each do |association, attributes|
+        append_not_null_conditions(association, attributes)
+      end
+    end
+
+    def update_relation
+      @relation = yield(@relation)
+    end
+
+    private
+
+    ASSOCIATIONS = {
+      events: { model: ::GobiertoCalendars::Event, start_attribute: "starts_at", end_attribute: "ends_at" },
+      invitations: { model: ::GobiertoPeople::Invitation, start_attribute: "start_date", end_attribute: "end_date" },
+      trips: { model: ::GobiertoPeople::Trip, start_attribute: "start_date", end_attribute: "end_date" },
+      gifts: { model: ::GobiertoPeople::Gift, start_attribute: "date", end_attribute: "date" }
+    }.freeze
+
+    def add_join(association)
+      @relation = relation.left_outer_joins(association).distinct if relation.reflect_on_association(association)
+    end
+
+    def add_interval_conditions(start_date, end_date)
+      return if start_date.blank? && end_date.blank?
+
+      @relation = relation.where(interval_conditions(start_date, end_date), start: start_date, end: end_date)
+    end
+
+    def append_not_null_conditions(association, attributes)
+      table_name = ASSOCIATIONS[association][:model].table_name
+      attributes.each do |attribute_name|
+        @relation = relation.where.not(table_name => { attribute_name => nil })
+      end
+    end
+
+    def condition_components_for_attribute(attribute, operator = nil)
+      operator ||= attribute == :start ? ">=" : "<="
+
+      @joins.inject({}) do |result, (association, _)|
+        table_name = ASSOCIATIONS[association][:model].table_name
+        table_attribute = ASSOCIATIONS[association][:"#{attribute}_attribute"]
+
+        result.update(association => "#{table_name}.#{table_attribute} #{operator} :#{attribute}")
+      end
+    end
+
+    def interval_conditions(start_date, end_date)
+      start_conditions = start_date.present? ? condition_components_for_attribute(:start) : {}
+      end_conditions = end_date.present? ? condition_components_for_attribute(:end) : {}
+      start_conditions.merge(end_conditions) do |_, start_condition, end_condition|
+        [start_condition, end_condition].compact.join(" and ")
+      end.values.join(" or ")
+    end
+
+    def append_condition(attribute_name, attribute_value, operator = "=")
+      @relation = relation.where("#{events_table}.#{attribute_name} #{operator} ?", attribute_value)
+    end
+  end
+end

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -13,10 +13,13 @@ module GobiertoPeople
       def justice_department
         @justice_department ||= gobierto_people_departments(:justice_department)
       end
+      alias department_with_trips justice_department
 
       def culture_department
         @culture_department ||= gobierto_people_departments(:culture_department)
       end
+      alias department_with_gifts culture_department
+      alias department_with_invitations culture_department
 
       def ecology_department_old
         @ecology_department_old ||= gobierto_people_departments(:ecology_department_old)
@@ -49,10 +52,25 @@ YAML
         ]
       end
 
+      def departments_with_trips
+        @departments_with_trips ||= [department_with_trips]
+      end
+
+      def departments_with_gifts
+        @departments_with_gifts ||= [department_with_gifts]
+      end
+
+      def departments_with_invitations
+        @departments_with_invitations ||= [department_with_invitations]
+      end
+
       def richard
         @richard ||= gobierto_people_people(:richard)
       end
       alias culture_department_person richard
+      alias person_with_gifts_and_department richard
+      alias person_with_invitations_and_department richard
+      alias person_with_trips_and_department richard
 
       def tamara
         @tamara ||= gobierto_people_people(:tamara)
@@ -67,7 +85,18 @@ YAML
         ".pure-u-1.pure-u-md-7-24"
       end
 
+      def people_summary
+        ".people-summary"
+      end
+
+      def clear_activities
+        GobiertoPeople::Trip.destroy_all
+        GobiertoPeople::Gift.destroy_all
+        GobiertoPeople::Invitation.destroy_all
+      end
+
       def test_sidebar_contents
+        clear_activities
         culture_department.events.destroy_all
 
         with_current_site(site) do
@@ -91,6 +120,7 @@ YAML
       end
 
       def test_index
+        clear_activities
         with_current_site(site) do
           visit gobierto_people_department_people_path(justice_department)
 
@@ -111,6 +141,7 @@ YAML
       end
 
       def test_index_filtered_by_date
+        clear_activities
         site.events.where.not(id: neil.events.pluck(:id)).destroy_all
 
         departments = [
@@ -192,6 +223,92 @@ YAML
         end
       end
 
+      def test_index_with_trips
+        GobiertoCalendars::Event.destroy_all
+        GobiertoPeople::Gift.destroy_all
+        GobiertoPeople::Invitation.destroy_all
+        set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
+        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+
+        with_current_site(site) do
+          visit gobierto_people_department_people_path(
+            department_with_trips,
+            start_date: start_date,
+            end_date: end_date
+          )
+          within departments_sidebar do
+            departments.each do |department|
+              if departments_with_trips.include?(department)
+                assert has_link? department.name
+              else
+                assert has_no_link? department.name
+              end
+            end
+          end
+
+          within people_summary do
+            assert has_content? person_with_trips_and_department.name
+          end
+        end
+      end
+
+      def test_index_with_gifts
+        GobiertoCalendars::Event.destroy_all
+        GobiertoPeople::Trip.destroy_all
+        GobiertoPeople::Invitation.destroy_all
+        set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
+        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+
+        with_current_site(site) do
+          visit gobierto_people_department_people_path(
+            department_with_gifts,
+            start_date: start_date,
+            end_date: end_date
+          )
+          within departments_sidebar do
+            departments.each do |department|
+              if departments_with_gifts.include?(department)
+                assert has_link? department.name
+              else
+                assert has_no_link? department.name
+              end
+            end
+          end
+
+          within people_summary do
+            assert has_content? person_with_gifts_and_department.name
+          end
+        end
+      end
+
+      def test_index_with_invitations
+        GobiertoCalendars::Event.destroy_all
+        GobiertoPeople::Gift.destroy_all
+        GobiertoPeople::Trip.destroy_all
+        set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
+        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+
+        with_current_site(site) do
+          visit gobierto_people_department_people_path(
+            department_with_invitations,
+            start_date: start_date,
+            end_date: end_date
+          )
+          within departments_sidebar do
+            departments.each do |department|
+              if departments_with_invitations.include?(department)
+                assert has_link? department.name
+              else
+                assert has_no_link? department.name
+              end
+            end
+          end
+
+          within people_summary do
+            assert has_content? person_with_invitations_and_department.name
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Related with https://github.com/PopulateTools/issues/issues/581


## :v: What does this PR do?

Includes people and departments in personas/departamentos/department with activities between filter dates of events, trips, gifts and invitations, not only events

## :mag: How should this be manually tested?

Visit `personas/departamentos/department_slug` and change the date filter, checking the presence of people and departments with only trips, gifts or invitations between the filter dates


## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No