### PR TITLE
Move fixture date to avoid random tests

### DIFF
--- a/test/fixtures/gobierto_calendars/events.yml
+++ b/test/fixtures/gobierto_calendars/events.yml
@@ -27,7 +27,7 @@ richard_published:
     'en' => 'Future government event',
     'es' => 'Future government event',
   }.to_json %>
-  slug: <%= "#{1.month.from_now.strftime('%F')}-future-government-event" %>
+  slug: <%= "#{1.year.from_now.strftime('%F')}-future-government-event" %>
   description_translations: <%= {
     'en' => 'The <strong>President</strong> will analyze the progress of the measures adopted in the first days of the Government.',
     'es' => 'El <strong>Presidente</strong> analizará la marcha de las medidas adoptadas en los primeros días de Gobierno.',


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates the date of a fixture event to try to avoid random failures in the test suite.
