### PR TITLE
Override page template

### DIFF
--- a/app/decorators/gobierto_cms/page_decorator.rb
+++ b/app/decorators/gobierto_cms/page_decorator.rb
@@ -41,7 +41,7 @@ module GobiertoCms
     end
 
     def default_template
-      "gobierto_cms/pages/templates/#{sub_template}"
+      "gobierto_cms/pages/templates/#{@object.template || sub_template}"
     end
 
   end

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -17,6 +17,7 @@ module GobiertoAdmin
         :attachment_ids,
         :section,
         :published_on,
+        :template,
         :parent
       )
 

--- a/app/views/gobierto_cms/pages/templates/_raw_page.html.erb
+++ b/app/views/gobierto_cms/pages/templates/_raw_page.html.erb
@@ -1,0 +1,1 @@
+<%== render_liquid(@page.body) %>

--- a/db/migrate/20190214131608_add_template_to_pages.rb
+++ b/db/migrate/20190214131608_add_template_to_pages.rb
@@ -1,0 +1,5 @@
+class AddTemplateToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :gcms_pages, :template, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_18_085402) do
+ActiveRecord::Schema.define(version: 2019_02_14_131608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -441,6 +441,7 @@ ActiveRecord::Schema.define(version: 2018_10_18_085402) do
     t.jsonb "body_source_translations"
     t.datetime "archived_at"
     t.datetime "published_on", null: false
+    t.string "template"
     t.index ["archived_at"], name: "index_gcms_pages_on_archived_at"
     t.index ["body_source_translations"], name: "index_gcms_pages_on_body_source_translations", using: :gin
     t.index ["body_translations"], name: "index_gcms_pages_on_body_translations", using: :gin

--- a/test/decorators/gobierto_cms/page_decorator_test.rb
+++ b/test/decorators/gobierto_cms/page_decorator_test.rb
@@ -27,6 +27,9 @@ module GobiertoCms
     def test_template
       assert_equal "gobierto_cms/pages/templates/page", site_page_decorated.template
       assert_equal "gobierto_participation/processes/pages/templates/news", themes_page_decorated.template
+
+      site_page_decorated.template = "raw_page"
+      assert_equal "gobierto_cms/pages/templates/raw_page", site_page_decorated.template
     end
 
     def test_summary

--- a/test/fixtures_archive/gobierto_cms/pages/madrid/other.yml
+++ b/test/fixtures_archive/gobierto_cms/pages/madrid/other.yml
@@ -7,6 +7,7 @@ site_news_1:
   site: madrid
   collection: site_news
   published_on: <%= Date.current %>
+  template:
 
 consultation_faq:
   title_translations: <%= { 'en' => 'Consultation page FAQ', 'es' => 'FAQ consultas' }.to_json %>
@@ -17,6 +18,7 @@ consultation_faq:
   site: madrid
   collection: site_pages
   published_on: <%= Date.current %>
+  template:
 
 privacy:
   title_translations: <%= {'en' => 'Privacy', 'es' => 'Privacidad' }.to_json %>
@@ -27,6 +29,7 @@ privacy:
   site: madrid
   collection: site_pages
   published_on: <%= Date.current %>
+  template:
 
 cookies:
   title_translations: <%= {'en' => 'Cookies', 'es' => 'Cookies' }.to_json %>
@@ -36,6 +39,7 @@ cookies:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:draft] %>
   site: madrid
   published_on: <%= Date.current %>
+  template:
 
 themes:
   title_translations: <%= {'en' => 'Themes in the site', 'es' => 'Temas en el sitio' }.to_json %>
@@ -46,6 +50,7 @@ themes:
   site: madrid
   collection: news
   published_on: <%= Date.current %>
+  template:
 
 themes_draft:
   title_translations: <%= {'en' => 'Themes draft', 'es' => 'Borrador de temas' }.to_json %>
@@ -56,6 +61,7 @@ themes_draft:
   site: madrid
   collection: news
   published_on: <%= Date.current %>
+  template:
 
 notice_1:
   title_translations: <%= {'en' => 'Notice 1 title', 'es' => 'Título de la noticia 1' }.to_json %>
@@ -66,6 +72,7 @@ notice_1:
   site: madrid
   collection: gender_violence_process_news
   published_on: <%= Date.current %>
+  template:
 
 notice_2:
   title_translations: <%= {'en' => 'Notice 2 title', 'es' => 'Título de la noticia 2' }.to_json %>
@@ -76,6 +83,7 @@ notice_2:
   site: madrid
   collection: gender_violence_process_news
   published_on: <%= Date.current %>
+  template:
 
 about_site:
   title_translations: <%= { 'es' => 'Sobre el sitio', 'en' => 'About site' }.to_json %>
@@ -92,6 +100,7 @@ about_site:
   site: madrid
   collection: site_pages
   published_on: <%= Date.current %>
+  template:
 
 about_participation:
   title_translations: <%= {
@@ -111,6 +120,7 @@ about_participation:
   site: madrid
   collection: site_pages
   published_on: <%= Date.current %>
+  template:
 
 about_participation_details:
   title_translations: <%= {
@@ -130,6 +140,7 @@ about_participation_details:
   site: madrid
   collection: site_pages
   published_on: <%= Date.current %>
+  template:
 
 generic_site_page:
   title_translations: <%= {
@@ -148,6 +159,7 @@ generic_site_page:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: madrid
   published_on: <%= Date.current %>
+  template:
 
 how_to_participate:
   title_translations: <%= {
@@ -167,3 +179,4 @@ how_to_participate:
   site: madrid
   collection: participation_pages
   published_on: <%= Date.current %>
+  template:

--- a/test/fixtures_archive/gobierto_cms/pages/santander/first_level.yml
+++ b/test/fixtures_archive/gobierto_cms/pages/santander/first_level.yml
@@ -16,6 +16,7 @@ cms_section_l0_p0_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l0_p1_page:
   title_translations: <%= {
@@ -35,6 +36,7 @@ cms_section_l0_p1_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l0_p2d_page:
   title_translations: <%= {
@@ -54,6 +56,7 @@ cms_section_l0_p2d_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l0_p3a_page:
   title_translations: <%= {
@@ -73,4 +76,5 @@ cms_section_l0_p3a_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
   archived_at: <%= 5.days.ago %>

--- a/test/fixtures_archive/gobierto_cms/pages/santander/other.yml
+++ b/test/fixtures_archive/gobierto_cms/pages/santander/other.yml
@@ -6,3 +6,4 @@ about:
   visibility_level: <%= GobiertoCms::Page.visibility_levels[:active] %>
   site: santander
   published_on: <%= Date.current %>
+  template:

--- a/test/fixtures_archive/gobierto_cms/pages/santander/second_level.yml
+++ b/test/fixtures_archive/gobierto_cms/pages/santander/second_level.yml
@@ -18,6 +18,7 @@ cms_section_l1_p0p0_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p0p1_page:
   title_translations: <%= {
@@ -37,6 +38,7 @@ cms_section_l1_p0p1_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p0p2d_page:
   title_translations: <%= {
@@ -56,6 +58,7 @@ cms_section_l1_p0p2d_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p0p3a_page:
   title_translations: <%= {
@@ -75,6 +78,7 @@ cms_section_l1_p0p3a_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
   archived_at: <%= 5.days.ago %>
 
 ## p1 children
@@ -97,6 +101,7 @@ cms_section_l1_p1p0_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 ## p2d children
 
@@ -118,6 +123,7 @@ cms_section_l1_p2dp0_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p2dp1d_page:
   title_translations: <%= {
@@ -137,6 +143,7 @@ cms_section_l1_p2dp1d_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p2dp2a_page:
   title_translations: <%= {
@@ -156,6 +163,7 @@ cms_section_l1_p2dp2a_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
   archived_at: <%= 5.days.ago %>
 
 ## p3a children
@@ -178,6 +186,7 @@ cms_section_l1_p3ap0_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p3ap1d_page:
   title_translations: <%= {
@@ -197,6 +206,7 @@ cms_section_l1_p3ap1d_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
 
 cms_section_l1_p3ap2a_page:
   title_translations: <%= {
@@ -216,4 +226,5 @@ cms_section_l1_p3ap2a_page:
   site: santander
   collection: santander_cms_pages
   published_on: <%= 10.days.ago %>
+  template:
   archived_at: <%= 5.days.ago %>

--- a/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_cms/page_form_test.rb
@@ -14,7 +14,8 @@ module GobiertoAdmin
           slug: "page-form-slug",
           collection_id: collection.id,
           published_on: Time.zone.parse('30-12-1994 2:00'),
-          visibility_level: page.visibility_level
+          visibility_level: page.visibility_level,
+          template: nil
         }
       end
 
@@ -29,7 +30,8 @@ module GobiertoAdmin
           body_translations: nil,
           slug: nil,
           visibility_level: nil,
-          published_on: nil
+          published_on: nil,
+          template: nil
         )
       end
 


### PR DESCRIPTION
## :v: What does this PR do?

This PR allows pages to define it's own template, and override the template defined by the collection.

I have also added a template without any kind of menu, breadcrumb or title, to have the whole content of a page displayed in the view.

## :mag: How should this be manually tested?

You can override the template and check a page:

http://madrid.gobify.net/pagina/como-funciona-un-presupuesto
