### PR TITLE
Load populate data import tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: adb688770f62967bceac51c92e503e141cb14ca3
+  revision: de1ed0fb9a7ccca8988bc5154b2f5c1994f0b62e
   specs:
-    gobierto_data (0.0.1)
+    gobierto_data (0.1.0)
       actionpack (>= 5.0.0.1)
       activesupport (>= 5.0.0)
       aws-sdk (~> 2.11, >= 2.11.45)
@@ -10,6 +10,7 @@ GIT
       elasticsearch-extensions (~> 0.0.27)
       ine-places (~> 0.3.0)
       oj (~> 3.5, >= 3.5.0)
+      rake (~> 12.3.2)
 
 GIT
   remote: https://github.com/ferblape/webpacker.git
@@ -86,13 +87,13 @@ GEM
     ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
-    aws-sdk (2.11.218)
-      aws-sdk-resources (= 2.11.218)
-    aws-sdk-core (2.11.218)
+    aws-sdk (2.11.223)
+      aws-sdk-resources (= 2.11.223)
+    aws-sdk-core (2.11.223)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.218)
-      aws-sdk-core (= 2.11.218)
+    aws-sdk-resources (2.11.223)
+      aws-sdk-core (= 2.11.223)
     aws-ses (0.6.0)
       builder
       mail (> 2.2.5)
@@ -311,7 +312,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     ntlm-http (0.1.1)
-    oj (3.7.8)
+    oj (3.7.9)
     os (1.0.0)
     paper_trail (10.2.0)
       activerecord (>= 4.2, < 6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: de1ed0fb9a7ccca8988bc5154b2f5c1994f0b62e
+  revision: 814933d614c7fe05ffac21e838d6cf8d0f9531d6
   specs:
     gobierto_data (0.1.0)
       actionpack (>= 5.0.0.1)

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
 require File.expand_path("../config/application", __FILE__)
 
 Rails.application.load_tasks
+
+# Load tasks from gobierto_data
+spec = Gem::Specification.find_by_name "gobierto_data"
+load "#{spec.gem_dir}/lib/tasks/data.rake"


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates gobierto_data with the new Rake tasks that enable updating population and debt automatically.

## :mag: How should this be manually tested?

If you run `bin/rails -T gobierto_data` tasks should be listed.