### PR TITLE
Budgets last year with data is now dynamic

### DIFF
--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -34,7 +34,13 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
 
   def load_year
     if params[:year].nil?
-      redirect_to gobierto_budgets_budgets_path(GobiertoBudgets::SearchEngineConfiguration::Year.last)
+      default_year = if budgets_elaboration_active?
+        GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data - 1
+      else
+        GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data
+      end
+
+      redirect_to gobierto_budgets_budgets_path(default_year)
     else
       @year = params[:year].to_i
     end

--- a/app/controllers/gobierto_budgets/budgets_elaboration_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_elaboration_controller.rb
@@ -31,7 +31,7 @@ class GobiertoBudgets::BudgetsElaborationController < GobiertoBudgets::Applicati
   end
 
   def load_year
-    @year = GobiertoBudgets::SearchEngineConfiguration::Year.last + 1
+    @year = GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data
   end
 
 end

--- a/app/models/gobierto_budgets/data/lines.rb
+++ b/app/models/gobierto_budgets/data/lines.rb
@@ -85,7 +85,7 @@ module GobiertoBudgets
 
         result = []
         data.sort_by { |k, _| k }.each do |year, v|
-          next if year > GobiertoBudgets::SearchEngineConfiguration::Year.last(force_default_last_year)
+          next if year > GobiertoBudgets::SearchEngineConfiguration::Year.last
           result.push(
             date: year.to_s,
             value: v,

--- a/app/models/gobierto_budgets/search_engine_configuration/year.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/year.rb
@@ -4,11 +4,18 @@ module GobiertoBudgets
   module SearchEngineConfiguration
     class Year
 
-      DEFAULT_LAST_YEAR_WITH_DATA = 2018
+      DEFAULT_LAST_YEAR_WITH_DATA = Date.today.year
 
       def self.last(force = false)
         return DEFAULT_LAST_YEAR_WITH_DATA if force || current_site.nil?
-        cached(:last) { last_year_with_data }
+
+        cached(:last) do
+          if current_site.gobierto_budgets_settings && current_site.gobierto_budgets_settings.settings["budgets_elaboration"]
+            last_year_with_data - 1
+          else
+            last_year_with_data
+          end
+        end
       end
 
       def self.first
@@ -27,10 +34,8 @@ module GobiertoBudgets
         end
       end
 
-      # private class methods
-
       def self.last_year_with_data
-        DEFAULT_LAST_YEAR_WITH_DATA.downto(first) do |year|
+        (DEFAULT_LAST_YEAR_WITH_DATA + 1).downto(first) do |year|
           if GobiertoBudgets::BudgetLine.any_data?(site: current_site, index: ::GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, year: year)
             return year
           end
@@ -38,8 +43,9 @@ module GobiertoBudgets
 
         DEFAULT_LAST_YEAR_WITH_DATA
       end
-      private_class_method :last_year_with_data
 
+      # private class methods
+      #
       def self.budgets_elaboration_disabled?
         current_site.gobierto_budgets_settings && !current_site.gobierto_budgets_settings.settings["budgets_elaboration"]
       end

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -1,7 +1,7 @@
 <% title t('.header') %>
 
 <% content_for :body_attributes do %>
-  <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{GobiertoBudgets::SearchEngineConfiguration::Year.last + 1}"} %>
+  <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data}"} %>
 <% end %>
 
 <div class="column">

--- a/lib/tasks/gobierto_budgets/fixtures.rake
+++ b/lib/tasks/gobierto_budgets/fixtures.rake
@@ -17,7 +17,7 @@ namespace :gobierto_budgets do
 
       organizations = [INE::Places::Place.find_by_slug("madrid"), INE::Places::Place.find_by_slug("santander"), "wadus"]
       organizations.each do |organization|
-        (GobiertoBudgets::SearchEngineConfiguration::Year.last - 1..GobiertoBudgets::SearchEngineConfiguration::Year.last + 1).each do |year|
+        (GobiertoBudgets::SearchEngineConfiguration::Year.last - 2..GobiertoBudgets::SearchEngineConfiguration::Year.last).each do |year|
           import_gobierto_budgets_for_organization(organization, year)
           import_gobierto_budgets_data_for_organization(organization, year)
         end

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -17,7 +17,7 @@ class GobiertoBudgets::ExecutionPpageTest < ActionDispatch::IntegrationTest
   end
 
   def last_year
-    2017
+    Date.today.year - 1
   end
 
   def test_execution_information

--- a/test/models/gobierto_budgets/search_engine_configuration/year_test.rb
+++ b/test/models/gobierto_budgets/search_engine_configuration/year_test.rb
@@ -10,6 +10,10 @@ module GobiertoBudgets
         @site ||= sites(:madrid)
       end
 
+      def year
+        @year ||= Date.today.year
+      end
+
       def setup
         super
         ::GobiertoCore::CurrentScope.current_site = site
@@ -21,20 +25,20 @@ module GobiertoBudgets
       end
 
       def test_last_year_when_no_data
-        assert_equal 2018, subject_class.last
+        assert_equal year - 1, subject_class.last
       end
 
       def test_last_year_when_data_and_elaboration_enabled
         GobiertoBudgets::BudgetLine.stub(:any_data?, true) do
           site.gobierto_budgets_settings.settings["budgets_elaboration"] = true
           site.save!
-          assert_equal 2018, subject_class.last
+          assert_equal year, subject_class.last
         end
       end
 
       def test_last_year_when_data_and_elaboration_disabled
         GobiertoBudgets::BudgetLine.stub(:any_data?, true) do
-          assert_equal 2018, subject_class.last
+          assert_equal year, subject_class.last
         end
       end
 


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes an issue with budgets new data: the year of the last data was hardcoded in the code, so when we load data from a new year we need to send a PR and deploy.

Now, this value is dynamic, the last year of data is read from the storage and all the charts, year dropdowns and so on are updated dynamically.

## :mag: How should this be manually tested?

In staging check sites with and without ellaboration work correctly (already check for Mataró).

