### PR TITLE
Support custom categories upload in a given locale

### DIFF
--- a/lib/tasks/gobierto_budgets/custom_categories.rake
+++ b/lib/tasks/gobierto_budgets/custom_categories.rake
@@ -2,8 +2,8 @@
 
 namespace :gobierto_budgets do
   namespace :custom_categories do
-    desc "Import categories"
-    task :import, [:site_domain, :file_path] => [:environment] do |_t, args|
+    desc "Import categories, providing the site_domain, the file path to the categories and the locale"
+    task :import, [:site_domain, :file_path, :locale] => [:environment] do |_t, args|
       def area_name(area)
         case area
         when 'E'
@@ -15,19 +15,18 @@ namespace :gobierto_budgets do
         end
       end
 
-      # TODO: import data in different locales
       def custom_name(row)
         row["Nombre"]
       end
 
       def custom_description(row)
-        row["Descripción"]
+        # Keep both column names for compatibility reasons
+        row["Descripcion"] || row["Descripción"]
       end
 
+      I18n.locale = args[:locale]
       site = Site.find_by!(domain: args[:site_domain])
-      ine_code = site.place.id
 
-      I18n.locale = 'ca'
       CSV.foreach(args[:file_path], headers: true) do |row|
         c = GobiertoBudgets::Category.find_or_create_by! site: site, area_name: area_name(row['Area']), kind: row['Tipo'], code: row['Codigo']
         c.custom_name = custom_name(row)


### PR DESCRIPTION
## :v: What does this PR do?

This PR improves the task to customize budget line categories and adds support to multiple locales.

Also, I have added a new page to the developers section describing these useful tasks:

https://gobierto.readme.io/docs/customizing-budget-lines-translations

## :mag: How should this be manually tested?

When you run the task you should be able to create the budget lines in that locale.
