### PR TITLE
Show updated total budget when available in execution summary stats

### DIFF
--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -235,15 +235,15 @@ module GobiertoBudgets
       year = @year
       previous_year = year - 1
 
-      last_expenses_budgeted = BudgetTotal.budgeted_for(organization_id, year)
-      last_income_budgeted = BudgetTotal.budgeted_for(organization_id, year, BudgetLine::INCOME)
-      previous_expenses_budgeted = BudgetTotal.budgeted_for(organization_id, previous_year)
-      previous_income_budgeted = BudgetTotal.budgeted_for(organization_id, previous_year, BudgetLine::INCOME)
+      last_expenses_budgeted     = GobiertoBudgets::BudgetTotal.budgeted_updated_for(organization_id, year)                              || GobiertoBudgets::BudgetTotal.budgeted_for(organization_id, year)
+      last_income_budgeted       = GobiertoBudgets::BudgetTotal.budgeted_updated_for(organization_id, year, BudgetLine::INCOME)          || GobiertoBudgets::BudgetTotal.budgeted_for(organization_id, year, BudgetLine::INCOME)
+      previous_expenses_budgeted = GobiertoBudgets::BudgetTotal.budgeted_updated_for(organization_id, previous_year)                     || GobiertoBudgets::BudgetTotal.budgeted_for(organization_id, previous_year)
+      previous_income_budgeted   = GobiertoBudgets::BudgetTotal.budgeted_updated_for(organization_id, previous_year, BudgetLine::INCOME) || GobiertoBudgets::BudgetTotal.budgeted_for(organization_id, previous_year, BudgetLine::INCOME)
 
-      last_expenses_execution = BudgetTotal.execution_for(organization_id, year)
-      last_income_execution = BudgetTotal.execution_for(organization_id, year, BudgetLine::INCOME)
-      previous_expenses_execution = BudgetTotal.execution_for(organization_id, previous_year)
-      previous_income_execution = BudgetTotal.execution_for(organization_id, previous_year, BudgetLine::INCOME)
+      last_expenses_execution     = GobiertoBudgets::BudgetTotal.execution_for(organization_id, year)
+      last_income_execution       = GobiertoBudgets::BudgetTotal.execution_for(organization_id, year, BudgetLine::INCOME)
+      previous_expenses_execution = GobiertoBudgets::BudgetTotal.execution_for(organization_id, previous_year)
+      previous_income_execution   = GobiertoBudgets::BudgetTotal.execution_for(organization_id, previous_year, BudgetLine::INCOME)
 
       {
         last_income_budgeted:                   last_income_budgeted,


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates the budget total execution summary, to use the updated budget when the data is available.

## :mag: How should this be manually tested?

This was an issue in many sites, the % of execution was greater than the 100%

## :eyes: Screenshots

### Before this PR

![Screen Shot 2019-03-12 at 11 29 58](https://user-images.githubusercontent.com/17616/54194264-19dd8880-44bc-11e9-8468-e83324504515.png)

### After this PR

![Screen Shot 2019-03-12 at 11 30 02](https://user-images.githubusercontent.com/17616/54194301-31b50c80-44bc-11e9-9964-f1b58f0917a6.png)

