### PR TITLE
Remove invoices data endpoint fallback

### DIFF
--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -15,11 +15,7 @@ window.GobiertoBudgets.InvoicesController = (function() {
   InvoicesController.prototype.show = function() {
     $tableHTML = $("#providers-table");
 
-    if(window.populateData.endpoint === ""){
-      dataEndpoint = "/presupuestos/proveedores-facturas.csv"
-    } else {
-      dataEndpoint = window.populateData.endpoint + '/datasets/ds-facturas-municipio.csv'
-    }
+    dataEndpoint = "/presupuestos/proveedores-facturas.csv"
 
     let municipalityId = window.populateData.municipalityId;
     let maxYearUrl = dataEndpoint + '?filter_by_location_id='+municipalityId+'&sort_desc_by=date&limit=1';


### PR DESCRIPTION
Closes [issues#578](/PopulateTools/issues/issues/578)

## :v: What does this PR do?

This PR the dependency of PD from Gobierto now that all sites use the internal index to store providers and invoices.

## :mag: How should this be manually tested?

- API request should be to the internal endpoint
- Data should be present in the endpoint
