### PR TITLE
Fix different JS errors

### DIFF
--- a/app/javascript/gobierto_admin/modules/gobierto_budgets_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_budgets_controller.js
@@ -15,9 +15,7 @@ window.GobiertoAdmin.GobiertoBudgetsController = (function() {
         crossDomain: true,
         dataType: "json",
         method: "GET",
-        data: function(params) {
-          return { query: params.term };
-        },
+        data: params => ({ query: params.term }),
         processResults: function(data) {
           if(data === undefined) return [];
           var results = $.map(data.suggestions, function (obj) {

--- a/app/javascript/gobierto_admin/modules/sites_controller.js
+++ b/app/javascript/gobierto_admin/modules/sites_controller.js
@@ -1,16 +1,17 @@
 import 'select2'
+import 'webpack-jquery-ui/autocomplete'
 
 window.GobiertoAdmin.SitesController = (function() {
   function SitesController() {}
 
-  function _handleSiteLocationAutocomplete() {
-    var locationFieldHandler = "#site_location_name";
-    var municipalityFieldHandler = "#site_municipality_id";
+  function _handleSiteLocationAutocomplete(municipalities_suggestion_url) {
+    var locationFieldHandler = "#site_organization_name";
+    var municipalityFieldHandler = "#site_organization_id";
     var autocompleteOptions = {
       source: function(request, response) {
         var element = $(this)[0].element;
         $.ajax({
-          url: element.data("autocompleteUrl"),
+          url: municipalities_suggestion_url,
           crossDomain: true,
           dataType: "json",
           method: "GET",
@@ -78,9 +79,9 @@ window.GobiertoAdmin.SitesController = (function() {
     }
   }
 
-  SitesController.prototype.edit = function(site_modules_with_root_path) {
-    _handleSiteLocationAutocomplete();
-    _homePage(site_modules_with_root_path);
+  SitesController.prototype.edit = function(options) {
+    _handleSiteLocationAutocomplete(options.municipalities_suggestion_url);
+    _homePage(options.site_modules_with_root_path);
   };
 
   return SitesController;

--- a/app/javascript/gobierto_observatory/modules/application.js
+++ b/app/javascript/gobierto_observatory/modules/application.js
@@ -32,8 +32,12 @@ import {
 
 function selectSection(html){
   var $el = $('[data-breadcrumb-sub-item]');
-  if($el.prev()[0].tagName !== "SPAN")
-    $('<span>/</span>').insertBefore($el);
+  var $prev = $el.prev();
+  if($prev !== undefined && $prev[0] !== undefined){
+    if($prev[0].tagName !== "SPAN") {
+      $('<span>/</span>').insertBefore($el);
+    }
+  }
 
   if(html === undefined) {
     $('.sub_sections li a').each(function(){
@@ -51,7 +55,7 @@ $(document).on('turbolinks:click', function (event) {
     selectSection($(event.target).html());
     return;
   }
-})
+});
 
 var vis_population;
 

--- a/app/views/gobierto_admin/sites/_form.html.erb
+++ b/app/views/gobierto_admin/sites/_form.html.erb
@@ -240,6 +240,9 @@
 
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
-    window.GobiertoAdmin.sites_controller.edit("<%= APP_CONFIG["site_modules_with_root_path"] %>");
+    window.GobiertoAdmin.sites_controller.edit({
+      municipalities_suggestion_url: '<%= @services_config.municipalities_suggestions_endpoint %>',
+      site_modules_with_root_path: '<%= APP_CONFIG["site_modules_with_root_path"] %>'
+    });
   <% end %>
 <% end %>


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes two JS rollbars:

- on site form, the organization autocomplete was broken
- in the observatory page, if the data loads a bit slower, the breadcrumb got broken

## :mag: How should this be manually tested?

Read above