### PR TITLE
Fix observatory card flip. Bootstrap integration tests with chromedriver.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,19 @@ jobs:
             sudo curl --output /tmp/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
             sudo chmod ugo+x /tmp/phantomjs
             sudo ln -sf /tmp/phantomjs /usr/local/bin/phantomjs
+      - run:
+          name: Install Google Chrome
+          command: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+            sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - run:
+          name: Install chromedriver
+          command: |
+            curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/73.0.3683.20/chromedriver_linux64.zip"
+            sudo unzip /tmp/chromedriver_linux64.zip chromedriver -d /usr/local/bin
+            sudo chmod +x /usr/local/bin/chromedriver
+
 
       # Copy database config
       - run: cp config/database.yml.example config/database.yml

--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,8 @@ RAILS_MAX_THREADS=5
 INTEGRATION_DEBUG=false
 INTEGRATION_INSPECTOR=false
 
-# Populate data variables
-# - API Token
-TBI_API_TOKEN=
-# - Main endpoint
+# Populate Data
 POPULATE_DATA_ENDPOINT=
-# - Suggestion endpoint for municipalities suggestion
 MUNICIPALITIES_SUGGESTIONS_ENDPOINT=
 
 # Elastic search URL

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,8 @@ group :test do
   gem "minitest-stub-const"
   gem "mocha"
   gem "poltergeist"
+  gem "rack-cors"
+  gem "selenium-webdriver"
   gem "spy"
   gem "timecop"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
       mail
     case_transform (0.2)
       activesupport
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chroma (0.2.0)
     cliver (0.3.2)
     cloudinary (1.11.1)
@@ -335,6 +337,7 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.1)
     rack (2.0.6)
+    rack-cors (1.0.3)
     rack-protection (2.0.5)
       rack
     rack-proxy (0.6.5)
@@ -407,6 +410,7 @@ GEM
     ruby_px (0.5.0)
       activesupport (>= 4.2.5)
     rubyntlm (0.6.2)
+    rubyzip (1.2.2)
     safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
@@ -424,6 +428,9 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -552,6 +559,7 @@ DEPENDENCIES
   pg (~> 1.1)
   poltergeist
   puma
+  rack-cors
   rails (~> 5.2.1)
   rails-html-sanitizer
   rb-readline
@@ -563,6 +571,7 @@ DEPENDENCIES
   ruby_px
   sassc
   savon (~> 2.12.0)
+  selenium-webdriver
   sidekiq (~> 5.2.1)
   sidekiq-monitor-stats
   simple_calendar (~> 2.2)

--- a/app/controllers/stubbed_external_request_controller.rb
+++ b/app/controllers/stubbed_external_request_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class StubbedExternalRequestController < ApplicationController
+
+  def show
+    render json: PopulateData::ApiMock.generic_indicator_data
+  end
+
+end

--- a/app/javascript/gobierto_observatory/modules/application.js
+++ b/app/javascript/gobierto_observatory/modules/application.js
@@ -165,7 +165,7 @@ $(document).on('turbolinks:load', function() {
   });
 
   // Show dataset info on click
-  $('.card_container .widget_headline > i.fa').click(function() {
+  $('.card_container .widget_headline > i.fas').click(function() {
     $(this).closest('.card_container').toggleClass('hover');
   });
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,12 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Add support for HTTP OPTIONS method
+  config.middleware.insert_before(0, Rack::Cors) do
+    allow do
+      origins "*"
+      resource "*", headers: :any, methods: [:get, :post, :options]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 require "sidekiq/web"
 
 Rails.application.routes.draw do
+
+  get("/populate_data_mock/datasets/*dataset_file", to: "stubbed_external_request#show") if Rails.env.test?
+
   unless Rails.env.production?
     get "/sandbox" => "sandbox#index"
     get "/sandbox/*template" => "sandbox#show"

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -5,7 +5,17 @@ madrid:
   configuration_data: <%= {
     "links_markup" => %Q{<a href="http://madrid.es">Ayuntamiento de Madrid</a>},
     "logo" => "http://www.madrid.es/assets/images/logo-madrid.png",
-    "modules" => ["GobiertoBudgets", "GobiertoBudgetConsultations", "GobiertoPeople", "GobiertoCms", "GobiertoParticipation", "GobiertoIndicators", "GobiertoPlans", "GobiertoCitizensCharters"],
+    "modules" => [
+      "GobiertoBudgets",
+      "GobiertoBudgetConsultations",
+      "GobiertoPeople",
+      "GobiertoCms",
+      "GobiertoParticipation",
+      "GobiertoIndicators",
+      "GobiertoPlans",
+      "GobiertoCitizensCharters",
+      "GobiertoObservatory",
+    ],
     "default_locale" => "en",
     "available_locales" => ["en", "es"],
     "home_page" => "GobiertoParticipation",

--- a/test/integration/gobierto_observatory/observatory/index_test.rb
+++ b/test/integration/gobierto_observatory/observatory/index_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/populate_data/api_mock"
+
+module GobiertoObservatory
+  module Observatory
+    class IndexTest < ActionDispatch::IntegrationTest
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def first_card
+        first(".card_container")
+      end
+
+      def first_card_front
+        first_card.find(".front")
+      end
+
+      def first_card_back
+        first_card.find(".back")
+      end
+
+      def first_card_back_visible?
+        first_card["class"].include?("hover")
+      end
+
+      def test_index
+        with_chrome_driver do
+          PopulateData::ApiMock.stub_endpoint
+
+          with_current_site(site) do
+            visit gobierto_observatory_root_path
+
+            assert_equal "Inhabitants", first_card_front.find("h3").text
+            assert first_card_front.text.include?("INE")
+            assert first_card_back.text.include?("Indicator description")
+          end
+        end
+      end
+
+      def test_flip_card
+        with_chrome_driver do
+          PopulateData::ApiMock.stub_endpoint
+
+          with_current_site(site) do
+            visit gobierto_observatory_root_path
+
+            refute first_card_back_visible?
+
+            first_card.find(".fa-question-circle").click
+
+            assert first_card_back_visible?
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -15,8 +15,13 @@ class SiteTest < ActiveSupport::TestCase
     recipe_spy.calls.first.args
   end
 
-  def site
-    @site ||= sites(:madrid)
+  def madrid
+    @madrid ||= sites(:madrid)
+  end
+  alias site madrid
+
+  def santander
+    @santander ||= sites(:santander)
   end
 
   def organization_site
@@ -108,14 +113,14 @@ class SiteTest < ActiveSupport::TestCase
   end
 
   def test_seeder_called_after_modules_updated
-    configuration_data = site.configuration_data
+    configuration_data = santander.configuration_data
     configuration_data["modules"].push "GobiertoObservatory"
-    site.configuration_data = configuration_data
-    site.save!
+    santander.configuration_data = configuration_data
+    santander.save!
     assert module_seeder_spy.has_been_called?
     assert module_site_seeder_spy.has_been_called?
-    assert_equal ["GobiertoObservatory", site], module_seeder_spy.calls.first.args
-    assert_equal ["gobierto_populate", "GobiertoObservatory", site], module_site_seeder_spy.calls.first.args
+    assert_equal ["GobiertoObservatory", santander], module_seeder_spy.calls.first.args
+    assert_equal ["gobierto_populate", "GobiertoObservatory", santander], module_site_seeder_spy.calls.first.args
   end
 
   def test_invalid_if_municipality_blank

--- a/test/support/populate_data/api_mock.rb
+++ b/test/support/populate_data/api_mock.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PopulateData
+  class ApiMock
+
+    def self.stub_endpoint
+      APP_CONFIG["populate_data"]["endpoint"] = "http://localhost:#{Capybara.current_session.server.port}/populate_data_mock"
+    end
+
+    def self.generic_indicator_data
+      data = [2017, 2018].map do |year|
+        {
+          value: 500_000 + year * 5,
+          location_id: place.id,
+          date: "#{year}-01-01",
+          province_id: place.province_id,
+          autonomous_region_id: place.province.autonomous_region_id,
+          _id: "#{place.id}/#{year}-01-01"
+        }
+      end
+
+      {
+        "data": data,
+        "metadata": {
+          "indicator": {
+            "name": "Indicator name",
+            "description": "Indicator description",
+            "source name": "INE"
+          }
+        }
+      }
+    end
+
+    def self.place
+      INE::Places::Place.find_by_slug("madrid")
+    end
+    private_class_method :place
+
+  end
+end


### PR DESCRIPTION
Closes #2189 

## :v: What does this PR do?

- Fixes a markup bug that made the observatory cards not turning
- Sets up a helper for progessively start using chromedriver
- Sets up a test helper for mocking Populate Data requests

## :book: Does this PR require updating the documentation?

You need `chromedriver` in local:

```bash
brew cask install chromedriver
```

Development docs updated [here](https://gobierto.readme.io/v0.1/docs/development-environment-1#section-integration-tests-drivers).