### PR TITLE
Create new save widget

### DIFF
--- a/app/decorators/gobierto_admin/moderated_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/moderated_resource_decorator.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class ModeratedResourceDecorator < BaseDecorator
+    def initialize(resource)
+      @object = resource
+    end
+
+    def has_publication_status?
+      @has_publication_status ||= respond_to?(:visibility_level)
+    end
+
+    def publication_status
+      @publication_status ||= publicable? && visibility_level == unpublished_value ? :not_published : :approved
+    end
+
+    def published?
+      @published ||= publication_status == :approved
+    end
+
+    # This method will change with moderation concern
+    def publicable?
+      @publicable ||= true
+    end
+
+    # This method will change with moderation concern
+    def sent?
+      @sent ||= false
+    end
+
+    def step
+      @step ||= if publicable?
+                  published? ? :published : :publicable
+                elsif new_record?
+                  :new
+                elsif sent?
+                  :sent
+                else
+                  :pending
+                end
+    end
+
+    def locked?
+      @locked ||= [:new, :pending].include?(step)
+    end
+
+    def step_action
+      MODERATION_STEPS[step][:action]
+    end
+
+    def moderation_status
+      MODERATION_STEPS[step][:moderation_status]
+    end
+
+    def moderation_style
+      MODERATION_STEPS[step][:moderation_style]
+    end
+
+    def step_disabled?
+      MODERATION_STEPS[step][:disabled]
+    end
+
+    def step_visibility_value
+      @step_visibility_value ||= published? ? unpublished_value : (self.class.visibility_levels.keys - [unpublished_value]).first
+    end
+
+    private
+
+    MODERATION_STEPS = { new: { action: :send, moderation_status: :not_sent, disabled: true, moderation_style: :not_published },
+                         pending: { action: :send, moderation_status: :not_sent, disabled: false, moderation_style: :not_published },
+                         sent: { action: :publish, moderation_status: :under_review, disabled: true, moderation_style: :in_revision },
+                         publicable: { action: :publish, moderation_status: :approved, disabled: false, moderation_style: :approved },
+                         published: { action: :unpublish, moderation_status: :approved, disabled: false, moderation_style: :approved } }.freeze
+
+    def unpublished_value
+      "draft"
+    end
+  end
+end

--- a/app/decorators/gobierto_admin/moderated_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/moderated_resource_decorator.rb
@@ -2,8 +2,15 @@
 
 module GobiertoAdmin
   class ModeratedResourceDecorator < BaseDecorator
-    def initialize(resource)
+    attr_accessor :current_admin, :moderation_policy
+
+    delegate :moderable_has_moderation?, to: :moderation_policy
+
+    def initialize(resource, opts = {})
       @object = resource
+      @current_admin = opts.delete(:current_admin)
+      @current_site = opts.delete(:current_site)
+      @moderation_policy = GobiertoAdmin::ModerationPolicy.new(current_admin: @current_admin, current_site: @current_site, moderable: @object)
     end
 
     def has_publication_status?

--- a/app/decorators/gobierto_admin/versioned_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/versioned_resource_decorator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class VersionedResourceDecorator < BaseDecorator
+    def initialize(resource)
+      @object = resource
+    end
+
+    def has_versions?
+      @has_versions ||= respond_to?(:paper_trail)
+    end
+
+    def versions_count
+      @versions_count ||= versions.length
+    end
+
+    def new_version?
+      @new_version ||= new_record?
+    end
+
+    def current_version
+      @current_version = last_version? ? versions_count : version.index
+    end
+
+    def last_version?
+      @last_version ||= paper_trail.live?
+    end
+
+    def live_version
+      @live_version ||= new_record? || !has_versions? ? self : self.class.find(id)
+    end
+
+    def recent_versions(limit = 9)
+      @recent_versions ||= versions.unscope(:order).order(created_at: :desc).limit(limit)
+    end
+  end
+end

--- a/app/helpers/site_helper.rb
+++ b/app/helpers/site_helper.rb
@@ -22,11 +22,11 @@ module SiteHelper
     url
   end
 
-  def class_if(class_name, condition)
+  def class_if(class_name, condition, fallback = "")
     if condition
       class_name
     else
-      ''
+      fallback
     end
   end
 

--- a/app/models/concerns/gobierto_common/moderable.rb
+++ b/app/models/concerns/gobierto_common/moderable.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module Moderable
+    extend ActiveSupport::Concern
+
+    included do
+      has_one :moderation, class_name: "GobiertoAdmin::Moderation", as: :moderable, autosave: true, dependent: :destroy
+
+      delegate :stage, :available_stages, :locked_edition?, to: :moderation, prefix: true
+    end
+
+    class_methods do
+      def extra_moderation_permissions_lookup_attributes
+        define_method :permissions_lookup_attributes do |action|
+          base_permissions_lookup_attributes(action) +
+            yield(self).map { |attrs_set| attrs_set.merge(action_name: action) }
+        end
+      end
+
+      def default_moderation_stage
+        define_method :default_moderation_stage do
+          yield self
+        end
+      end
+    end
+
+    def moderation
+      super || build_moderation(stage: default_moderation_stage)
+    end
+
+    def permissions_lookup_attributes
+      base_permissions_lookup_attributes.map
+    end
+
+    def default_moderation_stage
+      :not_sent
+    end
+
+    private
+
+    def base_permissions_lookup_attributes(action)
+      [{
+        namespace: moderation.moderable_type.deconstantize.underscore,
+        resource_name: moderation.moderable_type.demodulize.underscore,
+        resource_id: moderation.moderable_id,
+        action_name: action
+      }]
+    end
+  end
+end

--- a/app/models/gobierto_admin/moderation.rb
+++ b/app/models/gobierto_admin/moderation.rb
@@ -8,12 +8,15 @@ class GobiertoAdmin::Moderation < ApplicationRecord
   belongs_to :moderable, polymorphic: true
 
   enum stage: { not_sent: 0,
-                in_review: 1,
-                approved: 2,
-                rejected: 3 }
+                sent: 1,
+                in_review: 2,
+                approved: 3,
+                rejected: 4 }
 
-  STAGES_FLOW = { not_sent: { in_review: [:edit] },
-                  in_review: { approved: [:moderate],
+  STAGES_FLOW = { not_sent: { sent: [:edit] },
+                  sent: { in_review: [:moderate] },
+                  in_review: { sent: [:moderate],
+                               approved: [:moderate],
                                rejected: [:moderate] },
                   approved: { in_review: [:edit, :moderate],
                               rejected: [:moderate] },
@@ -21,6 +24,7 @@ class GobiertoAdmin::Moderation < ApplicationRecord
                               approved: [:moderate] } }.with_indifferent_access.freeze
 
   LOCKED_EDITION = { not_sent: [:visibility_level],
+                     sent: [:visibility_level],
                      in_review: [:visibility_level],
                      approved: [],
                      rejected: [:visibility_level] }.with_indifferent_access.freeze

--- a/app/models/gobierto_admin/moderation.rb
+++ b/app/models/gobierto_admin/moderation.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_admin"
+
+class GobiertoAdmin::Moderation < ApplicationRecord
+  belongs_to :site
+  belongs_to :admin
+  belongs_to :moderable, polymorphic: true
+
+  enum stage: { not_sent: 0,
+                in_review: 1,
+                approved: 2,
+                rejected: 3 }
+
+  STAGES_FLOW = { not_sent: { in_review: [:edit] },
+                  in_review: { approved: [:moderate],
+                               rejected: [:moderate] },
+                  approved: { in_review: [:edit, :moderate],
+                              rejected: [:moderate] },
+                  rejected: { in_review: [:moderate],
+                              approved: [:moderate] } }.with_indifferent_access.freeze
+
+  LOCKED_EDITION = { not_sent: [:visibility_level],
+                     in_review: [:visibility_level],
+                     approved: [],
+                     rejected: [:visibility_level] }.with_indifferent_access.freeze
+
+  def available_stages
+    STAGES_FLOW[stage].keys
+  end
+
+  def available_stages_for_action(action)
+    STAGES_FLOW[stage].select do |_, actions|
+      actions.include? action
+    end
+  end
+
+  def actions_for_stage(next_stage)
+    return [] unless STAGES_FLOW[stage].has_key? next_stage
+
+    STAGES_FLOW[stage][next_stage]
+  end
+
+  def locked_edition?(attribute)
+    LOCKED_EDITION[stage].include?(attribute.to_sym)
+  end
+
+  def reachable_stages_for_action(action, initial_stage = nil, accumulated = [])
+    initial_stage ||= stage
+
+    available_stages = STAGES_FLOW[initial_stage].select do |stage, actions|
+      accumulated.exclude?(stage) && actions.include?(action)
+    end
+
+    return accumulated if available_stages.blank?
+
+    accumulated += available_stages.keys
+    available_stages.keys.map { |stage| reachable_stages_for_action(action, stage, accumulated) }.flatten.uniq
+  end
+end

--- a/app/policies/gobierto_admin/moderation_policy.rb
+++ b/app/policies/gobierto_admin/moderation_policy.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class ModerationPolicy < ::GobiertoAdmin::BasePolicy
+    attr_reader :moderable
+
+    def initialize(attributes)
+      super(attributes)
+      @moderable = attributes[:moderable]
+    end
+
+    def moderate?
+      can_perform_action_on_resource? :moderate
+    end
+
+    def edit?
+      can_perform_action_on_resource? :edit
+    end
+
+    def allowed_to?(next_step)
+      !moderable_has_moderation? ||
+        moderable.moderation.actions_for_stage(next_step).any? do |action|
+          can_perform_action_on_resource?(action)
+        end
+    end
+
+    def publish_as_editor?
+      return true unless moderable_has_moderation?
+
+      edit? && !moderable.moderation_locked_edition?(:visibility_level)
+    end
+
+    def moderable_has_moderation?
+      moderable.class.include? GobiertoCommon::Moderable
+    end
+
+    private
+
+    def can_perform_action_on_resource?(action)
+      manage? ||
+        moderable.permissions_lookup_attributes(action).any? { |lookup_attributes| current_admin.permissions.where(lookup_attributes).exists? }
+    end
+  end
+end

--- a/app/views/gobierto_admin/shared/_admin_widget_moderate.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_moderate.html.erb
@@ -1,0 +1,31 @@
+<% if resource.moderable_has_moderation? && resource.moderation_policy.moderate? && resource.moderation_reachable_stages.any? %>
+  <div class="widget_save_v2 m_b_2">
+
+    <div class="w_s_content">
+
+      <h4><%= t("gobierto_admin.shared.moderation_save_widget.moderation") %></h4>
+
+      <div class="form_item">
+
+        <div class="options compact">
+          <%= f.collection_radio_buttons(:moderation_stage, resource.moderation_reachable_stages, :first, :first) do |b| %>
+            <div class="option">
+              <%= b.radio_button %>
+              <%= b.label do %>
+                <span></span>
+                <%= t("gobierto_admin.shared.moderation_save_widget.moderation_status.#{b.text}") %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+      </div>
+
+      <div class="w_actions m_b_1">
+        <button class="button medium"><%= t("gobierto_admin.shared.moderation_save_widget.save") %></button>
+      </div>
+
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -1,0 +1,104 @@
+<% versioned_resource = GobiertoAdmin::VersionedResourceDecorator.new(resource) %>
+<% moderated_resource = GobiertoAdmin::ModeratedResourceDecorator.new(versioned_resource.has_versions? ? versioned_resource.live_version : resource) %>
+
+<div class="pure-u-1 pure-u-md-1-4">
+
+  <div class="widget_save_v2 m_b_2">
+
+    <div class="w_s_content">
+
+      <div class="w_actions m_b_1">
+        <button class="button medium"><%= t("gobierto_admin.shared.moderation_save_widget.save") %></button>
+        <button class="button medium light"><%= t("gobierto_admin.shared.moderation_save_widget.preview") %></button>
+      </div>
+
+      <% if versioned_resource.has_versions? %>
+        <div class="pure-g f_small m_t_2">
+          <div class="pure-u-1-2">
+            <%= t("gobierto_admin.shared.moderation_save_widget.edit_version") %>
+          </div>
+          <div class="pure-u-1-2">
+            <% if versioned_resource.new_version? %>
+              <%= t("gobierto_admin.shared.moderation_save_widget.new_version") %>
+            <% else %>
+              <strong class="p_h_1">
+                <%= versioned_resource.current_version %>
+              </strong>
+              <%= render partial: "gobierto_admin/shared/versions_select", locals: { resource: versioned_resource } %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if moderated_resource.has_publication_status? %>
+        <div class="pure-g f_small m_t_1">
+          <div class="pure-u-1-2">
+            <%= t("gobierto_admin.shared.moderation_save_widget.publish_status") %>
+          </div>
+          <div class="pure-u-1-2">
+            <span class="i_p_status <%= moderated_resource.publication_status %>"><%= t("gobierto_admin.shared.moderation_save_widget.publication_status.#{moderated_resource.publication_status}") %></span>
+          </div>
+        </div>
+      <% end %>
+
+    </div>
+
+    <% if moderated_resource.has_publication_status? %>
+      <div class="publication_section m_v_2">
+
+        <div class="w_s_content">
+
+          <% if versioned_resource.has_versions? %>
+            <div class="pure-g f_small m_b_1">
+              <div class="pure-u-1-2">
+                <%= t("gobierto_admin.shared.moderation_save_widget.published_version") %>
+              </div>
+              <div class="pure-u-1-2">
+                <% if moderated_resource.published? %>
+                  <div class="pure-u-1-2">
+                    <strong class="p_h_1">
+                      <%= versioned_resource.versions_count %>
+                    </strong>
+                  </div>
+                <% else %>
+                  <%= t("gobierto_admin.shared.moderation_save_widget.published_version_blank") %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <div class="w_s_txt_msg f_small m_t_4">
+            <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.step}") %>
+          </div>
+
+          <div class="m_t_1">
+            <%= f.button(
+                  t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.step_action}"),
+                  disabled: moderated_resource.step_disabled?,
+                  class: "bl",
+                  name: "#{f.object_name}[visibility_level]",
+                  value: moderated_resource.step_visibility_value
+                ) %>
+          </div>
+
+        </div>
+
+      </div>
+    <% end %>
+
+    <div class="w_s_content">
+
+      <div class="pure-g f_small">
+        <div class="pure-u-1-2">
+          <%= t("gobierto_admin.shared.moderation_save_widget.moderation") %>
+        </div>
+        <div class="pure-u-1-2">
+          <span class="i_p_status <%= moderated_resource.moderation_style %>"><%= t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.moderation_status}") %></span>
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+
+</div>

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -77,7 +77,8 @@
                   disabled: moderated_resource.step_disabled?,
                   class: "bl",
                   name: "#{f.object_name}[visibility_level]",
-                  value: moderated_resource.step_visibility_value
+                  value: moderated_resource.step_visibility_value,
+                  data: { confirm: t("gobierto_admin.shared.moderation_save_widget.confirm") }
                 ) %>
           </div>
 

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -68,12 +68,12 @@
           <% end %>
 
           <div class="w_s_txt_msg f_small m_t_4">
-            <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.step}") %>
+            <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.publish_moderation_step}") %>
           </div>
 
           <div class="m_t_1">
             <%= f.button(
-                  t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.step_action}"),
+                  t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.publish_step_action}"),
                   disabled: moderated_resource.step_disabled?,
                   class: "bl",
                   name: "#{f.object_name}[visibility_level]",
@@ -94,7 +94,7 @@
           <%= t("gobierto_admin.shared.moderation_save_widget.moderation") %>
         </div>
         <div class="pure-u-1-2">
-          <span class="i_p_status <%= moderated_resource.moderation_style %>"><%= t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.moderation_status}") %></span>
+          <span class="i_p_status <%= moderated_resource.moderation_style %>"><%= t("gobierto_admin.shared.moderation_save_widget.moderation_status.#{moderated_resource.moderation_status}") %></span>
         </div>
       </div>
 
@@ -102,4 +102,5 @@
 
   </div>
 
+  <%= render partial: "gobierto_admin/shared/admin_widget_moderate", locals: { f: f, resource: moderated_resource } %>
 </div>

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -1,5 +1,5 @@
 <% versioned_resource = GobiertoAdmin::VersionedResourceDecorator.new(resource) %>
-<% moderated_resource = GobiertoAdmin::ModeratedResourceDecorator.new(versioned_resource.has_versions? ? versioned_resource.live_version : resource) %>
+<% moderated_resource = GobiertoAdmin::ModeratedResourceDecorator.new(versioned_resource.has_versions? ? versioned_resource.live_version : resource, current_admin: current_admin, current_site: current_site) %>
 
 <div class="pure-u-1 pure-u-md-1-4">
 

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -7,10 +7,12 @@
 
     <div class="w_s_content">
 
-      <div class="w_actions m_b_1">
-        <button class="button medium"><%= t("gobierto_admin.shared.moderation_save_widget.save") %></button>
-        <button class="button medium light"><%= t("gobierto_admin.shared.moderation_save_widget.preview") %></button>
-      </div>
+      <% if moderated_resource.moderation_policy.edit? %>
+        <div class="w_actions m_b_1">
+          <button class="button medium"><%= t("gobierto_admin.shared.moderation_save_widget.save") %></button>
+          <button class="button medium light"><%= t("gobierto_admin.shared.moderation_save_widget.preview") %></button>
+        </div>
+      <% end %>
 
       <% if versioned_resource.has_versions? %>
         <div class="pure-g f_small m_t_2">
@@ -67,20 +69,22 @@
             </div>
           <% end %>
 
-          <div class="w_s_txt_msg f_small m_t_4">
-            <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.publish_moderation_step}") %>
-          </div>
+          <% if moderated_resource.moderation_policy.edit? %>
+            <div class="w_s_txt_msg f_small m_t_4">
+              <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.publish_moderation_step}") %>
+            </div>
 
-          <div class="m_t_1">
-            <%= f.button(
-                  t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.publish_step_action}"),
-                  disabled: moderated_resource.step_disabled?,
-                  class: "bl",
-                  name: "#{f.object_name}[visibility_level]",
-                  value: moderated_resource.step_visibility_value,
-                  data: { confirm: t("gobierto_admin.shared.moderation_save_widget.confirm") }
-                ) %>
-          </div>
+            <div class="m_t_1">
+              <%= f.button(
+                    t("gobierto_admin.shared.moderation_save_widget.#{moderated_resource.publish_step_action}"),
+                    disabled: moderated_resource.step_disabled?,
+                    class: "bl",
+                    name: "#{f.object_name}[visibility_level]",
+                    value: moderated_resource.step_visibility_value,
+                    data: { confirm: t("gobierto_admin.shared.moderation_save_widget.confirm") }
+                  ) %>
+            </div>
+          <% end %>
 
         </div>
 

--- a/app/views/gobierto_admin/shared/_versions_select.html.erb
+++ b/app/views/gobierto_admin/shared/_versions_select.html.erb
@@ -1,0 +1,29 @@
+<% if resource.recent_versions.count > 1 %>
+  <span class="g_popup_context">
+    <a href="" class="f_soft"><%= t("gobierto_admin.shared.moderation_save_widget.see_versions") %></a>
+
+    <div class="g_popup">
+
+      <h3><%= t("gobierto_admin.shared.moderation_save_widget.last_versions") %></h3>
+
+      <ul>
+      <% resource.recent_versions.each_with_index do |version| %>
+        <% active = version.index + 1 == resource.current_version %>
+        <li>
+          <%= link_to(
+            "#{active ? "-> " : ""} #{version.index + 1} - #{time_ago_in_words(version.created_at)}",
+            { version: class_if(version.index + 1, version.index + 1 != resource.versions_count, nil) }.compact,
+            { class: class_if("active", active, nil) }.compact
+            ) %>
+        </li>
+      <% end %>
+      </ul>
+
+      <% if resource.recent_versions.last.index > 0 %>
+        <a href=""><%= t("gobierto_admin.shared.moderation_save_widget.see_all") %></a>
+      <% end %>
+
+    </div>
+
+  </span>
+<% end %>

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -28,6 +28,35 @@ ca:
       form_locale_switchers:
         define_content_in_locale: Defineix el contingut en la versió en %{locale_name}
         translate: Traduxir
+      moderation_save_widget:
+        approved: Aprovat
+        edit_version: Editant versió
+        last_versions: Últimes versions
+        moderation: Moderació
+        moderation_info:
+          new: Un cop guardis el teu contingut, podràs enviar-lo a moderació.
+          pending: Quan el teu contingut estigui llest per a ser revisat per un moderador,
+            fes click a Enviar.
+          publicable: Fes click a Publicar perquè aquesta versió sigui visible públicament.
+          published: La versió està publicada.
+          sent: El teu contingut ha estat enviat per a revisió. Rebràs una notificació
+            quan s'aprovi o et demanin canvis.
+        new_version: Nova (no guardada)
+        not_sent: No enviat
+        preview: Previsualitzar
+        publication_status:
+          approved: Publicada
+          not_published: No publicada
+        publish: Publicar
+        publish_status: Estat
+        published_version: Versió publicada
+        published_version_blank: sense publicar encara
+        save: Guardar
+        see_all: veure totes
+        see_versions: veure versions
+        send: Enviar
+        under_review: En revisió
+        unpublish: Despublicar
       recover:
         confirm: Si es recupera un element, es tornarà a llistar de nou.
         element: Recuperar element

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -47,7 +47,7 @@ ca:
           in_review: En revisió
           not_sent: No enviat
           rejected: No aprovat
-          sent: En revisió
+          sent: Sent
         new_version: Nova (no guardada)
         preview: Previsualitzar
         publication_status:

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -29,21 +29,26 @@ ca:
         define_content_in_locale: Defineix el contingut en la versió en %{locale_name}
         translate: Traduxir
       moderation_save_widget:
-        approved: Aprovat
         confirm: Estàs segur?
         edit_version: Editant versió
         last_versions: Últimes versions
         moderation: Moderació
         moderation_info:
           new: Un cop guardis el teu contingut, podràs enviar-lo a moderació.
-          pending: Quan el teu contingut estigui llest per a ser revisat per un moderador,
+          not_sent: Quan el teu contingut estigui llest per a ser revisat per un moderador,
             fes click a Enviar.
           publicable: Fes click a Publicar perquè aquesta versió sigui visible públicament.
           published: La versió està publicada.
+          rejected: La versió està rebutjada.
           sent: El teu contingut ha estat enviat per a revisió. Rebràs una notificació
             quan s'aprovi o et demanin canvis.
+        moderation_status:
+          approved: Aprovat
+          in_review: En revisió
+          not_sent: No enviat
+          rejected: No aprovat
+          sent: En revisió
         new_version: Nova (no guardada)
-        not_sent: No enviat
         preview: Previsualitzar
         publication_status:
           approved: Publicada
@@ -56,7 +61,6 @@ ca:
         see_all: veure totes
         see_versions: veure versions
         send: Enviar
-        under_review: En revisió
         unpublish: Despublicar
       recover:
         confirm: Si es recupera un element, es tornarà a llistar de nou.

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -30,6 +30,7 @@ ca:
         translate: Traduxir
       moderation_save_widget:
         approved: Aprovat
+        confirm: Estàs segur?
         edit_version: Editant versió
         last_versions: Últimes versions
         moderation: Moderació

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -28,6 +28,35 @@ en:
       form_locale_switchers:
         define_content_in_locale: Define the content in %{locale_name} version
         translate: Translate
+      moderation_save_widget:
+        approved: Approved
+        edit_version: Editing version
+        last_versions: Last versions
+        moderation: Moderation
+        moderation_info:
+          new: After saving your content, it can be sent to moderation.
+          pending: When your content is ready to be reviewed by a moderator, click
+            on Send.
+          publicable: Click on Publish to make this version publicly visible.
+          published: Version published.
+          sent: Your content has been sent for review. You will receive a notification
+            if it is approved or you are asked for changes.
+        new_version: New (not saved)
+        not_sent: Not sent
+        preview: Preview
+        publication_status:
+          approved: Published
+          not_published: Not published
+        publish: Publish
+        publish_status: Status
+        published_version: Published version
+        published_version_blank: not published yet
+        save: Save
+        see_all: see all
+        see_versions: see versions
+        send: Send
+        under_review: Under review
+        unpublish: Unpublish
       recover:
         confirm: If you recover an element, it will be listed again
         element: Recover element

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -29,21 +29,26 @@ en:
         define_content_in_locale: Define the content in %{locale_name} version
         translate: Translate
       moderation_save_widget:
-        approved: Approved
         confirm: Are you sure?
         edit_version: Editing version
         last_versions: Last versions
         moderation: Moderation
         moderation_info:
           new: After saving your content, it can be sent to moderation.
-          pending: When your content is ready to be reviewed by a moderator, click
+          not_sent: When your content is ready to be reviewed by a moderator, click
             on Send.
           publicable: Click on Publish to make this version publicly visible.
           published: Version published.
+          rejected: Version rejected.
           sent: Your content has been sent for review. You will receive a notification
             if it is approved or you are asked for changes.
+        moderation_status:
+          approved: Approved
+          in_review: Under review
+          not_sent: Not sent
+          rejected: Rejected
+          sent: Under review
         new_version: New (not saved)
-        not_sent: Not sent
         preview: Preview
         publication_status:
           approved: Published
@@ -56,7 +61,6 @@ en:
         see_all: see all
         see_versions: see versions
         send: Send
-        under_review: Under review
         unpublish: Unpublish
       recover:
         confirm: If you recover an element, it will be listed again

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -30,6 +30,7 @@ en:
         translate: Translate
       moderation_save_widget:
         approved: Approved
+        confirm: Are you sure?
         edit_version: Editing version
         last_versions: Last versions
         moderation: Moderation

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -47,7 +47,7 @@ en:
           in_review: Under review
           not_sent: Not sent
           rejected: Rejected
-          sent: Under review
+          sent: Sent
         new_version: New (not saved)
         preview: Preview
         publication_status:

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -28,6 +28,35 @@ es:
       form_locale_switchers:
         define_content_in_locale: Define el contenido en su versión %{locale_name}
         translate: Traducir
+      moderation_save_widget:
+        approved: Aprobado
+        edit_version: Editando versión
+        last_versions: Últimas versiones
+        moderation: Moderación
+        moderation_info:
+          new: Una vez guardes tu contenido, podrás enviarlo a moderación.
+          pending: Cuando tu contenido esté listo para ser revisado por un moderador,
+            haz click en Enviar.
+          publicable: Haz click en Publicar para que esta versión sea visible publicamente.
+          published: La versión está publicada.
+          sent: Tu contenido ha sido enviado para revisión. Recibirás una notificación
+            cuando se apruebe o te soliciten cambios.
+        new_version: Nueva (no guardada)
+        not_sent: No enviado
+        preview: Previsualizar
+        publication_status:
+          approved: Publicada
+          not_published: No publicada
+        publish: Publicar
+        publish_status: Estado
+        published_version: Versión publicada
+        published_version_blank: sin publicar todavía
+        save: Guardar
+        see_all: ver todas
+        see_versions: ver versiones
+        send: Enviar
+        under_review: En revisión
+        unpublish: Despublicar
       recover:
         confirm: Si recuperas un elemento, se volverá a listar de nuevo.
         element: Recuperar elemento

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -47,7 +47,7 @@ es:
           in_review: En revisión
           not_sent: No enviado
           rejected: Rechazado
-          sent: En revisión
+          sent: Enviado
         new_version: Nueva (no guardada)
         preview: Previsualizar
         publication_status:

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -30,6 +30,7 @@ es:
         translate: Traducir
       moderation_save_widget:
         approved: Aprobado
+        confirm: Estás seguro?
         edit_version: Editando versión
         last_versions: Últimas versiones
         moderation: Moderación

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -29,21 +29,26 @@ es:
         define_content_in_locale: Define el contenido en su versión %{locale_name}
         translate: Traducir
       moderation_save_widget:
-        approved: Aprobado
         confirm: Estás seguro?
         edit_version: Editando versión
         last_versions: Últimas versiones
         moderation: Moderación
         moderation_info:
           new: Una vez guardes tu contenido, podrás enviarlo a moderación.
-          pending: Cuando tu contenido esté listo para ser revisado por un moderador,
+          not_sent: Cuando tu contenido esté listo para ser revisado por un moderador,
             haz click en Enviar.
           publicable: Haz click en Publicar para que esta versión sea visible publicamente.
           published: La versión está publicada.
+          rejected: La versión está rechazada.
           sent: Tu contenido ha sido enviado para revisión. Recibirás una notificación
             cuando se apruebe o te soliciten cambios.
+        moderation_status:
+          approved: Aprobado
+          in_review: En revisión
+          not_sent: No enviado
+          rejected: Rechazado
+          sent: En revisión
         new_version: Nueva (no guardada)
-        not_sent: No enviado
         preview: Previsualizar
         publication_status:
           approved: Publicada
@@ -56,7 +61,6 @@ es:
         see_all: ver todas
         see_versions: ver versiones
         send: Enviar
-        under_review: En revisión
         unpublish: Despublicar
       recover:
         confirm: Si recuperas un elemento, se volverá a listar de nuevo.

--- a/db/migrate/20190401094419_create_gobierto_admin_moderations.rb
+++ b/db/migrate/20190401094419_create_gobierto_admin_moderations.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGobiertoAdminModerations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :admin_moderations do |t|
+      t.references :site
+      t.references :moderable, polymorphic: true
+      t.references :admin
+      t.integer :stage, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_11_184537) do
+ActiveRecord::Schema.define(version: 2019_04_01_094419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -99,6 +99,19 @@ ActiveRecord::Schema.define(version: 2019_03_11_184537) do
   create_table "admin_groups_admins", id: false, force: :cascade do |t|
     t.bigint "admin_id", null: false
     t.bigint "admin_group_id", null: false
+  end
+
+  create_table "admin_moderations", force: :cascade do |t|
+    t.bigint "site_id"
+    t.string "moderable_type"
+    t.bigint "moderable_id"
+    t.bigint "admin_id"
+    t.integer "stage", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_id"], name: "index_admin_moderations_on_admin_id"
+    t.index ["moderable_type", "moderable_id"], name: "index_admin_moderations_on_moderable_type_and_moderable_id"
+    t.index ["site_id"], name: "index_admin_moderations_on_site_id"
   end
 
   create_table "census_items", id: :serial, force: :cascade do |t|


### PR DESCRIPTION


Closes #2181


## :v: What does this PR do?
* Creates a save widget to manage from admin the visibility and versions and inform about moderation status of resources in their edition forms.
* The methods used by the widget relative to version are included in a decorator. Version info and select aren't shown if the resource doesn't have paper_trail enabled.
* The visibility status and version methods are encapsulated in other decorator, which is prepared to implement the moderation flow described in #2182. At the moment, the default flow is to allow any user to publish/unpublish a resource from the widget, since the moderation status is always approved.
* The new widget expects a resource and a form builder. Te resource will be used to initialize the different decorators.
* The preview button is not implemented yet, I'd like to have a little more definition about this. It's a link to front with the changes previously saved?

## :mag: How should this be manually tested?

Replace, for example, the current widget from a form partial:

```ruby
<%= render partial: 'gobierto_admin/shared/save_widget', locals: { f: f, levels: @project_visibility_levels } %>
```

with:
```ruby
<%= render partial: "gobierto_admin/shared/admin_widget_save_v2", locals: { f: f, resource: @project_form.persisted? ? @project : @project_form.project } %>
```

This can be tested better combined with the changes introduced in the PR for the project of a plan

## :eyes: Screenshots

### Before this PR

<img width="1081" alt="Screen Shot 2019-03-29 at 17 56 16" src="https://user-images.githubusercontent.com/446459/55249445-5ba45800-524c-11e9-98bb-1fe9afabf31a.png">

### After this PR

<img width="1098" alt="Screen Shot 2019-03-29 at 17 56 54" src="https://user-images.githubusercontent.com/446459/55249460-63fc9300-524c-11e9-9780-3517eb7fa0cf.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
