### PR TITLE
Fix condition on receipt to avoid sum if first option is null

### DIFF
--- a/app/javascript/gobierto_budgets/modules/receipt_controller.js
+++ b/app/javascript/gobierto_budgets/modules/receipt_controller.js
@@ -76,8 +76,7 @@ window.GobiertoBudgets.ReceiptController = (function() {
       },
       methods: {
         total: function(o) {
-          return (this.selected.length && typeof this.selected[0] === 'object')
-            ? _.sumBy(this.selected, this.categories[o]) : _.sum(this.selected.filter(Number))
+          return this.selected.length ? _.sumBy(this.selected, this.categories[o]) : _.sum(this.selected.filter(Number))
         },
         localizedName: function(attr) {
           return attr['name_' + this.locale] || attr['name'];


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes a condition in the receipts section. Before, if the first option wasn't selected, the total amount wasn't calculated.

## :mag: How should this be manually tested?

Use the receipt combining all the options without including the first one. The total should update.

## :eyes: Screenshots

### Before this PR

![Screen Shot 2019-04-04 at 17 58 28](https://user-images.githubusercontent.com/17616/55570253-525f3380-5703-11e9-9816-8dc1a5024169.png)

### After this PR

![Screen Shot 2019-04-04 at 18 04 47](https://user-images.githubusercontent.com/17616/55570673-25f7e700-5704-11e9-92e7-72a3fb6014c2.png)


