### PR TITLE
Add actions to admin group permissions

### DIFF
--- a/app/controllers/gobierto_admin/admin_groups_controller.rb
+++ b/app/controllers/gobierto_admin/admin_groups_controller.rb
@@ -22,7 +22,10 @@ module GobiertoAdmin
 
       @admin_group_form = AdminGroupForm.new(
         @admin_group.attributes.except(*ignored_admin_group_attributes).merge(
-          modules: @admin_group.modules_permissions.where(action_name: "manage").pluck(:resource_name),
+          modules_actions: @admin_group.modules_permissions.distinct.pluck(:resource_name).map do |resource_name|
+            [resource_name,
+             @admin_group.modules_permissions.where(resource_name: resource_name).distinct.pluck(:action_name)]
+          end.to_h,
           people: @admin_group.people_permissions.where(action_name: "manage").pluck(:resource_id),
           site_options: @admin_group.site_options_permissions.where(action_name: "manage").pluck(:resource_name),
           all_people: @admin_group.people_permissions.where(action_name: "manage_all").exists?
@@ -81,9 +84,9 @@ module GobiertoAdmin
       params.require(:admin_group).permit(
         :name,
         :all_people,
-        modules: [],
         people: [],
-        site_options: []
+        site_options: [],
+        modules_actions: {}
       )
     end
 

--- a/app/javascript/gobierto_admin/modules/admin_groups_controller.js
+++ b/app/javascript/gobierto_admin/modules/admin_groups_controller.js
@@ -3,19 +3,40 @@ window.GobiertoAdmin.AdminGroupsController = (function() {
     function AdminGroupsController() {}
 
     AdminGroupsController.prototype.form = function() {
-      _addToggleGobiertoPeopleBehaviors();
+      _addToggleModulesBehaviors();
+      _addToggleActionsBehaviors();
       _addToggleAllPeopleBehaviors();
       _addTogglePersonBehaviors();
     };
 
 
-    function _addToggleGobiertoPeopleBehaviors() {
-      var $checkbox = $("[data-behavior='toggle-module-GobiertoPeople']");
-      $checkbox.click(function() {
+    function _addToggleModulesBehaviors() {
+      $("[data-behavior='toggle-module']").click(function() {
+        let $modules_actions_block = $(`#modules_actions_${this.value}`);
+        let $subresources_block = $(`#subresources_${this.value}`);
         if (this.checked) {
-          $('#people_permissions').show('slow');
+          $modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']").prop('disabled', false);
+          $modules_actions_block.show('slow');
+          if ($modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']:checked").length == 0) {
+            $modules_actions_block.find("[data-class='modules_action'] input[type='checkbox'][value='manage']").prop('checked', true);
+          }
+          $subresources_block.show('slow');
         } else {
-          $('#people_permissions').hide('slow');
+          $modules_actions_block.hide('slow');
+          $modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']").prop('disabled', true);
+          $subresources_block.hide('slow');
+        }
+      });
+    }
+
+    function _addToggleActionsBehaviors() {
+      $("[data-behavior='toggle-action']").click(function() {
+        if (!this.checked) {
+          let module_name = this.parentElement.getAttribute("data-module")
+          let $modules_actions_block = $(`#modules_actions_${this.parentElement.getAttribute("data-module")}`);
+          if ($modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']:checked").length == 0) {
+            $(`input[type='checkbox'][data-behavior='toggle-module'][value='${module_name}']`).trigger("click");
+          }
         }
       });
     }

--- a/app/views/gobierto_admin/admin_groups/_form.html.erb
+++ b/app/views/gobierto_admin/admin_groups/_form.html.erb
@@ -38,38 +38,54 @@
             <%= f.collection_check_boxes(:modules, Array(@site_modules), :namespace, :name) do |module_b| %>
               <div class="option">
                 <% check_module_permission = @admin_group && @admin_group.permissions.by_namespace("site_module").resource_names.map(&:camelize).include?(module_b.value) %>
-                <%= module_b.check_box(data: { behavior: "toggle-module-#{module_b.value}" }, checked: check_module_permission) %>
+                <%= module_b.check_box(data: { behavior: "toggle-module" }, checked: check_module_permission) %>
                 <%= module_b.label do %>
                   <span></span>
                   <%= module_b.text %>
                 <% end %>
-              </div>
+                <% module_active = f.object.modules_actions.keys.include?(module_b.object.namespace.underscore) %>
 
-              <% if module_b.text == 'Gobierto People' %>
-                <% module_active = f.object.modules.include?(module_b.object.namespace.underscore) %>
+                <div class="option_suboptions" id="<%= "modules_actions_#{module_b.value}" %>" style="<%= module_active ? '' : 'display: none;' %>">
+                  <h3><%= t(".actions") %></h3>
 
-                <div class="option_suboptions" id="people_permissions" style="<%= module_active ? '' : 'display: none;' %>">
-
-                  <div class="option">
-                    <%= f.check_box :all_people %>
-                    <%= f.label :all_people do %>
-                      <span></span><b><%= t('.all') %></b>
-                    <% end %>
-                  </div>
-
-                  <%= f.collection_check_boxes(:people, Array(@people), :id, :name) do |person_b| %>
-                    <% person_site_id = person_b.object.site_id %>
-
-                    <div class="option" data-class="site_person" data-site-id="<%= person_site_id %>">
-                      <%= person_b.check_box(checked: @admin_group && @admin_group.people_permissions.exists?(resource_id: person_b.object.id)) %>
-                      <%= person_b.label do %>
-                        <span></span><%= person_b.object.name %>
+                  <%= f.collection_check_boxes("modules_actions[#{module_b.value.underscore}]", @admin_group_form.action_names(:modules_actions).map { |action| [action, t(".action_names.#{action}")] }, :first, :last) do |action_b| %>
+                    <div class="option" data-class="<%= "modules_action" %>" data-module="<%= module_b.value %>">
+                      <%= action_b.check_box(data: { behavior: "toggle-action" },
+                                             id: "modules_action_#{module_b.value.underscore}_#{action_b.value}",
+                                             checked: @admin_group && @admin_group.modules_permissions.exists?(resource_name: module_b.value.underscore, action_name: action_b.value)) %>
+                      <%= action_b.label(for: "modules_action_#{module_b.value.underscore}_#{action_b.value}") do %>
+                        <span></span><%= action_b.text %>
                       <% end %>
                     </div>
+
                   <% end %>
 
                 </div>
-              <% end %>
+
+                <% if module_b.text == 'Gobierto People' %>
+                  <div class="option_suboptions" id="<%= "subresources_#{module_b.value}" %>" style="<%= module_active ? '' : 'display: none;' %>">
+                    <h3><%= t(".people") %></h3>
+
+                    <div class="option">
+                      <%= f.check_box :all_people %>
+                      <%= f.label :all_people do %>
+                        <span></span><b><%= t('.all') %></b>
+                      <% end %>
+                    </div>
+
+                    <%= f.collection_check_boxes(:people, Array(@people), :id, :name) do |person_b| %>
+                      <% person_site_id = person_b.object.site_id %>
+
+                      <div class="option" data-class="site_person" data-site-id="<%= person_site_id %>">
+                        <%= person_b.check_box(checked: @admin_group && @admin_group.people_permissions.exists?(resource_id: person_b.object.id)) %>
+                        <%= person_b.label do %>
+                          <span></span><%= person_b.object.name %>
+                      <% end %>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
             <% end %>
           </div>
 

--- a/config/locales/gobierto_admin/views/admin_groups/ca.yml
+++ b/config/locales/gobierto_admin/views/admin_groups/ca.yml
@@ -7,14 +7,20 @@ ca:
       edit:
         title: 'Permisos del grup: %{name}'
       form:
+        action_names:
+          edit: Editar
+          manage: Administrar
+          moderate: Moderar
+        actions: Accions
         all: Tots
         members:
           one: Hi ha un administrador amb aquest grup.
           other: Hi ha %{count} administradors amb aquest grup.
           zero: Aquest grup no té administradors.
         modules_permissions: Mòduls
+        people: Persones
         placeholders:
-          name: Grup global d'administradors
+          name: Grup glo bal d'administradors
         site_options_permissions: Lloc web
       index:
         header:

--- a/config/locales/gobierto_admin/views/admin_groups/en.yml
+++ b/config/locales/gobierto_admin/views/admin_groups/en.yml
@@ -7,12 +7,18 @@ en:
       edit:
         title: 'Permissions of group: %{name}'
       form:
+        action_names:
+          edit: Edit
+          manage: Manage
+          moderate: Moderate
+        actions: Actions
         all: All
         members:
           one: There is an admin with this group.
           other: There are %{count} admins with this group.
           zero: This group doesn't have admins.
         modules_permissions: Modules
+        people: People
         placeholders:
           name: Global admins group
         site_options_permissions: Site

--- a/config/locales/gobierto_admin/views/admin_groups/es.yml
+++ b/config/locales/gobierto_admin/views/admin_groups/es.yml
@@ -7,12 +7,18 @@ es:
       edit:
         title: 'Permisos del grupo: %{name}'
       form:
+        action_names:
+          edit: Editar
+          manage: Administrar
+          moderate: Moderar
+        actions: Acciones
         all: Todos
         members:
           one: Hay un administrador con este grupo.
           other: Hay %{count} administradores con este grupo.
           zero: Este grupo no tiene administradores.
         modules_permissions: Módulos
+        people: Personas
         placeholders:
           name: Grupo global de administradores
         site_options_permissions: Sitio

--- a/test/forms/gobierto_admin/admin_group_form_test.rb
+++ b/test/forms/gobierto_admin/admin_group_form_test.rb
@@ -61,7 +61,7 @@ module GobiertoAdmin
     end
 
     def test_modules_initialization
-      assert_equal [], subject.new.modules
+      assert_equal({}, subject.new.modules_actions)
     end
 
     ## Tests related to permissions
@@ -69,7 +69,7 @@ module GobiertoAdmin
     def test_change_authorization_level_updates_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople),
+          modules_actions: { gobierto_people: [:manage] },
           people: [richard.id]
         )
       )
@@ -79,7 +79,7 @@ module GobiertoAdmin
 
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople),
+          modules_actions: { gobierto_people: [:manage] },
           people: [richard.id]
         )
       )
@@ -89,7 +89,9 @@ module GobiertoAdmin
     end
 
     def test_grant_module_permissions
-      form = subject.new(madrid_group_params.merge(modules: %w(GobiertoPeople GobiertoBudgetConsultations GobiertoParticipation)))
+      form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage],
+                                                                      gobierto_budget_consultations: [:manage],
+                                                                      gobierto_participation: [:manage] }))
 
       assert_equal 2, tony.modules_permissions.size
 
@@ -99,7 +101,7 @@ module GobiertoAdmin
     end
 
     def test_revoke_module_permissions
-      form = subject.new(madrid_group_params.merge(modules: %w(GobiertoPeople)))
+      form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage] }))
 
       assert_equal 2, tony.modules_permissions.size
 
@@ -112,7 +114,7 @@ module GobiertoAdmin
     # for empty collections.
     # Use this test to make sure .where.not(attribute: collection) syntax is used
     def test_revoke_all_module_permissions
-      form = subject.new(madrid_group_params.merge(modules: []))
+      form = subject.new(madrid_group_params.merge(modules_actions: {}))
 
       assert form.save
 
@@ -120,7 +122,7 @@ module GobiertoAdmin
     end
 
     def test_revoke_gobierto_people_permissions_revokes_people_permissions
-      form = subject.new(madrid_group_params.merge(modules: %w(GobiertoBudgetConsultations)))
+      form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_budget_consultations: [:manage] }))
 
       assert form.save
 
@@ -130,7 +132,7 @@ module GobiertoAdmin
     def test_grant_person_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople GobiertoBudgetConsultations),
+          modules_actions: { gobierto_people: [:manage], gobierto_budget_consultations: [:manage] },
           people: [richard.id, tamara.id, kali.id]
         )
       )
@@ -143,7 +145,7 @@ module GobiertoAdmin
     def test_grant_all_people_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople),
+          modules_actions: { gobierto_people: [:manage] },
           people: [],
           all_people: "1"
         )
@@ -160,7 +162,7 @@ module GobiertoAdmin
     def test_grant_person_permissions_without_site_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople GobiertoBudgetConsultations),
+          modules_actions: { gobierto_people: [:manage], gobierto_budget_consultations: [:manage] },
           people: [richard.id, tamara.id, kali.id]
         )
       )
@@ -178,7 +180,7 @@ module GobiertoAdmin
     def test_grant_person_permissions_without_gobierto_people_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoBudgetConsultations),
+          modules_actions: { gobierto_budget_consultations: [:manage] },
           people: [richard.id, kali.id, tamara.id]
         )
       )
@@ -191,7 +193,7 @@ module GobiertoAdmin
     def test_revoke_person_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople),
+          modules_actions: { gobierto_people: [:manage] },
           people: [richard.id]
         )
       )
@@ -204,7 +206,7 @@ module GobiertoAdmin
     def test_revoke_all_people_permissions
       form = subject.new(
         madrid_group_params.merge(
-          modules: %w(GobiertoPeople),
+          modules_actions: { gobierto_people: [:manage] },
           people: [],
           all_people: "0"
         )

--- a/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
+++ b/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
@@ -30,29 +30,34 @@ module GobiertoAdmin
     end
 
     def test_admin_group_update
-      with_current_site(site) do
-        with_signed_in_admin(manager_admin) do
-          visit edit_admin_admin_group_path(madrid_group)
+      with_javascript do
+        with_current_site(site) do
+          with_signed_in_admin(manager_admin) do
+            visit edit_admin_admin_group_path(madrid_group)
 
-          within "form.edit_admin_group" do
-            fill_in "admin_group_name", with: "Admin Group changed name"
+            within "form.edit_admin_group" do
+              fill_in "admin_group_name", with: "Admin Group changed name"
 
-            check "Gobierto Participation"
+              find("label[for='admin_group_modules_gobiertoparticipation']").click
+              find("label[for='admin_group_site_options_vocabularies']").click
+              find("label[for='admin_group_site_options_templates']").click
 
-            uncheck "Vocabularies"
-            check "Templates"
+              click_button "Update"
+            end
 
-            click_button "Update"
-          end
+            assert has_message?("Admins Group was successfully updated")
 
-          assert has_message?("Admins Group was successfully updated")
 
-          within "form.edit_admin_group" do
-            assert has_field?("admin_group_name", with: "Admin Group changed name")
-            assert has_checked_field?("Gobierto Participation")
-            assert has_no_checked_field?("Gobierto Budgets")
-            assert has_no_checked_field?("Vocabularies")
-            assert has_checked_field?("Templates")
+            within "form.edit_admin_group" do
+              assert has_field?("admin_group_name", with: "Admin Group changed name")
+              assert find("#admin_group_modules_gobiertoparticipation", visible: false).checked?
+              assert find("#modules_action_gobierto_participation_manage", visible: false).checked?
+              refute find("#modules_action_gobierto_participation_edit", visible: false).checked?
+              refute find("#modules_action_gobierto_participation_moderate", visible: false).checked?
+              refute find("#admin_group_modules_gobiertobudgets", visible: false).checked?
+              refute find("#admin_group_site_options_vocabularies", visible: false).checked?
+              assert find("#admin_group_site_options_templates", visible: false).checked?
+            end
           end
         end
       end


### PR DESCRIPTION
Related with #2182 

## :v: What does this PR do?

Allows the creation of permissions in admin groups for gobierto modules with different actions.

Before this, all permissions had "manage" or "manage_all" action name. After this, also "edit", "moderate", "edit_all" and "moderate_all" can be created for modules and subresources as people in Gobierto People module.

In Gobierto People, the actions selected affects to the People subsection: If "moderate" and "edit" are selected, when "All" option is checked, both permissions with "moderate_all" and a "edit_all" will be created. If some people is selected, two permissions for each person will be created, with "moderate" and "edit" actions.

For the other sections of admin group permissions with no choices for action, by default the action of the permissions created is "manage" as usual.

## :mag: How should this be manually tested?

Visit an admin group and edit its permissions

## :eyes: Screenshots

### Before this PR
![admin_group_before](https://user-images.githubusercontent.com/446459/55731430-834caa80-5a1a-11e9-9c81-a6e4b6fbe6ac.gif)

### After this PR
![admin_group_after](https://user-images.githubusercontent.com/446459/55731452-8b0c4f00-5a1a-11e9-91bf-f8dac6a649e0.gif)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
