### PR TITLE
Add link to documentation of each module

### DIFF
--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -12,7 +12,7 @@ module GobiertoAdmin
 
     helper_method :current_admin, :admin_signed_in?, :current_site, :managing_site?,
                   :managed_sites, :can_manage_sites?, :gobierto_cms_page_preview_path,
-                  :preview_item_url
+                  :preview_item_url, :module_doc_url
 
     rescue_from Errors::NotAuthorized, with: :raise_admin_not_authorized
 
@@ -53,6 +53,12 @@ module GobiertoAdmin
 
     def current_admin_module
       current_module == "gobierto_admin" && params[:controller].split("/")[1].camelize
+    end
+
+    def module_doc_url
+      current_admin_module.constantize.try(:doc_url)
+    rescue NameError
+      false
     end
 
     protected

--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -58,7 +58,7 @@ module GobiertoAdmin
     def module_doc_url
       current_admin_module.constantize.try(:doc_url)
     rescue NameError
-      false
+      "https://gobierto.readme.io/docs/administraci%C3%B3n-de-un-sitio"
     end
 
     protected

--- a/app/models/gobierto_budget_consultations.rb
+++ b/app/models/gobierto_budget_consultations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoBudgetConsultations
   def self.table_name_prefix
     "gbc_"
@@ -5,5 +7,9 @@ module GobiertoBudgetConsultations
 
   def self.searchable_models
     []
+  end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/consultas-sobre-presupuestos"
   end
 end

--- a/app/models/gobierto_budgets.rb
+++ b/app/models/gobierto_budgets.rb
@@ -1,5 +1,6 @@
-module GobiertoBudgets
+# frozen_string_literal: true
 
+module GobiertoBudgets
   def self.table_name_prefix
     'gb_'
   end
@@ -8,4 +9,7 @@ module GobiertoBudgets
     [ GobiertoBudgets::BudgetLine ]
   end
 
+  def self.doc_url
+    "https://gobierto.readme.io/docs/presupuestos"
+  end
 end

--- a/app/models/gobierto_calendars.rb
+++ b/app/models/gobierto_calendars.rb
@@ -1,5 +1,6 @@
-module GobiertoCalendars
+# frozen_string_literal: true
 
+module GobiertoCalendars
   def self.table_name_prefix
     'gc_'
   end

--- a/app/models/gobierto_citizens_charters.rb
+++ b/app/models/gobierto_citizens_charters.rb
@@ -20,4 +20,8 @@ module GobiertoCitizensCharters
   def self.module_submodules
     %w(services charters)
   end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/servicios-y-cartas-de-servicio"
+  end
 end

--- a/app/models/gobierto_cms.rb
+++ b/app/models/gobierto_cms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCms
   def self.table_name_prefix
     'gcms_'
@@ -5,5 +7,9 @@ module GobiertoCms
 
   def self.searchable_models
     [ GobiertoCms::Page ]
+  end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/cms"
   end
 end

--- a/app/models/gobierto_core.rb
+++ b/app/models/gobierto_core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoCore
   def self.table_name_prefix
     'gcore_'

--- a/app/models/gobierto_module_settings.rb
+++ b/app/models/gobierto_module_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GobiertoModuleSettings < ApplicationRecord
   self.table_name = 'gobierto_module_settings'
   belongs_to :site, touch: true

--- a/app/models/gobierto_observatory.rb
+++ b/app/models/gobierto_observatory.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoObservatory
+  def self.doc_url
+    "https://gobierto.readme.io/docs/observatorio"
+  end
+end

--- a/app/models/gobierto_participation.rb
+++ b/app/models/gobierto_participation.rb
@@ -12,4 +12,8 @@ module GobiertoParticipation
   def self.searchable_models
     [GobiertoParticipation::Process, GobiertoParticipation::Contribution]
   end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/participaci%C3%B3n"
+  end
 end

--- a/app/models/gobierto_people.rb
+++ b/app/models/gobierto_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GobiertoPeople
   def self.table_name_prefix
     "gp_"
@@ -25,5 +27,9 @@ module GobiertoPeople
 
   def self.remote_calendar_integrations
     %w( ibm_notes google_calendar microsoft_exchange )
+  end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/altos-cargos-y-agendas"
   end
 end

--- a/app/models/gobierto_plans.rb
+++ b/app/models/gobierto_plans.rb
@@ -4,4 +4,8 @@ module GobiertoPlans
   def self.table_name_prefix
     'gplan_'
   end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/planes"
+  end
 end

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -104,6 +104,12 @@
       </div>
     <% end %>
 
+    <% if module_doc_url %>
+      <div class="right pure-menu-link">
+        <%= link_to t(".view_documentation"), module_doc_url, target: "_blank" %>
+      </div>
+    <% end %>
+
     <% if current_site.present? %>
       <div class="right pure-menu-link">
           <%= link_to t(".view_site"), current_site.domain_url, target: "_blank" %>

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -26,6 +26,7 @@ ca:
         site_network: Xarxa
         templates: Plantilles
         users: Usuaris
+        view_documentation: Veure documentació
         view_item: Veure ítem
         view_site: Veure site
         vocabularies: Vocabularis

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -26,6 +26,7 @@ en:
         site_network: Network
         templates: Templates
         users: Users
+        view_documentation: View documentation
         view_item: View item
         view_site: View site
         vocabularies: Vocabularies

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -26,6 +26,7 @@ es:
         site_network: Red
         templates: Plantillas
         users: Usuarios
+        view_documentation: Ver documentación
         view_item: Ver ítem
         view_site: Ver site
         vocabularies: Vocabularios

--- a/test/integration/gobierto_admin/gobierto_people/view_documentation_test.rb
+++ b/test/integration/gobierto_admin/gobierto_people/view_documentation_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPeople
+    class ViewDocumentationTest < ActionDispatch::IntegrationTest
+
+      def setup
+        super
+        @path = edit_admin_people_configuration_settings_path
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def test_setting_update
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            assert has_link?("View documentation")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2217 

## :v: What does this PR do?

This PR adds a new method to modules main module file named `doc_url` which allows to define the URL to the docs.

In the GobiertoAdmin namespace, a method is defined to render the link in the views if the doc is defined.

## :mag: How should this be manually tested?

Check the link in the different modules of the admin.

## :eyes: Screenshots

### After this PR

![Screen Shot 2019-04-10 at 08 44 42](https://user-images.githubusercontent.com/17616/55857887-9d979d00-5b6e-11e9-9c84-0209ada99ff3.png)

## :book: Does this PR require updating the documentation?

Yes

- [x] new module/submodule settings?
