### PR TITLE
Update versions table

### DIFF
--- a/db/migrate/20190415093350_change_item_id_versions_column.rb
+++ b/db/migrate/20190415093350_change_item_id_versions_column.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeItemIdVersionsColumn < ActiveRecord::Migration[5.2]
+  def up
+    change_column :versions, :item_id, :integer, limit: 8
+  end
+
+  def down
+    change_column :versions, :item_id, :integer, limit: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_01_094419) do
+ActiveRecord::Schema.define(version: 2019_04_15_093350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -1033,7 +1033,7 @@ ActiveRecord::Schema.define(version: 2019_04_01_094419) do
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.integer "item_id", null: false
+    t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"


### PR DESCRIPTION


## :v: What does this PR do?

Updates the `item_id` column of `versions` from integer to bigint according to https://github.com/PopulateTools/gobierto/pull/2221

## :mag: How should this be manually tested?

The existing versions shouldn't be affected 

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No