### PR TITLE
2225 citizens charters change naming

### DIFF
--- a/config/locales/gobierto_admin/gobierto_citizens_charters/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/controllers/ca.yml
@@ -5,12 +5,12 @@ ca:
       charters:
         commitments:
           create:
-            success_html: El compromís s'ha creat correctament. <a href="%{link}">Veure</a>.
+            success_html: El indicador s'ha creat correctament. <a href="%{link}">Veure</a>.
           destroy:
-            destroy_failed: No s'ha pogut eliminar el compromís
-            success: El compromís s'ha pogut eliminar correctament
+            destroy_failed: No s'ha pogut eliminar l'indicador
+            success: L'indicador s'ha pogut eliminar correctament
           update:
-            success_html: El compromís s'ha actualizat correctament. <a href="%{link}">Veure</a>.
+            success_html: L'indicador s'ha actualizat correctament. <a href="%{link}">Veure</a>.
         create:
           success_html: La carta de servei ha estat creada correctament. <a href="%{link}">Veure</a>.
         destroy:

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/controllers/en.yml
@@ -5,12 +5,12 @@ en:
       charters:
         commitments:
           create:
-            success_html: The commitment has been correctly created. <a href="%{link}">View</a>.
+            success_html: The indicator has been correctly created. <a href="%{link}">View</a>.
           destroy:
-            destroy_failed: The commitment couldn't be deleted
-            success: The commitment has been correctly deleted
+            destroy_failed: The indicator couldn't be deleted
+            success: The indicator has been correctly deleted
           update:
-            success_html: The commitment has been correctly updated. <a href="%{link}">View</a>.
+            success_html: The indicator has been correctly updated. <a href="%{link}">View</a>.
         create:
           success_html: The charter has been correctly created. <a href="%{link}">View</a>.
         destroy:

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/controllers/es.yml
@@ -5,12 +5,12 @@ es:
       charters:
         commitments:
           create:
-            success_html: El compromiso ha sido creada correctamente. <a href="%{link}">Ver</a>.
+            success_html: El indicador ha sido creado correctamente. <a href="%{link}">Ver</a>.
           destroy:
-            destroy_failed: No se ha podido eliminar el compromiso
-            success: El compromiso ha sido eliminado correctamente
+            destroy_failed: No se ha podido eliminar el indicador
+            success: El indicador ha sido eliminado correctamente
           update:
-            success_html: El compromiso ha sido actualizado correctamente. <a href="%{link}">Ver</a>.
+            success_html: El indicador ha sido actualizado correctamente. <a href="%{link}">Ver</a>.
         create:
           success_html: La carta de servicio ha sido creada correctamente. <a href="%{link}">Ver</a>.
         destroy:

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/models/ca.yml
@@ -7,6 +7,10 @@ ca:
         slug: Slug
         title: Títol
         title_translations: Títol
+      gobierto_admin/gobierto_citizens_charters/commitment_form:
+        description: Compromís
+        slug: Slug
+        title: Títol
       gobierto_admin/gobierto_citizens_charters/editions_interval_form:
         period: Data de l'edició
         period_interval: Periodicitat

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/models/en.yml
@@ -7,6 +7,10 @@ en:
         slug: Slug
         title: Title
         title_translations: Title
+      gobierto_admin/gobierto_citizens_charters/commitment_form:
+        description: Commitment
+        slug: Slug
+        title: Title
       gobierto_admin/gobierto_citizens_charters/editions_interval_form:
         period: Edition date
         period_interval: Periodicity

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/models/es.yml
@@ -7,6 +7,10 @@ es:
         slug: Slug
         title: Título
         title_translations: Título
+      gobierto_admin/gobierto_citizens_charters/commitment_form:
+        description: Compromiso
+        slug: Slug
+        title: Título
       gobierto_admin/gobierto_citizens_charters/editions_interval_form:
         period: Fecha de la edición
         period_interval: Periodicidad

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
@@ -8,7 +8,7 @@ ca:
         commitments:
           commitment:
             see_recent: Veure mesura més recent
-            view_commitment: Veure compromís
+            view_commitment: Veure indicador
           form:
             placeholders:
               description: El 95% de les trucades han de ser ateses en menys d'1 minut
@@ -20,13 +20,13 @@ ca:
               editions: Nombre de mesuraments
               status: Estat
               title: Títol
-            new: Nou compromís
+            new: Nou indicador
           new:
-            title: Nous compromís
+            title: Nou indicador
         editions:
           index:
-            commitments_link: Ir a compromisos
-            empty_commitments: No hi ha compromisos creats encara.
+            commitments_link: Ir a indicadors
+            empty_commitments: No hi ha indicadors creats encara.
             month_interval: Mensuals
             month_period: "%{month} / %{year}"
             new: Nova mesurament
@@ -45,8 +45,8 @@ ca:
             year_interval: Anual
           index:
             all: Totes
-            cta_commitments_link: Crea el teu primer compromís
-            cta_commitments_message: Encara no hi ha compromisos creats per inserir
+            cta_commitments_link: Crea el teu primer indicador
+            cta_commitments_message: Encara no hi ha indicadors creats per inserir
               mesuraments.
             header:
               editions: Mesuraments
@@ -83,14 +83,14 @@ ca:
           title: Preferencies
       editions:
         index:
-          all_commitments_used: Tots els compromisos ja tenen valor
+          all_commitments_used: Tots els indicadors ja tenen valor
           errors:
             max_value_null: Valor màxim no pot ser zero per tenir nivells de compliment
             missing_values: Cal omplir el percentatge o el parell valor i valor màxim
           header:
             max_value: Valor màxim
             percentage: Percentatge
-            title: Compromís
+            title: Indicador
             value: Valor
       services:
         form:
@@ -120,6 +120,6 @@ ca:
           title: Editar
         navigation:
           charters: Cartes de serveis
-          commitments: Compromisos
+          commitments: Indicadors
           editions_intervals: Edicions
           services: Serveis

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/ca.yml
@@ -16,7 +16,7 @@ ca:
               title: Acord de nivell de servei del centre d'atenció telefònica
           index:
             header:
-              description: Descripció
+              description: Compromís
               editions: Nombre de mesuraments
               status: Estat
               title: Títol

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
@@ -16,7 +16,7 @@ en:
               title: Call center service level agreement
           index:
             header:
-              description: Description
+              description: Commitment
               editions: Númber of measurements
               status: Estaus
               title: Title

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/en.yml
@@ -8,7 +8,7 @@ en:
         commitments:
           commitment:
             see_recent: See latest measurement
-            view_commitment: View commitment
+            view_commitment: View indicator
           form:
             placeholders:
               description: 95% of incoming calls will be answered in less than 1 minute
@@ -20,13 +20,13 @@ en:
               editions: Númber of measurements
               status: Estaus
               title: Title
-            new: New commitment
+            new: New indicator
           new:
-            title: New commitment
+            title: New indicator
         editions:
           index:
-            commitments_link: Go to commitments
-            empty_commitments: No commitments created yet.
+            commitments_link: Go to indicators
+            empty_commitments: No indicators created yet.
             month_interval: Monthly
             month_period: "%{month} / %{year}"
             new: New measurement
@@ -45,8 +45,8 @@ en:
             year_interval: Yearly
           index:
             all: All
-            cta_commitments_link: Create your first commitment
-            cta_commitments_message: No commitments created yet. Commitments are required
+            cta_commitments_link: Create your first indicator
+            cta_commitments_message: No indicators created yet. Indicators are required
               to insert measurements.
             header:
               editions: Measurement
@@ -83,7 +83,7 @@ en:
           title: Preferences
       editions:
         index:
-          all_commitments_used: All the commitments already have value
+          all_commitments_used: All the indicators already have value
           errors:
             max_value_null: max_value can't be zero in order to have levels of compliance
             missing_values: Please, fill in the percentage or the value and max_value
@@ -91,7 +91,7 @@ en:
           header:
             max_value: Max Value
             percentage: Percentage
-            title: Commitment
+            title: Indicator
             value: Value
       services:
         form:
@@ -121,6 +121,6 @@ en:
           title: Edit
         navigation:
           charters: Services charters
-          commitments: Commitments
+          commitments: Indicators
           editions_intervals: Editions
           services: Services

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
@@ -8,7 +8,7 @@ es:
         commitments:
           commitment:
             see_recent: Ver medición más reciente
-            view_commitment: Ver compromiso
+            view_commitment: Ver indicador
           form:
             placeholders:
               description: El 95% de las llamadas serán atendidas en menos de 1 minuto
@@ -20,13 +20,13 @@ es:
               editions: Número de mediciones
               status: Estado
               title: Título
-            new: Nuevo compromiso
+            new: Nuevo indicador
           new:
-            title: Nuevo compromiso
+            title: Nuevo indicador
         editions:
           index:
-            commitments_link: Ir a compromisos
-            empty_commitments: No hay compromisos creados aún.
+            commitments_link: Ir a indicadores
+            empty_commitments: No hay indicadores creados aún.
             month_interval: Mensuales
             month_period: "%{month} / %{year}"
             new: Nueva medición
@@ -45,8 +45,8 @@ es:
             year_interval: Anual
           index:
             all: Todas
-            cta_commitments_link: Crea tu primer compromiso
-            cta_commitments_message: Todavía no hay compromisos creados para insertar
+            cta_commitments_link: Crea tu primer indicador
+            cta_commitments_message: Todavía no hay indicadores creados para insertar
               mediciones.
             header:
               editions: Mediciones
@@ -83,14 +83,14 @@ es:
           title: Preferencias
       editions:
         index:
-          all_commitments_used: Todos los compromisos ya tienen valor
+          all_commitments_used: Todos los indicadores ya tienen valor
           errors:
             max_value_null: El objetivo no puede ser cero para tener niveles de cumplimiento
             missing_values: Hay que rellenar el porcentaje o el par valor y objetivo
           header:
             max_value: Objetivo
             percentage: Porcentaje
-            title: Compromiso
+            title: Indicador
             value: Valor
       services:
         form:
@@ -120,6 +120,6 @@ es:
           title: Editar
         navigation:
           charters: Cartas de servicio
-          commitments: Compromisos
+          commitments: Indicadores
           editions_intervals: Ediciones
           services: Servicios

--- a/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_citizens_charters/views/es.yml
@@ -16,7 +16,7 @@ es:
               title: Acuerdo de nivel de servicio del call center
           index:
             header:
-              description: Descripción
+              description: Compromiso
               editions: Número de mediciones
               status: Estado
               title: Título

--- a/config/locales/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_citizens_charters/views/ca.yml
@@ -8,30 +8,30 @@ ca:
       index:
         about: Què són les cartes de serveis
         commitments:
-          one: 1 compromís
-          other: "%{count} compromisos"
-          zero: No hi ha compromisos
+          one: 1 indicador
+          other: "%{count} indicadors"
+          zero: No hi ha indicadors
         contact: Contacte
-        description_title: Informació sobre el compliment dels compromisos %{of_the_organization_name}
+        description_title: Informació sobre el compliment dels indicadors %{of_the_organization_name}
         global_progress: Compliment global
         introduction: L'Ajuntament publica les seves cartes de serveis amb els seus
-          respectius compromisos i graus de compliment. Explora les cartes i els nivells
-          de compliment dels compromisos que vam publicar de forma regular
+          respectius indicadors i graus de compliment. Explora les cartes i els nivells
+          de compliment dels indicadors que vam publicar de forma regular
         period: 'Dades corresponents a:'
         progress: Compliment
       show:
         about: Sobre aquesta carta
-        editions_details: Detall dels compromisos
-        global_progress: Complim els compromisos d'aquesta carta al
+        editions_details: Detall dels indicadors
+        global_progress: Complim els objectius dels indicadors d'aquesta carta al
         max_value: Objectiu
         see_all: Veure la carta completa
         see_all_subtitle: Missió, Visió, Serveis, Unitat responsable...
         value: Arribat
     events:
-      gobierto_citizens_charters_charter_commitment_archived: Compromisos arxivats
-      gobierto_citizens_charters_charter_commitment_created: Compromisos creats
-      gobierto_citizens_charters_charter_commitment_published: Compromisos publicats
-      gobierto_citizens_charters_charter_commitment_updated: Compromisos actualitzats
+      gobierto_citizens_charters_charter_commitment_archived: Indicadors arxivats
+      gobierto_citizens_charters_charter_commitment_created: Indicadors creats
+      gobierto_citizens_charters_charter_commitment_published: Indicadors publicats
+      gobierto_citizens_charters_charter_commitment_updated: Indicadors actualitzats
       gobierto_citizens_charters_charter_created: Carta creada
       gobierto_citizens_charters_charter_edition_created: Mesuraments creades
       gobierto_citizens_charters_charter_edition_deleted: Mesuraments eliminades

--- a/config/locales/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_citizens_charters/views/ca.yml
@@ -12,7 +12,8 @@ ca:
           other: "%{count} indicadors"
           zero: No hi ha indicadors
         contact: Contacte
-        description_title: Informació sobre el compliment dels indicadors %{of_the_organization_name}
+        description_title: Informació sobre el compliment dels compromisos dels indicadors
+          %{of_the_organization_name}
         global_progress: Compliment global
         introduction: L'Ajuntament publica les seves cartes de serveis amb els seus
           respectius indicadors i graus de compliment. Explora les cartes i els nivells

--- a/config/locales/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_citizens_charters/views/en.yml
@@ -8,30 +8,30 @@ en:
       index:
         about: What are service charters
         commitments:
-          one: 1 commitment
-          other: "%{count} commitments"
-          zero: No commitments found
+          one: 1 indicator
+          other: "%{count} indicators"
+          zero: No indicators found
         contact: Contact
-        description_title: Information on the fulfillment of the commitments %{of_the_organization_name}
+        description_title: Information on the fulfillment of the indicators %{of_the_organization_name}
         global_progress: Global compliance
         introduction: The City Council publishes its service charters with their respective
-          commitments and degrees of compliance. Explore the charters and fulfillment
-          levels of the commitments we publish on a regular basis
+          indicators and degrees of compliance. Explore the charters and fulfillment
+          levels of the indicators we publish on a regular basis
         period: 'Data corresponding to:'
         progress: Compliance
       show:
         about: About this charter
-        editions_details: Detail of the commitments
-        global_progress: We fulfill the commitments of this charter to
+        editions_details: Detail of the indicators
+        global_progress: We met the goals of the indicators of this charter to
         max_value: Goal
         see_all: See the full charter
         see_all_subtitle: Mission, Vision, Services, Responsible Unit...
         value: Reached
     events:
-      gobierto_citizens_charters_charter_commitment_archived: Commitments archived
-      gobierto_citizens_charters_charter_commitment_created: Commitments created
-      gobierto_citizens_charters_charter_commitment_published: Commitments published
-      gobierto_citizens_charters_charter_commitment_updated: Commitments updated
+      gobierto_citizens_charters_charter_commitment_archived: Indicators archived
+      gobierto_citizens_charters_charter_commitment_created: Indicators created
+      gobierto_citizens_charters_charter_commitment_published: Indicators published
+      gobierto_citizens_charters_charter_commitment_updated: Indicators updated
       gobierto_citizens_charters_charter_created: Charter created
       gobierto_citizens_charters_charter_edition_created: Measurements created
       gobierto_citizens_charters_charter_edition_deleted: Measurements deleted

--- a/config/locales/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_citizens_charters/views/en.yml
@@ -12,7 +12,8 @@ en:
           other: "%{count} indicators"
           zero: No indicators found
         contact: Contact
-        description_title: Information on the fulfillment of the indicators %{of_the_organization_name}
+        description_title: Information about the fulfillment of the commitments of
+          the indicators %{of_the_organization_name}
         global_progress: Global compliance
         introduction: The City Council publishes its service charters with their respective
           indicators and degrees of compliance. Explore the charters and fulfillment

--- a/config/locales/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_citizens_charters/views/es.yml
@@ -12,7 +12,8 @@ es:
           other: "%{count} indicadores"
           zero: No hay indicadores
         contact: Contacto
-        description_title: Información sobre el cumplimiento de los indicadores %{of_the_organization_name}
+        description_title: Información sobre el cumplimiento de los compromisos de
+          los indicadores %{of_the_organization_name}
         global_progress: Cumplimiento global
         introduction: El Ayuntamiento publica sus cartas de servicios con sus respectivos
           indicadores y grados de cumplimiento. Explora las cartas y los niveles de

--- a/config/locales/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_citizens_charters/views/es.yml
@@ -8,30 +8,31 @@ es:
       index:
         about: Qué son las cartas de servicios
         commitments:
-          one: 1 compromiso
-          other: "%{count} compromisos"
-          zero: No hay compromisos
+          one: 1 indicador
+          other: "%{count} indicadores"
+          zero: No hay indicadores
         contact: Contacto
-        description_title: Información sobre el cumplimiento de los compromisos %{of_the_organization_name}
+        description_title: Información sobre el cumplimiento de los indicadores %{of_the_organization_name}
         global_progress: Cumplimiento global
         introduction: El Ayuntamiento publica sus cartas de servicios con sus respectivos
-          compromisos y grados de cumplimiento. Explora las cartas y los niveles de
-          cumplimiento de los compromisos que publicamos de forma regular
+          indicadores y grados de cumplimiento. Explora las cartas y los niveles de
+          cumplimiento de los indicadores que publicamos de forma regular
         period: 'Datos correspondientes a:'
         progress: Cumplimiento
       show:
         about: Acerca de esta carta
-        editions_details: Detalle de los compromisos
-        global_progress: Cumplimos los compromisos de esta carta al
+        editions_details: Detalle de los indicadores
+        global_progress: Cumplimos los objetivos de los indicadores de esta carta
+          al
         max_value: Objetivo
         see_all: Ver la carta completa
         see_all_subtitle: Misión, Visión, Servicios, Unidad responsable...
         value: Alcanzado
     events:
-      gobierto_citizens_charters_charter_commitment_archived: Compromisos archivados
-      gobierto_citizens_charters_charter_commitment_created: Compromisos creados
-      gobierto_citizens_charters_charter_commitment_published: Compromisos publicados
-      gobierto_citizens_charters_charter_commitment_updated: Compromisos actualizados
+      gobierto_citizens_charters_charter_commitment_archived: Indicadores archivados
+      gobierto_citizens_charters_charter_commitment_created: Indicadores creados
+      gobierto_citizens_charters_charter_commitment_published: Indicadores publicados
+      gobierto_citizens_charters_charter_commitment_updated: Indicadores actualizados
       gobierto_citizens_charters_charter_created: Carta creada
       gobierto_citizens_charters_charter_edition_created: Mediciones creadas
       gobierto_citizens_charters_charter_edition_deleted: Mediciones borradas

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -99,7 +99,7 @@ ca:
       budget_line_item_expense: Partida pressupostària - Despesa
       budget_line_item_income: Partida pressupostària - Ingrés
       charter: Carta de serveis
-      charter_commitment: Carta de serveis - Compromís
+      charter_commitment: Carta de serveis - Indicador
       contribution_item: Aportacions
       drag_drop_instructions: Arrossegueu i deixeu anar al costat esquerre per a col·locar
         aquesta pàgina al menú

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -94,7 +94,7 @@ en:
       budget_line_item_expense: Budget line - Expense
       budget_line_item_income: Budget line - Income
       charter: Services charter
-      charter_commitment: Services charter - Commitment
+      charter_commitment: Services charter - Indicator
       contribution_item: Contribution
       drag_drop_instructions: Drag and drop on the left side to place this page in
         the menu

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -99,7 +99,7 @@ es:
       budget_line_item_expense: Partida presupuestaria - Gasto
       budget_line_item_income: Partida presupuestaria - Ingreso
       charter: Carta de servicios
-      charter_commitment: Carta de servicios - Compromiso
+      charter_commitment: Carta de servicios - Indicador
       contribution_item: Aportaciones
       drag_drop_instructions: Arrastre y suelte en la parte izquierda para colocar
         esta página en el menú

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/create_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/create_commitment_test.rb
@@ -70,7 +70,7 @@ module GobiertoAdmin
 
                 click_button "Create"
 
-                assert has_message?("The commitment has been correctly created.")
+                assert has_message?("The indicator has been correctly created.")
 
                 new_commitment = ::GobiertoCitizensCharters::Commitment.last
 

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
@@ -50,7 +50,7 @@ module GobiertoAdmin
                 find("a[data-method='delete']").click
               end
 
-              assert has_message?("The commitment has been correctly deleted")
+              assert has_message?("The indicator has been correctly deleted")
 
               refute site.commitments.exists?(id: commitment.id)
             end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
@@ -52,22 +52,22 @@ module GobiertoAdmin
               with_current_site(site) do
                 visit @path
 
-                fill_in "commitment_title_translations_en", with: "Commitment updated"
+                fill_in "commitment_title_translations_en", with: "Indicator updated"
                 fill_in "commitment_description_translations_en", with: "Commitment updated description"
                 click_link "ES"
-                fill_in "commitment_title_translations_es", with: "Compromiso actualizado"
+                fill_in "commitment_title_translations_es", with: "Indicador actualizado"
                 fill_in "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
 
                 click_button "Update"
 
-                assert has_message?("The commitment has been correctly updated.")
+                assert has_message?("The indicator has been correctly updated.")
 
                 visit @path
 
-                assert has_field? "commitment_title_translations_en", with: "Commitment updated"
+                assert has_field? "commitment_title_translations_en", with: "Indicator updated"
                 assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
                 click_link "ES"
-                assert has_field? "commitment_title_translations_es", with: "Compromiso actualizado"
+                assert has_field? "commitment_title_translations_es", with: "Indicador actualizado"
                 assert has_field? "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
               end
             end
@@ -87,22 +87,22 @@ module GobiertoAdmin
                 assert_no_difference "Activity.count" do
                   visit @draft_commitment_path
 
-                  fill_in "commitment_title_translations_en", with: "Commitment updated"
+                  fill_in "commitment_title_translations_en", with: "Indicator updated"
                   fill_in "commitment_description_translations_en", with: "Commitment updated description"
                   click_link "ES"
-                  fill_in "commitment_title_translations_es", with: "Compromiso actualizado"
+                  fill_in "commitment_title_translations_es", with: "Indicador actualizado"
                   fill_in "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
 
                   click_button "Update"
 
-                  assert has_message?("The commitment has been correctly updated.")
+                  assert has_message?("The indicator has been correctly updated.")
 
                   visit @draft_commitment_path
 
-                  assert has_field? "commitment_title_translations_en", with: "Commitment updated"
+                  assert has_field? "commitment_title_translations_en", with: "Indicator updated"
                   assert has_field? "commitment_description_translations_en", with: "Commitment updated description"
                   click_link "ES"
-                  assert has_field? "commitment_title_translations_es", with: "Compromiso actualizado"
+                  assert has_field? "commitment_title_translations_es", with: "Indicador actualizado"
                   assert has_field? "commitment_description_translations_es", with: "Descripción del compromiso actualizado"
                 end
               end
@@ -122,7 +122,7 @@ module GobiertoAdmin
 
                 click_button "Update"
 
-                assert has_message?("The commitment has been correctly updated.")
+                assert has_message?("The indicator has been correctly updated.")
 
                 visit @draft_commitment_path
 

--- a/test/integration/gobierto_citizens_charters/show_charter_test.rb
+++ b/test/integration/gobierto_citizens_charters/show_charter_test.rb
@@ -112,7 +112,7 @@ module GobiertoCitizensCharters
       global_progress = proportion.sum / proportion.count
       with_current_site(site) do
         visit @path
-        within "div.charter-subheader", text: "We fulfill the commitments of this charter to" do
+        within "div.charter-subheader", text: "We met the goals of the indicators of this charter to" do
           assert has_content? "#{ global_progress.round(1) }%"
         end
       end


### PR DESCRIPTION
Closes #2225, #2226 


## :v: What does this PR do?

* Replaces translations for commitments in application as:
  * ES: compromiso -> indicador
  * EN: commitment -> indicator
  * CA: compromís -> indicador
* Also replaces commitment/indicator description attribute name with compromiso/commitment/compromís.
* Expression "fulfilment of the commitments" is replaced with "fulfilment of the commitments of the indicators"
* Some missing translations in commitment/indicator form are added, as described in #2226.

## :mag: How should this be manually tested?

Visit citizens charters admin and front and check naming

## :eyes: Screenshots

### Before this PR

![2225-before](https://user-images.githubusercontent.com/446459/56307554-5e0c1a80-6145-11e9-8cba-65482662ef7a.gif)

### After this PR

![2225-after](https://user-images.githubusercontent.com/446459/56307590-711eea80-6145-11e9-8e04-77a6fb80e489.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
