### PR TITLE
Fix slash duplications in SiteDecorator#domain_url

### DIFF
--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -32,7 +32,7 @@ class SiteDecorator < BaseDecorator
                  "#{DOMAIN_URL_SCHEME}#{object.domain}"
                end
 
-    root_url_path.present? ? "#{root_url}/#{root_url_path}" : root_url
+    root_url_path.present? ? URI.join(root_url, root_url_path).to_s : root_url
   end
 
   private

--- a/test/decorators/site_decorator_test.rb
+++ b/test/decorators/site_decorator_test.rb
@@ -21,4 +21,12 @@ class SiteDecoratorTest < ActiveSupport::TestCase
       assert_equal "http://wadus.gobierto.test", @subject.domain_url
     end
   end
+
+  def test_domain_url_with_root_url_path
+    @subject.stubs(:root_url_path).returns("/test")
+    assert_equal "http://madrid.gobierto.test/test", @subject.domain_url
+
+    @subject.stubs(:root_url_path).returns("test_without_slash")
+    assert_equal "http://madrid.gobierto.test/test_without_slash", @subject.domain_url
+  end
 end


### PR DESCRIPTION
Related to https://github.com/PopulateTools/issues/issues/644


## :v: What does this PR do?

Fixes the URLs created with the `SiteDecorator` class avoiding duplicated `/` in paths

## :mag: How should this be manually tested?

Visit a site with `GOBIERTO_ROOT_URL_PATH` defined  with the form `/some_path_prefix`, visit admin panel and click on the "view site" link. The path shouldn't contain duplicated slashes

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?
No