### PR TITLE
Set default categories and projects names for not configured plans

### DIFF
--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -68,7 +68,11 @@ module GobiertoPlans
     private
 
     def level_key(level_size, level)
-      configuration_data["level" + level.to_s][level_size == 1 ? "one" : "other"][I18n.locale.to_s]
+      return configuration_data["level#{level}"][level_size == 1 ? "one" : "other"][I18n.locale.to_s] if configuration_data.present? && configuration_data.has_key?("level#{level}")
+
+      element_type = level < level_size ? "category" : "project"
+      I18n.t("gobierto_admin.gobierto_plans.plans.import_csv.defaults.#{element_type}", count: level_size, level: level + 1)
     end
+
   end
 end

--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -70,7 +70,7 @@ module GobiertoPlans
     def level_key(level_size, level)
       return configuration_data["level#{level}"][level_size == 1 ? "one" : "other"][I18n.locale.to_s] if configuration_data.present? && configuration_data.has_key?("level#{level}")
 
-      element_type = level < level_size ? "category" : "project"
+      element_type = level <= levels ? "category" : "project"
       I18n.t("gobierto_admin.gobierto_plans.plans.import_csv.defaults.#{element_type}", count: level_size, level: level + 1)
     end
 

--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -29,7 +29,7 @@ module GobiertoPlans
 
     def configuration_data
       data = read_attribute(:configuration_data)
-      JSON.parse(data) unless data.empty?
+      JSON.parse(data) unless data.blank?
     end
 
     def nodes

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -100,6 +100,7 @@ ignore_unused:
   - 'gobierto_admin.gobierto_citizens_charters.charters.editions_intervals.edition_interval.*_interval'
   - 'gobierto_citizens_charters.shared.*_interval'
   - 'gobierto_citizens_charters.shared.evolution.*'
+  - 'gobierto_admin.gobierto_plans.plans.import_csv.defaults.*'
 
 translation:
   api_key: ''

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -58,6 +58,13 @@ ca:
             title: Titol del pla
             year: 2018
         import_csv:
+          defaults:
+            category:
+              one: element de nivell %{level}
+              other: elements de nivell %{level}
+            project:
+              one: projecte
+              other: projectes
           latest_update: 'Última actualització: %{datetime}'
           no_data: Encara no hi ha dades carregades
           there_are: Hi ha %{info}

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -58,6 +58,13 @@ en:
             title: Plan title
             year: 2018
         import_csv:
+          defaults:
+            category:
+              one: item of level %{level}
+              other: items of level %{level}
+            project:
+              one: project
+              other: projects
           latest_update: 'Last updated: %{datetime}'
           no_data: No data loaded yet
           there_are: There are %{info}

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -58,6 +58,13 @@ es:
             title: Título del plan
             year: 2018
         import_csv:
+          defaults:
+            category:
+              one: elemento de nivel %{level}
+              other: elementos de nivel %{level}
+            project:
+              one: proyecto
+              other: proyectos
           latest_update: 'Última actualización: %{datetime}'
           no_data: Ningún dato cargado todavía
           there_are: Hay %{info}

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -211,3 +211,58 @@ sports_service_term:
   position: 2
   created_at: 2018-09-10 00:00:00
   updated_at: 2018-09-10 00:00:00
+
+## new_plan_categories_vocabulary
+
+economy_new_plan_term:
+  vocabulary: new_plan_categories_vocabulary
+  name_translations: <%= { 'en' => 'Economy',
+                           'es' => 'Economía' }.to_json %>
+  slug: economy-new-plan-term
+  level: 0
+  position: 0
+  created_at: 2016-11-01 00:02:00
+  updated_at: 2016-11-01 00:02:00
+
+taxes_new_plan_term:
+  vocabulary: new_plan_categories_vocabulary
+  name_translations: <%= { 'en' => 'Taxes',
+                           'es' => 'Impuestos' }.to_json %>
+  term_id: <%= ActiveRecord::FixtureSet.identify(:economy_new_plan_term) %>
+  slug: taxes-new-plan-term
+  level: 1
+  position: 0
+  created_at: 2016-11-01 00:02:00
+  updated_at: 2016-11-01 00:02:00
+
+public_facilities_new_plan_term:
+  vocabulary: new_plan_categories_vocabulary
+  name_translations: <%= { 'en' => 'Public facilities',
+                           'es' => 'Instalaciones públicas' }.to_json %>
+  slug: public-facilities-new-plan-term
+  level: 0
+  position: 1
+  created_at: 2016-11-01 00:02:00
+  updated_at: 2016-11-01 00:02:00
+
+sports_facilities_new_plan_term:
+  vocabulary: new_plan_categories_vocabulary
+  name_translations: <%= { 'en' => 'Sports facilities',
+                           'es' => 'Instalaciones deportivas' }.to_json %>
+  term_id: <%= ActiveRecord::FixtureSet.identify(:public_facilities_new_plan_term) %>
+  slug: sports-facilities-new-plan-term
+  level: 1
+  position: 0
+  created_at: 2016-11-01 00:02:00
+  updated_at: 2016-11-01 00:02:00
+
+libraries_new_plan_term:
+  vocabulary: new_plan_categories_vocabulary
+  name_translations: <%= { 'en' => 'Libraries',
+                           'es' => 'Bibliotecas' }.to_json %>
+  term_id: <%= ActiveRecord::FixtureSet.identify(:public_facilities_new_plan_term) %>
+  slug: libraries-new-plan-term
+  level: 1
+  position: 1
+  created_at: 2016-11-01 00:02:00
+  updated_at: 2016-11-01 00:02:00

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -27,3 +27,8 @@ citizens_services_categories:
   site: madrid
   name_translations: <%= { es: "Vocabulario de Servicios de Madrid", en: "Madrid Services Vocabulary" }.to_json %>
   slug: madrid_services_vocabulary
+
+new_plan_categories_vocabulary:
+  site: madrid
+  name_translations: <%= { es: "Nuevo Plan Estratégico", en: "New Strategic Plan" }.to_json %>
+  slug: strategic-plan

--- a/test/integration/gobierto_admin/gobierto_plans/plans/create_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/create_plan_test.rb
@@ -74,6 +74,67 @@ module GobiertoAdmin
           end
         end
       end
+
+      def test_create_plan_with_vocabulary
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            fill_in "plan_title_translations_en", with: "New plan title"
+            fill_in "plan_introduction_translations_en", with: "New plan introduction"
+
+            fill_in "plan_year", with: "2017"
+
+            select "pam", from: "plan_plan_type_id"
+            select "New Strategic Plan", from: "plan_vocabulary_id"
+
+            click_button "Create"
+
+            assert has_message? "Plan created successfully"
+
+            plan = site.plans.last
+
+            assert_equal "New Strategic Plan", plan.categories_vocabulary.name
+
+            activity = Activity.last
+            assert_equal plan, activity.subject
+            assert_equal admin, activity.author
+            assert_equal site.id, activity.site_id
+            assert_equal "gobierto_plans.plan_created", activity.action
+
+            visit admin_plans_plan_import_csv_path(plan)
+
+            assert has_no_content? "No data loaded yet"
+            assert has_content? "2 items of level 1"
+            assert has_content? "3 items of level 2"
+          end
+        end
+      end
+
+      def test_create_plan_without_vocabulary
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit @path
+
+            fill_in "plan_title_translations_en", with: "New plan title"
+            fill_in "plan_introduction_translations_en", with: "New plan introduction"
+
+            fill_in "plan_year", with: "2017"
+
+            select "pam", from: "plan_plan_type_id"
+
+            click_button "Create"
+
+            assert has_message? "Plan created successfully"
+
+            plan = site.plans.last
+
+            visit admin_plans_plan_import_csv_path(plan)
+
+            assert has_content? "No data loaded yet"
+          end
+        end
+      end
     end
   end
 end

--- a/test/models/gobierto_plans/plan_test.rb
+++ b/test/models/gobierto_plans/plan_test.rb
@@ -11,5 +11,25 @@ module GobiertoPlans
     def test_valid
       assert plan.valid?
     end
+
+    def test_to_s
+      plan_string = plan.to_s
+
+      assert plan_string.include? "3 axes"
+      assert plan_string.include? "1 line of action"
+      assert plan_string.include? "2 actions"
+      assert plan_string.include? "2 projects/actions"
+    end
+
+    def test_plan_without_configuration_to_s
+      plan.update_attribute(:configuration_data, nil)
+
+      plan_string = plan.to_s
+
+      assert plan_string.include? "3 items of level 1"
+      assert plan_string.include? "1 item of level 2"
+      assert plan_string.include? "2 items of level 3"
+      assert plan_string.include? "2 projects"
+    end
   end
 end


### PR DESCRIPTION
Closes #2236 


## :v: What does this PR do?

- Uses default names for categories and projects/nodes of plans when plan configuration doesn't include names for level categories or projects

## :mag: How should this be manually tested?
Create a new plan with configuration blank and select a vocabulary for categories with existing terms. Create a project and inspect import CSV tab. The project summary with the count of projects and categories for each level should appear

## :eyes: Screenshots

### Before this PR
![2236-before](https://user-images.githubusercontent.com/446459/56580912-161d4580-65d4-11e9-8d10-5e6f5fe9229b.gif)

### After this PR
![2236-after](https://user-images.githubusercontent.com/446459/56580942-23d2cb00-65d4-11e9-9728-8c5656aa2deb.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No