### PR TITLE
Small fixes in the admin

### DIFF
--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -179,7 +179,6 @@ menu.main {
   .menu_content,
   .collapse_menu span {
     visibility: visible;
-    overflow: hidden;
   }
 
   .collapse_menu {

--- a/app/javascript/gobierto_admin/modules/application.js
+++ b/app/javascript/gobierto_admin/modules/application.js
@@ -20,6 +20,8 @@ $(document).on('turbolinks:load', function() {
     e.preventDefault();
   });
 
+  $('input[autofocus]').focus();
+
   var $autocomplete = $('[data-autocomplete]');
 
   var searchOptions = {

--- a/app/javascript/gobierto_admin/modules/module-admin.js
+++ b/app/javascript/gobierto_admin/modules/module-admin.js
@@ -16,7 +16,6 @@ $(document).on('turbolinks:load', function() {
       $('.container').addClass('admin_content_column_with_menu_opened');
       $('.container').removeClass('admin_content_column_with_menu_closed');
     }
-
   });
 
   $('.open-new_row_content').click(function(e) {

--- a/app/javascript/gobierto_admin/modules/module-admin.js
+++ b/app/javascript/gobierto_admin/modules/module-admin.js
@@ -1,43 +1,39 @@
 $(document).on('turbolinks:load', function() {
 
-	var header_height = $('header.main').height() + 1;
-	$('menu.main').css('top', header_height);
-	$('.admin_content_column').css('padding-top', header_height);
-  // $('.widget_save.stick_in_parent').css('margin-top', header_height + 20);
+  var header_height = $('header.main').height() + 1;
+  $('menu.main').css('top', header_height);
+  $('.admin_content_column').css('padding-top', header_height);
 
+  $('.js-collapse-menu').click(function(e) {
+    e.preventDefault();
+    if($('menu.main').attr('data-menu-status') == 'open') {
+      $('menu.main').attr('data-menu-status', 'closed');
+      $('.container').removeClass('admin_content_column_with_menu_opened');
+      $('.container').addClass('admin_content_column_with_menu_closed');
+    }
+    else if($('menu.main').attr('data-menu-status') == 'closed') {
+      $('menu.main').attr('data-menu-status', 'open');
+      $('.container').addClass('admin_content_column_with_menu_opened');
+      $('.container').removeClass('admin_content_column_with_menu_closed');
+    }
 
-	$('.js-collapse-menu').click(function(e) {
-		e.preventDefault();
-		// $('menu.main').velocity({translateX: "-200px"});
+  });
 
-		if($('menu.main').attr('data-menu-status') == 'open') {
-			$('menu.main').attr('data-menu-status', 'closed');
-			$('.container').removeClass('admin_content_column_with_menu_opened');
-			$('.container').addClass('admin_content_column_with_menu_closed');
-		}
-		else if($('menu.main').attr('data-menu-status') == 'closed') {
-			$('menu.main').attr('data-menu-status', 'open');
-			$('.container').addClass('admin_content_column_with_menu_opened');
-			$('.container').removeClass('admin_content_column_with_menu_closed');
-		}
+  $('.open-new_row_content').click(function(e) {
+    e.preventDefault();
+    $('.new_row_add').hide();
+    $('.new_row_content').show();
+  });
 
-	});
+  $('.close-new_row_content').click(function(e) {
+    e.preventDefault();
+    $('.new_row_add').show();
+    $('.new_row_content').hide();
+  });
 
-	$('.open-new_row_content').click(function(e) {
-		e.preventDefault();
-		$('.new_row_add').hide();
-		$('.new_row_content').show();
-	});
-
-	$('.close-new_row_content').click(function(e) {
-		e.preventDefault();
-		$('.new_row_add').show();
-		$('.new_row_content').hide();
-	});
-
-	$('.open-new_block').click(function(e) {
-		e.preventDefault();
-		$('.new_block_content').show();
-	});
+  $('.open-new_block').click(function(e) {
+    e.preventDefault();
+    $('.new_block_content').show();
+  });
 
 });

--- a/app/views/gobierto_admin/admins/index.html.erb
+++ b/app/views/gobierto_admin/admins/index.html.erb
@@ -20,7 +20,10 @@
     <i class="fas fa-envelope"></i>
     <%= t(".send_invitations") %>
   <% end %>
-  <%= link_to t(".groups_and_permissions"), admin_admin_groups_path %>
+  <%= link_to  admin_admin_groups_path do %>
+    <i class="fas fa-users"></i>
+    <%= t(".groups_and_permissions") %>
+  <% end %>
   <%= link_to t(".new"), new_admin_admin_path, class: "button" %>
 </div>
 
@@ -29,6 +32,8 @@
   <th></th>
   <th><%= t(".header.admin") %></th>
   <th><%= t(".header.email") %></th>
+  <th><%= t(".header.role") %></th>
+  <th><%= t(".header.groups") %></th>
   <th><%= t(".header.last_sign_in_at") %></th>
   <th><%= t(".header.created_at") %></th>
   <th></th>
@@ -52,6 +57,12 @@
       </td>
       <td>
         <%= mail_to admin.email %>
+      </td>
+      <td>
+        <%= admin.authorization_level %>
+      </td>
+      <td>
+        <%= admin.admin_groups.pluck(:name).to_sentence.presence || " -- " %>
       </td>
       <td>
         <%= time_ago_in_words(admin.last_sign_in_at) if admin.last_sign_in_at %>

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
@@ -13,7 +13,7 @@
           <%= f.object.class.human_attribute_name(:name) %>
           <%= attribute_indication_tag required: true %>
         <% end %>
-        <%= text_field_tag "term[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym) %>
+        <%= text_field_tag "term[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym), autofocus: true %>
       </div>
 
       <div class="form_item input_text" data-locale="<%= locale %>">

--- a/app/views/gobierto_admin/gobierto_common/terms/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/terms/_form.html.erb
@@ -16,7 +16,7 @@
               <%= f.object.class.human_attribute_name(:name) %>
               <%= attribute_indication_tag required: true %>
             <% end %>
-            <%= text_field_tag "term[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym) %>
+            <%= text_field_tag "term[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale.to_sym), autofocus: true %>
           </div>
 
           <div class="form_item input_text" data-locale="<%= locale %>">

--- a/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/vocabularies/index.html.erb
@@ -26,7 +26,7 @@
           <% end %>
         </td>
         <td>
-          <%= link_to edit_admin_common_vocabulary_path(vocabulary), class: "open_remote_modal" do %>
+          <%= link_to admin_common_vocabulary_terms_path(vocabulary) do %>
             <%= vocabulary.name %>
           <% end %>
         </td>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -203,7 +203,7 @@
 
       <div class="collapse_menu">
         <a href="#" class="js-collapse-menu">
-          <i class="fas fa-caret-square-o-left"></i>
+          <i class="fas fa-caret-square-left"></i>
           <span><%= t(".collapse_menu") %></span>
         </a>
       </div>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -175,26 +175,24 @@
 
             <li><%= link_to t(".users"), admin_users_path %></li>
 
-            <% if current_site %>
-              <li>
-                <% if current_admin.can_customize_site? %>
-                  <%= link_to t(".edit_site"), edit_admin_site_path(current_site) %>
-                <% else %>
-                  <span><%= t(".edit_site") %></span>
+            <li>
+              <% if current_admin.can_customize_site? %>
+                <%= link_to t(".edit_site"), edit_admin_site_path(current_site) %>
+              <% elsif current_admin.can_edit_vocabularies? || current_admin.can_edit_templates? || current_admin.can_edit_custom_fields? %>
+                <span><%= t(".edit_site") %></span>
+              <% end %>
+              <ul>
+                <% if current_admin.can_edit_vocabularies? %>
+                  <li><%= link_to t(".vocabularies"), admin_common_vocabularies_path %></li>
                 <% end %>
-                <ul>
-                  <% if current_admin.can_edit_vocabularies? %>
-                    <li><%= link_to t(".vocabularies"), admin_common_vocabularies_path %></li>
-                  <% end %>
-                  <% if current_admin.can_edit_templates? %>
-                    <li><%= link_to t(".templates"), admin_gobierto_core_templates_path %></li>
-                  <% end %>
-                  <% if current_admin.can_edit_custom_fields? %>
-                    <li><%= link_to t(".custom_fields"), admin_common_custom_fields_module_resources_path %></li>
-                  <% end %>
-                </ul>
-              </li>
-            <% end %>
+                <% if current_admin.can_edit_templates? %>
+                  <li><%= link_to t(".templates"), admin_gobierto_core_templates_path %></li>
+                <% end %>
+                <% if current_admin.can_edit_custom_fields? %>
+                  <li><%= link_to t(".custom_fields"), admin_common_custom_fields_module_resources_path %></li>
+                <% end %>
+              </ul>
+            </li>
           </ul>
 
         </div>
@@ -225,12 +223,9 @@
     <%= render "gobierto_admin/layouts/analytics_footer_site" %>
   <% end %>
 
-  <script type="text/javascript">
+  <%= javascript_tag data: { "turbolinks-eval" => false } do %>
     I18n.defaultLocale = "<%= I18n.default_locale %>";
     I18n.locale = "<%= I18n.locale %>";
-  </script>
-
-  <%= javascript_tag data: { "turbolinks-eval" => false } do %>
     window.GobiertoAdmin.dirty_forms_component.handle("<%= t(".dirty_forms.message") %>");
     window.GobiertoAdmin.globalized_forms_component.handle();
     window.GobiertoAdmin.color_picker_component.handle();

--- a/config/locales/gobierto_admin/views/admins/ca.yml
+++ b/config/locales/gobierto_admin/views/admins/ca.yml
@@ -23,7 +23,9 @@ ca:
           admin: Administrador
           created_at: Creat
           email: Email
+          groups: Grups
           last_sign_in_at: Últim login
+          role: Rol
         new: Nou Administrador
         send_invitations: Enviar invitacions
         title: Administradors

--- a/config/locales/gobierto_admin/views/admins/en.yml
+++ b/config/locales/gobierto_admin/views/admins/en.yml
@@ -23,7 +23,9 @@ en:
           admin: Admin
           created_at: Created
           email: Email
+          groups: Groups
           last_sign_in_at: Last sign in
+          role: Role
         new: New Admin
         send_invitations: Send invitations
         title: Administrators

--- a/config/locales/gobierto_admin/views/admins/es.yml
+++ b/config/locales/gobierto_admin/views/admins/es.yml
@@ -23,7 +23,9 @@ es:
           admin: Administrador
           created_at: Creado
           email: Email
+          groups: Grupos
           last_sign_in_at: Último login
+          role: Rol
         new: Nuevo Administrador
         send_invitations: Enviar invitaciones
         title: Administradores

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
@@ -66,7 +66,8 @@ module GobiertoAdmin
 
                 assert has_message?("Vocabulary created successfully.")
 
-                click_link "Monetary Systems"
+                vocabulary = site.vocabularies.last
+                find(:xpath, %Q{//a[@href="#{edit_admin_common_vocabulary_path(vocabulary)}"]}).click
 
                 assert has_field?("vocabulary_name_translations_en", with: "Monetary Systems")
                 assert has_field?("vocabulary_slug", with: "monetary-systems-new")

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
@@ -43,7 +43,7 @@ module GobiertoCommon
               with_current_site(site) do
                 visit @path
 
-                click_link vocabulary.name
+                find(:xpath, %Q{//a[@href="#{edit_admin_common_vocabulary_path(vocabulary)}"]}).click
 
                 within "form.edit_vocabulary" do
                   fill_in "vocabulary_name_translations_en", with: "Animals updated"
@@ -54,7 +54,7 @@ module GobiertoCommon
 
                 assert has_message?("Vocabulary updated successfully.")
 
-                click_link vocabulary.name
+                find(:xpath, %Q{//a[@href="#{edit_admin_common_vocabulary_path(vocabulary)}"]}).click
 
                 assert has_field? "vocabulary_name_translations_en", with: "Animals updated"
                 assert has_field? "vocabulary_slug", with: "animals-updated"


### PR DESCRIPTION
## :v: What does this PR do?

This PR introduces some improvements in the admin:

1. The icon to close the sidebar is fixed and aligned
2. Now the list of admins shows the role of the admin and the groups it belongs to
3. Autofocus has been enabled in terms form but due to a bug in FF + Turbolinks sometimes it doesn't work.
4. The name of the vocabulary links to the terms

## :mag: How should this be manually tested?

Check these things I have described above

## :eyes: Screenshots

### Before this PR

![Screen Shot 2019-04-24 at 16 03 39](https://user-images.githubusercontent.com/17616/56665556-8bf3e080-66aa-11e9-9010-41e546a4f386.png)

### After this PR

![Screen Shot 2019-04-24 at 16 03 15](https://user-images.githubusercontent.com/17616/56665530-81d1e200-66aa-11e9-9ab4-a74fdaad2b10.png)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No