### PR TITLE
2237 optimize plan category terms decorator

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
@@ -128,13 +128,10 @@ module GobiertoAdmin
         end
       end
 
-      def tree(relation, level = 0)
-        level_relation = relation.where(level: level).order(position: :asc)
-        return [] if level_relation.blank?
-
-        level_relation.where(level: level).map do |node|
-          [node, tree(node.terms, level + 1)]
-        end.to_h
+      def tree(relation)
+        relation.order(position: :asc).where(level: relation.minimum(:level)).inject({}) do |tree, term|
+          tree.merge(term.ordered_tree)
+        end
       end
 
       def flatten_tree(relation, level = 0)

--- a/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
@@ -15,7 +15,7 @@ module GobiertoAdmin
 
         @global_progress = @plan.nodes.average(:progress).to_f
         @projects_filter_form = ::GobiertoAdmin::GobiertoPlans::ProjectsFilterForm.new(plan: @plan, admin: current_admin)
-        @terms = TreeDecorator.new(tree(@vocabulary.terms), decorator: ::GobiertoPlans::CategoryTermDecorator, options: { plan: @plan })
+        @terms = TreeDecorator.new(tree(@vocabulary.terms), decorator: ::GobiertoPlans::CategoryTermDecorator, options: { plan: @plan, vocabulary: @vocabulary, site: current_site })
       end
 
       def accumulated_values
@@ -38,7 +38,7 @@ module GobiertoAdmin
 
       def calculate_accumulated_values
         @accumulated_values ||= @vocabulary.terms.inject({}) do |calculations, term|
-          decorated_term = ::GobiertoPlans::CategoryTermDecorator.new(term, plan: @plan)
+          decorated_term = ::GobiertoPlans::CategoryTermDecorator.new(term, plan: @plan, vocabulary: @vocabulary, site: current_site)
 
           calculations.update(
             term.id => decorated_term.decorated_values

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -6,7 +6,9 @@ module GobiertoPlans
 
     def initialize(term, options = {})
       @object = term
-      @plan = options.delete(:plan)
+      @vocabulary = options[:vocabulary]
+      @plan = options[:plan]
+      @site = options[:site]
     end
 
     def categories

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -59,6 +59,10 @@ module GobiertoCommon
       [self, self_and_descendents.reorder(:level).sorted.where(term_id: id).map(&:ordered_self_and_descendants)].flatten
     end
 
+    def ordered_tree
+      { self => self_and_descendents.reorder(:level).sorted.where(term_id: id).inject({}) { |subtree, el| subtree.merge(el.ordered_tree) } }
+    end
+
     # positions_from_params arg: hash of arrays
     # The element with id 0 defines the order of the parent nodes
     # Example:


### PR DESCRIPTION
Closes #2237 

## :v: What does this PR do?

* Improves category terms decorator of plans using options to set plan, vocabulary and site
* Uses recursive queries to generate tree in ordered terms controller

[WIP] This PR shouldn't be merged unless https://github.com/PopulateTools/gobierto/pull/2191 is merged before because is built on top that.

## :mag: How should this be manually tested?

Visit plan tab of a plan

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No