### PR TITLE
645 fix filter

### DIFF
--- a/app/forms/gobierto_admin/gobierto_plans/projects_filter_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/projects_filter_form.rb
@@ -35,7 +35,7 @@ module GobiertoAdmin
           end_interval = (1 + div.to_f) / divisions * 100.0
           [
             [format_percentage(start_interval + (div.positive? ? 1 : 0)), format_percentage(end_interval)].join(" - "),
-            [start_interval, end_interval].join("-")
+            [div.positive? ? start_interval : -1.0, end_interval].join(" - ")
           ]
         end.unshift([I18n.t("gobierto_admin.gobierto_plans.projects.filter_form.progress"), nil])
       end

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -13,7 +13,7 @@ module GobiertoPlans
     scope :with_name, ->(name) { where("gplan_nodes.name_translations ->> 'en' ILIKE :name OR gplan_nodes.name_translations ->> 'es' ILIKE :name OR gplan_nodes.name_translations ->> 'ca' ILIKE :name", name: "%#{name}%") }
     scope :with_status, ->(status) { with_status_translation(status) }
     scope :with_category, ->(category) { where(gplan_categories_nodes: { category_id: GobiertoCommon::Term.find(category).last_descendants }) }
-    scope :with_progress, ->(progress) { where("progress > ? AND progress <= ?", *progress.split("-")) }
+    scope :with_progress, ->(progress) { where("progress > ? AND progress <= ?", *progress.split(" - ")) }
     scope :with_interval, ->(interval) { where("starts_at >= ? AND ends_at <= ?", *interval.split(",").map { |date| Date.parse(date) }) }
     scope :with_author, ->(author_id) { where(admin_id: author_id) }
     scope :with_admin_actions, lambda { |admin|

--- a/test/integration/gobierto_admin/gobierto_plans/projects/projects_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/projects_index_test.rb
@@ -28,10 +28,12 @@ module GobiertoAdmin
         def project_with_search_matching_name
           @project_with_search_matching_name ||= gobierto_plans_nodes(:political_agendas)
         end
+        alias project_with_half_progress project_with_search_matching_name
 
         def project_with_no_search_matching_name
           @project_with_no_search_matching_name ||= gobierto_plans_nodes(:scholarships_kindergartens)
         end
+        alias project_with_null_progress project_with_no_search_matching_name
 
         def test_admin_projects_index
           with_signed_in_admin(admin) do
@@ -81,6 +83,36 @@ module GobiertoAdmin
                 plan.nodes.each do |project|
                   assert has_selector?("tr#project-item-#{project.id}")
                 end
+              end
+            end
+          end
+        end
+
+        def test_filter_progress
+          allow_regular_admin_edit_plans
+
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within ".i_filters" do
+                select "0% - 25%", from: "projects_filter_progress"
+                click_button "Filter"
+              end
+
+              within "table#projects" do
+                assert has_selector?("tr#project-item-#{project_with_null_progress.id}")
+                assert has_no_selector?("tr#project-item-#{project_with_half_progress.id}")
+              end
+
+              within ".i_filters" do
+                select "26% - 50%", from: "projects_filter_progress"
+                click_button "Filter"
+              end
+
+              within "table#projects" do
+                assert has_no_selector?("tr#project-item-#{project_with_null_progress.id}")
+                assert has_selector?("tr#project-item-#{project_with_half_progress.id}")
               end
             end
           end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/645

## :v: What does this PR do?

Fixes plans projects filter to include projects with 0% progress when first option, which includes 0% is selected

[WIP] This PR shouldn't be merged unless #2191 is merged before because is built on top that.

## :mag: How should this be manually tested?
Visit projects tab of a plan and select a progress interval starting from 0%

## :eyes: Screenshots

### Before this PR
![645-before](https://user-images.githubusercontent.com/446459/56773827-445f7880-67c0-11e9-97d5-81392835e261.gif)

### After this PR
![645-after](https://user-images.githubusercontent.com/446459/56773833-4c1f1d00-67c0-11e9-8fd4-1bbc76874c62.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No