### PR TITLE
2234 plan tab summary

### DIFF
--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -1140,6 +1140,18 @@ table {
   .metric_label {
     font-size: $f8;
   }
+  .metric_progress_bar {
+    background: $color_neutral_soft;
+    margin: 14px 0 0 0;
+    width: 100%;
+    height: 8px;
+    border-radius: 8px;
+  }
+  .metric_progress_bar_progress {
+    background: $color_sem_yellow;
+    border-radius: 8px;
+    height: 100%;
+  }
 }
 
 .f_small {

--- a/app/views/gobierto_admin/gobierto_plans/categories/_plan_summary.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/categories/_plan_summary.html.erb
@@ -1,11 +1,14 @@
 <div class="pure-g">
 
-  <div class="pure-u-1 pure-u-md-1-2 p_h_r_2 ">
+  <div class="pure-u-1 pure-u-md-1-3 p_h_r_2">
     <div class="p_1 border-el">
       <h5><%= t(".global_progress") %></h5>
 
       <div class="m_t_1 metric metric_medium with_progress_bar">
         <div class="metric_value"><%= number_to_percentage(@global_progress, precision: 1, strip_insignificant_zeros: true) %></div>
+        <div class="metric_progress_bar">
+          <div class="metric_progress_bar_progress" style="width: <%= number_to_percentage(@global_progress, precision: 0) %>"></div>
+        </div>
       </div>
 
     </div>
@@ -13,7 +16,7 @@
 
   <% moderation_stage_values = @projects_filter_form.moderation_stage_values %>
   <% all_value = moderation_stage_values.values.map(&:count).sum %>
-  <div class="pure-u-1 pure-u-md-1-2">
+  <div class="pure-u-1 pure-u-md-2-3">
     <div class="p_1 border-el">
       <h5><%= t(".projects") %></h5>
 

--- a/app/views/sandbox/admin_plans_plan.html.erb
+++ b/app/views/sandbox/admin_plans_plan.html.erb
@@ -20,18 +20,21 @@
 
     <div class="pure-g">
 
-      <div class="pure-u-1 pure-u-md-1-2 p_h_r_2 ">
+      <div class="pure-u-1 pure-u-md-1-3 p_h_r_2 ">
         <div class="p_1 border-el">
           <h5>Progreso global</h5>
 
           <div class="m_t_1 metric metric_medium with_progress_bar">
             <div class="metric_value">34%</div>
+            <div class="metric_progress_bar">
+              <div class="metric_progress_bar_progress" style="width: 34%"></div>
+            </div>
           </div>
 
         </div>
       </div>
 
-      <div class="pure-u-1 pure-u-md-1-2">
+      <div class="pure-u-1 pure-u-md-2-3">
         <div class="p_1 border-el">
           <h5>Proyectos</h5>
 

--- a/test/integration/gobierto_admin/gobierto_plans/categories/categories_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/categories/categories_index_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPlans
+    module Categories
+      class CategoriesIndexTest < ActionDispatch::IntegrationTest
+        include Integration::AdminGroupsConcern
+
+        def setup
+          super
+          @path = admin_plans_plan_categories_path(plan)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def plan
+          @plan ||= gobierto_plans_plans(:strategic_plan)
+        end
+
+        def test_admin_categories_index
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "div.pure-u-md-1-3", text: "Global progress" do
+                within "div.metric_value" do
+                  assert has_content? "25%"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2234


## :v: What does this PR do?

Applies changes in https://github.com/PopulateTools/gobierto/pull/2252 related with plans summary

## :mag: How should this be manually tested?

Visit from admin a plan and go to the plan tab

## :eyes: Screenshots

### Before this PR
<img width="1095" alt="Screen Shot 2019-04-26 at 15 31 13" src="https://user-images.githubusercontent.com/446459/56811155-6399ec80-6838-11e9-9aa9-caaf4232df91.png">

### After this PR
<img width="1082" alt="Screen Shot 2019-04-26 at 15 30 30" src="https://user-images.githubusercontent.com/446459/56811168-6ac0fa80-6838-11e9-86cc-70aef89cf102.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
