### PR TITLE
2245 remove default actions for modules

### DIFF
--- a/app/forms/gobierto_admin/admin_group_form.rb
+++ b/app/forms/gobierto_admin/admin_group_form.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   class AdminGroupForm < BaseForm
     PERMISSION_TYPES = {
       site_options: { scope: :site_options_permissions, attribute: :resource_name },
-      modules_actions: { scope: :modules_permissions, attribute: :resource_name, action_names: [:manage, :edit, :moderate] },
+      modules_actions: { scope: :modules_permissions, attribute: :resource_name, action_names: { gobierto_plans: [:manage, :edit, :moderate] } },
       people: { scope: :people_permissions, attribute: :resource_id, parent_type: :modules_actions, parent: :gobierto_people, allow_all: true }
     }.freeze
 
@@ -47,10 +47,10 @@ module GobiertoAdmin
       @admin_group ||= AdminGroup.find_by(id: id).presence || build_admin_group
     end
 
-    def action_names(permission_type)
+    def action_names(permission_type, resource_name = nil)
       return unless PERMISSION_TYPES.has_key? permission_type
 
-      PERMISSION_TYPES[permission_type][:action_names] || [:manage]
+      PERMISSION_TYPES.dig(permission_type, :action_names, resource_name.to_sym) || [:manage]
     end
 
     private

--- a/app/javascript/gobierto_admin/modules/admin_groups_controller.js
+++ b/app/javascript/gobierto_admin/modules/admin_groups_controller.js
@@ -17,12 +17,14 @@ window.GobiertoAdmin.AdminGroupsController = (function() {
         if (this.checked) {
           $modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']").prop('disabled', false);
           $modules_actions_block.show('slow');
+          $modules_actions_block.prop("disabled", false);
           if ($modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']:checked").length == 0) {
             $modules_actions_block.find("[data-class='modules_action'] input[type='checkbox'][value='manage']").prop('checked', true);
           }
           $subresources_block.show('slow');
         } else {
           $modules_actions_block.hide('slow');
+          $modules_actions_block.prop("disabled", true);
           $modules_actions_block.find("[data-class='modules_action'] input[type='checkbox']").prop('disabled', true);
           $subresources_block.hide('slow');
         }

--- a/app/views/gobierto_admin/admin_groups/_form.html.erb
+++ b/app/views/gobierto_admin/admin_groups/_form.html.erb
@@ -45,22 +45,26 @@
                 <% end %>
                 <% module_active = f.object.modules_actions.keys.include?(module_b.object.namespace.underscore) %>
 
-                <div class="option_suboptions" id="<%= "modules_actions_#{module_b.value}" %>" style="<%= module_active ? '' : 'display: none;' %>">
-                  <h3><%= t(".actions") %></h3>
+                <% available_actions = @admin_group_form.action_names(:modules_actions, module_b.object.namespace.underscore) %>
+                <% if available_actions.count > 1 %>
+                  <div class="option_suboptions" id="<%= "modules_actions_#{module_b.value}" %>" style="<%= module_active ? '' : 'display: none;' %>">
+                    <h3><%= t(".actions") %></h3>
 
-                  <%= f.collection_check_boxes("modules_actions[#{module_b.value.underscore}]", @admin_group_form.action_names(:modules_actions).map { |action| [action, t(".action_names.#{action}")] }, :first, :last) do |action_b| %>
-                    <div class="option" data-class="<%= "modules_action" %>" data-module="<%= module_b.value %>">
-                      <%= action_b.check_box(data: { behavior: "toggle-action" },
-                                             id: "modules_action_#{module_b.value.underscore}_#{action_b.value}",
-                                             checked: @admin_group && @admin_group.modules_permissions.exists?(resource_name: module_b.value.underscore, action_name: action_b.value)) %>
-                      <%= action_b.label(for: "modules_action_#{module_b.value.underscore}_#{action_b.value}") do %>
-                        <span></span><%= action_b.text %>
-                      <% end %>
-                    </div>
+                    <%= f.collection_check_boxes("modules_actions[#{module_b.value.underscore}]", available_actions.map { |action| [action, t(".action_names.#{action}")] }, :first, :last) do |action_b| %>
+                      <div class="option" data-class="<%= "modules_action" %>" data-module="<%= module_b.value %>">
+                        <%= action_b.check_box(data: { behavior: "toggle-action" },
+                                               id: "modules_action_#{module_b.value.underscore}_#{action_b.value}",
+                                               checked: @admin_group && @admin_group.modules_permissions.exists?(resource_name: module_b.value.underscore, action_name: action_b.value)) %>
+                        <%= action_b.label(for: "modules_action_#{module_b.value.underscore}_#{action_b.value}") do %>
+                          <span></span><%= action_b.text %>
+                        <% end %>
+                      </div>
 
-                  <% end %>
-
-                </div>
+                    <% end %>
+                  </div>
+                <% else %>
+                  <%= hidden_field_tag "admin_group[modules_actions[#{module_b.object.namespace.underscore}]][]", available_actions, id: "modules_actions_#{module_b.value}", disabled: !module_active %>
+                <% end %>
 
                 <% if module_b.text == 'Gobierto People' %>
                   <div class="option_suboptions" id="<%= "subresources_#{module_b.value}" %>" style="<%= module_active ? '' : 'display: none;' %>">

--- a/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
+++ b/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
@@ -47,13 +47,9 @@ module GobiertoAdmin
 
             assert has_message?("Admins Group was successfully updated")
 
-
             within "form.edit_admin_group" do
               assert has_field?("admin_group_name", with: "Admin Group changed name")
               assert find("#admin_group_modules_gobiertoparticipation", visible: false).checked?
-              assert find("#modules_action_gobierto_participation_manage", visible: false).checked?
-              refute find("#modules_action_gobierto_participation_edit", visible: false).checked?
-              refute find("#modules_action_gobierto_participation_moderate", visible: false).checked?
               refute find("#admin_group_modules_gobiertobudgets", visible: false).checked?
               refute find("#admin_group_site_options_vocabularies", visible: false).checked?
               assert find("#admin_group_site_options_templates", visible: false).checked?
@@ -114,6 +110,41 @@ module GobiertoAdmin
               refute find("#admin_group_people_#{neil.id}", visible: false).checked?
               refute find("#admin_group_people_#{richard.id}", visible: false).checked?
             end
+          end
+        end
+      end
+    end
+
+    def test_admin_group_update_with_custom_actions_moderate
+      with_javascript do
+        with_current_site(site) do
+          with_signed_in_admin(manager_admin) do
+            visit edit_admin_admin_group_path(madrid_group)
+
+            within "form.edit_admin_group" do
+              find("label[for='admin_group_modules_gobiertoplans']").click
+              find("label[for='modules_action_gobierto_plans_moderate']").click
+              find("label[for='modules_action_gobierto_plans_manage']").click
+              find("label[for='admin_group_all_people']").click
+
+              click_button "Update"
+            end
+
+            assert has_message?("Admins Group was successfully updated")
+
+            within "form.edit_admin_group" do
+              assert find("#admin_group_modules_gobiertopeople", visible: false).checked?
+              refute find("#modules_action_gobierto_plans_manage", visible: false).checked?
+              refute find("#modules_action_gobierto_plans_edit", visible: false).checked?
+              assert find("#modules_action_gobierto_plans_moderate", visible: false).checked?
+              assert find("#admin_group_all_people", visible: false).checked?
+              refute find("#admin_group_people_#{neil.id}", visible: false).checked?
+              refute find("#admin_group_people_#{richard.id}", visible: false).checked?
+            end
+
+            assert_equal 7, madrid_group.permissions.count
+            assert GobiertoAdmin::Permission::GobiertoPlans.where(admin_group: madrid_group, action_name: "moderate").exists?
+            assert madrid_group.permissions.for_people.where(action_name: "manage_all").exists?
           end
         end
       end


### PR DESCRIPTION
Closes #2245 


## :v: What does this PR do?

* Allows to set different custom actions for each site module. If nothing is configured, the default action is "manage".
* Also if the module only have an action the checkboxes with the available actions for the module is not shown

## :mag: How should this be manually tested?

Visit an admin group edition form

## :eyes: Screenshots

### Before this PR
![2245-before](https://user-images.githubusercontent.com/446459/56846877-cc36a700-68d4-11e9-864a-d7e2ba09a1ef.gif)

### After this PR
![2245-after](https://user-images.githubusercontent.com/446459/56846882-db1d5980-68d4-11e9-9ae9-f8e12b21d83a.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No