### PR TITLE
2211 improve csv import

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -105,6 +105,15 @@ module GobiertoAdmin
 
       def import_data
         @plan = find_plan
+
+        if @plan.vocabulary_shared_with_other_plans?
+          redirect_to(
+            admin_plans_plan_import_csv_path(@plan),
+            alert: t("gobierto_admin.module_helper.not_enabled")
+          )
+          return
+        end
+
         if params[:plan].blank?
           redirect_to(
             admin_plans_plan_import_csv_path(@plan),

--- a/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
@@ -47,6 +47,9 @@ module GobiertoAdmin
       rescue CSVRowInvalid => e
         errors.add(:base, :invalid_row, row_data: e.message)
         false
+      rescue ActiveRecord::RecordNotDestroyed => e
+        errors.add(:base, :used_resource)
+        false
       end
 
       def csv_file_format

--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -65,6 +65,12 @@ module GobiertoPlans
       [title]
     end
 
+    def vocabulary_shared_with_other_plans?
+      return unless vocabulary_id
+
+      self.class.with_deleted.where(vocabulary_id: vocabulary_id).where.not(id: id).exists?
+    end
+
     private
 
     def level_key(level_size, level)

--- a/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
@@ -4,11 +4,18 @@
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
       <p><%== t(".warning") %></p>
-      <div class="form_item file_field">
-        <%= f.label :csv_file %>
-        <%= f.file_field :csv_file %>
-      </div>
-      <%= f.submit t(".submit"), class: "button", data: { disable_with: t(".disable_with"), confirm: t(".confirm_import") } %>
+
+      <% if @plan.vocabulary_shared_with_other_plans? %>
+        <p><%= t(".vocabulary_used_by_other_plans") %></p>
+        <p><%= t(".more_info_html", url: "https://gobierto.readme.io/docs/planes#section-importar-datos-de-un-plan") %></p>
+      <% else %>
+        <p><%= t(".more_info_html", url: "https://gobierto.readme.io/docs/planes#section-importar-datos-de-un-plan") %></p>
+        <div class="form_item file_field">
+          <%= f.label :csv_file %>
+          <%= f.file_field :csv_file %>
+        </div>
+        <%= f.submit t(".submit"), class: "button", data: { disable_with: t(".disable_with"), confirm: t(".confirm_import") } %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
@@ -3,7 +3,9 @@
 <%= form_for(@plan_data_form, as: :plan, url: admin_plans_plan_import_data_path(@plan), method: :patch, html: { multipart: true }) do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
-      <p><%== t(".warning") %></p>
+      <div class="flash-message notice">
+        <%== t(".warning") %>
+      </div>
 
       <% if @plan.vocabulary_shared_with_other_plans? %>
         <p><%= t(".vocabulary_used_by_other_plans") %></p>

--- a/config/locales/gobierto_admin/gobierto_plans/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/ca.yml
@@ -32,3 +32,5 @@ ca:
               invalid_columns: No estan totes les columnes necessàries
               invalid_format: Format de fitxer invàlid
               invalid_row: 'Hi ha una fila amb dades invàlid: %{row_data}'
+              used_resource: El vocabulari empra termes que s'usen en altres parts
+                de l'aplicació

--- a/config/locales/gobierto_admin/gobierto_plans/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/en.yml
@@ -32,3 +32,5 @@ en:
               invalid_columns: Required columns are missing
               invalid_format: Invalid file format
               invalid_row: 'There is an invalid row: %{row_data}'
+              used_resource: The vocabulary contains terms used in other parts of
+                the application

--- a/config/locales/gobierto_admin/gobierto_plans/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/es.yml
@@ -32,3 +32,5 @@ es:
               invalid_columns: No están todas las columnas necesarias
               invalid_format: Formato de fichero inválido
               invalid_row: 'Se ha encontrado una fila inválida: %{row_data}'
+              used_resource: El vocabulario emplea términos que se usan en otras partes
+                de la aplicación

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -54,7 +54,13 @@ ca:
         import_csv_form:
           confirm_import: Estàs segur? totes les dades actuals seran eliminats
           disable_with: Carregant...
+          more_info_html: Per obtenir més informació visita la documentació <a href="%{url}"
+            target="_blank">Importar datos de un plan</a>.
           submit: Importa des de fitxer CSV
+          vocabulary_used_by_other_plans: El vocabulari configurat per aquest pla
+            ja està configurat per a algun altre. Si us plau, crea un vocabulari nou
+            per aquest pla o elimina-de la configuració dels altres plans que ho estiguin
+            fent servir, atès que s'esborrarien les seves dades amb la importació.
           warning: "<strong>Avís</strong> Si importes un fitxer CSV s'eliminarà tot
             el contingut actual, de manera que es perdran tots els canvis que hagis
             realitzat a través de la interfície d'usuari web de Gobierto."

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -54,7 +54,13 @@ en:
         import_csv_form:
           confirm_import: Are you sure? All current data will be deleted
           disable_with: Loading...
+          more_info_html: For more information, visit the documentation <a href="%{url}"
+            target="_blank">Importar datos de un plan</a>.
           submit: Import from CSV file
+          vocabulary_used_by_other_plans: The vocabulary configured for this plan
+            is already configured for someone else. Please create a new vocabulary
+            for this plan or remove it from the configuration of the other plans using
+            it, since their data would be deleted with the import.
           warning: "<strong>Warning</strong> If you upload a CSV, all current content
             will be deleted, so any change you might have done through the Gobierto
             Web UI will be lost."

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -54,7 +54,13 @@ es:
         import_csv_form:
           confirm_import: "¿Estás seguro? Todos los datos actuales serán eliminados"
           disable_with: Cargando...
+          more_info_html: Para obtener más información visita la documentación de
+            cómo <a href="%{url}" target="_blank">Importar datos de un plan</a>.
           submit: Importar desde fichero CSV
+          vocabulary_used_by_other_plans: El vocabulario configurado para este plan
+            ya está configurado para algún otro. Por favor, crea un vocabulario nuevo
+            para este plan o elimínalo de la configuración de los otros planes que
+            lo estén usando, dado que se borrarían sus datos con la importación.
           warning: "<strong>Aviso</strong> Si importas un archivo CSV se eliminará
             todo el contenido actual, por lo que se perderán todos los cambios que
             hayas realizado a través de la interfaz de usuario web de Gobierto."

--- a/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
@@ -57,7 +57,9 @@ module GobiertoAdmin
               end
             end
 
-            assert has_message? "Data imported successfully"
+            within ".flash-message", match: :first do
+              assert has_content? "Data imported successfully"
+            end
 
             assert has_content? "5 axes"
             assert has_content? "39 lines of action"
@@ -86,7 +88,9 @@ module GobiertoAdmin
               end
             end
 
-            assert has_message? "Data imported successfully"
+            within ".flash-message", match: :first do
+              assert has_content? "Data imported successfully"
+            end
           end
         end
       end


### PR DESCRIPTION
Closes #2211


## :v: What does this PR do?

* Prevent imports from CSV in plans if the vocabulary of the plan is used in another plan.
* Adds a link from the import CSV form to documentation of plans about CSV import.
* Rescues the application from exceptions produced when a term of plan vocabulary is being used by another resource in the application and a CSV import is executed.

## :mag: How should this be manually tested?

Configure a plan with a vocabulary used by another plan or used by another part of the application (like political groups)

Visit import CSV form from admin dashboard and conf

## :eyes: Screenshots

### Before this PR

![2211-before](https://user-images.githubusercontent.com/446459/56915984-2d6aa000-6ab8-11e9-80ec-d90fd43cdf9c.gif)



### After this PR

![2211-after](https://user-images.githubusercontent.com/446459/56915993-3196bd80-6ab8-11e9-8413-abc803cce03f.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
