### PR TITLE
657 terms slug on plan import

### DIFF
--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -27,7 +27,7 @@ module GobiertoCommon
     parent_item_foreign_key :term_id
 
     def attributes_for_slug
-      [vocabulary_name, name]
+      [name]
     end
 
     def vocabulary_name

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -75,12 +75,12 @@ module GobiertoCommon
       positions_from_params.each do |parent_id, children_ids|
         if parent_id == "0"
           children_ids.each_with_index do |child_id, position|
-            where(id: child_id).update_all({ position: position, term_id: nil, level: 0 })
+            where(id: child_id).update_all(position: position, term_id: nil, level: 0)
           end
         else
           children_ids.each_with_index do |child_id, position|
             parent_level = find(parent_id).level
-            where(id: child_id).update_all({ position: position, term_id: parent_id, level: parent_level + 1 })
+            where(id: child_id).update_all(position: position, term_id: parent_id, level: parent_level + 1)
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
@@ -62,6 +62,7 @@ module GobiertoAdmin
 
             plan.reload
             assert_equal 247, plan.nodes.count
+            assert_equal "eix-1-economia-emprenedoria-i-ocupacio", plan.categories_vocabulary.terms.first.slug
           end
         end
       end

--- a/test/models/gobierto_common/term_test.rb
+++ b/test/models/gobierto_common/term_test.rb
@@ -17,8 +17,8 @@ class TermTest < ActiveSupport::TestCase
 
   def terms_with_dependencies
     @terms_with_dependencies ||= {
-      issue:  gobierto_common_terms(:culture_term),
-      scope:  gobierto_common_terms(:center_term),
+      issue: gobierto_common_terms(:culture_term),
+      scope: gobierto_common_terms(:center_term),
       political_group: gobierto_common_terms(:marvel_term)
     }
   end
@@ -79,7 +79,7 @@ class TermTest < ActiveSupport::TestCase
   end
 
   def test_update_parents_and_positions_to_root_level
-    positions_from_params = { "0" => [ term_without_dependencies.id, mammal ] }
+    positions_from_params = { "0" => [term_without_dependencies.id, mammal] }
 
     assert GobiertoCommon::Term.update_parents_and_positions(positions_from_params)
     term_without_dependencies.reload
@@ -92,7 +92,7 @@ class TermTest < ActiveSupport::TestCase
   end
 
   def test_update_parents_and_positions_reorder
-    positions_from_params = { "0" => [ term_without_dependencies.id, mammal ], mammal.id.to_s => [cat.id, dog.id] }
+    positions_from_params = { "0" => [term_without_dependencies.id, mammal], mammal.id.to_s => [cat.id, dog.id] }
 
     assert GobiertoCommon::Term.update_parents_and_positions(positions_from_params)
 
@@ -103,7 +103,7 @@ class TermTest < ActiveSupport::TestCase
   end
 
   def test_update_parents_and_positions_update_parent
-    positions_from_params = { "0" => [ term_without_dependencies.id, mammal ], term_without_dependencies.id.to_s => [cat.id, dog.id] }
+    positions_from_params = { "0" => [term_without_dependencies.id, mammal], term_without_dependencies.id.to_s => [cat.id, dog.id] }
 
     assert GobiertoCommon::Term.update_parents_and_positions(positions_from_params)
 

--- a/test/models/gobierto_common/term_test.rb
+++ b/test/models/gobierto_common/term_test.rb
@@ -114,4 +114,11 @@ class TermTest < ActiveSupport::TestCase
     assert_equal 1, dog.position
     assert_equal term_without_dependencies, dog.parent_term
   end
+
+  def test_create_term_slug
+    new_term = vocabulary.terms.new(name_translations: { en: "Term with long name", es: "Término con nombre largo" })
+    assert new_term.valid?
+    new_term.save
+    assert_equal "term-with-long-name", new_term.slug
+  end
 end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/657


## :v: What does this PR do?

Changes configuration to build default slug of terms to use only the name of term instead of a combination of vocabulary and term names 

## :mag: How should this be manually tested?

Import a plan and check the slugs of the categories or create new terms in a vocabulary

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No