### PR TITLE
Add empty script_name to action_mailer.default_url_options

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,7 +73,10 @@ Rails.application.configure do
     port: 1025
   }
 
-  config.action_mailer.default_url_options = { host: app_host }
+  config.action_mailer.default_url_options = {
+    host: app_host,
+    script_name: ""
+  }
   config.action_mailer.asset_host = "http://#{app_host}"
   config.action_mailer.perform_deliveries = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { script_name: "" }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   # config.i18n.fallbacks = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -87,5 +87,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("HOST"),
+    script_name: ""
+  }
 end


### PR DESCRIPTION
Closes PopulateTools/issues#640

## :v: What does this PR do?

Adds a `default_url_options` empty `script_name` option to avoid errors on URLs generated from mailer views.
The url helper methods, when called from mailer views, set the `script_name` configuration option with the `relative_url_root` configured for the application if no defaults are set. `relative_url_root` is set as ENV["GOBIERTO_ROOT_URL_PATH"] if the environment variable exists.

ENV["GOBIERTO_ROOT_URL_PATH"] is also used in routes as scope for all routes, so ENV["GOBIERTO_ROOT_URL_PATH"] was appearing twice in routes generated from mailer views.

## :mag: How should this be manually tested?

Create an admin and check the urls in the invitation email

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
