### PR TITLE
Use plan tab link by default if admin can manage plans

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/base_controller.rb
@@ -6,9 +6,13 @@ module GobiertoAdmin
       before_action { module_enabled!(current_site, "GobiertoPlans") }
       before_action { module_allowed!(current_admin, "GobiertoPlans") }
 
-      helper_method :gobierto_plans_plan_type_preview_url
+      helper_method :gobierto_plans_plan_type_preview_url, :current_admin_can_manage_plans?
 
       protected
+
+      def current_admin_can_manage_plans?
+        @can_manage_plans = current_admin.module_allowed_action?(current_admin_module, current_site, :manage)
+      end
 
       def gobierto_plans_plan_type_preview_url(plan, options = {})
         if plan.draft?

--- a/app/views/gobierto_admin/gobierto_plans/plans/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/index.html.erb
@@ -38,7 +38,7 @@
         <%= plan.plan_type.name %>
       </td>
       <td>
-        <%= link_to plan.title, admin_plans_plan_projects_path(plan) %>
+        <%= link_to plan.title, current_admin_can_manage_plans? ? admin_plans_plan_categories_path(plan) : admin_plans_plan_projects_path(plan) %>
       </td>
       <td>
         <%=  plan.year %>

--- a/app/views/gobierto_admin/gobierto_plans/projects/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/index.html.erb
@@ -1,7 +1,7 @@
 <div class="admin_breadcrumb">
   <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
   <%= link_to t("gobierto_admin.gobierto_plans.plans.index.title"), admin_plans_plans_path %> »
-  <%= link_to @plan.title, admin_plans_plan_categories_path(@plan) %> »
+  <%= link_to @plan.title, current_admin_can_manage_plans? ? admin_plans_plan_categories_path(@plan) : admin_plans_plan_projects_path(@plan) %> »
   <%= t("gobierto_admin.gobierto_plans.shared.navigation.projects_tab") %>
 </div>
 


### PR DESCRIPTION
Closes #2277

## :v: What does this PR do?

Makes the plan tab the default destination for links to plans in admin when the admin has manager permissions. Otherwise, the default destination is the projects index

## :mag: How should this be manually tested?
Visit the plan index from admin and click on a plan. The admin should be redirected to:
* Plan tab if has manager permissions.
* Projects tab if has only editor or moderator permissions.

## :eyes: Screenshots

### Before this PR
![2277-before](https://user-images.githubusercontent.com/446459/57526246-2b60d680-732d-11e9-9d8f-6006239597dd.gif)

### After this PR
![2277-after](https://user-images.githubusercontent.com/446459/57526256-3156b780-732d-11e9-984d-74523104752a.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
