### PR TITLE
2278 add view item in plans header

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
@@ -50,6 +50,7 @@ module GobiertoAdmin
 
       def find_vocabulary
         @plan = current_site.plans.find params[:plan_id]
+        @preview_item_url = gobierto_plans_plan_type_preview_url(@plan, host: current_site.domain)
         @vocabulary = @plan.categories_vocabulary
       end
 
@@ -67,6 +68,13 @@ module GobiertoAdmin
           current_admin: current_admin,
           current_site: current_site
         ).allowed_actions
+      end
+
+      def gobierto_plans_plan_type_preview_url(plan, options = {})
+        if plan.draft?
+          options.merge!(preview_token: current_admin.preview_token)
+        end
+        gobierto_plans_plan_url(plan.plan_type.slug, plan.year, options)
       end
     end
   end

--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -25,6 +25,7 @@ module GobiertoAdmin
 
       def edit
         @plan = find_plan
+        @preview_item_url = gobierto_plans_plan_type_preview_url(@plan, host: current_site.domain)
         @plan_types = find_plan_types
         @plan_visibility_levels = plan_visibility_levels
         @vocabularies = current_site.vocabularies

--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -10,12 +10,6 @@ module GobiertoAdmin
         @archived_plans = current_site.plans.only_archived.sort_by_updated_at
       end
 
-      def plan
-        @plan = find_plan
-        @vocabulary = @plan.categories_vocabulary
-        @terms = TreeDecorator.new(tree(@vocabulary.terms), decorator: BaseTermDecorator, options: { plan: @plan })
-      end
-
       def new
         @plan_form = PlanForm.new(site_id: current_site.id)
         @plan_visibility_levels = plan_visibility_levels

--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -139,6 +139,7 @@ module GobiertoAdmin
 
       def find_plan
         @plan = current_site.plans.find params[:plan_id]
+        @preview_item_url = gobierto_plans_plan_type_preview_url(@plan, host: current_site.domain)
       end
 
       def find_versioned_project

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -97,15 +97,15 @@
       <%= t(".notifications") %>
     </div>
 
-    <% if preview_item_url %>
-      <div class="right pure-menu-link">
-        <%= link_to t(".view_item"), preview_item_url, target: "_blank" %>
-      </div>
-    <% end %>
-
     <% if module_doc_url %>
       <div class="right pure-menu-link">
         <%= link_to t(".view_documentation"), module_doc_url, target: "_blank" %>
+      </div>
+    <% end %>
+
+    <% if preview_item_url %>
+      <div class="right pure-menu-link">
+        <%= link_to t(".view_item"), preview_item_url, target: "_blank" %>
       </div>
     <% end %>
 

--- a/test/integration/gobierto_admin/gobierto_plans/categories/categories_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/categories/categories_index_test.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_admin/previewable_item_test_module"
 
 module GobiertoAdmin
   module GobiertoPlans
     module Categories
       class CategoriesIndexTest < ActionDispatch::IntegrationTest
         include Integration::AdminGroupsConcern
+        include ::GobiertoAdmin::PreviewableItemTestModule
 
         def setup
           super
@@ -23,6 +25,15 @@ module GobiertoAdmin
 
         def plan
           @plan ||= gobierto_plans_plans(:strategic_plan)
+        end
+
+        def preview_test_conf
+          {
+            item_admin_path: @path,
+            item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain),
+            publish_proc: -> { plan.published! },
+            unpublish_proc: -> { plan.draft! }
+          }
         end
 
         def test_admin_categories_index

--- a/test/integration/gobierto_admin/gobierto_plans/plans/update_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/update_plan_test.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_admin/previewable_item_test_module"
 
 module GobiertoAdmin
   module GobiertoPlans
     class UpdatePlanTest < ActionDispatch::IntegrationTest
+      include ::GobiertoAdmin::PreviewableItemTestModule
+
       def setup
         super
         @path = new_admin_plans_plan_path
@@ -20,6 +23,13 @@ module GobiertoAdmin
 
       def plan
         @plan ||= gobierto_plans_plans(:strategic_plan)
+      end
+
+      def preview_test_conf
+        {
+          item_admin_path: edit_admin_plans_plan_path(plan),
+          item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain)
+        }
       end
 
       def test_update_plan

--- a/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_admin/previewable_item_test_module"
 
 module GobiertoAdmin
   module GobiertoPlans
     module Projects
       class CreateProjectTest < ActionDispatch::IntegrationTest
         include Integration::AdminGroupsConcern
+        include ::GobiertoAdmin::PreviewableItemTestModule
 
         def setup
           super
@@ -23,6 +25,15 @@ module GobiertoAdmin
 
         def plan
           @plan ||= gobierto_plans_plans(:strategic_plan)
+        end
+
+        def preview_test_conf
+          {
+            item_admin_path: @path,
+            item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain),
+            publish_proc: -> { plan.published! },
+            unpublish_proc: -> { plan.draft! }
+          }
         end
 
         def test_regular_admin_without_groups_create_project

--- a/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_admin/previewable_item_test_module"
 
 module GobiertoAdmin
   module GobiertoPlans
     module Projects
       class DeleteProjectTest < ActionDispatch::IntegrationTest
         include Integration::AdminGroupsConcern
+        include ::GobiertoAdmin::PreviewableItemTestModule
 
         def setup
           super
@@ -27,6 +29,15 @@ module GobiertoAdmin
 
         def project
           @project ||= gobierto_plans_nodes(:political_agendas)
+        end
+
+        def preview_test_conf
+          {
+            item_admin_path: @path,
+            item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain),
+            publish_proc: -> { plan.published! },
+            unpublish_proc: -> { plan.draft! }
+          }
         end
 
         def test_regular_admin_without_groups_delete_project

--- a/test/integration/gobierto_admin/gobierto_plans/projects/projects_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/projects_index_test.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_admin/previewable_item_test_module"
 
 module GobiertoAdmin
   module GobiertoPlans
     module Projects
       class ProjectsIndexTest < ActionDispatch::IntegrationTest
         include Integration::AdminGroupsConcern
+        include ::GobiertoAdmin::PreviewableItemTestModule
 
         def setup
           super
@@ -34,6 +36,15 @@ module GobiertoAdmin
           @project_with_no_search_matching_name ||= gobierto_plans_nodes(:scholarships_kindergartens)
         end
         alias project_with_null_progress project_with_no_search_matching_name
+
+        def preview_test_conf
+          {
+            item_admin_path: @path,
+            item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain),
+            publish_proc: -> { plan.published! },
+            unpublish_proc: -> { plan.draft! }
+          }
+        end
 
         def test_admin_projects_index
           with_signed_in_admin(admin) do

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_admin/previewable_item_test_module"
 
 module GobiertoAdmin
   module GobiertoPlans
     module Projects
       class UpdateProjectTest < ActionDispatch::IntegrationTest
         include Integration::AdminGroupsConcern
+        include ::GobiertoAdmin::PreviewableItemTestModule
 
         attr_reader :plan, :published_project, :unpublished_project, :path, :unpublished_path
 
@@ -25,6 +27,15 @@ module GobiertoAdmin
 
         def site
           @site ||= sites(:madrid)
+        end
+
+        def preview_test_conf
+          {
+            item_admin_path: @path,
+            item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain),
+            publish_proc: -> { plan.published! },
+            unpublish_proc: -> { plan.draft! }
+          }
         end
 
         def test_update_project_as_manager

--- a/test/support/concerns/gobierto_admin/previewable_item_test_module.rb
+++ b/test/support/concerns/gobierto_admin/previewable_item_test_module.rb
@@ -13,11 +13,18 @@ module GobiertoAdmin
       with_signed_in_admin(admin) do
         with_current_site(site) do
           # when published
-          visit preview_test_conf[:item_admin_path]
 
-          within ".widget_save" do
-            find("label", text: "Published").click
-            click_button "Update"
+          if preview_test_conf[:publish_proc]
+            preview_test_conf[:publish_proc].call
+
+            visit preview_test_conf[:item_admin_path]
+          else
+            visit preview_test_conf[:item_admin_path]
+
+            within ".widget_save" do
+              find("label", text: "Published").click
+              click_button "Update"
+            end
           end
 
           within("header") { click_link "View item" }
@@ -28,11 +35,18 @@ module GobiertoAdmin
           assert current_url.exclude? "preview_token=#{admin.preview_token}"
 
           # when draft
-          visit preview_test_conf[:item_admin_path]
 
-          within ".widget_save" do
-            click_draft_checkbox
-            click_button "Update"
+          if preview_test_conf[:unpublish_proc]
+            preview_test_conf[:unpublish_proc].call
+
+            visit preview_test_conf[:item_admin_path]
+          else
+            visit preview_test_conf[:item_admin_path]
+
+            within ".widget_save" do
+              click_draft_checkbox
+              click_button "Update"
+            end
           end
 
           within("header") { click_link "View item" }


### PR DESCRIPTION
Closes #2278


## :v: What does this PR do?

* Adds a "view item" link in header to plan in front on all tabs of plan admin panel.
* Reorders links displaying them in this order: "view site", "view item" and "view documentation"

## :mag: How should this be manually tested?

Visit a plan from admin and check that the "view item" link is present for all tabs. Also a preview token should appear if the plan is draft

## :eyes: Screenshots

### Before this PR

![2278-before](https://user-images.githubusercontent.com/446459/57533409-ff9a1c80-733d-11e9-8297-c8b5a8182a84.gif)

### After this PR

![2278-after](https://user-images.githubusercontent.com/446459/57534480-64ef0d00-7340-11e9-9e8b-dbe80b6df9d8.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
