### PR TITLE
2281 plans progress precission in front

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
@@ -13,7 +13,7 @@ module GobiertoAdmin
         find_vocabulary
         calculate_accumulated_values
 
-        @global_progress = @plan.nodes.average(:progress).to_f
+        @global_progress = @plan.global_progress
         @projects_filter_form = ::GobiertoAdmin::GobiertoPlans::ProjectsFilterForm.new(plan: @plan, admin: current_admin)
         @terms = TreeDecorator.new(tree(@vocabulary.terms), decorator: ::GobiertoPlans::CategoryTermDecorator, options: { plan: @plan, vocabulary: @vocabulary, site: current_site })
       end

--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -43,7 +43,8 @@ module GobiertoPlans
                     option_keys: @plan.configuration_data["option_keys"],
                     level_keys: level_keys,
                     show_table_header: @plan.configuration_data["show_table_header"],
-                    open_node: @plan.configuration_data["open_node"] }
+                    open_node: @plan.configuration_data["open_node"],
+                    global_progress: @plan.global_progress }
           )
         end
       end

--- a/app/decorators/gobierto_plans/row_node_decorator.rb
+++ b/app/decorators/gobierto_plans/row_node_decorator.rb
@@ -54,6 +54,7 @@ module GobiertoPlans
                   (category.nodes.where("#{ nodes_table_name }.name_translations @> ?::jsonb", { locale => node_data["Title"] }.to_json).first || category.nodes.new).tap do |node|
                     node.assign_attributes node_attributes
                     node.progress = progress_from_status(node.status) unless has_progress_column?
+                    node.progress ||= 0.0
                     node.visibility_level = :published
                     node.build_moderation(stage: :approved)
                     node.categories << category unless node.categories.include?(category)

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -9,7 +9,6 @@ module GobiertoAdmin
         :plan_id,
         :name_translations,
         :status_translations,
-        :progress,
         :starts_at,
         :ends_at,
         :options_json,
@@ -20,7 +19,8 @@ module GobiertoAdmin
         :visibility_level,
         :moderation_visibility_level,
         :moderation_stage,
-        :disable_attributes_edition
+        :disable_attributes_edition,
+        :progress
       )
 
       validates :plan, :admin, presence: true
@@ -92,6 +92,10 @@ module GobiertoAdmin
 
       def visibility_level
         @visibility_level ||= moderation_visibility_level || node.visibility_level || "draft"
+      end
+
+      def progress
+        @progress ||= node.progress || 0.0
       end
 
       def moderation_stage

--- a/app/javascript/gobierto_plans/modules/plan_types_controller.js
+++ b/app/javascript/gobierto_plans/modules/plan_types_controller.js
@@ -21,7 +21,7 @@ window.GobiertoPlans.PlanTypesController = (function() {
 
       Vue.filter('percent', function (value) {
         if (!value) return
-        return (value / 100).toLocaleString(I18n.locale, { style: 'percent', maximumSignificantDigits: 4 })
+        return (value / 100).toLocaleString(I18n.locale, { style: 'percent', maximumFractionDigits: 1 })
       });
 
       Vue.filter('date', function (date) {

--- a/app/javascript/gobierto_plans/modules/plan_types_controller.js
+++ b/app/javascript/gobierto_plans/modules/plan_types_controller.js
@@ -109,6 +109,7 @@ window.GobiertoPlans.PlanTypesController = (function() {
           showTable: {},
           showTableHeader: true,
           openNode: false,
+          globalProgress: 0,
           rootid: 0
         },
         created: function() {
@@ -134,9 +135,6 @@ window.GobiertoPlans.PlanTypesController = (function() {
           }
         },
         computed: {
-          globalProgress: function () {
-            return _.meanBy(this.json, 'attributes.progress')
-          },
           availableOpts: function () {
             // Filter options object only to those values present in the configuration (optionKeys)
             return _.pick(this.activeNode.attributes.options, _.filter(_.keys(this.activeNode.attributes.options), function (o) {
@@ -157,6 +155,8 @@ window.GobiertoPlans.PlanTypesController = (function() {
               var showTableHeader = json["show_table_header"];
               // If you can open a node (project)
               var openNode = json["open_node"];
+              // Global progress, provided by json
+              var globalProgress = json["global_progress"];
 
               // Hide spinner
               $(".js-toggle-overlay").removeClass('is-active');
@@ -165,6 +165,7 @@ window.GobiertoPlans.PlanTypesController = (function() {
               this.levelKeys = levelKeys;
               this.showTableHeader = showTableHeader;
               this.openNode = openNode;
+              this.globalProgress = globalProgress;
               this.optionKeys = Object.keys(optionKeys).reduce(function(c, k) {
                 return (c[k.toLowerCase()] = optionKeys[k]), c;
               }, {});

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -10,6 +10,8 @@ module GobiertoPlans
     has_and_belongs_to_many :categories, class_name: "GobiertoCommon::Term", association_foreign_key: :category_id, join_table: :gplan_categories_nodes
     has_paper_trail ignore: [:visibility_level]
 
+    validates :progress, presence: true
+
     scope :with_name, ->(name) { where("gplan_nodes.name_translations ->> 'en' ILIKE :name OR gplan_nodes.name_translations ->> 'es' ILIKE :name OR gplan_nodes.name_translations ->> 'ca' ILIKE :name", name: "%#{name}%") }
     scope :with_status, ->(status) { with_status_translation(status) }
     scope :with_category, ->(category) { where(gplan_categories_nodes: { category_id: GobiertoCommon::Term.find(category).last_descendants }) }

--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -44,6 +44,10 @@ module GobiertoPlans
       nodes.count
     end
 
+    def global_progress
+      nodes.average(:progress).to_f
+    end
+
     def to_s
       text = ""
       # "5 cats, 43 subcats, 151 subsubcats, 161 nodes"

--- a/db/migrate/20190510172357_change_gobierto_plans_node_progress_default_value.rb
+++ b/db/migrate/20190510172357_change_gobierto_plans_node_progress_default_value.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeGobiertoPlansNodeProgressDefaultValue < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :gplan_nodes, :progress, from: nil, to: 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_15_093350) do
+ActiveRecord::Schema.define(version: 2019_05_10_172357) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -873,7 +873,7 @@ ActiveRecord::Schema.define(version: 2019_04_15_093350) do
 
   create_table "gplan_nodes", force: :cascade do |t|
     t.jsonb "name_translations"
-    t.float "progress"
+    t.float "progress", default: 0.0
     t.jsonb "status_translations"
     t.date "starts_at"
     t.date "ends_at"

--- a/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
@@ -102,6 +102,30 @@ module GobiertoAdmin
             end
           end
         end
+
+        def test_regular_editor_default_progress_on_create_is_zero
+          allow_regular_admin_edit_plans
+
+          with_javascript do
+            with_signed_in_admin(regular_admin) do
+              with_current_site(site) do
+                visit @path
+
+                select "Scholarships for families in the Central District", from: "project_category_id"
+
+                fill_in "project_name_translations_en", with: "New project"
+                fill_in "project_status_translations_en", with: "Not started"
+
+                click_button "Save"
+
+                assert has_content? "Project created correctly."
+
+                project = plan.nodes.last
+                assert_equal 0.0, project.progress
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -38,6 +38,10 @@ module GobiertoPlans
       @projects ||= GobiertoPlans::Node.where(id: node_ids)
     end
 
+    def project_with_progress
+      @project_with_progress ||= gobierto_plans_nodes(:political_agendas)
+    end
+
     def test_plan
       with_javascript do
         with_current_site(site) do
@@ -67,13 +71,31 @@ module GobiertoPlans
       end
     end
 
+    def test_progress_precission
+      project_with_progress.update_attribute(:progress, 2.666666666666666)
+
+      with_javascript do
+        with_current_site(site) do
+          visit @path
+
+          assert has_content? "Strategic Plan introduction"
+
+          within "div.header-resume" do
+            within "span" do
+              assert has_content? "1.3%"
+            end
+          end
+        end
+      end
+    end
+
     def test_global_execution
       with_javascript do
         with_current_site(site) do
           visit @path
           within "div.header-resume" do
             within "span" do
-              assert has_content?("8.333%")
+              assert has_content?("25%")
             end
           end
         end


### PR DESCRIPTION
Closes #2281


## :v: What does this PR do?

* Adds presence validation and zero default value to plan nodes progress
* Sets 0.0 progress on projects/nodes imported from CSV if nothing defined
* Defines a `global_progress` method in plan model to be used both in plan admin panel and front
* Fixes progresses percentages display in front to use only a decimal number in float precision 

## :mag: How should this be manually tested?
Visit a plan and compare admin plan tab with front

## :eyes: Screenshots

### Before this PR
![2281-before](https://user-images.githubusercontent.com/446459/57556850-7c49ec80-7378-11e9-8443-97260a892925.gif)

### After this PR
![2281-after](https://user-images.githubusercontent.com/446459/57557128-435e4780-7379-11e9-8fb8-4ca16629a2b6.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
