### PR TITLE
661 fix missing plan configuration exceptions

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -87,7 +87,7 @@ module GobiertoAdmin
       end
 
       def import_csv
-        @plan = find_plan
+        @plan = ::GobiertoPlans::PlanDecorator.new(find_plan)
         @plan_data_form = PlanDataForm.new(plan: @plan)
       end
 

--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -40,10 +40,10 @@ module GobiertoPlans
 
           render(
             json: { plan_tree: plan_tree,
-                    option_keys: @plan.configuration_data["option_keys"],
-                    level_keys: level_keys,
-                    show_table_header: @plan.configuration_data["show_table_header"],
-                    open_node: @plan.configuration_data["open_node"],
+                    option_keys: @plan.configuration_data&.dig("option_keys") || {},
+                    level_keys: @plan.level_keys,
+                    show_table_header: @plan.configuration_data&.dig("show_table_header"),
+                    open_node: @plan.configuration_data&.dig("open_node"),
                     global_progress: @plan.global_progress }
           )
         end
@@ -58,10 +58,6 @@ module GobiertoPlans
 
     def find_plan
       valid_preview_token? ? @plan_type.plans.find_by!(year: params[:year]) : @plan_type.plans.published.find_by!(year: params[:year])
-    end
-
-    def level_keys
-      @plan.configuration_data.select { |k| k =~ /level\d\z/ }
     end
 
     def load_plans

--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -24,7 +24,7 @@ module GobiertoPlans
       load_year
       redirect_to gobierto_plans_plan_path(slug: params[:slug], year: @years.first) and return if @year.nil?
 
-      @plan = find_plan
+      @plan = PlanDecorator.new(find_plan)
 
       @site_stats = GobiertoPlans::SiteStats.new site: current_site, plan: @plan
       @plan_updated_at = @site_stats.plan_updated_at

--- a/app/decorators/gobierto_plans/plan_decorator.rb
+++ b/app/decorators/gobierto_plans/plan_decorator.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  class PlanDecorator < BaseDecorator
+    def initialize(plan)
+      @object = plan
+    end
+
+    def level_keys
+      @level_keys ||= begin
+                        level_keys = configuration_data&.select { |k| k =~ /level\d\z/ } || {}
+
+                        (0..levels + 1).each do |level|
+                          next if level_keys["level#{level}"].present?
+
+                          element_type = level <= levels ? "category" : "project"
+                          level_keys["level#{level}"] = default_translations(element_type, 1, level + 1)
+                        end
+
+                        level_keys
+                      end
+    end
+
+    def to_s
+      text = ""
+      # "5 cats, 43 subcats, 151 subsubcats, 161 nodes"
+      if levels && levels.positive?
+        (0..(levels)).each do |level|
+          category_size = categories.where(level: level).size
+          text += category_size.to_s + " " + level_key(category_size, level) + ", "
+        end
+      end
+
+      if nodes.any?
+        text += node_size.to_s + " " + level_key(node_size, levels + 1)
+      end
+
+      text
+    end
+
+    def level_key(level_size, level)
+      return configuration_data["level#{level}"][level_size == 1 ? "one" : "other"][I18n.locale.to_s] if configuration_data.present? && configuration_data.has_key?("level#{level}")
+
+      element_type = level <= levels ? "category" : "project"
+      I18n.t("gobierto_admin.gobierto_plans.plans.import_csv.defaults.#{element_type}", count: level_size, level: level + 1)
+    end
+
+    private
+
+    def default_translations(element_type, count, level)
+      {
+        "one" => site.configuration.available_locales.inject({}) do |translations, locale|
+          translations.update(
+            locale => I18n.t("gobierto_admin.gobierto_plans.plans.import_csv.defaults.#{element_type}", count: 1, level: level + 1)
+          )
+        end,
+        "other" => site.configuration.available_locales.inject({}) do |translations, locale|
+          translations.update(
+            locale => I18n.t("gobierto_admin.gobierto_plans.plans.import_csv.defaults.#{element_type}", count: 2, level: level + 1)
+          )
+        end
+      }
+    end
+  end
+end

--- a/app/decorators/gobierto_plans/plan_decorator.rb
+++ b/app/decorators/gobierto_plans/plan_decorator.rb
@@ -14,7 +14,7 @@ module GobiertoPlans
                           next if level_keys["level#{level}"].present?
 
                           element_type = level <= levels ? "category" : "project"
-                          level_keys["level#{level}"] = default_translations(element_type, 1, level + 1)
+                          level_keys["level#{level}"] = default_translations(element_type, level + 1)
                         end
 
                         level_keys
@@ -24,7 +24,7 @@ module GobiertoPlans
     def to_s
       text = ""
       # "5 cats, 43 subcats, 151 subsubcats, 161 nodes"
-      if levels && levels.positive?
+      if levels&.positive?
         (0..(levels)).each do |level|
           category_size = categories.where(level: level).size
           text += category_size.to_s + " " + level_key(category_size, level) + ", "
@@ -47,7 +47,7 @@ module GobiertoPlans
 
     private
 
-    def default_translations(element_type, count, level)
+    def default_translations(element_type, level)
       {
         "one" => site.configuration.available_locales.inject({}) do |translations, locale|
           translations.update(

--- a/app/helpers/gobierto_plans/plan_helper.rb
+++ b/app/helpers/gobierto_plans/plan_helper.rb
@@ -2,10 +2,10 @@
 
 module GobiertoPlans
   module PlanHelper
-    def level_name_pluralize(number_of_elements, translation_key)
-      count = number_of_elements == 1 ? "one" : "other"
+    def level_name_pluralize(plan, level)
+      elements_count = level <= @plan.levels ? plan.categories.where(level: level).count : plan.nodes.published.count
 
-      "#{number_of_elements} #{translation_key[count][I18n.locale.to_s]}"
+      "#{elements_count} #{plan.level_key(elements_count, level)}"
     end
   end
 end

--- a/app/models/gobierto_plans/plan.rb
+++ b/app/models/gobierto_plans/plan.rb
@@ -48,23 +48,6 @@ module GobiertoPlans
       nodes.average(:progress).to_f
     end
 
-    def to_s
-      text = ""
-      # "5 cats, 43 subcats, 151 subsubcats, 161 nodes"
-      if levels && levels.positive?
-        (0..(levels)).each do |level|
-          category_size = categories.where(level: level).size
-          text += category_size.to_s + " " + level_key(category_size, level) + ", "
-        end
-      end
-
-      if nodes.any?
-        text += node_size.to_s + " " + level_key(node_size, levels + 1)
-      end
-
-      text
-    end
-
     def attributes_for_slug
       [title]
     end
@@ -74,15 +57,5 @@ module GobiertoPlans
 
       self.class.with_deleted.where(vocabulary_id: vocabulary_id).where.not(id: id).exists?
     end
-
-    private
-
-    def level_key(level_size, level)
-      return configuration_data["level#{level}"][level_size == 1 ? "one" : "other"][I18n.locale.to_s] if configuration_data.present? && configuration_data.has_key?("level#{level}")
-
-      element_type = level <= levels ? "category" : "project"
-      I18n.t("gobierto_admin.gobierto_plans.plans.import_csv.defaults.#{element_type}", count: level_size, level: level + 1)
-    end
-
   end
 end

--- a/app/services/gobierto_plans/plan_tree.rb
+++ b/app/services/gobierto_plans/plan_tree.rb
@@ -31,7 +31,7 @@ class GobiertoPlans::PlanTree
       category_nodes = category.nodes
 
       data = if category.level.zero?
-               logo_url = if logo_options = @plan.configuration_data&.dig("level0_options")&.find { |option| option["slug"] == category.slug }
+               logo_url = if (logo_options = @plan.configuration_data&.dig("level0_options")&.find { |option| option["slug"] == category.slug })
                             logo_options["logo"]
                           else
                             ""

--- a/app/services/gobierto_plans/plan_tree.rb
+++ b/app/services/gobierto_plans/plan_tree.rb
@@ -31,12 +31,12 @@ class GobiertoPlans::PlanTree
       category_nodes = category.nodes
 
       data = if category.level.zero?
-               logo_url = if logo_options = @plan.configuration_data["level0_options"].find { |option| option["slug"] == category.slug }
+               logo_url = if logo_options = @plan.configuration_data&.dig("level0_options")&.find { |option| option["slug"] == category.slug }
                             logo_options["logo"]
                           else
                             ""
                           end
-               counter = !@plan.configuration_data["hide_level0_counters"]
+               counter = !@plan.configuration_data&.dig("hide_level0_counters")
                { id: category.id,
                  uid: category.uid,
                  type: "category",

--- a/app/views/gobierto_plans/plan_types/_planification-header.html.erb
+++ b/app/views/gobierto_plans/plan_types/_planification-header.html.erb
@@ -6,14 +6,11 @@
   </div>
 
   <div class="header-detail">
-    <% for i in 0..(@levels) %>
+    <% for i in 0..(@levels + 1) %>
       <div>
-        <%= level_name_pluralize(@plan.categories.where(level: i).size, @plan.configuration_data["level" + i.to_s]) %>
+        <%= level_name_pluralize(@plan, i) %>
       </div>
     <% end %>
-    <div>
-      <%= level_name_pluralize(@node_number, @plan.configuration_data["level" + (@levels + 1).to_s]) %>
-    </div>
   </div>
 
 </div>

--- a/test/decorators/gobierto_plans/plan_decorator.rb
+++ b/test/decorators/gobierto_plans/plan_decorator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPlans
+  class PlanDecoratorTest < ActiveSupport::TestCase
+    def plan
+      @plan ||= gobierto_plans_plans(:strategic_plan)
+    end
+
+    def decorated_plan
+      @decorated_plan ||= PlanDecorator.new(plan)
+    end
+
+    def test_to_s
+      plan_string = decorated_plan.to_s
+
+      assert plan_string.include? "3 axes"
+      assert plan_string.include? "1 line of action"
+      assert plan_string.include? "2 actions"
+      assert plan_string.include? "2 projects/actions"
+    end
+
+    def test_plan_without_configuration_to_s
+      plan.update_attribute(:configuration_data, nil)
+
+      plan_string = decorated_plan.to_s
+
+      assert plan_string.include? "3 items of level 1"
+      assert plan_string.include? "1 item of level 2"
+      assert plan_string.include? "2 items of level 3"
+      assert plan_string.include? "2 projects"
+    end
+
+    def test_level_keys_of_plan
+      assert_equal decorated_plan.level_keys, plan.configuration_data.slice("level0", "level1", "level2", "level3")
+    end
+  end
+end

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -139,7 +139,7 @@ module GobiertoPlans
                 assert has_selector?("li", count: actions.count)
 
                 find("h3", text: actions.first.name).click
-                assert has_selector?("div", text: (projects.last.progress).to_i.to_s + "%")
+                assert has_selector?("div", text: projects.last.progress.to_i.to_s + "%")
 
                 find("td", text: projects.first.name).click
 
@@ -291,7 +291,7 @@ module GobiertoPlans
                 assert has_selector?("li", count: actions.count)
 
                 find("h3", text: actions.first.name).click
-                assert has_selector?("div", text: (projects.last.progress).to_i.to_s + "%")
+                assert has_selector?("div", text: projects.last.progress.to_i.to_s + "%")
 
                 find("td", text: projects.first.name).click
 

--- a/test/models/gobierto_plans/plan_test.rb
+++ b/test/models/gobierto_plans/plan_test.rb
@@ -11,25 +11,5 @@ module GobiertoPlans
     def test_valid
       assert plan.valid?
     end
-
-    def test_to_s
-      plan_string = plan.to_s
-
-      assert plan_string.include? "3 axes"
-      assert plan_string.include? "1 line of action"
-      assert plan_string.include? "2 actions"
-      assert plan_string.include? "2 projects/actions"
-    end
-
-    def test_plan_without_configuration_to_s
-      plan.update_attribute(:configuration_data, nil)
-
-      plan_string = plan.to_s
-
-      assert plan_string.include? "3 items of level 1"
-      assert plan_string.include? "1 item of level 2"
-      assert plan_string.include? "2 items of level 3"
-      assert plan_string.include? "2 projects"
-    end
   end
 end


### PR DESCRIPTION
Closes PopulateTools/issues#661

## :v: What does this PR do?

* Avoid some errors produced when the configuration of a plan is blank.
* Defines a default level names configuration for levels not present in configuration plan attribute. The names are taken from the I18n translations
* Uses the count of published projects in the plan summary

## :mag: How should this be manually tested?

Edit a plan from admin, delete configuration and save.

## :eyes: Screenshots

### Before this PR
![661-before](https://user-images.githubusercontent.com/446459/57633984-c1526680-75a4-11e9-9b66-a20d3d526506.gif)

### After this PR
![661-after](https://user-images.githubusercontent.com/446459/57634340-6a995c80-75a5-11e9-9586-720c212b9083.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
