### PR TITLE
2320 custom fields at instance level

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -10,13 +10,26 @@ module GobiertoAdmin
         def index
           set_class_name
 
+          @custom_field_form = form_class.new(
+            resource_name: params[:module_resource_name],
+            instance_class_name: params[:instance_type],
+            instance_id: params[:instance_id]
+          )
+          @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
           @class_human_name = @class_name.constantize.model_name.human(count: 2)
-          @localized_custom_fields = current_site.custom_fields.where(class_name: @class_name).localized.sorted
-          @not_localized_custom_fields = current_site.custom_fields.where(class_name: @class_name).not_localized.sorted
+
+          @localized_custom_fields = current_site.custom_fields.where(class_name: @class_name, instance: @custom_field_form.instance).localized.sorted
+          @not_localized_custom_fields = current_site.custom_fields.where(class_name: @class_name, instance: @custom_field_form.instance).not_localized.sorted
         end
 
         def new
-          @custom_field_form = form_class.new(site_id: current_site.id, resource_name: params[:module_resource_name])
+          @custom_field_form = form_class.new(
+            site_id: current_site.id,
+            resource_name: params[:module_resource_name],
+            instance_class_name: params[:instance_type],
+            instance_id: params[:instance_id]
+          )
+          @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
           @types_with_options = @custom_field_form.types_with_options
         end
 
@@ -24,11 +37,16 @@ module GobiertoAdmin
           @custom_field_form = form_class.new(custom_field_params.merge(site_id: current_site.id, resource_name: params[:module_resource_name]))
           if @custom_field_form.save
             redirect_to(
-              admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: @custom_field_form.resource_param),
+              admin_common_custom_fields_module_resource_custom_fields_path(
+                module_resource_name: @custom_field_form.resource_param,
+                instance_type: @custom_field_form.instance_class_name,
+                instance_id: @custom_field_form.instance_id
+              ),
               notice: t(".success")
             )
           else
             @types_with_options = @custom_field_form.types_with_options
+            @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
             render :new
           end
         end
@@ -43,6 +61,7 @@ module GobiertoAdmin
           find_custom_field
 
           @custom_field_form = form_class.new(@custom_field.attributes.except(*ignored_custom_field_attributes).merge(site_id: current_site.id))
+          @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
           @types_with_options = @custom_field_form.types_with_options
         end
 
@@ -52,27 +71,42 @@ module GobiertoAdmin
           @custom_field_form = form_class.new(custom_field_params.merge(id: @custom_field.id, site_id: current_site.id))
           if @custom_field_form.save
             redirect_to(
-              admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: @custom_field_form.resource_param),
+              admin_common_custom_fields_module_resource_custom_fields_path(
+                module_resource_name: @custom_field_form.resource_param,
+                instance_type: @custom_field_form.instance_class_name,
+                instance_id: @custom_field_form.instance_id
+              ),
               notice: t(".success")
             )
           else
             @types_with_options = @custom_field_form.types_with_options
+            @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
             render :edit
           end
         end
 
         def destroy
           find_custom_field
-          module_resource_name = form_class.new(id: params[:id], site_id: current_site.id).resource_param
+
+          @custom_field_form = form_class.new(id: @custom_field.id, site_id: current_site.id)
+          module_resource_name = @custom_field_form.resource_param
 
           if @custom_field.destroy
             redirect_to(
-              admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: module_resource_name),
+              admin_common_custom_fields_module_resource_custom_fields_path(
+                module_resource_name: module_resource_name,
+                instance_type: @custom_field_form.instance_class_name,
+                instance_id: @custom_field_form.instance_id
+              ),
               notice: t(".success")
             )
           else
             redirect_to(
-              admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: module_resource_name),
+              admin_common_custom_fields_module_resource_custom_fields_path(
+                module_resource_name: module_resource_name,
+                instance_type: @custom_field_form.instance_class_name,
+                instance_id: @custom_field_form.instance_id
+              ),
               alert: t(".failed")
             )
           end
@@ -88,6 +122,8 @@ module GobiertoAdmin
           params.require(:custom_field).permit(
             :field_type,
             :uid,
+            :instance_class_name,
+            :instance_id,
             name_translations: [*I18n.available_locales],
             options_translations: {}
           )
@@ -102,7 +138,7 @@ module GobiertoAdmin
         end
 
         def ignored_custom_field_attributes
-          %w(created_at updated_at class_name site_id mandatory position)
+          %w(created_at updated_at class_name site_id mandatory position instance_type instance_id)
         end
 
         def find_custom_field

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/instance_level_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/instance_level_resources_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module CustomFields
+      class InstanceLevelResourcesController < BaseController
+        before_action :check_permissions!
+
+        def show
+          @available_resources = models_with_custom_fields
+          @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@class_name.constantize.find_by(id: params[:id]))
+        end
+
+        def index
+          @available_resources = modules_with_custom_fields.reject { |module_name, resources| resources.blank? || !current_admin.module_allowed?(module_name, current_site) }
+        end
+
+        def check_permissions!
+          raise_module_not_allowed unless current_admin.can_edit_custom_fields? && current_admin.module_allowed?(module_name, current_site)
+        end
+
+        def class_name
+          @class_name ||= params[:module_resource_name].tr("-", "/")&.camelize
+        end
+
+        def module_name
+          @module_name ||= class_name.deconstantize
+        end
+
+        private
+
+        def models_with_custom_fields
+          @models_with_custom_fields ||= module_name.constantize.send(:classes_with_custom_fields)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/instance_level_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/instance_level_resources_controller.rb
@@ -8,7 +8,7 @@ module GobiertoAdmin
 
         def show
           @available_resources = models_with_custom_fields
-          @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@class_name.constantize.find_by(id: params[:id]))
+          @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(class_name.constantize.where(site: current_site).find(params[:id]))
         end
 
         def index

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
@@ -7,7 +7,12 @@ module GobiertoAdmin
         before_action :check_permissions!
 
         def index
-          @available_resources = modules_with_custom_fields.reject { |module_name, resources| resources.blank? || !current_admin.module_allowed?(module_name, current_site) }
+          @available_resources = clean_modules_hash modules_with_custom_fields
+          @available_instances = clean_modules_hash(models_with_custom_fields_at_instance_level).transform_values do |classes|
+            classes.inject({}) do |hash, klass|
+              hash.update(klass => CollectionDecorator.new(klass.where(site: current_site).all, decorator: ::GobiertoAdmin::BaseResourceDecorator))
+            end
+          end
         end
 
         def check_permissions!
@@ -16,10 +21,20 @@ module GobiertoAdmin
 
         private
 
+        def models_with_custom_fields_at_instance_level
+          @models_with_custom_fields_at_instance_level ||= current_site.configuration.modules.map do |module_name|
+            [module_name, module_name.constantize.try(:classes_with_custom_fields_at_instance_level)]
+          end.to_h
+        end
+
         def modules_with_custom_fields
           @modules_with_custom_fields ||= current_site.configuration.modules.map do |module_name|
             [module_name, module_name.constantize.try(:classes_with_custom_fields)]
           end.to_h
+        end
+
+        def clean_modules_hash(modules_hash)
+          modules_hash.reject { |module_name, content| content.blank? || !current_admin.module_allowed?(module_name, current_site) }
         end
       end
     end

--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -27,14 +27,16 @@ module GobiertoAdmin
             version: params[:version]
           )
         )
+        initialize_custom_field_form
       end
 
       def update
         @project = @plan.nodes.find params[:id]
         @project_form = NodeForm.new(project_params.merge(id: params[:id], plan_id: params[:plan_id], admin: current_admin))
         @unpublish_url = unpublish_admin_plans_plan_project_path(@plan, @project)
+        initialize_custom_field_form
 
-        if @project_form.save
+        if @project_form.save && custom_fields_save
           success_message = if suggest_unpublish?
                               t(".suggest_unpublish_html", url: @unpublish_url)
                             else
@@ -65,12 +67,15 @@ module GobiertoAdmin
           options_json: {},
           admin: current_admin
         )
+        initialize_custom_field_form
       end
 
       def create
         @project_form = NodeForm.new(project_params.merge(id: params[:id], plan_id: params[:plan_id], admin: current_admin))
+        initialize_custom_field_form
 
         if @project_form.save
+          custom_fields_save
           redirect_to(
             edit_admin_plans_plan_project_path(@plan, @project_form.node),
             notice: t(".success")

--- a/app/decorators/gobierto_admin/base_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/base_resource_decorator.rb
@@ -10,6 +10,10 @@ module GobiertoAdmin
       @name ||= try(:name) || try(:title) || to_s
     end
 
+    def model_param
+      @object.class.name.underscore.tr("/", "-")
+    end
+
     def resource_model_name(count: 1)
       @resource_model_name ||= model_name.human(count: count)
     end

--- a/app/decorators/gobierto_admin/base_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/base_resource_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class BaseResourceDecorator < BaseDecorator
+    def initialize(resource, _opts = {})
+      @object = resource
+    end
+
+    def name
+      @name ||= try(:name) || try(:title) || to_s
+    end
+
+    def resource_model_name(count: 1)
+      @resource_model_name ||= model_name.human(count: count)
+    end
+  end
+end

--- a/app/decorators/gobierto_common/custom_field_record_decorator.rb
+++ b/app/decorators/gobierto_common/custom_field_record_decorator.rb
@@ -51,6 +51,12 @@ module GobiertoCommon
         field_tag: :file_field_tag,
         partial: "image",
         tag_attributes: {}
+      },
+      data_grid: {
+        class_names: "form_item file_field avatar_file_field",
+        field_tag: :hidden_field_tag,
+        partial: "data_grid",
+        tag_attributes: {}
       }
     }.freeze
 

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -13,6 +13,8 @@ module GobiertoAdmin
       )
 
       attr_writer(
+        :instance_class_name,
+        :instance_id,
         :options,
         :uid
       )
@@ -20,6 +22,7 @@ module GobiertoAdmin
       delegate :persisted?, to: :custom_field
 
       validates :name_translations, :site, :klass, :field_type, presence: true
+      validate :instance_type_is_enabled
 
       def custom_field
         @custom_field ||= custom_fields_relation.find_by(id: id) || build_custom_field
@@ -37,8 +40,28 @@ module GobiertoAdmin
         @class_name ||= custom_field.class_name || resource_name&.tr("-", "/")&.camelize
       end
 
+      def instance_class_name
+        @instance_class_name ||= parameterize(custom_field.instance_type)
+      end
+
+      def instance_type
+        @instance_type ||= instance_class_name&.tr("-", "/")&.camelize || custom_field.instance_type
+      end
+
+      def instance
+        @instance ||= instance_class&.find_by(id: instance_id) || custom_field.instance
+      end
+
+      def instance_id
+        @instance_id ||= custom_field.instance_id
+      end
+
       def resource_param
-        class_name.underscore.tr("/", "-")
+        parameterize(class_name)
+      end
+
+      def instance_type_param
+        parameterize(instance_class_name)
       end
 
       def human_class_name
@@ -69,6 +92,12 @@ module GobiertoAdmin
 
       private
 
+      def instance_type_is_enabled
+        return if instance.blank? || classes_with_custom_fields_at_instance_level.include?(instance_class)
+
+        errors.add(:instance_class_name, I18n.t("errors.messages.invalid"))
+      end
+
       def save_custom_field
         @custom_field = custom_field.tap do |attributes|
           attributes.site_id = site_id
@@ -77,12 +106,17 @@ module GobiertoAdmin
           attributes.field_type = field_type
           attributes.options = options
           attributes.uid = uid
+          attributes.instance = instance
         end
 
         return @custom_field if @custom_field.save
 
         promote_errors(@custom_field.errors)
         false
+      end
+
+      def parameterize(name)
+        name&.underscore&.tr("/", "-")
       end
 
       def klass
@@ -97,12 +131,29 @@ module GobiertoAdmin
                    end
       end
 
+      def instance_class
+        @instance_class ||= begin
+                              return unless instance_type
+
+                              klass = instance_type.constantize
+                              return unless classes_with_custom_fields_at_instance_level.include? klass
+
+                              klass
+                            rescue NameError
+                              nil
+                            end
+      end
+
       def custom_fields_relation
         site ? site.custom_fields : ::GobiertoCommon::CustomField.none
       end
 
       def site
         @site ||= Site.find_by(id: site_id)
+      end
+
+      def classes_with_custom_fields_at_instance_level
+        @classes_with_custom_fields_at_instance_level ||= class_name.deconstantize.constantize.try(:classes_with_custom_fields_at_instance_level) || []
       end
     end
   end

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -18,7 +18,7 @@ module GobiertoAdmin
       validates :site, presence: true
 
       def available_custom_fields
-        site.custom_fields.sorted.where(class_name: item.class.name)
+        site.custom_fields.sorted.where(class_name: item.class.name, instance_type: instance_type_options, instance_id: instance_id_options)
       end
 
       def custom_field_records
@@ -78,6 +78,18 @@ module GobiertoAdmin
       end
 
       private
+
+      def instance_type_options
+        return [nil] unless instance
+
+        [nil, instance.class.name]
+      end
+
+      def instance_id_options
+        return [nil] unless instance
+
+        [nil, instance.id]
+      end
 
       def site
         @site ||= Site.find_by(id: site_id || item.try(:site_id))

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -5,6 +5,7 @@ module GobiertoCommon
     include GobiertoCommon::Sortable
 
     belongs_to :site
+    belongs_to :instance, polymorphic: true
     has_many :records, dependent: :destroy, class_name: "CustomFieldRecord"
     validates :name, presence: true
 

--- a/app/models/gobierto_plans.rb
+++ b/app/models/gobierto_plans.rb
@@ -13,6 +13,10 @@ module GobiertoPlans
     [GobiertoPlans::Node]
   end
 
+  def self.classes_with_custom_fields_at_instance_level
+    [GobiertoPlans::Plan]
+  end
+
   def self.classes_with_vocabularies
     [GobiertoPlans::Node]
   end

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
@@ -4,6 +4,9 @@
              as: :custom_field,
              url: @custom_field_form.persisted? ? admin_common_custom_fields_custom_field_path(@custom_field_form) : admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: @custom_field_form.resource_name),
              data: { 'globalized-form-container' => true }) do |f| %>
+  <%= f.hidden_field :instance_class_name %>
+  <%= f.hidden_field :instance_id %>
+
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
 

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/edit.html.erb
@@ -1,9 +1,20 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
-  <%= link_to @custom_field_form.human_class_name, admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: @custom_field_form.resource_param) %> »
+  <% if @decorated_instance.present? %>
+    <%= @decorated_instance.resource_model_name(count: 2) %> »
+    <%= @decorated_instance.name %> »
+  <% end %>
+  <%= link_to(
+        @custom_field_form.human_class_name,
+        admin_common_custom_fields_module_resource_custom_fields_path(
+          module_resource_name: @custom_field_form.resource_param,
+          instance_type: @custom_field_form.instance_class_name,
+          instance_id: @custom_field_form.instance_id
+        )
+      ) %> »
   <%= t(".title", name: @custom_field_form.custom_field.name ) %>
 </div>
 
-<h1><%= t(".title", name: @custom_field_form.custom_field.name ) %></h1>
+<h1><%= @decorated_instance.present? ? t(".instance_title", field_name: @custom_field_form.custom_field.name, instance_name: @decorated_instance.name) : t(".title", name: @custom_field_form.custom_field.name ) %></h1>
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/edit.html.erb
@@ -2,8 +2,10 @@
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
   <% if @decorated_instance.present? %>
-    <%= @decorated_instance.resource_model_name(count: 2) %> »
-    <%= @decorated_instance.name %> »
+    <%= link_to(
+          @decorated_instance.name,
+          admin_common_custom_fields_module_resource_instance_level_resource_path(@custom_field_form.instance_class_name, @custom_field_form.instance_id)
+        ) %> »
   <% end %>
   <%= link_to(
         @custom_field_form.human_class_name,

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
@@ -2,8 +2,10 @@
   <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
   <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
   <% if @decorated_instance.present? %>
-    <%= @decorated_instance.resource_model_name(count: 2) %> »
-    <%= @decorated_instance.name %> »
+    <%= link_to(
+          @decorated_instance.name,
+          admin_common_custom_fields_module_resource_instance_level_resource_path(@custom_field_form.instance_class_name, @custom_field_form.instance_id)
+        ) %> »
   <% end %>
   <%= @class_human_name %>
 </div>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
@@ -1,10 +1,14 @@
 <div class="admin_breadcrumb">
   <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
   <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
+  <% if @decorated_instance.present? %>
+    <%= @decorated_instance.resource_model_name(count: 2) %> »
+    <%= @decorated_instance.name %> »
+  <% end %>
   <%= @class_human_name %>
 </div>
 
-<h1><%= t(".title") %></h1>
+<h1><%= @decorated_instance.present? ? t(".instance_title", instance_name: @decorated_instance.name) : t(".title") %></h1>
 
 <h3><%= t(".localized_custom_fields") %></h3>
 <div data-behavior="sortable-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "localized") %>">
@@ -57,7 +61,11 @@
   <% end %>
 </div>
 <div class="m_2">
-  <%= link_to new_admin_common_custom_fields_module_resource_custom_field_path(params[:module_resource_name]) do %>
+  <%= link_to new_admin_common_custom_fields_module_resource_custom_field_path(
+        params[:module_resource_name],
+        instance_type: @custom_field_form.instance_class_name,
+        instance_id: @custom_field_form.instance_id
+      ) do %>
     <i class="fas fa-plus-circle"></i>
     <%= t(".new") %>
   <% end %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/index.html.erb
@@ -12,56 +12,62 @@
 
 <h1><%= @decorated_instance.present? ? t(".instance_title", instance_name: @decorated_instance.name) : t(".title") %></h1>
 
-<h3><%= t(".localized_custom_fields") %></h3>
-<div data-behavior="sortable-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "localized") %>">
-  <% @localized_custom_fields.each do |custom_field| %>
-    <div class="list_item with_mandatory_option" id="item-<%= custom_field.id %>" data-id="<%= custom_field.id %>" c>
-      <i class="sort-handler fas fa-bars tipsit custom_handle"></i>
-      <label class="main"><%= custom_field.name %></label>
+<% if @localized_custom_fields.any? %>
+  <h3><%= t(".localized_custom_fields") %></h3>
+  <div data-behavior="sortable-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "localized") %>">
+    <% @localized_custom_fields.each do |custom_field| %>
+      <div class="list_item with_mandatory_option" id="item-<%= custom_field.id %>" data-id="<%= custom_field.id %>" c>
+        <i class="sort-handler fas fa-bars tipsit custom_handle"></i>
+        <label class="main"><%= custom_field.name %></label>
 
-      <div class="tools">
-        <%= link_to edit_admin_common_custom_fields_custom_field_path(custom_field),
-          title: t("views.edit"),
-          class: "tipsit" do %>
-          <i class="fas fa-edit"></i>
-        <% end %>
+        <div class="tools">
+          <%= link_to edit_admin_common_custom_fields_custom_field_path(custom_field),
+            title: t("views.edit"),
+            class: "tipsit" do %>
+            <i class="fas fa-edit"></i>
+          <% end %>
 
-        <%= link_to admin_common_custom_fields_custom_field_path(custom_field),
-          title: t("views.delete"),
-          method: :delete,
-          class: "tipsit",
-          data: { confirm: t("views.delete_confirm") } do %>
-          <i class="fas fa-trash"></i>
-        <% end %>
+          <%= link_to admin_common_custom_fields_custom_field_path(custom_field),
+            title: t("views.delete"),
+            method: :delete,
+            class: "tipsit",
+            data: { confirm: t("views.delete_confirm") } do %>
+            <i class="fas fa-trash"></i>
+          <% end %>
+        </div>
       </div>
-    </div>
-  <% end %>
-</div>
-<h3><%= t(".not_localized_custom_fields") %></h3>
-<div data-behavior="sortable-not-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "not_localized") %>">
-  <% @not_localized_custom_fields.each do |custom_field| %>
-    <div class="list_item with_mandatory_option" id="item-<%= custom_field.id %>" data-id="<%= custom_field.id %>" c>
-      <i class="sort-handler fas fa-bars tipsit custom_handle"></i>
-      <label class="main"><%= custom_field.name %></label>
+    <% end %>
+  </div>
+<% end %>
 
-      <div class="tools">
-        <%= link_to edit_admin_common_custom_fields_custom_field_path(custom_field),
-          title: t("views.edit"),
-          class: "tipsit" do %>
-          <i class="fas fa-edit"></i>
-        <% end %>
+<% if @not_localized_custom_fields.any? %>
+  <h3><%= t(".not_localized_custom_fields") %></h3>
+  <div data-behavior="sortable-not-localized" data-sortable-target="<%= admin_common_custom_fields_module_resource_sort_path(module_resource_name: params[:module_resource_name], localized: "not_localized") %>">
+    <% @not_localized_custom_fields.each do |custom_field| %>
+      <div class="list_item with_mandatory_option" id="item-<%= custom_field.id %>" data-id="<%= custom_field.id %>" c>
+        <i class="sort-handler fas fa-bars tipsit custom_handle"></i>
+        <label class="main"><%= custom_field.name %></label>
 
-        <%= link_to admin_common_custom_fields_custom_field_path(custom_field),
-          title: t("views.delete"),
-          method: :delete,
-          class: "tipsit",
-          data: { confirm: t("views.delete_confirm") } do %>
-          <i class="fas fa-trash"></i>
-        <% end %>
+        <div class="tools">
+          <%= link_to edit_admin_common_custom_fields_custom_field_path(custom_field),
+            title: t("views.edit"),
+            class: "tipsit" do %>
+            <i class="fas fa-edit"></i>
+          <% end %>
+
+          <%= link_to admin_common_custom_fields_custom_field_path(custom_field),
+            title: t("views.delete"),
+            method: :delete,
+            class: "tipsit",
+            data: { confirm: t("views.delete_confirm") } do %>
+            <i class="fas fa-trash"></i>
+          <% end %>
+        </div>
       </div>
-    </div>
-  <% end %>
-</div>
+    <% end %>
+  </div>
+<% end %>
+
 <div class="m_2">
   <%= link_to new_admin_common_custom_fields_module_resource_custom_field_path(
         params[:module_resource_name],

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/new.html.erb
@@ -2,8 +2,10 @@
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
   <% if @decorated_instance.present? %>
-    <%= @decorated_instance.resource_model_name(count: 2) %> »
-    <%= @decorated_instance.name %> »
+    <%= link_to(
+          @decorated_instance.name,
+          admin_common_custom_fields_module_resource_instance_level_resource_path(@custom_field_form.instance_class_name, @custom_field_form.instance_id)
+        ) %> »
   <% end %>
   <%= link_to(
         @custom_field_form.human_class_name,

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/new.html.erb
@@ -1,9 +1,20 @@
 <div class='admin_breadcrumb'>
   <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
   <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
-  <%= link_to @custom_field_form.human_class_name, admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: @custom_field_form.resource_name) %> »
+  <% if @decorated_instance.present? %>
+    <%= @decorated_instance.resource_model_name(count: 2) %> »
+    <%= @decorated_instance.name %> »
+  <% end %>
+  <%= link_to(
+        @custom_field_form.human_class_name,
+        admin_common_custom_fields_module_resource_custom_fields_path(
+          module_resource_name: @custom_field_form.resource_param,
+          instance_type: @custom_field_form.instance_class_name,
+          instance_id: @custom_field_form.instance_id
+        )
+      ) %> »
   <%= t(".title") %>
 </div>
 
-<h1><%= t(".title") %></h1>
+<h1><%= @decorated_instance.present? ? t(".instance_title", field_name: @custom_field_form.custom_field.name, instance_name: @decorated_instance.name) : t(".title", name: @custom_field_form.custom_field.name ) %></h1>
 <%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_data_grid.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_data_grid.html.erb
@@ -1,0 +1,8 @@
+<div class="<%= record.class_names %>">
+  <div class="form_item_data_grid">
+    <%= label_tag "#{ input_base_name }[#{ record.uid }][value]" do %>
+      <%= record.custom_field.name %>
+      <%= attribute_indication_tag required: record.required? %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/instance_level_resources/show.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/instance_level_resources/show.html.erb
@@ -1,0 +1,25 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.layouts.application.custom_fields"), admin_common_custom_fields_module_resources_path %> »
+  <%= @decorated_instance.name %>
+</div>
+
+<h1><%= t("gobierto_admin.layouts.application.custom_fields") %>: <%= @decorated_instance.name %></h1>
+
+<% if @available_resources.blank? %>
+  <%= t("gobierto_admin.gobierto_common.custom_fields.module_resources.index.empty") %>
+<% else %>
+  <% @available_resources.each do |resource| %>
+    <div class="list_item">
+      <%= link_to(
+            resource.model_name.human,
+            admin_common_custom_fields_module_resource_custom_fields_path(
+              module_resource_name: resource.name.underscore.gsub("/", "-"),
+              instance_type: params[:module_resource_name],
+              instance_id: params[:id]
+            )
+          ) %>
+    </div>
+  <% end %>
+<% end %>
+

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
@@ -18,7 +18,7 @@
       <% end %>
       <% if @available_instances.has_key?(module_name) %>
         <% @available_instances[module_name].each do |klass, instances| %>
-          <h3><%= t(".custom_fields_for_instances_of", name: klass.model_name.human) %></h3>
+          <h4><%= t(".custom_fields_for_instances_of", name: klass.model_name.human) %></h4>
           <% instances.each do |instance| %>
             <div class="list_item">
               <%= link_to instance.name, admin_common_custom_fields_module_resource_instance_level_resource_path(instance.model_param, instance.id) %> &nbsp;(<%= GobiertoCommon::CustomField.where(instance: instance).count %>)

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
@@ -16,6 +16,17 @@
           <%= link_to resource.model_name.human, admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: resource.name.underscore.gsub("/", "-")) %>
         </div>
       <% end %>
+      <% if @available_instances.has_key?(module_name) %>
+        <% @available_instances[module_name].each do |klass, instances| %>
+          <h3><%= t(".custom_fields_for_instances_of", name: klass.model_name.human) %></h3>
+          <% instances.each do |instance| %>
+            <div class="list_item">
+              <%= link_to instance.name, admin_common_custom_fields_module_resource_instance_level_resource_path(instance.model_param, instance.id) %> &nbsp;(<%= GobiertoCommon::CustomField.where(instance: instance).count %>)
+            </div>
+          <% end %>
+
+        <% end %>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_plans/plans/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/edit.html.erb
@@ -9,4 +9,6 @@
 
 <%= render 'gobierto_admin/gobierto_plans/shared/navigation' %>
 
+<%= link_to "Custom Fields", admin_common_custom_fields_module_resource_instance_level_resource_path("gobierto_plans-plan", @plan.id), target: "_blank" %>
+
 <%= render 'form' %>

--- a/app/views/gobierto_admin/gobierto_plans/plans/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/edit.html.erb
@@ -9,6 +9,4 @@
 
 <%= render 'gobierto_admin/gobierto_plans/shared/navigation' %>
 
-<%= link_to "Custom Fields", admin_common_custom_fields_module_resource_instance_level_resource_path("gobierto_plans-plan", @plan.id), target: "_blank" %>
-
 <%= render 'form' %>

--- a/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
@@ -85,6 +85,15 @@
       </div>
     </div>
     <%= render partial: "indicators", locals: { indicators: @project_form.indicators } if @project_form.indicators.present? %>
+
+    <%= render(
+      partial: "gobierto_admin/gobierto_common/custom_fields/forms/custom_fields",
+      locals: {
+        f: f,
+        item: @custom_fields_form,
+        form_name: "project"
+      }
+    ) %>
   </div>
 
   <div class="pure-u-1 pure-u-md-1-24"></div>

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
@@ -5,17 +5,20 @@ ca:
       custom_fields:
         custom_fields:
           edit:
+            instance_title: Edita %{field_name} de %{instance_name}
             title: Edita %{name}
           form:
             add_option: Afegir opció
             confirm: Estàs segur?
             crop: Retallar
           index:
+            instance_title: Camps personalitzats de %{instance_name}
             localized_custom_fields: Camps traduïbles
             new: Afegir nou camp
             not_localized_custom_fields: Camps no traduïbles
             title: Camps personalitzats
           new:
+            instance_title: Nou camp de %{instance_name}
             title: Nou camp
           new_option:
             cancel_new_option: Cancel·lar

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
@@ -26,4 +26,6 @@ ca:
             new: Nova opció
         module_resources:
           index:
+            custom_fields_for_instances_of: Camps personalitzats per a instàncies
+              de %{name}
             empty: De moment no hi ha cap model amb camps personalitzats habilitats

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
@@ -5,17 +5,20 @@ en:
       custom_fields:
         custom_fields:
           edit:
+            instance_title: Edit %{field_name} of %{instance_name}
             title: Edit %{name}
           form:
             add_option: Add option
             confirm: Are you sure?
             crop: Crop
           index:
+            instance_title: Custom fields of %{instance_name}
             localized_custom_fields: Translatable fields
             new: Add new field
             not_localized_custom_fields: Non-translatable fields
             title: Custom fields
           new:
+            instance_title: New field of %{instance_name}
             title: New field
           new_option:
             cancel_new_option: Cancel

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
@@ -26,4 +26,5 @@ en:
             new: New option
         module_resources:
           index:
+            custom_fields_for_instances_of: Custom fields for instances of %{name}
             empty: Currently there is no model with custom fields enabled

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
@@ -26,4 +26,6 @@ es:
             new: Nueva opción
         module_resources:
           index:
+            custom_fields_for_instances_of: Campos personalizados para instancias
+              de %{name}
             empty: De momento no hay ningún modelo con campos personalizados habilitados

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
@@ -5,17 +5,20 @@ es:
       custom_fields:
         custom_fields:
           edit:
+            instance_title: Editar %{field_name} de %{instance_name}
             title: Editar %{name}
           form:
             add_option: Añadir opción
             confirm: "¿Estás seguro?"
             crop: Recortar
           index:
+            instance_title: Campos personalizados de %{instance_name}
             localized_custom_fields: Campos traducibles
             new: Añadir nuevo campo
             not_localized_custom_fields: Campos no traducibles
             title: Campos personalizados
           new:
+            instance_title: Nuevo campo de %{instance_name}
             title: Nuevo campo
           new_option:
             cancel_new_option: Cancelar

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -11,6 +11,7 @@ ca:
       gobierto_admin/gobierto_common/custom_field_form:
         data_grid: Taula de dades
         field_type: Tipus de camp
+        image: Imatge
         localized_paragraph: Text llarg
         localized_string: Text (línia)
         multiple_options: Selecció múltiple

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -11,6 +11,7 @@ en:
       gobierto_admin/gobierto_common/custom_field_form:
         data_grid: Data grid
         field_type: Type of field
+        image: Image
         localized_paragraph: Long text
         localized_string: Text (line)
         multiple_options: Multiple selections

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -11,6 +11,7 @@ es:
       gobierto_admin/gobierto_common/custom_field_form:
         data_grid: Tabla de datos
         field_type: Tipo de campo
+        image: Imagen
         localized_paragraph: Texto largo
         localized_string: Texto (línea)
         multiple_options: Selección múltiple

--- a/config/locales/gobierto_plans/models/ca.yml
+++ b/config/locales/gobierto_plans/models/ca.yml
@@ -1,0 +1,10 @@
+---
+ca:
+  activerecord:
+    models:
+      gobierto_plans/node:
+        one: Projecte
+        other: Projectes
+      gobierto_plans/plan:
+        one: Pla
+        other: Plans

--- a/config/locales/gobierto_plans/models/en.yml
+++ b/config/locales/gobierto_plans/models/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  activerecord:
+    models:
+      gobierto_plans/node:
+        one: Project
+        other: Projects
+      gobierto_plans/plan:
+        one: Plan
+        other: Plans

--- a/config/locales/gobierto_plans/models/es.yml
+++ b/config/locales/gobierto_plans/models/es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  activerecord:
+    models:
+      gobierto_plans/node:
+        one: Proyecto
+        other: Proyectos
+      gobierto_plans/plan:
+        one: Plan
+        other: Planes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Rails.application.routes.draw do
         namespace :custom_fields do
           post "create_option", controller: "custom_fields"
           resources :module_resources, only: [:index, :show], param: :name do
+            resources :instance_level_resources, only: [:index, :show]
             resources :custom_fields, shallow: true, except: [:show], path: "" do
               collection do
                 resource :sort, only: [:create], controller: "sort"

--- a/db/migrate/20190528111414_add_reference_to_instance_in_custom_fields.rb
+++ b/db/migrate/20190528111414_add_reference_to_instance_in_custom_fields.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReferenceToInstanceInCustomFields < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :custom_fields, :instance, polymorphic: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_18_184430) do
+ActiveRecord::Schema.define(version: 2019_05_28_111414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -206,6 +206,9 @@ ActiveRecord::Schema.define(version: 2019_05_18_184430) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "instance_type"
+    t.bigint "instance_id"
+    t.index ["instance_type", "instance_id"], name: "index_custom_fields_on_instance_type_and_instance_id"
     t.index ["site_id", "uid", "class_name"], name: "index_custom_fields_on_site_id_and_uid_and_class_name", unique: true
     t.index ["site_id"], name: "index_custom_fields_on_site_id"
   end

--- a/test/fixtures/gobierto_admin/group_permissions.yml
+++ b/test/fixtures/gobierto_admin/group_permissions.yml
@@ -42,6 +42,18 @@ admin_site_options_vocabularies:
   resource_name: vocabularies
   action_name: manage
 
+admin_site_options_custom_fields:
+  admin_group: madrid_group
+  namespace: site_options
+  resource_name: custom_fields
+  action_name: manage
+
+manage_citizen_charters_madrid:
+  admin_group: madrid_group
+  namespace: site_module
+  resource_name: gobierto_citizens_charters
+  action_name: manage
+
 manage_plans_madrid:
   admin_group: madrid_manage_plans_group
   namespace: site_module

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -56,7 +56,7 @@ madrid_node_global:
   class_name: "GobiertoPlans::Node"
   mandatory: false
   position: 0
-  name_translations: <%= { en: "Status", es: "Estado" }.to_json %>
+  name_translations: <%= { en: "Status custom", es: "Estado custom" }.to_json %>
   field_type: <%= GobiertoCommon::CustomField.field_types[:single_option] %>
   uid: status
   options: <%= {
@@ -70,6 +70,6 @@ madrid_node_instance_level:
   instance: strategic_plan (GobiertoPlans::Plan)
   mandatory: false
   position: 0
-  name_translations: <%= { en: "Goals", es: "Objetivos" }.to_json %>
+  name_translations: <%= { en: "Goals custom", es: "Objetivos custom" }.to_json %>
   field_type: <%= GobiertoCommon::CustomField.field_types[:localized_string] %>
   uid: goals

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -50,3 +50,26 @@ madrid_site_custom_field:
   name_translations: <%= { en: "Population", es: "Población" }.to_json %>
   field_type: <%= GobiertoCommon::CustomField.field_types[:string] %>
   uid: population
+
+madrid_node_global:
+  site: madrid
+  class_name: "GobiertoPlans::Node"
+  mandatory: false
+  position: 0
+  name_translations: <%= { en: "Status", es: "Estado" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:single_option] %>
+  uid: status
+  options: <%= {
+    not_started: { en: "Not started", es: "No iniciado" },
+    started: { en: "Started", es: "Iniciado" }
+  }.to_json %>
+
+madrid_node_instance_level:
+  site: madrid
+  class_name: "GobiertoPlans::Node"
+  instance: strategic_plan (GobiertoPlans::Plan)
+  mandatory: false
+  position: 0
+  name_translations: <%= { en: "Goals", es: "Objetivos" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:localized_string] %>
+  uid: goals

--- a/test/fixtures/gobierto_plans/plans.yml
+++ b/test/fixtures/gobierto_plans/plans.yml
@@ -99,3 +99,104 @@ strategic_plan:
                                                         "en": "technical supervisor department"}},
     "show_table_header": false,
     "open_node": false }).inspect %>
+government_plan:
+  title_translations: <%= { 'en' => 'Government Plan',
+                            'es' => 'Plan de Gobierno' }.to_json %>
+  introduction_translations: <%= { 'en' => 'Government Plan introduction',
+                                  'es' => 'Plan de Gobierno introduction' }.to_json %>
+  footer_translations: <%= { 'en' => 'Government Plan footer',
+                             'es' => 'Plan de Gobierno footer' }.to_json %>
+  css: ".gobierto_planification section.level_0 .cat_1 {
+          background-color: rgba(0, 191, 255, 0.95);
+        }
+        .gobierto_planification section.level_0 .cat_1 .progress {
+          background-color: deepskyblue;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 {
+          background: rgba(0, 191, 255, 0.1);
+          color: deepskyblue;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-list .node-title h3,
+        .gobierto_planification section:not(.level_0).cat_1 .node-list .node-title h3 a {
+          color: deepskyblue;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-list .node-title .fas {
+          background: rgba(0, 191, 255, 0.1);
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-list.cat--negative .node-title h3,
+        .gobierto_planification section:not(.level_0).cat_1 .node-list.cat--negative .node-title h3 a {
+          color: white;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-list.cat--negative .node-title .fas {
+          background: white;
+          color: deepskyblue;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-breadcrumb {
+          border: 1px solid rgba(0, 191, 255, 0.75);
+          color: deepskyblue;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-breadcrumb a {
+          color: deepskyblue;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-breadcrumb .fas {
+          background: rgba(0, 191, 255, 0.1);
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-action-line table tbody tr:hover td {
+          background-color: rgba(0, 191, 255, 0.2);
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-project-detail .project-optional .row {
+          border-top: 1px solid rgba(0, 191, 255, 0.2);
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .node-project-detail .project-mandatory {
+          background-color: rgba(0, 191, 255, 0.2);
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .cat--negative {
+          background: deepskyblue;
+          color: white;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .cat--negative h3,
+        .gobierto_planification section:not(.level_0).cat_1 .cat--negative h3 a {
+          color: white;
+        }
+        .gobierto_planification section:not(.level_0).cat_1 .cat--negative .fas {
+          background: white;
+          color: deepskyblue;
+        }"
+  year: "2019"
+  slug: government-plan
+  site: madrid
+  categories_vocabulary: new_plan_categories_vocabulary
+  statuses_vocabulary: plan_projects_statuses_vocabulary
+  created_at: 2016-11-01 00:02:00
+  updated_at: 2016-11-01 00:02:00
+  plan_type: pam
+  visibility_level: <%= ::GobiertoPlans::Plan.visibility_levels['published'] %>
+  configuration_data: <%= JSON.pretty_generate({
+    "level0": {"one": {"ca": "eix", "es": "eje", "en": "axis"},
+               "other": {"ca": "eixos", "es": "ejes", "en": "axes"}},
+    "level1": {"one": {"ca": "línia d'actuació", "es": "línea de actuación", "en": "line of action"},
+               "other": {"ca": "línies d'actuació", "es": "líneas de actuación", "en": "lines of action"}},
+    "level2": {"one": {"ca": "actuació", "es": "actuación", "en": "action"},
+               "other": {"ca": "actuacions", "es": "actuaciones", "en": "actions"}},
+    "level3": {"one": {"ca": "projecte/acció", "es": "proyecto/acción", "en": "project/action"},
+               "other": {"ca": "projectes/accions", "es": "proyectos/acciones", "en": "projects/actions"}},
+    "level0_options": [{ "slug" => "people-and-families",
+                         "logo" => "http://gobierto.es/assets/v2/logo-gobierto.svg" },
+                        { "slug" => "city",
+                          "logo" => "http://gobierto.es/assets/v2/logo-gobierto.svg" },
+                        { "slug" => "economy",
+                          "logo" => "http://gobierto.es/assets/v2/logo-gobierto.svg" }],
+    "option_keys": { "GOALS": {"ca": "Metes",
+                              "es": "Objetivos",
+                              "en": "Goals"},
+                    "DESCRIPTION": {"ca": "Descripció",
+                                    "es": "Descripción",
+                                    "en": "Description"},
+                    "TECHNICAL_SUPERVISOR_AREA": {"ca": "àrea de supervisió tècnica",
+                                                  "es": "área de supervisor técnico",
+                                                  "en": "technical supervisor area"},
+                    "TECHNICAL_SUPERVISOR_DEPARTMENT": {"ca": "departament de supervisió tècnica",
+                                                        "es": "departamento de supervisor técnico",
+                                                        "en": "technical supervisor department"}},
+    "show_table_header": false,
+    "open_node": false }).inspect %>

--- a/test/forms/gobierto_admin/admin_group_form_test.rb
+++ b/test/forms/gobierto_admin/admin_group_form_test.rb
@@ -91,19 +91,20 @@ module GobiertoAdmin
     def test_grant_module_permissions
       form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage],
                                                                       gobierto_budget_consultations: [:manage],
-                                                                      gobierto_participation: [:manage] }))
+                                                                      gobierto_participation: [:manage],
+                                                                      gobierto_plans: [:manage] }))
 
-      assert_equal 2, tony.modules_permissions.size
+      assert_equal 3, tony.modules_permissions.size
 
       assert form.save
 
-      assert_equal 3, tony.modules_permissions.size
+      assert_equal 4, tony.modules_permissions.size
     end
 
     def test_revoke_module_permissions
       form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage] }))
 
-      assert_equal 2, tony.modules_permissions.size
+      assert_equal 3, tony.modules_permissions.size
 
       assert form.save
 
@@ -218,19 +219,19 @@ module GobiertoAdmin
     end
 
     def test_grant_site_options_permissions
-      form = subject.new(madrid_group_params.merge(site_options: %w(customize vocabularies templates)))
+      form = subject.new(madrid_group_params.merge(site_options: %w(customize vocabularies templates custom_fields)))
 
-      assert_equal 2, tony.site_options_permissions.size
+      assert_equal 3, tony.site_options_permissions.size
 
       assert form.save
 
-      assert_equal 3, tony.site_options_permissions.size
+      assert_equal 4, tony.site_options_permissions.size
     end
 
     def test_revoke_site_options_permissions
       form = subject.new(madrid_group_params.merge(site_options: %w(templates)))
 
-      assert_equal 2, tony.site_options_permissions.size
+      assert_equal 3, tony.site_options_permissions.size
 
       assert form.save
 

--- a/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
+++ b/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
@@ -142,7 +142,7 @@ module GobiertoAdmin
               refute find("#admin_group_people_#{richard.id}", visible: false).checked?
             end
 
-            assert_equal 7, madrid_group.permissions.count
+            assert_equal 9, madrid_group.permissions.count
             assert GobiertoAdmin::Permission::GobiertoPlans.where(admin_group: madrid_group, action_name: "moderate").exists?
             assert madrid_group.permissions.for_people.where(action_name: "manage_all").exists?
           end

--- a/test/integration/gobierto_admin/gobierto_common/custom_field_records/custom_field_records_form_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_field_records/custom_field_records_form_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module CustomFieldRecords
+      class CustomFieldRecordsFormTest < ActionDispatch::IntegrationTest
+        def path
+          @path ||= edit_admin_citizens_charters_charter_path(charter)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def charter
+          @charter ||= gobierto_citizens_charters_charters(:teleassistance_charter)
+        end
+
+        def instance_with_custom_fields
+          @instance_with_custom_fields ||= gobierto_plans_plans(:strategic_plan)
+        end
+
+        def resource_with_instance_level_custom_fields_path
+          @resource_with_instance_level_custom_fields_path ||= new_admin_plans_plan_project_path(plan_id: instance_with_custom_fields.id)
+        end
+
+        def instance_without_custom_fields
+          @instance_without_custom_fields ||= gobierto_plans_plans(:government_plan)
+        end
+
+        def resource_without_instance_level_custom_fields_path
+          @resource_without_instance_level_custom_fields_path ||= new_admin_plans_plan_project_path(plan_id: instance_without_custom_fields.id)
+        end
+
+        def charters_custom_fields
+          @charters_custom_fields ||= site.custom_fields.where(class_name: "GobiertoCitizensCharters::Charter")
+        end
+
+        def global_custom_field
+          @global_custom_field ||= gobierto_common_custom_fields(:madrid_node_global)
+        end
+
+        def instance_level_custom_field
+          @instance_level_custom_field ||= gobierto_common_custom_fields(:madrid_node_instance_level)
+        end
+
+        def test_custom_fields_record
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit path
+              charters_custom_fields.each do |custom_field|
+                assert has_content? custom_field.name
+              end
+            end
+          end
+        end
+
+        def test_instance_level_custom_fields
+          with(site: site, js: false, admin: admin) do
+            visit resource_with_instance_level_custom_fields_path
+
+            assert has_content? global_custom_field.name
+            assert has_content? instance_level_custom_field.name
+          end
+        end
+
+        def test_custom_fields_without_custom_fields
+          with(site: site, js: false, admin: admin) do
+            visit resource_without_instance_level_custom_fields_path
+
+            assert has_content? global_custom_field.name
+            assert has_no_content? instance_level_custom_field.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/create_custom_field_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/create_custom_field_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module CustomFields
+      class CreateCustomFieldTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: resource_param)
+          @instance_level_path = admin_common_custom_fields_module_resource_custom_fields_path(
+            module_resource_name: resource_param_with_instance_levels,
+            instance_type: resource_instance_type_param,
+            instance_id: resource_instance_id
+          )
+        end
+
+        def resource_class
+          @resource_class ||= ::GobiertoCitizensCharters::Service
+        end
+
+        def resource_param
+          @resource_param ||= resource_class.name.underscore.tr("/", "-")
+        end
+
+        def resource_class_with_instance_levels
+          @resource_class_with_instance_levels ||= ::GobiertoPlans::Node
+        end
+
+        def resource_param_with_instance_levels
+          @resource_param_with_instance_levels ||= resource_class_with_instance_levels.name.underscore.tr("/", "-")
+        end
+
+        def resource_instance
+          gobierto_plans_plans(:strategic_plan)
+        end
+
+        def resource_instance_type_param
+          @resource_instance_type_param ||= resource_instance.class.name.underscore.tr("/", "-")
+        end
+
+        def resource_instance_id
+          @resource_instance_id ||= resource_instance.id
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def unauthorized_admin
+          @unauthorized_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def test_permissions
+          with(site: site, js: false, admin: unauthorized_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+
+        def test_create_custom_field_errors
+          with(site: site, js: false, admin: admin) do
+            visit @path
+
+            click_link "Add new field"
+            click_button "Create"
+
+            assert has_alert?("can't be blank")
+          end
+        end
+
+        def test_create_custom_field
+          with(site: site, js: true, admin: admin) do
+            visit @path
+
+            click_link "Add new field"
+
+            fill_in "custom_field_name_translations_en", with: "Introduction (test creation)"
+            fill_in "custom_field_uid", with: "introduction"
+
+            click_link "ES"
+            fill_in "custom_field_name_translations_es", with: "Introducción (test de creación)"
+
+            within ".site-module-check-boxes" do
+              find("label", exact_text: "Long text").click
+            end
+
+            click_button "Create"
+
+            assert has_message?("Custom field created correctly")
+
+            assert ::GobiertoCommon::CustomField.where(class_name: resource_class.name).with_name_translation("Introduction (test creation)", :en).exists?
+
+            custom_field = ::GobiertoCommon::CustomField.last
+            assert_nil custom_field.instance
+          end
+        end
+
+        def test_create_custom_field_at_instance_level
+          admin.admin_groups << gobierto_admin_admin_groups(:madrid_manage_plans_group)
+
+          with(site: site, js: true, admin: admin) do
+            visit @instance_level_path
+
+            click_link "Add new field"
+
+            fill_in "custom_field_name_translations_en", with: "Instance introduction (test creation)"
+            fill_in "custom_field_uid", with: "introduction"
+
+            click_link "ES"
+            fill_in "custom_field_name_translations_es", with: "Introducción para instancia (test de creación)"
+
+            within ".site-module-check-boxes" do
+              find("label", exact_text: "Long text").click
+            end
+
+            click_button "Create"
+
+            assert has_message?("Custom field created correctly")
+
+            assert ::GobiertoCommon::CustomField.where(
+              class_name: resource_class_with_instance_levels.name
+            ).with_name_translation(
+              "Instance introduction (test creation)", :en
+            ).exists?
+
+            custom_field = ::GobiertoCommon::CustomField.last
+            assert_not_nil custom_field.instance
+            assert_equal resource_instance, custom_field.instance
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/custom_fields_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/custom_fields_index_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module GobiertoAdmin
+    class CustomFieldsIndexTest < ActionDispatch::IntegrationTest
+      attr_reader(
+        :path,
+        :instance_level_path,
+        :global_custom_field,
+        :instance_level_custom_field,
+        :instance,
+        :resource_class,
+        :admin,
+        :unauthorized_admin,
+        :site
+      )
+
+      def setup
+        super
+        @site = sites(:madrid)
+        @admin = gobierto_admin_admins(:tony)
+        @unauthorized_admin = gobierto_admin_admins(:steve)
+        @global_custom_field = gobierto_common_custom_fields(:madrid_node_global)
+        @instance_level_custom_field = gobierto_common_custom_fields(:madrid_node_instance_level)
+        @instance = gobierto_plans_plans(:strategic_plan)
+        @resource_class = GobiertoPlans::Node
+        @path = admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: parameterize(resource_class.name))
+        @instance_level_path = admin_common_custom_fields_module_resource_custom_fields_path(
+          module_resource_name: parameterize(resource_class.name),
+          instance_type: parameterize(instance.class.name),
+          instance_id: instance.id
+        )
+        admin.admin_groups << gobierto_admin_admin_groups(:madrid_manage_plans_group)
+      end
+
+      def parameterize(class_name)
+        class_name.underscore.tr("/", "-")
+      end
+
+      def test_permissions
+        with(site: site, js: false, admin: unauthorized_admin) do
+          visit path
+          assert has_content?("You are not authorized to perform this action")
+          assert_equal admin_root_path, current_path
+        end
+      end
+
+      def test_global_custom_fields_index
+        with(site: site, js: false, admin: admin) do
+          visit path
+
+          assert has_content? "Custom fields"
+          assert has_selector? "div#item-#{global_custom_field.id}"
+          assert has_no_selector? "div#item-#{instance_level_custom_field.id}"
+
+          within "div#item-#{global_custom_field.id}" do
+            assert has_content?(global_custom_field.name.to_s)
+          end
+        end
+      end
+
+      def test_instance_level_custom_fields_index
+        with(site: site, js: false, admin: admin) do
+          visit instance_level_path
+
+          assert has_content? "Custom fields of #{instance.title}"
+          assert has_selector? "div#item-#{instance_level_custom_field.id}"
+          assert has_no_selector? "div#item-#{global_custom_field.id}"
+
+          within "div#item-#{instance_level_custom_field.id}" do
+            assert has_content?(instance_level_custom_field.name.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/delete_custom_field_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/delete_custom_field_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module GobiertoAdmin
+    class DeleteCustomFieldTest < ActionDispatch::IntegrationTest
+      attr_reader(
+        :path,
+        :instance_level_path,
+        :global_custom_field,
+        :instance_level_custom_field,
+        :instance,
+        :resource_class,
+        :admin,
+        :unauthorized_admin,
+        :site
+      )
+
+      def setup
+        super
+        @site = sites(:madrid)
+        @admin = gobierto_admin_admins(:tony)
+        @unauthorized_admin = gobierto_admin_admins(:steve)
+        @global_custom_field = gobierto_common_custom_fields(:madrid_node_global)
+        @instance_level_custom_field = gobierto_common_custom_fields(:madrid_node_instance_level)
+        @instance = gobierto_plans_plans(:strategic_plan)
+        @resource_class = GobiertoPlans::Node
+        @path = admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: parameterize(resource_class.name))
+        @instance_level_path = admin_common_custom_fields_module_resource_custom_fields_path(
+          module_resource_name: parameterize(resource_class.name),
+          instance_type: parameterize(instance.class.name),
+          instance_id: instance.id
+        )
+        admin.admin_groups << gobierto_admin_admin_groups(:madrid_manage_plans_group)
+      end
+
+      def parameterize(class_name)
+        class_name.underscore.tr("/", "-")
+      end
+
+      def test_delete_global_custom_field
+        with(site: site, js: false, admin: admin) do
+          visit path
+
+          within "div#item-#{global_custom_field.id}" do
+            click_link "Delete"
+          end
+          assert has_content? "Custom field successfully deleted"
+          assert has_content? "Custom fields"
+          refute has_content? global_custom_field.name
+        end
+      end
+
+      def test_delete_instance_level_custom_field
+        with(site: site, js: false, admin: admin) do
+          visit instance_level_path
+
+          within "div#item-#{instance_level_custom_field.id}" do
+            click_link "Delete"
+          end
+          assert has_content? "Custom field successfully deleted"
+          assert has_content? "Custom fields of #{instance.title}"
+          refute has_content? instance_level_custom_field.name
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/update_custom_field_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/update_custom_field_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module GobiertoAdmin
+    class UpdateCustomFieldTest < ActionDispatch::IntegrationTest
+      attr_reader(
+        :path,
+        :instance_level_path,
+        :global_custom_field,
+        :instance_level_custom_field,
+        :instance,
+        :admin,
+        :unauthorized_admin,
+        :site
+      )
+
+      def setup
+        super
+        @site = sites(:madrid)
+        @admin = gobierto_admin_admins(:tony)
+        @unauthorized_admin = gobierto_admin_admins(:steve)
+        @global_custom_field = gobierto_common_custom_fields(:madrid_node_global)
+        @instance_level_custom_field = gobierto_common_custom_fields(:madrid_node_instance_level)
+        @instance = gobierto_plans_plans(:strategic_plan)
+        @path = edit_admin_common_custom_fields_custom_field_path(global_custom_field)
+        @instance_level_path = edit_admin_common_custom_fields_custom_field_path(instance_level_custom_field)
+        admin.admin_groups << gobierto_admin_admin_groups(:madrid_manage_plans_group)
+      end
+
+      def test_permissions
+        with(site: site, js: false, admin: unauthorized_admin) do
+          visit @path
+          assert has_content?("You are not authorized to perform this action")
+          assert_equal admin_root_path, current_path
+        end
+      end
+
+      def test_update_global_custom_field
+        with(site: site, js: true, admin: admin) do
+          visit @path
+
+          fill_in "custom_field_name_translations_en", with: "Updated"
+          fill_in "custom_field_uid", with: "updated"
+
+          click_link "ES"
+          fill_in "custom_field_name_translations_es", with: "Actualizado"
+
+          click_button "Update"
+
+          assert has_message?("Custom field updated correctly")
+
+          global_custom_field.reload
+
+          assert_nil global_custom_field.instance
+          assert_equal "Updated", global_custom_field.name
+        end
+      end
+
+      def test_update_instance_level_custom_field
+        with(site: site, js: true, admin: admin) do
+          visit @instance_level_path
+
+          assert has_content? instance.title
+
+          fill_in "custom_field_name_translations_en", with: "Updated"
+          fill_in "custom_field_uid", with: "updated"
+
+          click_link "ES"
+          fill_in "custom_field_name_translations_es", with: "Actualizado"
+
+          click_button "Update"
+
+          assert has_message?("Custom field updated correctly")
+          assert has_content?("Custom fields of #{instance.title}")
+
+          instance_level_custom_field.reload
+
+          assert_not_nil instance_level_custom_field.instance
+          assert_equal instance, instance_level_custom_field.instance
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
@@ -83,10 +83,12 @@ module GobiertoAdmin
 
                 select "Scholarships for families in the Central District", from: "project_category_id"
 
-                fill_in "project_name_translations_en", with: "New project"
+                within "div.globalized_fields", match: :first do
+                  fill_in "project_name_translations_en", with: "New project"
 
-                switch_locale "ES"
-                fill_in "project_name_translations_es", with: "Nuevo proyecto"
+                  switch_locale "ES"
+                  fill_in "project_name_translations_es", with: "Nuevo proyecto"
+                end
 
                 fill_in "project_starts_at", with: "2020-01-01"
                 fill_in "project_ends_at", with: "2021-01-01"


### PR DESCRIPTION
Closes #2320


## :v: What does this PR do?

* Adds a polymorphic association of custom fields with instance to allow creation of custom fields at instance level.
* Creates a configuration in modules to define which models allows custom fields at instance level.
* Changes controllers, forms and views to manage global custom fields and instance level custom fields.
* Configures `GobiertoPlans::Plan` to allow custom fields at instance level and includes custom field controls in admin projects edition and creation forms.
* Adds some integration tests.
* Adds a dummy control for data grid custom field type, pending of a future plugin definition.

## :mag: How should this be manually tested?

From admin go to an existing plan configuration and click on "Custom fields" link. Define some custom fields and edit or create a project of the plan

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![2320-after](https://user-images.githubusercontent.com/446459/58635609-967b4880-82ee-11e9-88ee-21add123352f.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
