### PR TITLE
Add fragment cache to plan JSON

### DIFF
--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -36,7 +36,9 @@ module GobiertoPlans
         end
 
         format.json do
-          plan_tree = GobiertoPlans::PlanTree.new(@plan).call
+          plan_tree = Rails.cache.fetch(@plan.cache_key + "/plan_tree") do
+            GobiertoPlans::PlanTree.new(@plan).call
+          end
 
           render(
             json: { plan_tree: plan_tree,

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -202,6 +202,9 @@ module GobiertoAdmin
             node.categories << category
           end
 
+          # Update plan cache
+          plan.touch
+
           save_moderation
 
           @node

--- a/app/javascript/gobierto_plans/modules/plan_types_controller.js
+++ b/app/javascript/gobierto_plans/modules/plan_types_controller.js
@@ -1,13 +1,21 @@
 import Vue from 'vue'
 Vue.config.productionTip = false
+import TurbolinksAdapter from 'vue-turbolinks'
+Vue.use(TurbolinksAdapter)
 
 window.GobiertoPlans.PlanTypesController = (function() {
 
     function PlanTypesController() {}
 
     PlanTypesController.prototype.show = function() {
-      if ($('body').attr('class').indexOf('gobierto_plans_plan_types_show') > -1) {
+      if ($('body').attr('class').indexOf('gobierto_plans_plan_types_show') !== -1) {
+        $('.planification-header').hide();
+        $('.planification-content').hide();
         _loadPlan();
+        $('.planification-header').show();
+        $('.planification-content').show();
+
+        //$('#gobierto-planification').show();
       }
     };
 

--- a/app/views/gobierto_plans/plan_types/show.html.erb
+++ b/app/views/gobierto_plans/plan_types/show.html.erb
@@ -2,12 +2,10 @@
   <%= link_to title(@plan.title), gobierto_plans_plan_path(slug: @plan.plan_type.slug) %>
 <% end %>
 
-<% content_for(:stylesheet_link) do %>
-  <% if @plan.css.present? %>
-    <style type="text/css">
-      <%== @plan.css %>
-    </style>
-  <% end %>
+<% if @plan.css.present? %>
+  <style type="text/css">
+    <%== @plan.css %>
+  </style>
 <% end %>
 
 <div class="column" data-turbolinks="false">

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "velocity-animate": "^1.5.1",
     "velocity-ui-pack": "^1.2.2",
     "vue": "^2.5.16",
+    "vue-turbolinks": "^2.0.4",
     "webpack-jquery-ui": "^2.0.1",
     "webpack-merge": "^4.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7891,7 +7891,14 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue@^2.5.16:
+vue-turbolinks@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/vue-turbolinks/-/vue-turbolinks-2.0.4.tgz#a64102b9641b2fc523570b84964620ea7b51aabb"
+  integrity sha512-UnozEGA+HCrETxnBGM3xrsevOOVEsLf1aHKapIANKAf5GdyA2nMXr3yfwlZ5o81PypSx73tfp9XW1nugMeydRA==
+  dependencies:
+    vue "^2.2.4"
+
+vue@^2.2.4, vue@^2.5.16:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
@@ -8216,4 +8223,3 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
-


### PR DESCRIPTION
Closes #660

## :v: What does this PR do?

This PR adds a fragment cache on the JSON generated with the tree of categories. It speeds-up the load of the plans in the front page.

It uses the attribute `cache_key` available in any object, so the cache can be expired calling `touch`.

## :mag: How should this be manually tested?

1. You can visit any plans page and except if it's the first visit it should load fast
2. You should update any project attribute, move a project from a category to another, create new categories, etc and the cache should get updated
3. You should check the import/export expires the cache too
