### PR TITLE
Order by id editions in API index

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_citizens_charters/api/editions_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_citizens_charters/api/editions_controller.rb
@@ -8,7 +8,7 @@ module GobiertoAdmin
           find_charter
 
           reference_edition = @charter.editions.new params.permit(:period, :period_interval)
-          @editions = @charter.editions.of_same_period(reference_edition)
+          @editions = @charter.editions.of_same_period(reference_edition).order(id: :asc)
           render json: @editions, each_serializer: ::GobiertoAdmin::GobiertoCitizensCharters::EditionSerializer
         end
 

--- a/app/views/gobierto_citizens_charters/charters/index.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/index.html.erb
@@ -16,10 +16,6 @@
             <%= t(".introduction") %>
           </p>
 
-          <p class="common-links">
-            <span><a href=""><%= t(".about") %></a></span><span><a href=""><%= t(".contact") %></a></span>
-          </p>
-
         </div>
       </div>
 

--- a/config/locales/gobierto_citizens_charters/views/ca.yml
+++ b/config/locales/gobierto_citizens_charters/views/ca.yml
@@ -6,12 +6,10 @@ ca:
         back: Tornar
         title: Details of %{title}
       index:
-        about: Què són les cartes de serveis
         commitments:
           one: 1 indicador
           other: "%{count} indicadors"
           zero: No hi ha indicadors
-        contact: Contacte
         description_title: Informació sobre el compliment dels compromisos dels indicadors
           %{of_the_organization_name}
         global_progress: Compliment global

--- a/config/locales/gobierto_citizens_charters/views/en.yml
+++ b/config/locales/gobierto_citizens_charters/views/en.yml
@@ -6,12 +6,10 @@ en:
         back: Return
         title: Detalls de %{title}
       index:
-        about: What are service charters
         commitments:
           one: 1 indicator
           other: "%{count} indicators"
           zero: No indicators found
-        contact: Contact
         description_title: Information about the fulfillment of the commitments of
           the indicators %{of_the_organization_name}
         global_progress: Global compliance

--- a/config/locales/gobierto_citizens_charters/views/es.yml
+++ b/config/locales/gobierto_citizens_charters/views/es.yml
@@ -6,12 +6,10 @@ es:
         back: Volver
         title: Detalles de %{title}
       index:
-        about: Qué son las cartas de servicios
         commitments:
           one: 1 indicador
           other: "%{count} indicadores"
           zero: No hay indicadores
-        contact: Contacto
         description_title: Información sobre el cumplimiento de los compromisos de
           los indicadores %{of_the_organization_name}
         global_progress: Cumplimiento global


### PR DESCRIPTION
Closes #2355


## :v: What does this PR do?

* Orders the editions in API index by id to avoid changes reloading page

## :mag: How should this be manually tested?

Visit editions table, edit rows and reload page

## :eyes: Screenshots

### Before this PR

![2355-before](https://user-images.githubusercontent.com/446459/58961673-ee5ff680-87a9-11e9-93e9-3500aca8a1c6.gif)

### After this PR

![2355-after](https://user-images.githubusercontent.com/446459/58961699-fe77d600-87a9-11e9-9c28-235b24a53240.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
