### PR TITLE
2375 - Avoid losing current edited cell data when submitting slickgrid form

### DIFF
--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
@@ -1,7 +1,7 @@
 import { Grid, Editors, Plugins } from 'slickgrid-es6';
 import { Select2Formatter, Select2Editor } from './data_grid_plugin_select2';
 import CheckboxDeleteRowPlugin from './checkbox_delete_row_plugin';
-import { applyPluginStyles } from './common_slickgrid_behavior';
+import { applyPluginStyles, preventLosingCurrentEdit } from './common_slickgrid_behavior';
 
 window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (function() {
 
@@ -13,9 +13,11 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
     grouped: { economic: {}, functional: {} }
   }
   var _organizationId
+  var _pluginCssClass = 'budgets'
 
   GobiertoCommonCustomFieldRecordsBudgetsPluginController.prototype.form = function(opts = {}) {
     _initializePlugin(opts.uid)
+    preventLosingCurrentEdit()
   };
 
   function _deserializeTableData(inputValue) {
@@ -80,7 +82,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
 
         let data = _deserializeTableData($(`#${id}`).find("input[name$='[value]'").val())
 
-        applyPluginStyles(element, "budgets")
+        applyPluginStyles(element, _pluginCssClass)
         _slickGrid(id, data)
       })
 

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/common_slickgrid_behavior.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/common_slickgrid_behavior.js
@@ -1,4 +1,5 @@
-export { applyPluginStyles }
+export { applyPluginStyles, preventLosingCurrentEdit }
+import { Slick } from 'slickgrid-es6';
 
 function applyPluginStyles(element, plugin_name_hint) {
   element.wrap("<div class='v_container'><div class='v_el v_el_level v_el_full_content'></div></div>");
@@ -6,4 +7,13 @@ function applyPluginStyles(element, plugin_name_hint) {
   element.find("div.data-container")
          .addClass("slickgrid-container")
          .css({ width: "100%", height: "500px" });
+}
+
+function preventLosingCurrentEdit() {
+  $(document).click(function(e) {
+    if ($(e.target).parents(".plugin_field").length == 0) {
+      var lock = Slick.GlobalEditorLock;
+      if (lock.isActive()) lock.commitCurrentEdit()
+    }
+  })
 }

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/human_resources_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/human_resources_plugin.js
@@ -1,7 +1,7 @@
 import { Grid, Editors, Plugins } from 'slickgrid-es6';
 import { Select2Formatter, Select2Editor } from './data_grid_plugin_select2';
 import CheckboxDeleteRowPlugin from './checkbox_delete_row_plugin';
-import { applyPluginStyles } from './common_slickgrid_behavior';
+import { applyPluginStyles, preventLosingCurrentEdit } from './common_slickgrid_behavior';
 import { DateEditor } from './datepicker_editor';
 
 window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsHumanResourcesPluginController = (function() {
@@ -9,9 +9,11 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsHumanResourcesPluginControl
   function GobiertoCommonCustomFieldRecordsHumanResourcesPluginController() {}
 
   var grid;
+  var _pluginCssClass = 'human_resources'
 
   GobiertoCommonCustomFieldRecordsHumanResourcesPluginController.prototype.form = function(opts = {}) {
     _handlePluginData(opts.uid);
+    preventLosingCurrentEdit()
   };
 
   function _deserializeTableData(inputValue) {
@@ -40,7 +42,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsHumanResourcesPluginControl
       let id = element.attr('id')
       let data = _deserializeTableData($(`#${id}`).find("input[name$='[value]'").val());
 
-      applyPluginStyles(element, "human_resources")
+      applyPluginStyles(element, _pluginCssClass)
       _slickGrid(id, data, vocabularyTerms)
     })
   }

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
@@ -1,7 +1,7 @@
 import { Grid, Editors, Plugins } from 'slickgrid-es6';
 import { Select2Formatter, Select2Editor } from './data_grid_plugin_select2';
 import CheckboxDeleteRowPlugin from './checkbox_delete_row_plugin';
-import { applyPluginStyles } from './common_slickgrid_behavior';
+import { applyPluginStyles, preventLosingCurrentEdit } from './common_slickgrid_behavior';
 
 const defaultStartYear = 2018;
 const defaultStartMonth = 12;
@@ -12,9 +12,11 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
   function GobiertoCommonCustomFieldRecordsIndicatorsPluginController() {}
 
   var grid;
+  var _pluginCssClass = 'indicators'
 
   GobiertoCommonCustomFieldRecordsIndicatorsPluginController.prototype.form = function(opts = {}) {
     _handlePluginData(opts.uid);
+    preventLosingCurrentEdit()
   };
 
   function _deserializeTableData(inputValue) {
@@ -44,7 +46,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
       let id = element.attr('id')
       let data = _deserializeTableData($(`#${id}`).find("input[name$='[value]'").val());
 
-      applyPluginStyles(element, "indicators")
+      applyPluginStyles(element, _pluginCssClass)
       _slickGrid(id, data, vocabularyTerms)
     })
   }


### PR DESCRIPTION
Closes #2375 

## :v: What does this PR do?

Previously if you clicked directly the submit button without having lost the cell focus before, that data was not commited and thus lost. This PR fixes that.

## How to review this

Check in http://talavan.gobify.net/admin/plans/15/projects/8687/edit

## :eyes: Screenshots

### After this PR

![cell_focus](https://user-images.githubusercontent.com/9287468/60343682-eb28e680-99b4-11e9-90c9-bc1008a11004.gif)



