### PR TITLE
2387 - Improve horiz/vert content disposition for SlickGrid

### DIFF
--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
@@ -1,7 +1,7 @@
 import { Grid, Editors, Plugins } from 'slickgrid-es6';
 import { Select2Formatter, Select2Editor } from './data_grid_plugin_select2';
 import CheckboxDeleteRowPlugin from './checkbox_delete_row_plugin';
-import { applyPluginStyles } from './common_slickgrid_behavior';
+import { applyPluginStyles, defaultSlickGridOptions } from './common_slickgrid_behavior';
 
 window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (function() {
 
@@ -190,18 +190,9 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
       }
     ];
 
-    // generice grid options
-    let options = {
-      editable: true,
-      enableAddRow: true,
-      enableCellNavigation: true,
-      asyncEditorLoading: false,
-      enableColumnReorder: false,
-      autoEdit: true,
-      itemsCountId: `${id}_items`
-    };
+    let customSlickGridOptions = { itemsCountId: `${id}_items` }
 
-    _initializeGrid(id, data, columns, options);
+    _initializeGrid(id, data, columns, { ...defaultSlickGridOptions, ...customSlickGridOptions });
     for (let i = 0; i < data.length; i++) _refreshRowAmount(i)
   }
 

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/common_slickgrid_behavior.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/common_slickgrid_behavior.js
@@ -20,5 +20,6 @@ var defaultSlickGridOptions = {
   asyncEditorLoading: false,
   enableColumnReorder: false,
   autoEdit: true,
+  forceFitColumns: true,
   autoHeight: true
 }

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/common_slickgrid_behavior.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/common_slickgrid_behavior.js
@@ -1,9 +1,24 @@
-export { applyPluginStyles }
+export { applyPluginStyles, defaultSlickGridOptions }
 
 function applyPluginStyles(element, plugin_name_hint) {
-  element.wrap("<div class='v_container'><div class='v_el v_el_level v_el_full_content'></div></div>");
+  element.wrap(`
+    <div class='v_container'>
+      <div class='v_el v_el_level v_el_full_content' style='padding: 20px'>
+      </div>
+    </div>`);
+
   element.find("div.custom_field_value").addClass(`${plugin_name_hint}_table`)
   element.find("div.data-container")
          .addClass("slickgrid-container")
-         .css({ width: "100%", height: "500px" });
+         .css({ width: "100%", "min-height": "150" });
+}
+
+var defaultSlickGridOptions = {
+  editable: true,
+  enableAddRow: true,
+  enableCellNavigation: true,
+  asyncEditorLoading: false,
+  enableColumnReorder: false,
+  autoEdit: true,
+  autoHeight: true
 }

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/human_resources_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/human_resources_plugin.js
@@ -1,7 +1,7 @@
 import { Grid, Editors, Plugins } from 'slickgrid-es6';
 import { Select2Formatter, Select2Editor } from './data_grid_plugin_select2';
 import CheckboxDeleteRowPlugin from './checkbox_delete_row_plugin';
-import { applyPluginStyles } from './common_slickgrid_behavior';
+import { applyPluginStyles, defaultSlickGridOptions } from './common_slickgrid_behavior';
 import { DateEditor } from './datepicker_editor';
 
 window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsHumanResourcesPluginController = (function() {
@@ -113,18 +113,9 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsHumanResourcesPluginControl
       }
     ];
 
-    // generice grid options
-    let options = {
-      editable: true,
-      enableAddRow: true,
-      enableCellNavigation: true,
-      asyncEditorLoading: false,
-      enableColumnReorder: false,
-      autoEdit: true,
-      itemsCountId: `${id}_items`
-    };
+    let customSlickGridOptions = { itemsCountId: `${id}_items` }
 
-    _initializeGrid(id, data, columns, options);
+    _initializeGrid(id, data, columns, { ...defaultSlickGridOptions, ...customSlickGridOptions });
   }
   return GobiertoCommonCustomFieldRecordsHumanResourcesPluginController;
 })();

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
@@ -56,7 +56,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
 
     function _dateColumn(startYear, startMonth, offset) {
       let headerName = _headerDateName(startYear, startMonth, offset);
-      return {id: headerName, name: headerName, field: headerName, width: 100, editor: Editors.Text};
+      return { id: headerName, name: headerName, field: headerName, minWidth: 100, editor: Editors.Text };
     }
 
     function _initializeGrid(id, data, columns, options) {
@@ -79,7 +79,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
           let columns = args.grid.getColumns();
           let lastColumn = columns.pop();
           let lastYear = lastColumn.headerDateNameFunction(lastColumn.startYear, lastColumn.startMonth, lastColumn.offset)
-          let columnDefinition = {id: lastYear, name: lastYear, field: lastYear, width: 100, editor: Editors.Text};
+          let columnDefinition = {id: lastYear, name: lastYear, field: lastYear, minWidth: 100, editor: Editors.Text};
           lastColumn.offset++;
           columns.push(columnDefinition);
           columns.push(lastColumn);
@@ -143,7 +143,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
       id: "indicator",
       name: I18n.t("gobierto_admin.custom_fields_plugins.indicators.indicator"),
       field: "indicator",
-      width: 120,
+      minWidth: 120,
       cssClass: "cell-title",
       formatter: Select2Formatter,
       editor: Select2Editor,
@@ -167,7 +167,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
       id: new_column_id,
       name: I18n.t("gobierto_admin.custom_fields_plugins.data_grid.add"),
       field: new_column_id,
-      witdh: 50,
+      minWidth: 100,
       headerCssClass: `add-${new_column_id}`,
       sortable: false,
       headerDateNameFunction: _headerDateName,

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
@@ -1,7 +1,7 @@
 import { Grid, Editors, Plugins } from 'slickgrid-es6';
 import { Select2Formatter, Select2Editor } from './data_grid_plugin_select2';
 import CheckboxDeleteRowPlugin from './checkbox_delete_row_plugin';
-import { applyPluginStyles } from './common_slickgrid_behavior';
+import { applyPluginStyles, defaultSlickGridOptions } from './common_slickgrid_behavior';
 
 const defaultStartYear = 2018;
 const defaultStartMonth = 12;
@@ -150,17 +150,6 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
       dataSource: indicatorsDictionary
     }];
 
-    // generice grid options
-    let options = {
-      editable: true,
-      enableAddRow: true,
-      enableCellNavigation: true,
-      asyncEditorLoading: false,
-      enableColumnReorder: false,
-      autoEdit: true,
-      itemsCountId: `${id}_items`
-    };
-
     var indicatorsNames = $.map(vocabularyTerms, function(item) { return item.name_translations[I18n.locale]});
 
     if (data.length === 0) {
@@ -187,7 +176,9 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
       offset: dateColumnsCount
     });
 
-    _initializeGrid(id, data, columns, options);
+    let customSlickGridOptions = { itemsCountId: `${id}_items` }
+
+    _initializeGrid(id, data, columns, { ...defaultSlickGridOptions, ...customSlickGridOptions });
   }
   return GobiertoCommonCustomFieldRecordsIndicatorsPluginController;
 })();


### PR DESCRIPTION
Closes #2387 

## :v: What does this PR do?

Improves horizontal and vertical content disposition for Slickgrid tables.

## :mag: How should this be manually tested?

...

## :eyes: Screenshots

### Before this PR

![image](https://user-images.githubusercontent.com/9287468/60347678-35fb2c00-99be-11e9-81f0-636a7021ea4e.png)

### After this PR

When the table is empty:

![image](https://user-images.githubusercontent.com/9287468/60347699-41e6ee00-99be-11e9-875c-b9868d5fb1e3.png)

If you add new rows, the height is readjusted:

![add_rows](https://user-images.githubusercontent.com/9287468/60347919-c0439000-99be-11e9-8d27-a75baf74818d.gif)

For the indicators table, which has variable width, once the columns don't fit in the page anymore a horizontal scrollbar appears:

![horizontal_scrolling](https://user-images.githubusercontent.com/9287468/60348035-0c8ed000-99bf-11e9-9615-0e00ecc7c3d2.gif)
