### PR TITLE
2392 version issues

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -34,6 +34,7 @@ module GobiertoAdmin
         @project = @plan.nodes.find params[:id]
         @project_form = NodeForm.new(project_params.merge(id: params[:id], plan_id: params[:plan_id], admin: current_admin))
         @unpublish_url = unpublish_admin_plans_plan_project_path(@plan, @project)
+        @version_index = @project_form.version_index
         initialize_custom_field_form
 
         if @project_form.save && custom_fields_save

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -114,7 +114,7 @@ module GobiertoAdmin
         custom_field_records.each do |record|
           record.item_has_versions = with_version
 
-          save_success = with_version && force_new_version && !changed? ? record.paper_trail.save_with_version : record.save
+          save_success = with_version && force_new_version && !record.changed? ? record.paper_trail.save_with_version : record.save
           unless save_success
             promote_errors(record.errors)
             return false

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -119,6 +119,8 @@ module GobiertoAdmin
       end
 
       def save_custom_fields
+        return custom_field_records if with_version && !force_new_version && !changed?
+
         custom_field_records.each do |record|
           record.item_has_versions = with_version
 

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -74,10 +74,18 @@ module GobiertoAdmin
       end
 
       def changed?
-        custom_field_records.any?(&:changed?)
+        custom_field_records.any? { |custom_field| version_changed?(custom_field) }
       end
 
       private
+
+      def version_changed?(custom_field)
+        if with_version && version_index.present?
+          (custom_field.versions[version_index]&.reify || custom_field.clone.reload).slice(*attributes_for_new_version) != custom_field.slice(*attributes_for_new_version)
+        else
+          custom_field.changed?
+        end
+      end
 
       def instance_type_options
         return [nil] unless instance
@@ -121,6 +129,10 @@ module GobiertoAdmin
           end
         end
         custom_field_records
+      end
+
+      def attributes_for_new_version
+        %w(item_type item_id custom_field_id payload)
       end
     end
   end

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -138,7 +138,7 @@ module GobiertoAdmin
       end
 
       def attributes_updated?
-        return unless allow_edit_attributes?
+        return if @node.new_record? || !allow_edit_attributes?
 
         nodes_attributes_differ?(set_node_attributes, versioned_node)
       end
@@ -233,6 +233,7 @@ module GobiertoAdmin
         set_version_and_visiblity_level
 
         if @node.valid?
+          @node.restore_attributes(ignored_attributes) if @node.changed? && ignored_attributes.present?
           force_new_version && !attributes_updated? ? @node.paper_trail.save_with_version : @node.save
 
           if allow_edit_attributes? && !@node.categories.include?(category)
@@ -270,7 +271,15 @@ module GobiertoAdmin
       end
 
       def attributes_for_new_version
-        %w(name_translations status_translations progress starts_at ends_at options) & @passed_attributes
+        @attributes_for_new_version ||= version_attributes & @passed_attributes
+      end
+
+      def version_attributes
+        %w(name_translations status_id progress starts_at ends_at options)
+      end
+
+      def ignored_attributes
+        @ignored_attributes ||= version_attributes - @passed_attributes
       end
     end
   end

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -28,6 +28,7 @@ module GobiertoAdmin
       )
 
       validates :plan, :admin, presence: true
+      validates :progress, presence: true, if: -> { @passed_attributes.include?("progress") }
       validates :category, :name_translations, presence: true, if: -> { allow_edit_attributes? }
       validates :status_id, presence: true, if: -> { allow_edit_attributes? && statuses_vocabulary.present? }
       validate :options_json_format
@@ -269,7 +270,7 @@ module GobiertoAdmin
       end
 
       def attributes_for_new_version
-        %w(name_translations status_translations progress starts_at ends_at options)
+        %w(name_translations status_translations progress starts_at ends_at options) & @passed_attributes
       end
     end
   end

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -38,14 +38,13 @@ module GobiertoAdmin
       def initialize(options = {})
         options = options.to_h.with_indifferent_access
         ordered_options = options.slice(:id, :plan_id, :admin).merge!(options)
-
+        @passed_attributes = ordered_options.keys
         super(ordered_options)
+        set_publication_version
       end
 
       def save
         check_visibility_level if allow_edit_attributes?
-        set_publication_version if has_versions?
-
         save_node if valid?
       end
 
@@ -150,6 +149,8 @@ module GobiertoAdmin
       end
 
       def set_publication_version
+        return if @version.present? || !has_versions?
+
         @visibility_level, @version = visibility_level.to_s.split("-")
 
         @published_version = @visibility_level == "published" ? (@version || node.published_version).to_i : nil

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -14,8 +14,6 @@ module GobiertoPlans
     has_vocabulary :statuses
     belongs_to :status, class_name: "GobiertoCommon::Term"
 
-    validates :progress, presence: true
-
     delegate :name, to: :status, prefix: true
 
     scope :with_name, ->(name) { where("gplan_nodes.name_translations ->> 'en' ILIKE :name OR gplan_nodes.name_translations ->> 'es' ILIKE :name OR gplan_nodes.name_translations ->> 'ca' ILIKE :name", name: "%#{name}%") }

--- a/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPlans
+    module Projects
+      class ProjectVersionsTest < ActionDispatch::IntegrationTest
+        include Integration::AdminGroupsConcern
+
+        attr_reader :plan, :create_path, :project
+
+        def setup
+          super
+          @plan = gobierto_plans_plans(:strategic_plan)
+          @create_path = new_admin_plans_plan_project_path(plan)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def remove_custom_fields_with_callbacks
+          ::GobiertoCommon::CustomFieldPlugin.with_callbacks.each do |plugin|
+            ::GobiertoCommon::CustomField.with_plugin_type(plugin.type).destroy_all
+          end
+        end
+
+        def create_project
+          visit create_path
+
+          within "form" do
+            select "Scholarships for families in the Central District", from: "project_category_id"
+
+            fill_in "project_name_translations_en", with: "Project with versions"
+
+            fill_in "project_starts_at", with: "2020-01-01"
+            fill_in "project_ends_at", with: "2021-01-01"
+            select "Active", from: "project_status_id"
+
+            within "div.widget_save_v2.editor" do
+              click_button "Save"
+            end
+          end
+          @project = ::GobiertoPlans::Node.with_name_translation("Project with versions", :en).last
+        end
+
+        def all_versions_are_equal(project, versions_number)
+          return false unless versions_number == project.versions.count
+
+          ::GobiertoCommon::CustomFieldRecord.where(item: project).each do |record|
+            next if record.custom_field.plugin? && %w(progress).include?(record.custom_field.configuration.plugin_type)
+
+            return false unless versions_number == record.versions.count
+          end
+
+          true
+        end
+
+        def test_create_project_as_manager
+          with(site: site, js: true, admin: admin) do
+            create_project
+
+            assert has_message? "Project created correctly."
+            assert has_content? "Project with versions"
+            assert has_content? "Editing version\n1"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\nnot published yet"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+          end
+
+          assert all_versions_are_equal(project, 1)
+        end
+
+        def test_create_new_version_as_manager
+          with(site: site, js: true, admin: admin) do
+            create_project
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Project with versions: Version 2"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+          end
+
+          assert all_versions_are_equal(project, 2)
+        end
+
+        def test_create_new_custom_field_version_as_manager
+          with(site: site, js: true, admin: admin) do
+
+            create_project
+
+            within "form" do
+              fill_in "project_custom_records_goals_value_en", with: "Custom field updated"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+          end
+
+          assert all_versions_are_equal(project, 2)
+        end
+
+        def test_publish_last_version_as_manager
+          with(site: site, js: true, admin: admin) do
+
+            create_project
+
+            within "form" do
+              fill_in "project_custom_records_goals_value_en", with: "Custom field updated"
+
+              find("label[for$='approved']").click
+
+              within "div.widget_save_v2.editor" do
+                click_button "Publish"
+              end
+            end
+
+            page.accept_alert
+
+            assert has_link? "Unpublish"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nPublished"
+            assert has_content? "Published version\n2"
+            assert has_content? "Current version is the published one."
+
+          end
+
+          assert all_versions_are_equal(project, 2)
+        end
+
+        def test_publish_old_version
+          with(site: site, js: true, admin: admin) do
+
+            create_project
+
+            within "form" do
+              fill_in "project_custom_records_goals_value_en", with: "Custom field updated"
+
+              find("label[for$='approved']").click
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            visit edit_admin_plans_plan_project_path(plan, project, version: 1)
+
+            within "form" do
+              within "div.widget_save_v2.editor" do
+                click_button "Publish"
+              end
+            end
+
+            page.accept_alert
+
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+          end
+
+          assert all_versions_are_equal(project, 2)
+        end
+
+        def test_publish_old_version_with_changes
+          with(site: site, js: true, admin: admin) do
+
+            create_project
+
+            within "form" do
+              fill_in "project_custom_records_goals_value_en", with: "Custom field updated"
+
+              find("label[for$='approved']").click
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            visit edit_admin_plans_plan_project_path(plan, project, version: 1)
+
+            fill_in "project_custom_records_goals_value_en", with: "Custom field updated from first version"
+
+            within "form" do
+              within "div.widget_save_v2.editor" do
+                click_button "Publish"
+              end
+            end
+
+            page.accept_alert
+
+            assert has_content? "Editing version\n3"
+            assert has_content? "Status\nPublished"
+            assert has_content? "Published version\n3"
+            assert has_content? "Current version is the published one."
+
+          end
+
+          assert all_versions_are_equal(project, 3)
+        end
+
+        def test_save_from_old_version_without_changes
+          with(site: site, js: true, admin: admin) do
+
+            create_project
+
+            within "form" do
+              fill_in "project_custom_records_goals_value_en", with: "Custom field updated"
+
+              find("label[for$='approved']").click
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            visit edit_admin_plans_plan_project_path(plan, project, version: 1)
+
+            within "form" do
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            assert has_content? "Editing version\n3"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\nnot published yet"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+          end
+
+          assert all_versions_are_equal(project, 3)
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
@@ -244,6 +244,44 @@ module GobiertoAdmin
 
           assert all_versions_are_equal(project, 3)
         end
+
+        def test_save_new_version_and_change_status
+          with(site: site, js: true, admin: admin) do
+
+            create_project
+
+            within "form" do
+              fill_in "project_custom_records_goals_value_en", with: "Custom field updated"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            visit edit_admin_plans_plan_project_path(plan, project, version: 1)
+
+            within "form" do
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            within "form" do
+              find("label[for$='approved']").click
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            assert has_content? "Editing version\n3"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\nnot published yet"
+            assert has_content? "Click on Publish to make this version publicly visible."
+          end
+
+          assert all_versions_are_equal(project, 3)
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #2392

## :v: What does this PR do?

Fixes some errors related with versions and moderation status of projects:

* Makes version of projects and custom field records increase synchronously.
* Allows to create or update projects without sending the progress in the request params.
* Allows admins with edition and moderation permissions to publish an old version of a project with different custom field values between versions and not create a new version.

## :mag: How should this be manually tested?

Visit a project in admin with custom fields defined, make changes and create new versions. Change versions and publish them.

## :eyes: Screenshots

### Before this PR

![2392-before](https://user-images.githubusercontent.com/446459/60386100-50520a00-9a91-11e9-9b1e-a411ad3abc24.gif)


### After this PR

![2392-after](https://user-images.githubusercontent.com/446459/60386128-8f805b00-9a91-11e9-9916-54218a88a625.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
