### PR TITLE
2408 human resources cost functions

### DIFF
--- a/test/fixtures/gobierto_plans/plan_tree.json
+++ b/test/fixtures/gobierto_plans/plan_tree.json
@@ -156,8 +156,8 @@
                         "en": "Human Resources",
                         "ca": "Recursos Humans"
                       },
-                      "budgeted_amount": 26667,
-                      "executed_amount": 26667,
+                      "budgeted_amount": 80000,
+                      "executed_amount": 80000,
                       "executed_percentage": "100 %"
                     }
                   }

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/decorators/gobierto_plans/category_term_decorator_human_resources_attachment.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/decorators/gobierto_plans/category_term_decorator_human_resources_attachment.rb
@@ -26,8 +26,8 @@ module GobiertoPlans
 
       return super_result if records_functions.empty?
 
-      total_cost = records_functions.map(&:cost).sum
-      total_executed = records_functions.map { |f| f.cost * f.progress }.sum
+      total_cost = records_functions.map(&:planned_cost).sum
+      total_executed = records_functions.map(&:executed_cost).sum
 
       super_result[:human_resources][:budgeted_amount] = total_cost.round
       super_result[:human_resources][:executed_amount] = total_executed.round

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/models/gobierto_common/custom_field_functions/human_resource.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/models/gobierto_common/custom_field_functions/human_resource.rb
@@ -12,12 +12,16 @@ module GobiertoCommon::CustomFieldFunctions
       end
     end
 
-    def cost(options = {})
+    def executed_cost(options = {})
       percentages = progress_percentages(options[:date] || Date.current)
 
       percentages.each_with_index.inject(0) do |total, (percentage, index)|
         total + percentage * data[index].cost
-      end / percentages.size.to_f
+      end
+    end
+
+    def planned_cost(_options = {})
+      data.map(&:cost).sum
     end
 
     private

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_human_resources_attachment_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_human_resources_attachment_test.rb
@@ -15,12 +15,35 @@ module GobiertoPlans
       decorator.nodes_data.first[:attributes][:plugins_data][:human_resources]
     end
 
+    def human_resource_record
+      gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+    end
+
+    def human_resources
+      [
+        {
+          human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
+          cost: 30_000,
+          start_date: 1.day.ago.to_date.to_s,
+          end_date: 1.day.from_now.to_date.to_s
+        },
+        {
+          human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+          cost: 20_000,
+          start_date: 1.day.ago.to_date.to_s,
+          end_date: 1.day.from_now.to_date.to_s
+        }
+      ]
+    end
+
     def test_plugin_data
+      human_resource_record.update(payload: { human_resources: human_resources })
+
       assert_equal "Human Resources", plugin_data[:title_translations][:en]
 
-      assert_equal 26_667, plugin_data[:budgeted_amount]
-      assert_equal 26_667, plugin_data[:executed_amount]
-      assert_equal "100 %", plugin_data[:executed_percentage]
+      assert_equal 50_000, plugin_data[:budgeted_amount]
+      assert_equal 25000, plugin_data[:executed_amount]
+      assert_equal "50 %", plugin_data[:executed_percentage]
     end
 
   end

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/models/gobierto_common/custom_field_functions/human_resource_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/models/gobierto_common/custom_field_functions/human_resource_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon::CustomFieldFunctions
+  class HumanResourceTest < ActiveSupport::TestCase
+
+    attr_accessor :item, :human_resource_record, :source_calculations_record
+
+    def setup
+      super
+
+      @item = gobierto_plans_nodes(:political_agendas)
+      @item.paper_trail.save_with_version
+      @item.update_attribute(:ends_at, 2.days.from_now)
+      @item.update_attribute(:ends_at, 3.days.from_now)
+
+      @human_resource_record = gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+      @human_resource_record.paper_trail.save_with_version
+      @human_resource_record.update(
+        payload:
+        {
+          human_resources: [
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
+              cost: 30_000,
+              start_date: 1.day.ago.to_date.to_s,
+              end_date: 1.day.from_now.to_date.to_s
+            },
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+              cost: 20_000,
+              start_date: 1.day.ago.to_date.to_s,
+              end_date: 1.day.from_now.to_date.to_s
+            },
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+              cost: 10_000,
+              start_date: 1.day.ago.to_date.to_s,
+              end_date: 1.day.from_now.to_date.to_s
+            }
+          ]
+        },
+        item_has_versions: true
+      )
+      @human_resource_record.update(
+        payload:
+        {
+          human_resources: [
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
+              cost: 35_000,
+              start_date: 1.day.from_now.to_date.to_s,
+              end_date: 2.days.from_now.to_date.to_s
+            },
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+              cost: 25_000,
+              start_date: 1.day.from_now.to_date.to_s,
+              end_date: 2.days.from_now.to_date.to_s
+            },
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+              cost: 20_000,
+              start_date: 1.day.from_now.to_date.to_s,
+              end_date: 2.days.from_now.to_date.to_s
+            }
+          ]
+        },
+        item_has_versions: true
+      )
+    end
+
+    def test_progress
+      assert_equal 0.0, human_resource_record.functions.progress
+    end
+
+    def test_planned_cost
+      assert_equal 80_000.0, human_resource_record.functions.planned_cost
+    end
+
+    def test_executed_cost
+      assert_equal 0.0, human_resource_record.functions.executed_cost
+    end
+
+    def test_versions_planned_cost
+      assert_equal 80_000.0, human_resource_record.functions(version: 1).planned_cost
+      assert_equal 60_000.0, human_resource_record.functions(version: 2).planned_cost
+      assert_equal 80_000.0, human_resource_record.functions(version: 3).planned_cost
+    end
+
+    def test_versions_executed_cost
+      assert_equal 80_000.0, human_resource_record.functions(version: 1).executed_cost
+      assert_equal 30_000.0, human_resource_record.functions(version: 2).executed_cost
+      assert_equal 0.0, human_resource_record.functions(version: 3).executed_cost
+    end
+
+    def test_versions_progress
+      assert_equal 1.0, human_resource_record.functions(version: 1).progress
+      assert_equal 0.5, human_resource_record.functions(version: 2).progress
+      assert_equal 0.0, human_resource_record.functions(version: 3).progress
+    end
+  end
+end


### PR DESCRIPTION
Closes #2408


## :v: What does this PR do?
* Implements functions for executed and planned cost in human resources plugin
* Adds some tests

## :mag: How should this be manually tested?

Edit a project in the human resources plugin and check data in front

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No