### PR TITLE
Fix configuration of custom fields with vocabulary type

### DIFF
--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -90,7 +90,7 @@ module GobiertoAdmin
         @options ||= {}.tap do |opts|
           opts[:configuration] ||= {}
           opts.merge!(options_translations.except("new_option")) if has_options? && options_translations
-          if ::GobiertoCommon::CustomField.has_vocabulary?(plugin_type)
+          if has_vocabulary?
             opts[:vocabulary_id] = vocabulary_id if vocabulary_id
             opts[:configuration][:vocabulary_type] = vocabulary_type if vocabulary_type.present?
           end
@@ -117,7 +117,7 @@ module GobiertoAdmin
       end
 
       def has_options?
-        @has_options ||= !::GobiertoCommon::CustomField.has_vocabulary?(plugin_type) && custom_field.has_options?
+        @has_options ||= !has_vocabulary? && custom_field.has_options?
       end
 
       def valid_resource_name?

--- a/app/javascript/gobierto_admin/modules/gobierto_common_custom_fields_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_common_custom_fields_controller.js
@@ -13,6 +13,9 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldsController = (function() {
 
       if ($(this).data().hasVocabulary) {
         $("#vocabulary").show();
+        if ($(this).data().hasOptions) {
+          $("#vocabulary_type").show();
+        }
       } else if ($(this).data().hasOptions) {
         $("#options").show();
       }

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -61,7 +61,7 @@ module GobiertoCommon
     end
 
     def has_vocabulary?
-      if (plugin_type = options&.dig(*%w(configuration plugin_type))&.to_sym)
+      if (plugin_type = configuration.plugin_type&.to_sym)
         self.class.has_vocabulary?(plugin_type)
       else
         /vocabulary/.match?(field_type)


### PR DESCRIPTION
Closes #2412
Closes #2413

## :v: What does this PR do?
* Fixes some methods to determine the options to be shown depending on the type of custom field or type of plugin in case the type is plugin.
* With the fix also the options jsonb field is generated correctly and this prevents errors in front in the creation of projects with custom fields of type vocabulary.

## :mag: How should this be manually tested?

Visit admin and create or edit a custom field of type vocabulary. Go to a project with this field. 

## :eyes: Screenshots

### Before this PR

![2413-before](https://user-images.githubusercontent.com/446459/60454201-87602100-9c33-11e9-82ff-d32a637b5ab6.gif)


### After this PR

![2413-after](https://user-images.githubusercontent.com/446459/60454214-921ab600-9c33-11e9-821e-1d80cbf44cad.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
