### PR TITLE
2402 progress plugin issues

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/base_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module CustomFields
+      class BaseController < GobiertoAdmin::BaseController
+
+        def module_doc_url
+          "https://gobierto.readme.io/docs/campos-personalizados"
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoAdmin
   module GobiertoCommon
     module CustomFields
-      class CustomFieldsController < BaseController
+      class CustomFieldsController < GobiertoCommon::CustomFields::BaseController
         before_action :check_permissions!
         before_action :check_class, except: :create_option
 

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/instance_level_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/instance_level_resources_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoAdmin
   module GobiertoCommon
     module CustomFields
-      class InstanceLevelResourcesController < BaseController
+      class InstanceLevelResourcesController < GobiertoCommon::CustomFields::BaseController
         before_action :check_permissions!
 
         def show

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
@@ -3,7 +3,7 @@
 module GobiertoAdmin
   module GobiertoCommon
     module CustomFields
-      class ModuleResourcesController < BaseController
+      class ModuleResourcesController < GobiertoCommon::CustomFields::BaseController
         before_action :check_permissions!
 
         def index

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -141,7 +141,15 @@ module GobiertoAdmin
       end
 
       def plugin_configuration
-        @plugin_configuration ||= custom_field.configuration.plugin_configuration || plugin&.default_configuration
+        return unless plugin&.has_configuration?
+
+        @plugin_configuration ||= custom_field.configuration.plugin_configuration
+      end
+
+      def plugin_configuration_defaults
+        ::GobiertoCommon::CustomFieldPlugin.all.inject({}) do |defaults, plugin|
+          defaults.update(plugin.type => JSON.pretty_generate(plugin.default_configuration))
+        end
       end
 
       def plugin
@@ -219,6 +227,8 @@ module GobiertoAdmin
       end
 
       def plugin_configuration_format
+        return unless plugin_configuration
+
         JSON.parse(plugin_configuration)
       rescue JSON::ParserError
         errors.add :plugin_configuration, I18n.t("errors.messages.invalid")

--- a/app/javascript/gobierto_admin/modules/gobierto_common_custom_fields_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_common_custom_fields_controller.js
@@ -5,6 +5,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldsController = (function() {
     _handleItemTypeSelection()
     _handlePluginTypeSelection()
     _handleBehaviors()
+    _handlePluginOptionsDefault()
   };
 
   function _handleItemTypeSelection() {
@@ -20,7 +21,10 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldsController = (function() {
         $("#options").show();
       }
 
-      if ($(this).data().type === "plugin") _handlePluginOptionsVisibility($('.js-plugin-type-option[checked="checked"]'));
+      if ($(this).data().type === "plugin") {
+        _handlePluginOptionsVisibility($('.js-plugin-type-option[checked="checked"]'));
+        _handlePluginOptionsDefault();
+      }
 
       // Show options related to type
       if ($(this).data().type) {
@@ -30,12 +34,34 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldsController = (function() {
   }
 
   function _handlePluginOptionsVisibility(selection) {
-      selection.attr("has_vocabulary") === "true"
-        ? $("#vocabulary").show()
-        : $("#vocabulary").hide()
-      selection.attr("has_configuration") === "true"
-        ? $("#configuration").show()
-        : $("#configuration").hide()
+    let defaults = $("#configuration").data("defaults");
+    let current_type = $("#configuration").data("type");
+    let current_value = $("#configuration").attr("data-value")
+
+    selection.attr("has_vocabulary") === "true"
+      ? $("#vocabulary").show()
+      : $("#vocabulary").hide()
+
+    if (selection.attr("has_configuration") === "true") {
+      $("#configuration").show();
+
+      selection.val() === current_type
+        ? $("#custom_field_plugin_configuration").val(current_value)
+        : $("#custom_field_plugin_configuration").val(defaults[selection.val()]);
+    } else {
+      $("#configuration").hide();
+    }
+  }
+
+  function _handlePluginOptionsDefault() {
+    let defaults = $("#configuration").data("defaults");
+
+    $("#custom_field_plugin_configuration").change(function(e) {
+      if ($("#custom_field_plugin_configuration").val().length === 0) {
+        let selection = $('.js-plugin-type-option:checked').val();
+        $("#custom_field_plugin_configuration").val(defaults[selection]);
+      }
+    });
   }
 
   function _handlePluginTypeSelection() {

--- a/app/models/gobierto_common/custom_field_functions/base.rb
+++ b/app/models/gobierto_common/custom_field_functions/base.rb
@@ -6,7 +6,7 @@ module GobiertoCommon
       attr_accessor :record
 
       delegate :custom_field, :value, to: :record
-      delegate :configuration, to: :custom_field
+      delegate :configuration, :site, to: :custom_field
 
       def initialize(record, options = {})
         @record = versioned_record(record, options[:version])

--- a/app/models/gobierto_common/custom_field_validators/base.rb
+++ b/app/models/gobierto_common/custom_field_validators/base.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module CustomFieldValidators
+    class Base
+      attr_accessor :custom_field_form
+
+      def initialize(custom_field_form)
+        @custom_field_form = custom_field_form
+      end
+
+      def valid?
+        true
+      end
+    end
+  end
+end

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
@@ -82,7 +82,10 @@
           <% end %>
         <% end %>
         <%= content_tag :div, class: "form_block" do %>
-          <%= content_tag :div, id: "configuration", class: "form_item", style: @custom_field_form.plugin&.has_configuration? ? nil : "display: none;" do %>
+          <%= content_tag :div, id: "configuration", class: "form_item", style: @custom_field_form.plugin&.has_configuration? ? nil : "display: none;", data: {
+                defaults: @custom_field_form.plugin_configuration_defaults,
+                type: @custom_field_form.plugin_type,
+                value: JSON.pretty_generate(@custom_field_form.plugin_configuration) } do %>
             <%= render partial: "plugin_configuration_form", locals: { f: f } %>
           <% end %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_plugin_configuration_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_plugin_configuration_form.html.erb
@@ -1,6 +1,6 @@
 <h4 class="options compact"><%= t(".configuration") %></h4>
 <div class="field_item_def_cont">
   <div class="form_item textarea">
-    <%= text_area_tag "custom_field[plugin_configuration]", JSON.pretty_generate(f.object.plugin_configuration) %>
+    <%= text_area_tag "custom_field[plugin_configuration]", f.object.plugin_configuration.present? ? JSON.pretty_generate(f.object.plugin_configuration) : nil %>
   </div>
 </div>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_plugin_configuration_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_plugin_configuration_form.html.erb
@@ -1,4 +1,10 @@
-<h4 class="options compact"><%= t(".configuration") %></h4>
+<h4 class="options compact">
+  <%= t(".configuration") %>
+  <%= link_to "#{module_doc_url}#section-plugin", target: "_blank" do %>
+    <i class="fas fa-question-circle"></i>
+  <% end %>
+</h4>
+
 <div class="field_item_def_cont">
   <div class="form_item textarea">
     <%= text_area_tag "custom_field[plugin_configuration]", f.object.plugin_configuration.present? ? JSON.pretty_generate(f.object.plugin_configuration) : nil %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_plugin_configuration_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_plugin_configuration_form.html.erb
@@ -7,6 +7,13 @@
 
 <div class="field_item_def_cont">
   <div class="form_item textarea">
-    <%= text_area_tag "custom_field[plugin_configuration]", f.object.plugin_configuration.present? ? JSON.pretty_generate(f.object.plugin_configuration) : nil %>
+    <%= text_area_tag(
+          "custom_field[plugin_configuration]",
+          if (configuration = f.object.plugin_configuration).present?
+              configuration.is_a?(Hash) ? JSON.pretty_generate(configuration) : configuration
+          else
+            nil
+          end
+        ) %>
   </div>
 </div>

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
@@ -10,23 +10,23 @@ module GobiertoCommon::CustomFieldFunctions
     end
 
     def progress(options = {})
-      ids = configuration.plugin_configuration["custom_field_ids"] || []
       uids = configuration.plugin_configuration["custom_field_uids"] || []
 
-      return if ids.blank? && uids.blank?
+      return if uids.blank?
 
-      t = GobiertoCommon::CustomField.arel_table
-
-      calculation_custom_fields = site.custom_fields.where(
-        t[:uid].in(uids).or(t[:id].in(ids))
-      )
+      calculation_custom_fields = site.custom_fields.find_by!(uid: uids)
 
       calculation_records = GobiertoCommon::CustomFieldRecord.where(item: record.item, custom_field: calculation_custom_fields)
-      progress_items = calculation_records.map { |record| record.functions(version: @version).try(:progress, options) }.compact
+      progress_items = calculation_records.map { |record| record.functions(version: @version).progress(options) }.compact
 
       return if progress_items.blank?
 
       progress_items.instance_eval { sum / size.to_f }
+
+    rescue StandardError => e
+      Rollbar.error(e)
+
+      nil
     end
 
     def update_progress!

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
@@ -17,12 +17,12 @@ module GobiertoCommon::CustomFieldFunctions
 
       t = GobiertoCommon::CustomField.arel_table
 
-      custom_fields = GobiertoCommon::CustomField.where(instance: custom_field.instance).where(
+      calculation_custom_fields = site.custom_fields.where(
         t[:uid].in(uids).or(t[:id].in(ids))
       )
 
-      records = GobiertoCommon::CustomFieldRecord.where(item: record.item, custom_field: custom_fields)
-      progress_items = records.map { |record| record.functions(version: @version).try(:progress, options) }.compact
+      calculation_records = GobiertoCommon::CustomFieldRecord.where(item: record.item, custom_field: calculation_custom_fields)
+      progress_items = calculation_records.map { |record| record.functions(version: @version).try(:progress, options) }.compact
 
       return if progress_items.blank?
 

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_validators/progress.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_validators/progress.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GobiertoCommon::CustomFieldValidators
+  class Progress < Base
+
+    def valid?
+      return if custom_field_form.errors[:plugin_configuration].present?
+
+      configuration = JSON.parse(custom_field_form.plugin_configuration)
+
+      if configuration
+        return if all_uids_present?(configuration) && records_respond_to_progress?(configuration)
+
+        custom_field_form.errors.add(:options, I18n.t("errors.messages.custom_fields.options.wrong_custom_field_uids"))
+      end
+    end
+
+    private
+
+    def all_uids_present?(configuration)
+      configuration["custom_field_uids"].blank? ||
+        custom_field_form.site.custom_fields.where(uid: configuration["custom_field_uids"]).count == configuration["custom_field_uids"].count
+    end
+
+    def records_respond_to_progress?(configuration)
+      custom_field_form.site.custom_fields.where(uid: configuration["custom_field_uids"]).all? do |custom_field|
+        custom_field.records.new.functions.respond_to?(:progress)
+      end
+    end
+
+  end
+end

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/ca.yml
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/ca.yml
@@ -1,11 +1,17 @@
 ---
 ca:
+  errors:
+    messages:
+      custom_fields:
+        options:
+          wrong_custom_field_uids: Els uids configurats no existeixen o pertanyen
+            a camps personalitzats que no tenen definit un valor de progrés
   gobierto_admin:
+    custom_fields_plugins:
+      progress:
+        progress: Progrés
     gobierto_common:
       custom_fields:
         custom_fields:
           plugin:
             progress: Progrés
-    custom_fields_plugins:
-      progress:
-        progress: Progrés

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/en.yml
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/en.yml
@@ -1,11 +1,17 @@
 ---
 en:
+  errors:
+    messages:
+      custom_fields:
+        options:
+          wrong_custom_field_uids: The configuration uids doesn't existe or belongs
+            to custom fields which doesn't have a definition for progress
   gobierto_admin:
+    custom_fields_plugins:
+      progress:
+        progress: Progress
     gobierto_common:
       custom_fields:
         custom_fields:
           plugin:
             progress: Progress
-    custom_fields_plugins:
-      progress:
-        progress: Progress

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/es.yml
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/es.yml
@@ -1,11 +1,17 @@
 ---
 es:
+  errors:
+    messages:
+      custom_fields:
+        options:
+          wrong_custom_field_uids: Los uids configurados no existen o pertenecen a
+            campos personalizados que no tienen definido un valor de progreso
   gobierto_admin:
+    custom_fields_plugins:
+      progress:
+        progress: Progreso
     gobierto_common:
       custom_fields:
         custom_fields:
           plugin:
             progress: Progreso
-    custom_fields_plugins:
-      progress:
-        progress: Progreso

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/lib/custom_fields_progress_plugin/railtie.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/lib/custom_fields_progress_plugin/railtie.rb
@@ -12,7 +12,7 @@ else
           progress: {
             requires_vocabulary: false,
             has_configuration: true,
-            default_configuration: { "custom_field_ids": [], "custom_field_uids": [] },
+            default_configuration: { "custom_field_uids": [] },
             callbacks: [:update_progress!]
           }
         )

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/lib/tasks/custom_field_plugins/progress/calculate_progress.rake
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/lib/tasks/custom_field_plugins/progress/calculate_progress.rake
@@ -4,9 +4,18 @@ namespace :custom_field_plugins do
   namespace :progress do
     desc "Calculate total progress of plugin custom field records of type progress based on the other configured fields"
     task calculate_progress: :environment do
-      GobiertoCommon::CustomField.with_plugin_type("progress").each do |custom_field|
+
+      GobiertoCommon::CustomField.with_plugin_type("progress").where.not(instance: nil).each do |custom_field|
         custom_field.instance.nodes.each do |node|
           custom_field.records.find_or_initialize_by(item: node).functions.update_progress!
+        end
+      end
+
+      GobiertoPlans::Plan.where.not(id: GobiertoCommon::CustomField.with_plugin_type("progress").where.not(instance: nil)).each do |plan|
+        plan.site.custom_fields.with_plugin_type("progress").where(instance: nil).each do |custom_field|
+          plan.nodes.each do |node|
+            custom_field.records.find_or_initialize_by(item: node).functions.update_progress!
+          end
         end
       end
 

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/test/models/gobierto_common/custom_field_functions/progress_test.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/test/models/gobierto_common/custom_field_functions/progress_test.rb
@@ -51,20 +51,8 @@ module GobiertoCommon::CustomFieldFunctions
             {
               human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
               cost: 35_000,
-              start_date: 1.day.from_now.to_date.to_s,
-              end_date: 2.days.from_now.to_date.to_s
-            },
-            {
-              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
-              cost: 25_000,
-              start_date: 1.day.from_now.to_date.to_s,
-              end_date: 2.days.from_now.to_date.to_s
-            },
-            {
-              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
-              cost: 20_000,
-              start_date: 1.day.from_now.to_date.to_s,
-              end_date: 2.days.from_now.to_date.to_s
+              start_date: 1.day.ago.to_date.to_s,
+              end_date: 3.days.from_now.to_date.to_s
             }
           ]
         },
@@ -72,21 +60,47 @@ module GobiertoCommon::CustomFieldFunctions
       )
     end
 
+    def plan
+      @plan = gobierto_plans_plans :strategic_plan
+    end
+
+    def progress_custom_field
+      @progress_custom_field ||= progress_record.custom_field
+    end
+
     def test_progress
-      assert_equal 0.0, progress_record.functions.progress
+      assert_equal 0.25, progress_record.functions.progress
     end
 
     def test_versions_progress
       assert_equal 1.0, progress_record.functions(version: 1).progress
       assert_equal 0.5, progress_record.functions(version: 2).progress
-      assert_equal 0.0, progress_record.functions(version: 3).progress
+      assert_equal 0.25, progress_record.functions(version: 3).progress
+    end
+
+    def test_progress_defined_for_instance
+      progress_record.custom_field.update_attribute(:instance, plan)
+
+      assert_equal 0.25, progress_record.functions.progress
+    end
+
+    def test_progress_refered_to_not_existing_custom_field
+      progress_custom_field.update_attribute(:options, {"configuration"=>{"plugin_type"=>"progress", "plugin_configuration"=>{"custom_field_uids"=>["wadus"]}}})
+
+      assert_nil progress_record.functions.progress
+    end
+
+    def test_progress_refered_to_custom_field_not_providing_progress_function
+      progress_custom_field.update_attribute(:options, {"configuration"=>{"plugin_type"=>"progress", "plugin_configuration"=>{"custom_field_uids"=>["goals"]}}})
+
+      assert_nil progress_record.functions.progress
     end
 
     def test_update_progress!
       progress_record.functions.update_progress!
 
       item.reload
-      assert_equal 0.0, item.progress
+      assert_equal 25.0, item.progress
     end
   end
 end


### PR DESCRIPTION
Closes #2402

## :v: What does this PR do?

Makes some changes to custom fields and progress plugin custom field:

* Uses the custom fields defined in the configuration of progress plugins regardless their instance setting
* Displays a default configuration for progress plugins if not present in edit/new forms. The default configuration 
* Adds links to documentation about custom fields in the admin header of custom fields and near to the progress configuration textarea
* Changes rake update_progress task to include progress plugins defined at global level.
* Changes the default progress plugin configuration to only include other custom fields uid.
* Allows plugins to declare validations to be called creating and updating them. Adds validation method to progress plugin to validate that all custom fields referred by uid exist and their records functions respond to `progress`

Pending:

- [x] if the configuration is incorrect and references to an invalid custom field, it should notify via Rollbar (this should be prevented by the validation provided by the plugin)
- [ ] Create site activities when update progress task is executed.

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Yes! Some documentation about custom fields and progress plugin has been added at https://gobierto.readme.io/docs/campos-personalizados#section-plugin and linked from custom fields admin views with `module_doc_url` and near to progress configuration textarea
