### PR TITLE
2357 categories front

### DIFF
--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -36,8 +36,9 @@ module GobiertoPlans
         end
 
         format.json do
-          plan_tree = Rails.cache.fetch(@plan.cache_key + "/plan_tree") do
-            GobiertoPlans::PlanTree.new(@plan).call
+          plan_tree, global_progress = Rails.cache.fetch(@plan.cache_key + "/plan_tree") do
+            tree = GobiertoPlans::PlanTree.new(@plan)
+            [tree.call, tree.global_progress]
           end
 
           render(
@@ -46,7 +47,7 @@ module GobiertoPlans
                     level_keys: @plan.level_keys,
                     show_table_header: @plan.configuration_data&.dig("show_table_header"),
                     open_node: @plan.configuration_data&.dig("open_node"),
-                    global_progress: @plan.global_progress }
+                    global_progress: global_progress }
           )
         end
       end

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -4,12 +4,15 @@ module GobiertoPlans
   class CategoryTermDecorator < BaseTermDecorator
     include ActionView::Helpers::NumberHelper
 
+    attr_reader :cached_attributes
+
     def initialize(term, options = {})
       @object = term
       @vocabulary = options[:vocabulary]
       @plan = options[:plan]
       @site = options[:site]
       @with_published_versions = options[:with_published_versions]
+      @cached_attributes = options[:cached_attributes]
     end
 
     def categories

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -155,6 +155,10 @@ module GobiertoPlans
       ::GobiertoPlans::Node.node_custom_field_records(plan, node).map do |record|
         next if record.custom_field.field_type == "plugin"
 
+        record = record.versions[node.version_index]&.reify if node.version_index.negative?
+
+        next if record.blank?
+
         {
           value: record.value_string,
           raw_value: record.raw_value,

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -9,6 +9,7 @@ module GobiertoPlans
       @vocabulary = options[:vocabulary]
       @plan = options[:plan]
       @site = options[:site]
+      @with_published_versions = options[:with_published_versions]
     end
 
     def categories
@@ -21,6 +22,10 @@ module GobiertoPlans
 
     def plan
       @plan ||= site.plans.find_by_vocabulary_id(vocabulary.id)
+    end
+
+    def with_published_versions?
+      @with_published_versions.present?
     end
 
     def uid
@@ -57,7 +62,7 @@ module GobiertoPlans
     end
 
     def nodes
-      plan.nodes.where(gplan_categories_nodes: { category_id: object.id })
+      base_relation.where(gplan_categories_nodes: { category_id: object.id })
     end
 
     def nodes_data
@@ -118,7 +123,11 @@ module GobiertoPlans
     protected
 
     def descending_nodes
-      @descending_nodes ||= plan.nodes.where("gplan_categories_nodes.category_id IN (#{self.class.tree_sql_for(self)})")
+      @descending_nodes ||= base_relation.where("gplan_categories_nodes.category_id IN (#{self.class.tree_sql_for(self)})")
+    end
+
+    def base_relation
+      @base_relation ||= with_published_versions? ? plan.nodes.published : plan.nodes
     end
 
     def vocabulary

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -61,21 +61,25 @@ module GobiertoPlans
     end
 
     def nodes_data
-      CollectionDecorator.new(nodes.published, decorator: GobiertoPlans::ProjectDecorator).map.with_index do |node, index|
-        node = node.at_current_version
+      CollectionDecorator.new(
+        nodes.published,
+        decorator: GobiertoPlans::ProjectDecorator,
+        opts: { plan: plan, site: site }
+      ).map.with_index do |node, index|
         { id: node.id,
           uid: uid + "." + index.to_s,
           type: "node",
           level: level + 1,
-          attributes: { title: node.name_translations,
-                        parent_id: id,
-                        progress: node.progress,
-                        starts_at: node.starts_at,
-                        ends_at: node.ends_at,
-                        status: node.status&.name_translations,
-                        options: node.options,
-                        plugins_data: node_plugins_data(plan, node),
-                        custom_field_records: node_custom_field_records(node)
+          attributes: {
+            title: node.at_current_version.name_translations,
+            parent_id: id,
+            progress: node.at_current_version.progress,
+            starts_at: node.at_current_version.starts_at,
+            ends_at: node.at_current_version.ends_at,
+            status: node.at_current_version.status&.name_translations,
+            options: node.at_current_version.options,
+            plugins_data: node_plugins_data(plan, node),
+            custom_field_records: node_custom_field_records(node)
           },
           children: [] }
       end

--- a/app/decorators/gobierto_plans/project_decorator.rb
+++ b/app/decorators/gobierto_plans/project_decorator.rb
@@ -2,8 +2,13 @@
 
 module GobiertoPlans
   class ProjectDecorator < BaseDecorator
-    def initialize(project)
+    attr_reader :plan, :site
+
+    def initialize(project, opts = {})
       @object = project
+      options = opts[:opts] || {}
+      @plan = options[:plan]
+      @site = options[:site]
     end
 
     def version_index
@@ -11,9 +16,19 @@ module GobiertoPlans
     end
 
     def at_current_version
-      return self unless version_index.negative?
+      @at_current_version ||= begin
+                                versioned_project = version_index.negative? ? versions[version_index].reify : self
 
-      versions[version_index].reify
+                                versioned_project.tap do |attributes|
+                                  attributes.assign_attributes node_plugins_attributes
+                                end
+                              end
+    end
+
+    private
+
+    def node_plugins_attributes
+      {}
     end
   end
 end

--- a/app/decorators/gobierto_plans/project_decorator.rb
+++ b/app/decorators/gobierto_plans/project_decorator.rb
@@ -2,13 +2,20 @@
 
 module GobiertoPlans
   class ProjectDecorator < BaseDecorator
-    attr_reader :plan, :site
 
     def initialize(project, opts = {})
       @object = project
       options = opts[:opts] || {}
       @plan = options[:plan]
       @site = options[:site]
+    end
+
+    def plan
+      @plan ||= GobiertoPlans::Plan.find_by(categories_vocabulary: project.categories.first.vocabulary)
+    end
+
+    def site
+      @site ||= plan&.site
     end
 
     def version_index
@@ -30,5 +37,6 @@ module GobiertoPlans
     def node_plugins_attributes
       {}
     end
+
   end
 end

--- a/app/models/gobierto_common/custom_field_functions/base.rb
+++ b/app/models/gobierto_common/custom_field_functions/base.rb
@@ -19,7 +19,7 @@ module GobiertoCommon
 
         version_index = version_number - record.item.versions.length
 
-        return record unless record.versions[version_index].present?
+        return record unless record.versions[version_index].present? && record.versions[version_index].reify.present?
 
         record.versions[version_index].reify
       end

--- a/app/services/gobierto_plans/plan_tree.rb
+++ b/app/services/gobierto_plans/plan_tree.rb
@@ -5,7 +5,6 @@ class GobiertoPlans::PlanTree
 
   def initialize(plan)
     @plan = plan
-    @categories = CollectionDecorator.new(@plan.categories.where(term_id: nil).sorted, decorator: GobiertoPlans::CategoryTermDecorator)
     @vocabulary = @plan.categories_vocabulary
     @tree_decorator = TreeDecorator.new(
       terms_tree(@vocabulary.terms),

--- a/app/services/gobierto_plans/plan_tree.rb
+++ b/app/services/gobierto_plans/plan_tree.rb
@@ -17,7 +17,25 @@ class GobiertoPlans::PlanTree
     plan_tree(@tree_decorator, include_nodes)
   end
 
+  def global_progress
+    return unless (progress_values = progresses_with_version.values.compact).present?
+
+    progress_values.sum / progress_values.count.to_f
+  end
+
   private
+
+  def progresses_with_version
+    @progresses_with_version ||= CollectionDecorator.new(
+      @plan.nodes.published,
+      decorator: GobiertoPlans::ProjectDecorator,
+      opts: { plan: @plan, site: @plan.site }
+    ).inject({}) do |progresses, node|
+      progresses.update(
+        node.id => node.at_current_version.progress
+      )
+    end
+  end
 
   def terms_tree(relation)
     relation.order(position: :asc).where(level: relation.minimum(:level)).inject({}) do |tree, term|

--- a/app/services/gobierto_plans/plan_tree.rb
+++ b/app/services/gobierto_plans/plan_tree.rb
@@ -9,7 +9,13 @@ class GobiertoPlans::PlanTree
     @tree_decorator = TreeDecorator.new(
       terms_tree(@vocabulary.terms),
       decorator: ::GobiertoPlans::CategoryTermDecorator,
-      options: { plan: @plan, vocabulary: @vocabulary, site: @plan.site }
+      options: {
+        plan: @plan,
+        vocabulary: @vocabulary,
+        site: @plan.site,
+        with_published_versions: true,
+        cached_attributes: { progress: progresses_with_version }
+      }
     )
   end
 

--- a/test/decorators/gobierto_plans/category_term_decorator_test.rb
+++ b/test/decorators/gobierto_plans/category_term_decorator_test.rb
@@ -24,6 +24,14 @@ module GobiertoPlans
       @action ||= GobiertoPlans::CategoryTermDecorator.new(gobierto_common_terms(:center_basic_needs_plan_term))
     end
 
+    def custom_field_record
+      @custom_field_record ||= gobierto_common_custom_field_records :political_agendas_custom_field_record_localized_description
+    end
+
+    def project
+      @project ||= gobierto_plans_nodes :political_agendas
+    end
+
     def projects
       node_ids = GobiertoPlans::CategoriesNode.where(category_id: actions.pluck(:id)).pluck(:node_id)
       @projects ||= GobiertoPlans::Node.where(id: node_ids)
@@ -54,6 +62,27 @@ module GobiertoPlans
       node_attributes = decorator.nodes_data.first[:attributes]
 
       assert_equal 7, node_attributes[:custom_field_records].size
+    end
+
+    def test_versioned_custom_field_record
+      project.paper_trail.save_with_version
+      project.update_attribute(:ends_at, 2.days.ago)
+
+      custom_field_record.paper_trail.save_with_version
+      custom_field_record.update(
+        payload: { "description" => { "es" => "Descripción corta", "en" => "Short description" } },
+        item_has_versions: true
+      )
+
+      decorator = GobiertoPlans::CategoryTermDecorator.new(
+        gobierto_common_terms(:center_basic_needs_plan_term)
+      )
+
+      assert_equal custom_field_record.versions[0].reify.value, decorator.nodes_data.first[:attributes][:custom_field_records].first[:value]
+
+      project.update_attribute(:published_version, 2)
+
+      assert_equal "<p>Short description</p>\n", decorator.nodes_data.first[:attributes][:custom_field_records].first[:value]
     end
 
   end

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/decorators/gobierto_plans/category_term_decorator_budgets_attachment.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/decorators/gobierto_plans/category_term_decorator_budgets_attachment.rb
@@ -27,7 +27,7 @@ module GobiertoPlans
       )
       records_functions = ::GobiertoPlans::Node.node_custom_field_records(plan, node)
                                                .where(custom_field: budgets_fields)
-                                               .map(&:functions)
+                                               .map { |record| record.functions(version: node.published_version) }
 
       return super_result if records_functions.empty?
 

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/decorators/gobierto_plans/category_term_decorator_indicators_attachment.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/decorators/gobierto_plans/category_term_decorator_indicators_attachment.rb
@@ -20,8 +20,11 @@ module GobiertoPlans
         { configuration: { plugin_type: "indicators" } }.to_json
       )
       records = ::GobiertoPlans::Node.node_custom_field_records(plan, node).where(custom_field: indicators_fields)
+      versioned_records = records.map do |record|
+        ::GobiertoCommon::CustomFieldFunctions::Base.new(record, version: node.published_version).record
+      end
 
-      records.map(&:payload).flatten.compact.each do |payload|
+      versioned_records.map(&:payload).flatten.compact.each do |payload|
         next unless payload["indicator"]
 
         indicator = ::GobiertoCommon::Term.find(payload["indicator"])

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_human_resources_attachment_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_human_resources_attachment_test.rb
@@ -15,6 +15,10 @@ module GobiertoPlans
       decorator.nodes_data.first[:attributes][:plugins_data][:human_resources]
     end
 
+    def project
+      @project ||= gobierto_plans_nodes :political_agendas
+    end
+
     def human_resource_record
       gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
     end
@@ -43,6 +47,26 @@ module GobiertoPlans
 
       assert_equal 50_000, plugin_data[:budgeted_amount]
       assert_equal 25000, plugin_data[:executed_amount]
+      assert_equal "50 %", plugin_data[:executed_percentage]
+    end
+
+    def test_versioned_plugin_data
+      project.paper_trail.save_with_version
+      project.update_attribute(:ends_at, 2.days.ago)
+
+      human_resource_record.paper_trail.save_with_version
+      human_resource_record.update(
+        payload: { human_resources: human_resources },
+        item_has_versions: true
+      )
+
+      assert_equal 80_000, plugin_data[:budgeted_amount]
+      assert_equal 80_000, plugin_data[:executed_amount]
+      assert_equal "100 %", plugin_data[:executed_percentage]
+
+      project.update_attribute(:published_version, 2)
+      assert_equal 50_000, plugin_data[:budgeted_amount]
+      assert_equal 25_000, plugin_data[:executed_amount]
       assert_equal "50 %", plugin_data[:executed_percentage]
     end
 

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/decorators/gobierto_plans/project_decorator_progress_attachment.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/decorators/gobierto_plans/project_decorator_progress_attachment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  module ProjectDecoratorProgressAttachment
+
+    extend ActiveSupport::Concern
+
+    private
+
+    def node_plugins_attributes
+      super_result = super
+
+      calculation_plugin = ::GobiertoPlans::Node.node_custom_field_records(plan, object).where(custom_field: site.custom_fields.with_plugin_type(:progress)).find_by(item: object)
+      if calculation_plugin.present?
+        super_result[:progress] = calculation_plugin.functions(version: published_version).progress&.*(100)
+      end
+
+      super_result
+    end
+
+  end
+end

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/lib/custom_fields_progress_plugin/railtie.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/lib/custom_fields_progress_plugin/railtie.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+require_relative "../../app/decorators/gobierto_plans/project_decorator_progress_attachment"
+
+def attach_module(config, origin, module_class)
+  if config.plugins_attached_modules[origin]
+    config.plugins_attached_modules[origin].append(module_class)
+  else
+    config.plugins_attached_modules[origin] = [module_class]
+  end
+end
+
 begin
   require "rails/railtie"
 rescue LoadError
@@ -19,6 +29,7 @@ else
         conf.custom_field_plugins_packs += %w(progress)
         conf.autoload_paths += Dir[Pathname.new(base_path).join("app", "models")]
         conf.eager_load_paths += Dir[Pathname.new(base_path).join("app", "models")]
+        attach_module(conf, "::GobiertoPlans::ProjectDecorator", ::GobiertoPlans::ProjectDecoratorProgressAttachment)
         conf.i18n.load_path += Dir[File.join(base_path, "config", "locales", "**", "*.{rb,yml}")]
       end
 

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPlans
+  class PlanShowTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = gobierto_plans_plan_path(slug: plan_type.slug, year: plan.year)
+      plan.touch
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def plan
+      @plan ||= gobierto_plans_plans(:strategic_plan)
+    end
+
+    def plan_type
+      @plan_type ||= plan.plan_type
+    end
+
+    def action_lines
+      @action_lines ||= CollectionDecorator.new(plan.categories.where(level: 1).sorted, decorator: GobiertoPlans::CategoryTermDecorator).to_a
+    end
+
+    def actions
+      @actions ||= CollectionDecorator.new(plan.categories.where(level: 2).sorted, decorator: GobiertoPlans::CategoryTermDecorator).to_a
+    end
+
+    def projects
+      node_ids = GobiertoPlans::CategoriesNode.where(category_id: actions.pluck(:id)).pluck(:node_id)
+      @projects ||= GobiertoPlans::Node.where(id: node_ids)
+    end
+
+    def published_project
+      @published_project ||= gobierto_plans_nodes(:political_agendas)
+    end
+
+    alias project_with_progress published_project
+
+    def draft_projects
+      @draft_projects ||= plan.nodes.draft
+    end
+
+    def human_resources_record
+      @human_resources_record ||= gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+    end
+
+    def publish_last_version_on_all_projects!
+      projects.each do |project|
+        project.published!
+        project.update_attribute(:published_version, project.versions.count)
+      end
+      plan.touch
+    end
+
+    def test_native_progress_is_ignored
+      project_with_progress.update_attribute(:progress, 2.666666666666666)
+      plan.touch
+
+      with(site: site, js: true) do
+        visit @path
+
+        assert has_content? "Strategic Plan introduction"
+
+        within "div.header-resume" do
+          within "span" do
+            assert has_content? "100%"
+          end
+        end
+      end
+    end
+
+    def test_global_execution
+      with(site: site, js: true) do
+        visit @path
+        within "div.header-resume" do
+          within "span" do
+            assert has_content?("100%")
+          end
+        end
+      end
+    end
+
+    def test_global_execution_with_all_nodes_published
+      publish_last_version_on_all_projects!
+      with(site: site, js: true) do
+        visit @path
+        within "div.header-resume" do
+          within "span" do
+            assert has_content?("50%")
+          end
+        end
+      end
+    end
+
+    def test_draft_project
+      with(site: site, js: true) do
+        visit @path
+
+        within "section.level_0" do
+          within "div.node-root.cat_1" do
+            find("a").click
+          end
+        end
+
+        within ".planification-content" do
+          within "section.level_1.cat_1" do
+            within ".lines-header" do
+              assert has_content?("1 line of action")
+            end
+
+            within ".lines-list" do
+              assert has_content?(action_lines.first.name)
+              assert has_content?("2 actions")
+
+              assert has_content?("100%")
+            end
+
+            assert has_selector?("h3", text: action_lines.first.name)
+            find("h3", text: action_lines.first.name).click
+          end
+
+          within "section.level_2.cat_1" do
+            assert has_content?(action_lines.first.name)
+
+            within "ul.action-line--list" do
+              assert has_selector?("li", count: actions.count)
+
+              find("h3", text: actions.first.name).click
+              assert has_no_content? draft_projects.first.name
+
+              find("h3", text: actions.last.name).click
+              assert has_no_content? published_project.name
+            end
+          end
+        end
+      end
+    end
+
+    def test_versioned_project
+      published_project.paper_trail.save_with_version
+      published_project.update_attribute(:ends_at, 2.days.from_now)
+      human_resources_record.update(
+        payload:
+        {
+          human_resources: [
+            {
+              human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
+              cost: 35_000,
+              start_date: 1.day.ago.to_date.to_s,
+              end_date: 1.day.from_now.to_date.to_s
+            }
+          ]
+        },
+        item_has_versions: true
+      )
+
+      plan.touch
+
+      with(site: site, js: true) do
+        visit @path
+
+        within "div.header-resume" do
+          assert has_content?("100%")
+        end
+
+        published_project.update_attribute(:published_version, 2)
+        plan.touch
+
+        visit @path
+
+        within "div.header-resume" do
+          assert has_content?("50%")
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Closes #2357


## :v: What does this PR do?

* Uses accumulated values on plan categories with published projects in their published versions
* Shows the published version of each project for native attributes and custom fields.

## :mag: How should this be manually tested?

Visit a plan, create different versions of projects and change published versions.
In front, only published projects should appear in their version and the totals should correspond with their version values.

## :eyes: Screenshots

### Before this PR
![2357-before](https://user-images.githubusercontent.com/446459/60806175-963e5a80-a182-11e9-9c1d-71ebc3fcfe8a.gif)

### After this PR
![2357-after](https://user-images.githubusercontent.com/446459/60806194-9e969580-a182-11e9-9eda-b46d79f9bcea.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
