### PR TITLE
Prevent initialize indicator grid with an empty object

### DIFF
--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
@@ -17,7 +17,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
   };
 
   function _deserializeTableData(inputValue) {
-    if (inputValue && inputValue !== "null") return JSON.parse(inputValue)
+    if (inputValue && inputValue !== "null" && inputValue !== "{}") return JSON.parse(inputValue)
     return []
   }
 

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/indicators_plugin.js
@@ -17,8 +17,13 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsIndicatorsPluginController 
   };
 
   function _deserializeTableData(inputValue) {
-    if (inputValue && inputValue !== "null" && inputValue !== "{}") return JSON.parse(inputValue)
-    return []
+    let inputDict = JSON.parse(inputValue);
+
+    if ( Array.isArray(inputDict) ) {
+      return inputDict;
+    } else {
+      return [];
+    }
   }
 
   function _handlePluginData(uid) {


### PR DESCRIPTION
Closes PopulateTools/issues#704


## :v: What does this PR do?

* Fixes wrong indicator plugin display when the payload of the record contains an empty object. 

## :mag: How should this be manually tested?

Visit a project with a plugin of type human resources and create some values. Go to the admin of custom fields and change the type to indicators of the previous fields. When editing the project the custom field should be empty and with correct height

## :eyes: Screenshots

### Before this PR

<img width="726" alt="Screen Shot 2019-07-08 at 17 19 56" src="https://user-images.githubusercontent.com/446459/60821852-a8c98b80-a1a4-11e9-844f-5001c6b43fc7.png">

### After this PR

<img width="734" alt="Screen Shot 2019-07-08 at 17 18 53" src="https://user-images.githubusercontent.com/446459/60821865-acf5a900-a1a4-11e9-92fb-11f9c8b538fb.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
