### PR TITLE
Perform Google Authorization callback in the site domain

### DIFF
--- a/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/_google_calendar_fields.html.erb
+++ b/app/views/gobierto_admin/gobierto_calendars/calendar_configuration/_google_calendar_fields.html.erb
@@ -4,7 +4,7 @@
 
     <div class="form_item input_text">
       <p><%= t('.share_link') %></p>
-      <p><input type="text" name="google_calendar_invitation_url" value="<%= new_gobierto_people_google_calendar_authorization_url(token: @collection.container.google_calendar_token, host: ENV['BASE_HOST']) %>"/></p>
+      <p><input type="text" name="google_calendar_invitation_url" value="<%= new_gobierto_people_google_calendar_authorization_url(token: @collection.container.google_calendar_token, host: current_site.domain) %>"/></p>
     </div>
 
   <% else %>


### PR DESCRIPTION
## :v: What does this PR do?

This PR forces the domain to perform the Google Authentication verification to be in the site domain, so the cookie set to verify the admin is set in the proper domain.

## :mag: How should this be manually tested?

Try to connect a google calendar.
