### PR TITLE
2435 - Fix datepicker initialization on project admin form

### DIFF
--- a/app/javascript/gobierto_admin/modules/application.js
+++ b/app/javascript/gobierto_admin/modules/application.js
@@ -83,6 +83,16 @@ $(document).on('turbolinks:load', function() {
   });
 });
 
+function datepickerStartDate($datepicker) {
+  if ($datepicker.data("startdate")) {
+    return new Date($datepicker.data("startdate"))
+  } else if ($datepicker.data("allowBlank")) {
+    return undefined
+  } else {
+    return new Date()
+  }
+}
+
 function addDatepickerBehaviors() {
   let $datepickerWithBehavior = $('input[data-behavior!="none"].air-datepicker')
 
@@ -93,15 +103,13 @@ function addDatepickerBehaviors() {
     var $toDatePickers   = $datepickerWithBehavior.filter(':odd');
 
     $toDatePickers.each(function(index, toDatePicker) {
+      let $toDatePicker = $(toDatePicker);
 
       // Check if properties were informed before set defaults
       const toDatePickerDEFAULTS = {
-        autoClose: ($(toDatePicker).data('autoclose') === undefined)
+        autoClose: ($toDatePicker.data('autoclose') === undefined)
           ? true
-          : ($(toDatePicker).data('autoclose')),
-        startDate: ($(toDatePicker).data('startdate') === undefined)
-          ? new Date()
-          : new Date($(toDatePicker).data('startdate'))
+          : ($toDatePicker.data('autoclose'))
       }
 
       // Datepicker end time
@@ -111,37 +119,36 @@ function addDatepickerBehaviors() {
           $(instance.el).trigger("datepicker-change");
 
           // Updates first datepicker if end_date is earlier
-          if (selectedDate < $(fromDatePicker).data('datepicker').lastSelectedDate) {
+          if (selectedDate < $fromDatePicker.data('datepicker').lastSelectedDate) {
             selectedDate.setHours(selectedDate.getHours() - 1)
-            setDateOnBindedDatepicker(selectedDate, fromDatePicker)
+            setDateOnBindedDatepicker(selectedDate, $fromDatePicker[0])
           }
         }
       }
-      if (!$(toDatePicker).data('allowBlank')) {
-        toDatePickerOPTIONS = {
-          ...toDatePickerOPTIONS, startDate: toDatePickerDEFAULTS.startDate
-        }
-      }
-      $(toDatePicker).datepicker(toDatePickerOPTIONS);
+
+      let toDatepickerDate = datepickerStartDate($toDatePicker);
+
+      if (toDatepickerDate) toDatePickerOPTIONS.startDate = toDatepickerDate
+
+      $toDatePicker.datepicker(toDatePickerOPTIONS);
 
       // Datepicker start time
-      var fromDatePicker = $fromDatePickers[index];
+      var $fromDatePicker = $($fromDatePickers[index]);
+      let fromDatepickerDate = datepickerStartDate($fromDatePicker);
 
       // Check if properties were informed before set defaults
       const fromDatePickerDEFAULTS = {
-        autoClose: ($(fromDatePicker).data('autoclose') === undefined)
+        autoClose: ($fromDatePicker.data('autoclose') === undefined)
           ? true
-          : ($(fromDatePicker).data('autoclose')),
-        minutesStep: ($(fromDatePicker).data('minutesstep') === undefined)
+          : ($fromDatePicker.data('autoclose')),
+        minutesStep: ($fromDatePicker.data('minutesstep') === undefined)
           ? 5
-          : ($(fromDatePicker).data('minutesstep')),
-        startDate: ($(fromDatePicker).data('startdate') === undefined)
-          ? new Date()
-          : new Date($(fromDatePicker).data('startdate')),
+          : ($fromDatePicker.data('minutesstep')),
+        startDate: fromDatepickerDate
       }
 
-      if($(fromDatePicker).data('range') === undefined) {
-        $(fromDatePicker).datepicker({
+      if($fromDatePicker.data('range') === undefined) {
+        $fromDatePicker.datepicker({
           autoClose: fromDatePickerDEFAULTS.autoClose,
           minutesStep: fromDatePickerDEFAULTS.minutesStep,
           startDate: fromDatePickerDEFAULTS.startDate,
@@ -160,17 +167,10 @@ function addDatepickerBehaviors() {
           }
         });
 
-        if(!$(fromDatePicker).data('allowBlank')){
-          var date = new Date($(fromDatePicker).data('startdate'));
-
-          $(fromDatePicker).data('datepicker').selectDate(date);
-        }
-        if($(toDatePicker).length && !$(toDatePicker).data('allowBlank')){
-          date = new Date($(toDatePicker).data('startdate'));
-          $(toDatePicker).data('datepicker').selectDate(date);
-        }
+        if (fromDatepickerDate) $fromDatePicker.data("datepicker").selectDate(fromDatepickerDate);
+        if (toDatepickerDate) $toDatePicker.data("datepicker").selectDate(toDatepickerDate);
       } else {
-        $(fromDatePicker).datepicker({
+        $fromDatePicker.datepicker({
           autoClose: fromDatePickerDEFAULTS.autoClose,
           onSelect: function onSelect(_, selectedDate, instance) {
             $(instance.el).trigger("datepicker-change");

--- a/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
@@ -41,6 +41,7 @@
               data: {
                 "language": I18n.locale,
                 "date-format": "yyyy-mm-dd",
+                "startDate": microseconds_since_epoch(f, :starts_at),
                 "allow-blank": true
               },
               class: "air-datepicker",
@@ -57,6 +58,7 @@
               data: {
                 "language": I18n.locale,
                 "date-format": "yyyy-mm-dd",
+                "startDate": microseconds_since_epoch(f, :ends_at),
                 "allow-blank": true
               },
               class: "air-datepicker",

--- a/test/fixtures/gobierto_plans/nodes.yml
+++ b/test/fixtures/gobierto_plans/nodes.yml
@@ -1,38 +1,40 @@
 political_agendas:
-  name_translations: <%= { 'en' => 'Publish political agendas',
-                            'es' => 'Publicar agendas políticas' }.to_json %>
+  name_translations: <%= {
+    en: "Publish political agendas",
+    es: "Publicar agendas políticas"
+  }.to_json %>
   status: in_progress_plan_status_term
   progress: 50
-  starts_at: 2016-11-01 00:02:00
-  ends_at: 2019-11-01 00:02:00
-  options: <%= { 'objetivos' => 'Improve pedestrian and vehicle safety',
-                 'temporality' => 'annual' }.to_json %>
+  starts_at: 2016-11-01
+  ends_at: 2019-11-01
+  options: <%= {
+    objetivos: "Improve pedestrian and vehicle safety",
+    temporality: "annual"
+  }.to_json %>
   categories: center_basic_needs_plan_term
-  created_at: 2016-11-01 00:02:00
-  updated_at: 2016-11-01 00:02:00
-  visibility_level: <%= GobiertoPlans::Node.visibility_levels['published'] %>
+  visibility_level: <%= GobiertoPlans::Node.visibility_levels["published"] %>
   published_version: 1
 
 scholarships_kindergartens:
-  name_translations: <%= { 'en' => 'Scholarships in kindergartens',
-                           'es' => 'Becas en guarderías'}.to_json %>
+  name_translations: <%= {
+    en: "Scholarships in kindergartens",
+    es: "Becas en guarderías"
+  }.to_json %>
   status: active_plan_status_term
   progress: 0
-  starts_at: 2016-11-01 00:02:00
-  ends_at: 2019-11-01 00:02:00
+  starts_at: 2016-11-01
+  ends_at: 2019-11-01
   categories: center_scholarships_plan_term
-  created_at: 2016-11-01 00:02:00
-  updated_at: 2016-11-01 00:02:00
-  visibility_level: <%= GobiertoPlans::Node.visibility_levels['draft'] %>
+  visibility_level: <%= GobiertoPlans::Node.visibility_levels["draft"] %>
 
 scholarships_in_school_cateens:
   name_translations: <%= {
-    en: 'Scholarships in school canteens',
-    es: 'Becas en comedores escolares'
+    en: "Scholarships in school canteens",
+    es: "Becas en comedores escolares"
   }.to_json %>
   status:
   progress: 0
-  starts_at: 2016-11-01 00:02:00
-  ends_at: 2019-11-01 00:02:00
+  starts_at: 2016-11-01
+  ends_at: 2019-11-01
   categories: economy_economic_plan_term
-  visibility_level: <%= GobiertoPlans::Node.visibility_levels['draft'] %>
+  visibility_level: <%= GobiertoPlans::Node.visibility_levels["draft"] %>


### PR DESCRIPTION
Closes #2435 

## :v: What does this PR do?

Fixes initialization of datepicker in project page and avoids a conflict between the `startDate` and `allowBlank` options.

## :mag: How should this be manually tested?

http://dip-******.gobify.net/admin/plans/28/projects/10527/edit