### PR TITLE
Plans / Restore assigned amount column

### DIFF
--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
@@ -164,7 +164,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
         id: "budget_line",
         name: i18n("budget_line"),
         field: "budget_line",
-        width: 290,
+        width: 310,
         cssClass: "cell-title",
         formatter: Select2Formatter,
         editor: Select2Editor,
@@ -182,14 +182,14 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
         id: "full_amount",
         name: i18n("full_amount"),
         field: "full_amount",
-        width: 120,
+        width: 100,
         cssClass: "cell-title disabled"
       },
       {
         id: "assigned_amount",
         name: i18n("assigned_amount"),
         field: "assigned_amount",
-        width: 120,
+        width: 100,
         cssClass: "cell-title disabled"
       }
     ];

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/budgets_plugin.js
@@ -111,6 +111,9 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
       if (jsonData) {
         var amount = jsonData.forecast.updated_amount || jsonData.forecast.original_amount
         updatedRow.full_amount = `${Math.round(amount).toLocaleString(I18n.locale)} €`
+        if (updatedRow.weight) {
+          updatedRow.assigned_amount = `${Math.round(amount * updatedRow.weight / 100).toLocaleString(I18n.locale)} €`
+        }
         _grid.invalidateRow(row)
         _grid.render()
       }
@@ -161,7 +164,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
         id: "budget_line",
         name: i18n("budget_line"),
         field: "budget_line",
-        width: 300,
+        width: 290,
         cssClass: "cell-title",
         formatter: Select2Formatter,
         editor: Select2Editor,
@@ -171,7 +174,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
         id: "weight",
         name: `${i18n("weight")} %`,
         field: "weight",
-        width: 80,
+        width: 65,
         cssClass: "cell-title",
         editor: Editors.Integer
       },
@@ -179,6 +182,13 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsBudgetsPluginController = (
         id: "full_amount",
         name: i18n("full_amount"),
         field: "full_amount",
+        width: 120,
+        cssClass: "cell-title disabled"
+      },
+      {
+        id: "assigned_amount",
+        name: i18n("assigned_amount"),
+        field: "assigned_amount",
         width: 120,
         cssClass: "cell-title disabled"
       }

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/ca.yml
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/ca.yml
@@ -4,11 +4,11 @@ ca:
     custom_fields_plugins:
       budgets:
         area: Àrea
-        assigned_amount: Import assignat
+        assigned_amount: Assignat
         budget_line: Partida pressupostària
         custom: Personalitzada
         economic: Econòmica
-        full_amount: Import complet
+        full_amount: Total
         functional: Funcional
         not_available: No disp.
         weight: Pes

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/en.yml
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/en.yml
@@ -4,11 +4,11 @@ en:
     custom_fields_plugins:
       budgets:
         area: Area
-        assigned_amount: Assigned amount
+        assigned_amount: Assigned
         budget_line: Budget line
         custom: Custom
         economic: Economic
-        full_amount: Full amount
+        full_amount: Total
         functional: Functional
         not_available: Not avail.
         weight: Weight

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/es.yml
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/config/locales/gobierto_admin/gobierto_common/custom_fields/es.yml
@@ -4,11 +4,11 @@ es:
     custom_fields_plugins:
       budgets:
         area: Área
-        assigned_amount: Importe asignado
+        assigned_amount: Asignado
         budget_line: Partida presupuestaria
         custom: Personalizada
         economic: Económica
-        full_amount: Importe completo
+        full_amount: Total
         functional: Funcional
         not_available: No disp.
         weight: Peso


### PR DESCRIPTION
Closes #2432 

## :v: What does this PR do?

Restores the assigned amount column, which gets automatically updated when changing the weight.

## :mag: How should this be manually tested?

http://dip-******.gobify.net/admin/plans/28/projects/10527/edit

## :eyes: Screenshots

![Captura de pantalla 2019-07-10 a las 13 41 04](https://user-images.githubusercontent.com/9287468/60966390-6a54dd80-a318-11e9-9077-b1e468a4ab07.png)