### PR TITLE
2395 - Save widget design iteration

### DIFF
--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -58,7 +58,8 @@ textarea {
   }
 }
 
-input[type=text].slim {
+input[type=text].slim,
+input[type=email].slim {
   height: auto;
   padding: 0.25em;
 }
@@ -258,7 +259,7 @@ button.light,
 
 button.gigantic,
 .button.gigantic {
-  font-size: 1.3em;
+  font-size: 1.3rem;
   height: initial;
   padding: 1.4em 4em 1.2em;
   margin: 1em 0;
@@ -270,7 +271,7 @@ button.gigantic,
 
 button.medium,
 .button.medium {
-  font-size: 0.85em;
+  font-size: 0.85rem;
   padding: .65em 1em 0.5em;
   @include border-radius(4px);
   display: inline-block;
@@ -278,7 +279,7 @@ button.medium,
 
 button.small,
 .button.small {
-  font-size: 0.85em;
+  font-size: 0.85rem;
   padding: 0.45em 1em 0.3em;
   height: initial;
   line-height: 1.2em;
@@ -739,6 +740,7 @@ select {
 
   .options.compact {
     font-size: 0.85em;
+    line-height: 1.8;
 
     .option {
       border: 0;

--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -1186,6 +1186,10 @@ table {
 .f_small {
   font-size: .85em;
   line-height: 1.2;
+
+  .form_item .options.compact {
+    font-size: 1em;
+  }
 }
 .f_soft,
 a.f_soft,

--- a/app/decorators/gobierto_admin/moderated_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/moderated_resource_decorator.rb
@@ -92,6 +92,12 @@ module GobiertoAdmin
                                        end
     end
 
+    def status_style_class(staus_text)
+      Hash[PUBLISH_MODERATION_STEPS.values.map do |dic|
+        [dic[:moderation_status], dic[:moderation_style]]
+      end][staus_text.to_sym] || :in_revision
+    end
+
     private
 
     def publish_moderation_status

--- a/app/javascript/gobierto_admin/modules/gobierto_plans_plan_projects_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_plans_plan_projects_controller.js
@@ -1,7 +1,7 @@
 window.GobiertoAdmin.GobiertoPlansPlanProjectsController = (function() {
   function GobiertoPlansPlanProjectsController() {}
 
-  GobiertoPlansPlanProjectsController.prototype.form = function(opts) {
+  GobiertoPlansPlanProjectsController.prototype.index = function(opts) {
     _handleSubmitChangeBehaviors();
   };
 
@@ -20,6 +20,19 @@ window.GobiertoAdmin.GobiertoPlansPlanProjectsController = (function() {
       }
     })
   }
+
+  GobiertoPlansPlanProjectsController.prototype.form = function(opts) {
+    $(".js-admin-widget-save label").click(function(e) {
+      var styleClass = $(e.target).attr("data-status-style")
+      let $dropdownToggle = $(e.target).closest(".js-admin-widget-save").find("span.i_p_status")
+
+      $dropdownToggle.removeClass()
+      $dropdownToggle.addClass(`i_p_status ${styleClass}`)
+
+      var newStateText = e.target.textContent.trim();
+      $(".g_popup_context .i_p_status a").text(newStateText);
+    })
+  };
 
   return GobiertoPlansPlanProjectsController;
 })();

--- a/app/views/gobierto_admin/gobierto_plans/projects/_filter_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/_filter_form.html.erb
@@ -52,6 +52,6 @@
 
 <% content_for :javascript_hook do %>
   <%= javascript_tag do %>
-    window.GobiertoAdmin.gobierto_plans_plan_projects_controller.form()
+    window.GobiertoAdmin.gobierto_plans_plan_projects_controller.index()
   <% end %>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
@@ -102,3 +102,9 @@
   <%= render partial: "gobierto_admin/shared/admin_widget_save_v2", locals: { f: f, resource: @project_form.persisted? ? @project : @project_form.project } %>
 </div>
 <% end %>
+
+<% content_for :javascript_hook do %>
+  <%= javascript_tag do %>
+    window.GobiertoAdmin.gobierto_plans_plan_projects_controller.form()
+  <% end %>
+<% end %>

--- a/app/views/gobierto_admin/shared/_admin_widget_moderate.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_moderate.html.erb
@@ -15,7 +15,7 @@
           </a>
         </span>
 
-        <div class="g_popup">
+        <div class="g_popup" style="width: 150px; min-width: 150px;">
           <h3><%= t("gobierto_admin.shared.moderation_save_widget.moderation") %></h3>
 
           <div class="form_item">

--- a/app/views/gobierto_admin/shared/_admin_widget_moderate.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_moderate.html.erb
@@ -1,33 +1,40 @@
-<% if resource.moderable_has_moderation? && resource.moderation_policy.moderate? && resource.persisted? %>
-  <div class="widget_save_v2 m_b_2 moderator">
+<div class="w_s_content">
+  <div class="pure-g f_small">
 
-    <div class="w_s_content">
+    <div class="pure-u-1-2">
+      <%= t("gobierto_admin.shared.moderation_save_widget.moderation") %>
+    </div>
 
-      <h4><%= t("gobierto_admin.shared.moderation_save_widget.moderation") %></h4>
+    <div class="pure-u-1-2">
+      <span class="g_popup_context js-admin-widget-save">
 
-      <div class="form_item">
+        <span class="i_p_status <%= resource.moderation_style %>">
+          <a title="<%= t('gobierto_admin.shared.moderation_save_widget.change_moderation_status') %>">
+            <%= t("gobierto_admin.shared.moderation_save_widget.moderation_status.#{resource.moderation_status}") %>
+            <i class="fas fa-caret-down"></i>
+          </a>
+        </span>
 
-        <div class="options compact">
-          <%= f.collection_radio_buttons(:moderation_stage, resource.moderation_reachable_stages, :first, :first) do |b| %>
-            <div class="option">
-              <%= b.radio_button %>
-              <%= b.label do %>
-                <span></span>
-                <%= t("gobierto_admin.shared.moderation_save_widget.moderation_status.#{b.text}") %>
+        <div class="g_popup">
+          <h3><%= t("gobierto_admin.shared.moderation_save_widget.moderation") %></h3>
+
+          <div class="form_item">
+            <div class="options compact">
+              <%= f.collection_radio_buttons(:moderation_stage, resource.moderation_reachable_stages, :first, :first) do |b| %>
+                <div class="option">
+                  <%= b.radio_button(id: "project_moderation_stage_#{b.text}") %>
+                  <%= b.label("data-status-style" => resource.status_style_class(b.text)) do %>
+                    <span></span>
+                    <%= t("gobierto_admin.shared.moderation_save_widget.moderation_status.#{b.text}") %>
+                  <% end %>
+                </div>
               <% end %>
             </div>
-          <% end %>
+          </div>
         </div>
 
-      </div>
-
-      <div class="w_actions m_b_1">
-        <% if resource.moderation_reachable_stages.any? %>
-          <button class="button medium"><%= t("gobierto_admin.shared.moderation_save_widget.save") %></button>
-        <% end %>
-      </div>
-
+      </span>
     </div>
 
   </div>
-<% end %>
+</div>

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -1,5 +1,6 @@
 <% versioned_resource = GobiertoAdmin::VersionedResourceDecorator.new(resource) %>
 <% moderated_resource = GobiertoAdmin::ModeratedResourceDecorator.new(versioned_resource.has_versions? ? versioned_resource.live_version : resource, current_admin: current_admin, current_site: current_site) %>
+<% moderation_policy = moderated_resource.moderation_policy %>
 
 <div class="pure-u-1 pure-u-md-1-4">
 
@@ -9,7 +10,7 @@
 
       <div class="w_s_content">
 
-        <% if moderated_resource.moderation_policy.edit? %>
+        <% if moderation_policy.edit? ||moderation_policy.moderate? %>
           <div class="w_actions m_b_1">
             <button class="button medium"><%= t("gobierto_admin.shared.moderation_save_widget.save") %></button>
             <%= f.button(
@@ -55,6 +56,10 @@
 
       </div>
 
+      <% if moderated_resource.moderable_has_moderation? && moderation_policy.moderate? && moderated_resource.persisted? %>
+        <%= render "gobierto_admin/shared/admin_widget_moderate", f: f, resource: moderated_resource %>
+      <% end %>
+
       <% if moderated_resource.has_publication_status? %>
         <div class="publication_section m_v_2">
 
@@ -79,7 +84,7 @@
               </div>
             <% end %>
 
-            <% if moderated_resource.moderation_policy.moderate? || moderated_resource.moderation_policy.edit? && moderated_resource.publicable? %>
+            <% if moderation_policy.moderate? || moderation_policy.edit? && moderated_resource.publicable? %>
               <div class="w_s_txt_msg f_small m_t_4">
                 <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{versioned_resource.current_version_publication_step}_html", url: @unpublish_url) %>
               </div>
@@ -88,12 +93,12 @@
                       t("gobierto_admin.shared.moderation_save_widget.publish"),
                       disabled: versioned_resource.current_version_published?,
                       class: "bl",
-                      name: "#{f.object_name}[#{moderated_resource.moderation_policy.moderate? ? "moderation_visibility_level" : "visibility_level"}]",
+                      name: "#{f.object_name}[#{moderation_policy.moderate? ? "moderation_visibility_level" : "visibility_level"}]",
                       value: [moderated_resource.step_published_value, versioned_resource.current_version].compact.join("-"),
                       data: { confirm: t("gobierto_admin.shared.moderation_save_widget.confirm") }
                     ) %>
               </div>
-            <% elsif moderated_resource.moderation_policy.edit? %>
+            <% elsif moderation_policy.edit? %>
               <div class="w_s_txt_msg f_small m_t_4">
                 <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.publish_moderation_step}") %>
               </div>
@@ -115,23 +120,6 @@
         </div>
       <% end %>
 
-      <div class="w_s_content">
-
-        <div class="pure-g f_small">
-          <div class="pure-u-1-2">
-            <%= t("gobierto_admin.shared.moderation_save_widget.moderation") %>
-          </div>
-          <div class="pure-u-1-2">
-            <span class="i_p_status <%= moderated_resource.moderation_style %>"><%= t("gobierto_admin.shared.moderation_save_widget.moderation_status.#{moderated_resource.moderation_status}") %></span>
-          </div>
-        </div>
-
-      </div>
-
     </div>
-
-    <%= render partial: "gobierto_admin/shared/admin_widget_moderate", locals: { f: f, resource: moderated_resource } %>
-
   </div>
-
 </div>

--- a/app/views/gobierto_admin/shared/_versions_select.html.erb
+++ b/app/views/gobierto_admin/shared/_versions_select.html.erb
@@ -1,6 +1,9 @@
 <% if resource.recent_versions.count > 1 %>
   <span class="g_popup_context">
-    <a href="" class="f_soft"><%= t("gobierto_admin.shared.moderation_save_widget.see_versions") %></a>
+    <a href="" class="f_soft">
+      <i class="fas fa-history"
+         title="<%= t('gobierto_admin.shared.moderation_save_widget.previous_versions') %>"></i>
+    </a>
 
     <div class="g_popup">
 

--- a/app/views/gobierto_admin/shared/_versions_select.html.erb
+++ b/app/views/gobierto_admin/shared/_versions_select.html.erb
@@ -5,7 +5,7 @@
          title="<%= t('gobierto_admin.shared.moderation_save_widget.previous_versions') %>"></i>
     </a>
 
-    <div class="g_popup">
+    <div class="g_popup" style="width: 200px; min-width: 200px;">
 
       <h3><%= t("gobierto_admin.shared.moderation_save_widget.last_versions") %></h3>
 

--- a/app/views/sandbox/_admin_modal_item_permissions.html.erb
+++ b/app/views/sandbox/_admin_modal_item_permissions.html.erb
@@ -1,0 +1,42 @@
+<div class="modal mfp-hide" id="modal_item_permissions">
+
+
+  <h3>Añadir usuario</h3>
+
+  <div class="pure-g">
+    <div class="pure-u-1-2">
+      SELECT2
+    </div>
+    <div class="pure-u-1-2">
+      <div class="form_item input_text ">
+        <div class="button medium">Añadir</div>
+      </div>
+    </div>
+  </div>
+
+
+  <h3>Usuarios con acceso</h3>
+
+  <table>
+  <tr>
+    <th>Usuario</th>
+    <th>Correo-e</th>
+    <th>Acceso concendido</th>
+    <th></th>
+  </tr>
+
+  <% for i in 0..4 %>
+  <tr>
+    <td><strong>Fernando Blat</strong></td>
+    <td>fernando@dival.es</td>
+    <td>hace 2 horas </td>
+    <td class="">
+      <%= link_to '<i class="fas fa-user-times"></i> Eliminar acceso'.html_safe, '', class:'view_item' %>
+    </td>
+  </tr>
+  <% end %>
+
+  </table>
+
+
+</div>

--- a/app/views/sandbox/_admin_widget_save_moderation.html.erb
+++ b/app/views/sandbox/_admin_widget_save_moderation.html.erb
@@ -1,0 +1,45 @@
+<h3>Moderación</h3>
+
+<div class="form_item">
+
+  <div class="options compact">
+
+		<div class="option">
+      <input type="radio" id="opt_1" name="opt" value="1" checked="">
+      <label for="opt_1">
+        <span></span>
+        Enviado
+     </label>
+    </div>
+
+		<div class="option">
+      <input type="radio" id="opt_2" name="opt" value="2" checked="">
+      <label for="opt_2">
+        <span></span>
+        En revisión
+     </label>
+    </div>
+
+    <div class="option">
+      <input type="radio" id="opt_3" name="opt" value="3">
+      <label for="opt_3">
+        <span></span>
+        Aprobado
+      </label>
+    </div>
+
+    <div class="option">
+      <input type="radio" id="opt_4" name="opt" value="4">
+      <label for="opt_4">
+        <span></span>
+        Rechazado
+      </label>
+    </div>
+
+  </div>
+
+</div>
+
+<div class="w_actions m_b_1">
+  <button class="button medium">Guardar</button>
+</div>

--- a/app/views/sandbox/_admin_widget_save_v2.html.erb
+++ b/app/views/sandbox/_admin_widget_save_v2.html.erb
@@ -95,13 +95,28 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
         Moderación
       </div>
       <div class="pure-u-1-2">
-        <span class="i_p_status not_published">No enviado</span>
+        <span class="g_popup_context">
+          <span class="i_p_status not_published">
+            <a href="" title="Cambiar estado moderación">
+              No enviado
+              <i class="fas fa-caret-down"></i>
+            </a>
+          </span>
+
+          <div class="g_popup">
+
+            <%= render "admin_widget_save_moderation.html.erb"%>
+
+          </div>
+
+        </span>
       </div>
     </div>
 
   </div>
 
 </div>
+
 
 
 
@@ -140,7 +155,7 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
       <div class="pure-u-1-2">
         <strong class="p_h_1">1</strong>
         <span class="g_popup_context">
-          <a href="" class="f_soft">ver anteriores</a>
+          <a href="" class="f_soft"><i class="fas fa-history" title="ver anteriores"></i></a>
 
           <div class="g_popup">
 
@@ -224,7 +239,21 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
         Moderación
       </div>
       <div class="pure-u-1-2">
-        <span class="i_p_status not_published">No enviado</span>
+        <span class="g_popup_context">
+          <span class="i_p_status not_published">
+            <a href="" title="Cambiar estado moderación">
+              No enviado
+              <i class="fas fa-caret-down"></i>
+            </a>
+          </span>
+
+          <div class="g_popup">
+
+            <%= render "admin_widget_save_moderation.html.erb"%>
+
+          </div>
+
+        </span>
       </div>
     </div>
 
@@ -266,7 +295,7 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
       <div class="pure-u-1-2">
         <strong class="p_h_1">1</strong>
         <span class="g_popup_context">
-          <a href="" class="f_soft">ver anteriores</a>
+          <a href="" class="f_soft"><i class="fas fa-history" title="ver anteriores"></i></a>
 
           <div class="g_popup">
 
@@ -350,7 +379,21 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
         Moderación
       </div>
       <div class="pure-u-1-2">
-        <span class="i_p_status in_revision">En revisión</span>
+        <span class="g_popup_context">
+          <span class="i_p_status in_revision">
+            <a href="" title="Cambiar estado moderación">
+              En revisión
+              <i class="fas fa-caret-down"></i>
+            </a>
+          </span>
+
+          <div class="g_popup">
+
+            <%= render "admin_widget_save_moderation.html.erb"%>
+
+          </div>
+
+        </span>
       </div>
     </div>
 
@@ -394,7 +437,7 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
       <div class="pure-u-1-2">
         <strong class="p_h_1">1</strong>
         <span class="g_popup_context">
-          <a href="" class="f_soft">ver anteriores</a>
+          <a href="" class="f_soft"><i class="fas fa-history" title="ver anteriores"></i></a>
 
           <div class="g_popup">
 
@@ -478,7 +521,21 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
         Moderación
       </div>
       <div class="pure-u-1-2">
-        <span class="i_p_status approved">Aprobado</span>
+        <span class="g_popup_context">
+          <span class="i_p_status approved">
+            <a href="" title="Cambiar estado moderación">
+              Aprobado
+              <i class="fas fa-caret-down"></i>
+            </a>
+          </span>
+
+          <div class="g_popup">
+
+            <%= render "admin_widget_save_moderation.html.erb"%>
+
+          </div>
+
+        </span>
       </div>
     </div>
 
@@ -522,7 +579,7 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
       <div class="pure-u-1-2">
         <strong class="p_h_1">1</strong>
         <span class="g_popup_context">
-          <a href="" class="f_soft">ver anteriores</a>
+          <a href="" class="f_soft"><i class="fas fa-history" title="ver anteriores"></i></a>
 
           <div class="g_popup">
 
@@ -606,7 +663,21 @@ txt_msg_5 = "La versión actual es la que está publicada.  Despublicar."
         Moderación
       </div>
       <div class="pure-u-1-2">
-        <span class="i_p_status approved">Aprobado</span>
+        <span class="g_popup_context">
+          <span class="i_p_status approved">
+            <a href="" title="Cambiar estado moderación">
+              Aprobado
+              <i class="fas fa-caret-down"></i>
+            </a>
+          </span>
+
+          <div class="g_popup">
+
+            <%= render "admin_widget_save_moderation.html.erb"%>
+
+          </div>
+
+        </span>
       </div>
     </div>
 

--- a/app/views/sandbox/admin_plans_plan_projects_project.html.erb
+++ b/app/views/sandbox/admin_plans_plan_projects_project.html.erb
@@ -2,10 +2,18 @@
   <%= link_to 'Inicio', 'admin' %> »
   <%= link_to 'Planificación', 'admin_plans' %> »
   <%= link_to 'Plan Actuación Municipal', 'admin_plans_plan' %> »
-
 </div>
 
-<h1>Proyectos de Plan Actuación Municipal</h1>
+<div class="pure-g">
+  <div class="pure-u-md-2-3">
+    <h1>Proyectos de Plan Actuación Municipal</h1>
+  </div>
+  <div class="pure-u-md-1-3 right">
+    <%= link_to '<i class="fas icon fa-users"></i> Permisos'.html_safe, '#modal_item_permissions', class: 'open_modal button outline rounded' %>
+  </div>
+</div>
+
+<%= render "admin_modal_item_permissions.html.erb" %>
 
 <div class="tabs">
   <ul>
@@ -106,7 +114,7 @@
 
         <div class="v_heading">
           <div>
-            
+
           </div>
 
           <div class="v_el_decorated">
@@ -202,108 +210,9 @@
 
     <%= render "admin_widget_save_v2.html.erb", locals: { only_save_button: true } %>
 
-    <div class="widget_save_v2 m_b_2">
-
-      <div class="w_s_content">
-
-        <h4>Moderación</h4>
-
-        <div class="form_item">
-
-          <div class="options compact">
-
-        		<div class="option">
-              <input type="radio" id="opt_1" name="opt" value="1" checked="">
-              <label for="opt_1">
-                <span></span>
-                En revisión
-             </label>
-            </div>
-
-            <div class="option">
-              <input type="radio" id="opt_2" name="opt" value="2">
-              <label for="opt_2">
-                <span></span>
-                Aprobado
-              </label>
-            </div>
-
-            <div class="option">
-              <input type="radio" id="opt_2" name="opt" value="2">
-              <label for="opt_2">
-                <span></span>
-                Rechazado
-              </label>
-            </div>
-
-          </div>
-
-        </div>
-
-        <div class="w_actions m_b_1">
-          <button class="button medium">Guardar</button>
-        </div>
-
-      </div>
-
-    </div>
-
     <%# render "admin_widget_attachment.html.erb" %>
 
 
   </div>
 
 </div>
-
-<script type="text/javascript">
-
-$(document).ready(function(){
-
-  // Toggle selected element child
-  $('.v_container .v_el .icon-caret').click(function(e) {
-    e.preventDefault();
-
-    // ToDo: Don't relay on icon specific names
-    if($(this).is('.fa-caret-right')) {
-      $(this).removeClass('fa-caret-right');
-      $(this).addClass('fa-caret-down');
-    }
-    else {
-      $(this).removeClass('fa-caret-down');
-      $(this).addClass('fa-caret-right');
-    }
-
-    $(this).parent().parent().parent().parent().find('> .v_el').toggleClass('el-opened');
-
-  });
-
-  // Close all elements except first level
-  $('.v_container .v_heading .fa-caret-square-right').click(function(e) {
-    // closes all elements
-    $('.v_container .v_el_level .v_el').removeClass('el-opened');
-  });
-
-  // Open all elements except first level
-  $('.v_container .v_heading .fa-caret-square-down').click(function(e) {
-    // Opens all elements
-    $('.v_container .v_el_level .v_el').addClass('el-opened');
-  });
-
-  // show only action buttons (edit, delete) when hovering an item
-  // ToDo: Control that only elements for the item are shown, not for it's parents
-  $('.v_el').hover(
-    function(e) {
-      $(this).first('.v_el_actions').addClass('v_el_active');
-    },
-    function(e) {
-      $(this).first('.v_el_actions').removeClass('v_el_active');
-    }
-  );
-
-  // only for sandbox
-  $('.sandbox_remove_decorated_content').click(function(e) {
-    $('.v_el_decorated').toggle();
-  });
-
-});
-</script>

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -29,6 +29,7 @@ ca:
         define_content_in_locale: Defineix el contingut en la versió en %{locale_name}
         translate: Traduxir
       moderation_save_widget:
+        change_moderation_status: Canvia l'estat de moderació
         confirm: Estàs segur?
         edit_version: Editant versió
         last_versions: Últimes versions

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -54,6 +54,7 @@ ca:
           sent: Sent
         new_version: Nova (no guardada)
         preview: Previsualitzar
+        previous_versions: Versions anteriors
         publication_status:
           approved: Publicada
           not_published: No publicada
@@ -63,7 +64,6 @@ ca:
         published_version_blank: sense publicar encara
         save: Guardar
         see_all: veure totes
-        see_versions: veure versions
         send: Enviar
         unpublish: Despublicar
       recover:

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -53,6 +53,7 @@ en:
           sent: Sent
         new_version: New (not saved)
         preview: Preview
+        previous_versions: Previous versions
         publication_status:
           approved: Published
           not_published: Not published
@@ -62,7 +63,6 @@ en:
         published_version_blank: not published yet
         save: Save
         see_all: see all
-        see_versions: see versions
         send: Send
         unpublish: Unpublish
       recover:

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -29,6 +29,7 @@ en:
         define_content_in_locale: Define the content in %{locale_name} version
         translate: Translate
       moderation_save_widget:
+        change_moderation_status: Cambiar estado de moderación
         confirm: Are you sure?
         edit_version: Editing version
         last_versions: Last versions

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -29,6 +29,7 @@ es:
         define_content_in_locale: Define el contenido en su versión %{locale_name}
         translate: Traducir
       moderation_save_widget:
+        change_moderation_status: Cambiar estado de moderación
         confirm: "¿Estás seguro?"
         edit_version: Editando versión
         last_versions: Últimas versiones

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -54,6 +54,7 @@ es:
           sent: Enviado
         new_version: Nueva (no guardada)
         preview: Previsualizar
+        previous_versions: Versiones anteriores
         publication_status:
           approved: Publicada
           not_published: No publicada
@@ -63,7 +64,6 @@ es:
         published_version_blank: sin publicar todavía
         save: Guardar
         see_all: ver todas
-        see_versions: ver versiones
         send: Enviar
         unpublish: Despublicar
       recover:

--- a/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
@@ -65,6 +65,12 @@ module GobiertoAdmin
           true
         end
 
+        def choose_moderation_status(status_text)
+          find(".js-admin-widget-save a").click
+          find("label", text: status_text).click
+          find("body").click # lose popover hover so it closes
+        end
+
         def test_create_project_as_manager
           with default_test_context do
             create_project
@@ -121,15 +127,11 @@ module GobiertoAdmin
 
             create_project
 
-            within "form" do
-              select "Not started", from: "project_custom_records_status_value"
+            select "Not started", from: "project_custom_records_status_value"
 
-              find("label[for$='approved']").click
+            choose_moderation_status "Approved"
 
-              within "div.widget_save_v2.editor" do
-                click_button "Publish"
-              end
-            end
+            click_button "Publish"
 
             page.accept_alert
 
@@ -149,14 +151,12 @@ module GobiertoAdmin
 
             create_project
 
-            within "form" do
-              select "Not started", from: "project_custom_records_status_value"
+            select "Not started", from: "project_custom_records_status_value"
 
-              find("label[for$='approved']").click
+            choose_moderation_status "Approved"
 
-              within "div.widget_save_v2.editor" do
-                click_button "Save"
-              end
+            within "div.widget_save_v2.editor" do
+              click_button "Save"
             end
 
             visit edit_admin_plans_plan_project_path(plan, project, version: 1)
@@ -187,14 +187,12 @@ module GobiertoAdmin
             assert has_content?("Editing version\n1")
             assert has_content?("not published yet")
 
-            within "form" do
-              select "Not started", from: "project_custom_records_status_value"
+            select "Not started", from: "project_custom_records_status_value"
 
-              find("label[for$='approved']").click
+            choose_moderation_status "Approved"
 
-              within "div.widget_save_v2.editor" do
-                click_button "Save"
-              end
+            within "div.widget_save_v2.editor" do
+              click_button "Save"
             end
 
             assert has_content?("Editing version\n2")
@@ -232,14 +230,12 @@ module GobiertoAdmin
 
             create_project
 
-            within "form" do
-              select "Not started", from: "project_custom_records_status_value"
+            select "Not started", from: "project_custom_records_status_value"
 
-              find("label[for$='approved']").click
+            choose_moderation_status "Approved"
 
-              within "div.widget_save_v2.editor" do
-                click_button "Save"
-              end
+            within "div.widget_save_v2.editor" do
+              click_button "Save"
             end
 
             visit edit_admin_plans_plan_project_path(plan, project, version: 1)
@@ -281,12 +277,10 @@ module GobiertoAdmin
               end
             end
 
-            within "form" do
-              find("label[for$='approved']").click
+            choose_moderation_status "Approved"
 
-              within "div.widget_save_v2.editor" do
-                click_button "Save"
-              end
+            within "div.widget_save_v2.editor" do
+              click_button "Save"
             end
 
             assert has_content? "Editing version\n3"


### PR DESCRIPTION
Closes #2395 

## :v: What does this PR do?

- Replaces "View versions" with icon
- Implements new design of the save/moderation widget
- Changes moderation widget position so it appears under status

## :mag: How should this be manually tested?

You can check it in http://dip-******.gobify.net/admin/plans/28/projects/10525/edit

## :eyes: Screenshots

After discussing with @Crashillo we've decided to decrease the popover width to avoid overlap with slickgrid tables.

**With original design**

![Captura de pantalla 2019-07-10 a las 16 02 27](https://user-images.githubusercontent.com/9287468/60975521-6cc13280-a32c-11e9-884e-53d196aaa77f.png)

**Implemented version**

![Captura de pantalla 2019-07-10 a las 16 01 37](https://user-images.githubusercontent.com/9287468/60975542-7185e680-a32c-11e9-91d6-771c927f390c.png)





