### PR TITLE
Fix progress calculation query

### DIFF
--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
@@ -14,7 +14,7 @@ module GobiertoCommon::CustomFieldFunctions
 
       return if uids.blank?
 
-      calculation_custom_fields = site.custom_fields.find_by!(uid: uids)
+      calculation_custom_fields = uids.map { |uid| site.custom_fields.find_by!(uid: uid) }
 
       calculation_records = GobiertoCommon::CustomFieldRecord.where(item: record.item, custom_field: calculation_custom_fields)
       progress_items = calculation_records.map { |record| record.functions(version: @version).progress(options) }.compact


### PR DESCRIPTION
Closes #2437


## :v: What does this PR do?

Fixes the method used to calculate progress in custom fields of this type. The method now includes all the custom fields configured in the plugin to make the calculation

## :mag: How should this be manually tested?

Visit a project with a progress plugin with more than one custom fields configured to calculate the progress and change the data

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No