### PR TITLE
2379 admin projects visibility

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -138,8 +138,13 @@ module GobiertoAdmin
       end
 
       def set_filters
-        @relation = base_relation
         @form = ProjectsFilterForm.new(filter_params.merge(plan: @plan, admin: current_admin))
+        @relation = if @form.admin_actions.present?
+                      GobiertoAdmin::AdminResourcesQuery.new(current_admin, relation: @plan.nodes).allowed(include_moderated: false)
+                    else
+                      base_relation
+                    end
+
         @form.filter_params.each do |param|
           @relation = @relation.send(:"with_#{param}", filter_params[param])
         end
@@ -167,7 +172,11 @@ module GobiertoAdmin
       end
 
       def base_relation
-        @plan.nodes
+        if current_admin.module_allowed_action?("GobiertoPlans", current_site, :moderate)
+          @plan.nodes
+        else
+          GobiertoAdmin::AdminResourcesQuery.new(current_admin, relation: @plan.nodes).allowed
+        end
       end
 
       def filter_params

--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -156,7 +156,7 @@ module GobiertoAdmin
       end
 
       def find_versioned_project
-        @project = @plan.nodes.find params[:id]
+        @project = base_relation.find params[:id]
 
         return if params[:version].blank?
 

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -237,6 +237,10 @@ module GobiertoAdmin
           @node.restore_attributes(ignored_attributes) if @node.changed? && ignored_attributes.present?
           force_new_version && !attributes_updated? ? @node.paper_trail.save_with_version : @node.save
 
+          set_permissions_group(@node, action_name: :edit) do |group|
+            group.admins << @node.owner unless @node.owner.blank? || group.admins.where(id: @node.admin_id).exists?
+          end
+
           if allow_edit_attributes? && !@node.categories.include?(category)
             @node.categories.where(vocabulary: plan.categories_vocabulary).each do |plan_category|
               @node.categories.delete plan_category
@@ -248,10 +252,6 @@ module GobiertoAdmin
           plan.touch
 
           save_moderation
-
-          set_permissions_group(@node, action_name: :edit) do |group|
-            group.admins << @node.owner unless @node.owner.blank? || group.admins.where(id: @node.admin_id).exists?
-          end
 
           @node
         else

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -121,7 +121,7 @@ module GobiertoAdmin
       end
 
       def allow_edit_attributes?
-        moderation_policy.edit? && !disable_attributes_edition
+        !disable_attributes_edition && (moderation_policy.edit? || allow_moderate?)
       end
 
       def allow_moderate?

--- a/app/javascript/gobierto_admin/modules/application.js
+++ b/app/javascript/gobierto_admin/modules/application.js
@@ -116,7 +116,7 @@ function addDatepickerBehaviors() {
       let toDatePickerOPTIONS = {
         autoClose: toDatePickerDEFAULTS.autoClose,
         onSelect: function onSelect(a, selectedDate, instance) {
-          $(instance.el).trigger("datepicker-change");
+          if (instance.visible) $(instance.el).trigger("datepicker-change");
 
           // Updates first datepicker if end_date is earlier
           if (selectedDate < $fromDatePicker.data('datepicker').lastSelectedDate) {
@@ -153,7 +153,7 @@ function addDatepickerBehaviors() {
           minutesStep: fromDatePickerDEFAULTS.minutesStep,
           startDate: fromDatePickerDEFAULTS.startDate,
           onSelect: function onSelect(_, selectedDate, instance) {
-            $(instance.el).trigger("datepicker-change");
+            if (instance.visible) $(instance.el).trigger("datepicker-change");
 
             // data-bind=true links fromDatePicker to toDatePicker
             // on fromDatePicker selection, updates toDatePicker +1h

--- a/app/models/concerns/gobierto_common/moderable.rb
+++ b/app/models/concerns/gobierto_common/moderable.rb
@@ -22,7 +22,7 @@ module GobiertoCommon
       def extra_moderation_permissions_lookup_attributes
         define_method :permissions_lookup_attributes do |action|
           base_permissions_lookup_attributes(action) +
-            yield(self).map { |attrs_set| attrs_set.merge(action_name: action) }
+            yield(self, action.to_sym).map { |attrs_set| attrs_set.merge(action_name: action) }
         end
       end
 
@@ -54,7 +54,7 @@ module GobiertoCommon
     def base_permissions_lookup_attributes(action)
       [{
         namespace: moderation.moderable_type.deconstantize.underscore,
-        resource_type: moderation.moderable_type.demodulize.underscore,
+        resource_type: moderation.moderable_type,
         resource_id: moderation.moderable_id,
         action_name: action
       }]

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -48,12 +48,16 @@ module GobiertoPlans
       end
     }
 
-    extra_moderation_permissions_lookup_attributes do |_|
-      [{
-        namespace: "site_module",
-        resource_type: "gobierto_plans",
-        resource_id: nil
-      }]
+    extra_moderation_permissions_lookup_attributes do |node, action|
+      if node.new_record? || action != :edit
+        [{
+          namespace: "site_module",
+          resource_type: "gobierto_plans",
+          resource_id: nil
+        }]
+      else
+        []
+      end
     end
 
     default_moderation_stage do |node|

--- a/app/policies/gobierto_admin/gobierto_plans/project_policy.rb
+++ b/app/policies/gobierto_admin/gobierto_plans/project_policy.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
       attr_reader :project
 
       ALLOWED_ACTIONS = { edit: [:index, :edit, :update, :new, :create, :destroy, :update_attributes],
-                          moderate: [:index, :edit, :update],
+                          moderate: [:index, :edit, :update, :update_attributes],
                           manage: [] }.freeze
 
       def initialize(attributes)

--- a/app/queries/gobierto_admin/admin_resources_query.rb
+++ b/app/queries/gobierto_admin/admin_resources_query.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class AdminResourcesQuery
+
+    class NotImplementedError < StandardError; end
+
+    attr_reader :relation
+
+    def initialize(admin, options = {})
+      @admin = admin
+      @relation = (options[:relation] || model.all)
+      @permission_action_name ||= (options[:permission_action_name] || :edit)
+      @moderation_stages ||= moderation_keys(options[:moderation_stages])
+    end
+
+    def allowed(include_moderated: true)
+      if @admin.managing_user?
+        relation
+      else
+        condition = groups_admins_join_table[:admin_id].eq(@admin.id)
+        condition = condition.or(moderations_table[:stage].in(@moderation_stages)) if include_moderated
+        relation.joins(join_manager.join_sources).distinct.where(condition)
+      end
+    end
+
+    def join_manager
+      @join_manager ||= model_table.join(permissions_table, Arel::Nodes::OuterJoin).on(
+        model_table[:id].eq(permissions_table[:resource_id]).and(
+          permissions_table[:resource_type].eq(relation.model.name)
+        ).and(
+          permissions_table["action_name"].eq(@permission_action_name)
+        )
+      ).join(groups_admins_join_table, Arel::Nodes::OuterJoin).on(
+        groups_admins_join_table[:admin_group_id].eq(permissions_table[:admin_group_id])
+      ).join(moderations_table, Arel::Nodes::OuterJoin).on(
+        model_table[:id].eq(moderations_table[:moderable_id]).and(
+          moderations_table[:moderable_type].eq(relation.model.name)
+        )
+      )
+    end
+
+    private
+
+    def moderation_keys(moderation_stages)
+      moderation_stages ||= [:approved]
+
+      moderation_stages.map do |stage|
+        ::GobiertoAdmin::Moderation.stages[stage]
+      end
+    end
+
+    def model_table
+      @model_table ||= relation.model.arel_table
+    end
+
+    def permissions_table
+      @permissions_table ||= ::GobiertoAdmin::GroupPermission.arel_table
+    end
+
+    def groups_admins_join_table
+      @groups_admins_join_table ||= ::GobiertoAdmin::GroupsAdmin.arel_table
+    end
+
+    def moderations_table
+      @moderations_table ::GobiertoAdmin::Moderation.arel_table
+    end
+
+    def model
+      raise NotImplementedError, "Must override this method"
+    end
+
+  end
+end

--- a/app/views/gobierto_admin/gobierto_plans/shared/_navigation.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/shared/_navigation.html.erb
@@ -14,8 +14,10 @@
       </li>
     <% end %>
 
-    <li class="<%= class_if('active', controller_name == "plans") %>">
-      <%= link_to t(".configuration_tab"), edit_admin_plans_plan_path(@plan), data: { turbolinks: false } %>
-    </li>
+    <% if current_admin.module_allowed_action?("GobiertoPlans", current_site, :manage) %>
+      <li class="<%= class_if('active', controller_name == "plans") %>">
+        <%= link_to t(".configuration_tab"), edit_admin_plans_plan_path(@plan), data: { turbolinks: false } %>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/test/fixtures/gobierto_admin/group_permissions.yml
+++ b/test/fixtures/gobierto_admin/group_permissions.yml
@@ -71,3 +71,9 @@ moderate_plans_madrid:
   namespace: site_module
   resource_type: gobierto_plans
   action_name: moderate
+
+edit_political_agendas:
+  admin_group: political_agendas_permissions_group
+  namespace: gobierto_plans
+  resource: political_agendas (GobiertoPlans::Node)
+  action_name: edit

--- a/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
@@ -66,6 +66,7 @@ module GobiertoAdmin
 
         def test_regular_editor_admin_delete_project_with_empty_author
           allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(project)
 
           with_signed_in_admin(regular_admin) do
             with_current_site(site) do
@@ -83,6 +84,7 @@ module GobiertoAdmin
 
         def test_regular_editor_admin_delete_other_author_project
           allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(project)
           project.update(admin_id: admin.id)
 
           with_signed_in_admin(regular_admin) do
@@ -99,6 +101,7 @@ module GobiertoAdmin
         def test_regular_editor_admin_delete_own_project
           allow_regular_admin_edit_plans
           project.update(admin_id: regular_admin.id)
+          allow_regular_admin_edit_project(project)
 
           with_signed_in_admin(regular_admin) do
             with_current_site(site) do

--- a/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
@@ -41,12 +41,10 @@ module GobiertoAdmin
         end
 
         def test_regular_admin_without_groups_delete_project
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit @path
+          with(site: site, admin: regular_admin) do
+            visit @path
 
-              assert has_alert? "You are not authorized to perform this action"
-            end
+            assert has_alert? "You are not authorized to perform this action"
           end
         end
 

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -209,7 +209,7 @@ module GobiertoAdmin
         end
 
         def test_edit_project_as_regular_editor
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(published_project)
 
           with_signed_in_admin(regular_admin) do
             with_current_site(site) do
@@ -250,7 +250,7 @@ module GobiertoAdmin
         end
 
         def test_edit_not_approved_project_as_regular_editor
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
 
           with(site: site, admin: regular_admin) do
             visit unpublished_path
@@ -290,7 +290,7 @@ module GobiertoAdmin
         end
 
         def test_unpublish_approved_project_as_regular_editor
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(published_project)
 
           with_signed_in_admin(regular_admin) do
             with_current_site(site) do
@@ -315,7 +315,7 @@ module GobiertoAdmin
         end
 
         def test_publish_not_approved_project_as_regular_editor
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
 
           with_signed_in_admin(regular_admin) do
             with_current_site(site) do
@@ -329,7 +329,7 @@ module GobiertoAdmin
         end
 
         def test_send_project_as_regular_editor
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
           unpublished_project.moderation.not_sent!
           create_custom_fields_records
 
@@ -360,7 +360,7 @@ module GobiertoAdmin
         end
 
         def test_edit_project_as_regular_editor_and_moderator
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
           allow_regular_admin_moderate_plans
 
           with_signed_in_admin(regular_admin) do
@@ -402,7 +402,7 @@ module GobiertoAdmin
         end
 
         def test_moderate_project_as_regular_editor_and_moderator
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
           allow_regular_admin_moderate_plans
           create_custom_fields_records
 
@@ -450,7 +450,7 @@ module GobiertoAdmin
         end
 
         def test_editor_changes_version_and_publish
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
           unpublished_project.moderation.approved!
 
           with_signed_in_admin(regular_admin) do
@@ -494,7 +494,7 @@ module GobiertoAdmin
         end
 
         def test_editor_changes_version_edits_and_publish
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
           unpublished_project.moderation.approved!
 
           with_signed_in_admin(regular_admin) do
@@ -574,7 +574,7 @@ module GobiertoAdmin
         end
 
         def test_editor_changes_published_version_to_first
-          allow_regular_admin_edit_plans
+          allow_regular_admin_edit_project(unpublished_project)
           create_custom_fields_records
           unpublished_project.moderation.approved!
 

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -83,40 +83,38 @@ module GobiertoAdmin
         end
 
         def test_update_project_as_manager
-          with_signed_in_admin(admin) do
-            with_current_site(site) do
-              visit path
+          with(site: site, admin: admin) do
+            visit path
 
-              within "form" do
-                fill_in "project_name_translations_en", with: "Updated project"
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
 
-                fill_in "project_starts_at", with: "2020-01-01"
-                fill_in "project_ends_at", with: "2021-01-01"
-                select "Active", from: "project_status_id"
-                select "3%", from: "project_progress"
+              fill_in "project_starts_at", with: "2020-01-01"
+              fill_in "project_ends_at", with: "2021-01-01"
+              select "Active", from: "project_status_id"
+              select "3%", from: "project_progress"
 
-                within "div.widget_save_v2.editor" do
-                  click_button "Save"
-                end
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
               end
-
-              assert has_message? "Project updated correctly."
-              assert has_content? "Updated project"
-              assert has_content? "Editing version\n2"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\n1"
-              assert has_content? "Click on Publish to make this version publicly visible."
-
-              published_project.reload
-
-              assert_equal "Updated project", published_project.name
-              assert_equal "Active", published_project.status.name
-              assert_equal 3.0, published_project.progress
-              assert_equal Date.parse("2020-01-01"), published_project.starts_at
-              assert_equal Date.parse("2021-01-01"), published_project.ends_at
-              assert published_project.published?
-              assert published_project.moderation.approved?
             end
+
+            assert has_message? "Project updated correctly."
+            assert has_content? "Updated project"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+            published_project.reload
+
+            assert_equal "Updated project", published_project.name
+            assert_equal "Active", published_project.status.name
+            assert_equal 3.0, published_project.progress
+            assert_equal Date.parse("2020-01-01"), published_project.starts_at
+            assert_equal Date.parse("2021-01-01"), published_project.ends_at
+            assert published_project.published?
+            assert published_project.moderation.approved?
           end
         end
 
@@ -200,52 +198,48 @@ module GobiertoAdmin
         def test_edit_project_as_regular_manager
           allow_regular_admin_manage_plans
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit path
-              assert has_message? "You are not authorized to perform this action"
-            end
+          with(site: site, admin: regular_admin) do
+            visit path
+            assert has_message? "You are not authorized to perform this action"
           end
         end
 
         def test_edit_project_as_regular_editor
           allow_regular_admin_edit_project(published_project)
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit path
+          with(site: site, admin: regular_admin) do
+            visit path
 
-              within "form" do
-                fill_in "project_name_translations_en", with: "Updated project"
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
 
-                fill_in "project_starts_at", with: "2020-01-01"
-                fill_in "project_ends_at", with: "2021-01-01"
-                select "Active", from: "project_status_id"
-                select "3%", from: "project_progress"
+              fill_in "project_starts_at", with: "2020-01-01"
+              fill_in "project_ends_at", with: "2021-01-01"
+              select "Active", from: "project_status_id"
+              select "3%", from: "project_progress"
 
-                assert has_no_content? "Moderation"
-                within "div.widget_save_v2.editor" do
-                  click_button "Save"
-                end
+              assert has_no_content? "Moderation"
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
               end
-
-              assert has_message? "Project updated correctly."
-              assert has_content? "Updated project"
-              assert has_content? "Editing version\n2"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\n1"
-              assert has_content? "Click on Publish to make this version publicly visible."
-
-              published_project.reload
-
-              assert_equal "Updated project", published_project.name
-              assert_equal "Active", published_project.status.name
-              assert_equal 3.0, published_project.progress
-              assert_equal Date.parse("2020-01-01"), published_project.starts_at
-              assert_equal Date.parse("2021-01-01"), published_project.ends_at
-              assert published_project.published?
-              assert published_project.moderation.approved?
             end
+
+            assert has_message? "Project updated correctly."
+            assert has_content? "Updated project"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+            published_project.reload
+
+            assert_equal "Updated project", published_project.name
+            assert_equal "Active", published_project.status.name
+            assert_equal 3.0, published_project.progress
+            assert_equal Date.parse("2020-01-01"), published_project.starts_at
+            assert_equal Date.parse("2021-01-01"), published_project.ends_at
+            assert published_project.published?
+            assert published_project.moderation.approved?
           end
         end
 
@@ -292,38 +286,34 @@ module GobiertoAdmin
         def test_unpublish_approved_project_as_regular_editor
           allow_regular_admin_edit_project(published_project)
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit path
+          with(site: site, admin: regular_admin) do
+            visit path
 
-              within "div.widget_save_v2" do
-                click_link "Unpublish"
-              end
-
-              assert has_message? "Project unpublished correctly."
-              assert has_content? "Editing version\n1"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\nnot published yet"
-              assert has_content? "Click on Publish to make this version publicly visible."
-
-              published_project.reload
-
-              assert published_project.draft?
-              assert published_project.moderation.approved?
+            within "div.widget_save_v2" do
+              click_link "Unpublish"
             end
+
+            assert has_message? "Project unpublished correctly."
+            assert has_content? "Editing version\n1"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\nnot published yet"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+            published_project.reload
+
+            assert published_project.draft?
+            assert published_project.moderation.approved?
           end
         end
 
         def test_publish_not_approved_project_as_regular_editor
           allow_regular_admin_edit_project(unpublished_project)
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
 
-              within "div.widget_save_v2" do
-                assert has_button?("Publish", disabled: true)
-              end
+            within "div.widget_save_v2" do
+              assert has_button?("Publish", disabled: true)
             end
           end
         end
@@ -333,29 +323,27 @@ module GobiertoAdmin
           unpublished_project.moderation.not_sent!
           create_custom_fields_records
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
 
-              within "div.widget_save_v2" do
-                click_button "Send"
-              end
-
-              within "div.widget_save_v2" do
-                assert has_button?("Publish", disabled: true)
-              end
-
-              assert has_message? "Project updated correctly."
-              assert has_content? "Editing version\n1"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\nnot published yet"
-              assert has_content? "Your content has been sent for review. You will receive a notification if it is approved or you are asked for changes."
-
-              unpublished_project.reload
-
-              assert unpublished_project.draft?
-              assert unpublished_project.moderation.sent?
+            within "div.widget_save_v2" do
+              click_button "Send"
             end
+
+            within "div.widget_save_v2" do
+              assert has_button?("Publish", disabled: true)
+            end
+
+            assert has_message? "Project updated correctly."
+            assert has_content? "Editing version\n1"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\nnot published yet"
+            assert has_content? "Your content has been sent for review. You will receive a notification if it is approved or you are asked for changes."
+
+            unpublished_project.reload
+
+            assert unpublished_project.draft?
+            assert unpublished_project.moderation.sent?
           end
         end
 
@@ -363,41 +351,39 @@ module GobiertoAdmin
           allow_regular_admin_edit_project(unpublished_project)
           allow_regular_admin_moderate_plans
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
 
-              within "form" do
-                fill_in "project_name_translations_en", with: "Updated project"
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
 
-                fill_in "project_starts_at", with: "2020-01-01"
-                fill_in "project_ends_at", with: "2021-01-01"
-                select "In progress", from: "project_status_id"
-                select "3%", from: "project_progress"
+              fill_in "project_starts_at", with: "2020-01-01"
+              fill_in "project_ends_at", with: "2021-01-01"
+              select "In progress", from: "project_status_id"
+              select "3%", from: "project_progress"
 
-                assert has_css? "div.widget_save_v2"
-                within "div.widget_save_v2" do
-                  click_button "Save"
-                end
+              assert has_css? "div.widget_save_v2"
+              within "div.widget_save_v2" do
+                click_button "Save"
               end
-
-              assert has_message? "Project updated correctly."
-              assert has_content? "Updated project"
-              assert has_content? "Editing version\n2"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\nnot published yet"
-              assert has_content? "Click on Publish to make this version publicly visible."
-
-              unpublished_project.reload
-
-              assert_equal "Updated project", unpublished_project.name
-              assert_equal "In progress", unpublished_project.status.name
-              assert_equal 3.0, unpublished_project.progress
-              assert_equal Date.parse("2020-01-01"), unpublished_project.starts_at
-              assert_equal Date.parse("2021-01-01"), unpublished_project.ends_at
-              assert unpublished_project.draft?
-              assert unpublished_project.moderation.sent?
             end
+
+            assert has_message? "Project updated correctly."
+            assert has_content? "Updated project"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\nnot published yet"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+            unpublished_project.reload
+
+            assert_equal "Updated project", unpublished_project.name
+            assert_equal "In progress", unpublished_project.status.name
+            assert_equal 3.0, unpublished_project.progress
+            assert_equal Date.parse("2020-01-01"), unpublished_project.starts_at
+            assert_equal Date.parse("2021-01-01"), unpublished_project.ends_at
+            assert unpublished_project.draft?
+            assert unpublished_project.moderation.sent?
           end
         end
 
@@ -406,46 +392,44 @@ module GobiertoAdmin
           allow_regular_admin_moderate_plans
           create_custom_fields_records
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
 
-              within "form" do
-                within "div.widget_save_v2" do
-                  choose_moderation_status "Under review"
-                  click_button "Save"
-                end
+            within "form" do
+              within "div.widget_save_v2" do
+                choose_moderation_status "Under review"
+                click_button "Save"
               end
-
-              assert has_message? "Project updated correctly."
-
-              unpublished_project.reload
-
-              assert unpublished_project.draft?
-              assert unpublished_project.moderation.in_review?
-
-              within "form" do
-                within "div.widget_save_v2" do
-                  choose_moderation_status "Rejected"
-                end
-
-                within "div.widget_save_v2" do
-                  click_button "Publish"
-                end
-              end
-
-              assert has_message? "The project is not approved but still published"
-              assert has_link? "Unpublish"
-              assert has_content? "Editing version\n1"
-              assert has_content? "Status\nPublished"
-              assert has_content? "Published version\n1"
-              assert has_content? "Current version is the published one."
-
-              unpublished_project.reload
-
-              assert unpublished_project.published?
-              assert unpublished_project.moderation.rejected?
             end
+
+            assert has_message? "Project updated correctly."
+
+            unpublished_project.reload
+
+            assert unpublished_project.draft?
+            assert unpublished_project.moderation.in_review?
+
+            within "form" do
+              within "div.widget_save_v2" do
+                choose_moderation_status "Rejected"
+              end
+
+              within "div.widget_save_v2" do
+                click_button "Publish"
+              end
+            end
+
+            assert has_message? "The project is not approved but still published"
+            assert has_link? "Unpublish"
+            assert has_content? "Editing version\n1"
+            assert has_content? "Status\nPublished"
+            assert has_content? "Published version\n1"
+            assert has_content? "Current version is the published one."
+
+            unpublished_project.reload
+
+            assert unpublished_project.published?
+            assert unpublished_project.moderation.rejected?
           end
         end
 
@@ -453,43 +437,41 @@ module GobiertoAdmin
           allow_regular_admin_edit_project(unpublished_project)
           unpublished_project.moderation.approved!
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
-              within "form" do
-                fill_in "project_name_translations_en", with: "Updated project"
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
 
-                fill_in "project_starts_at", with: "2020-01-01"
-                fill_in "project_ends_at", with: "2021-01-01"
-                select "3%", from: "project_progress"
+              fill_in "project_starts_at", with: "2020-01-01"
+              fill_in "project_ends_at", with: "2021-01-01"
+              select "3%", from: "project_progress"
 
-                within "div.widget_save_v2" do
-                  click_button "Save"
-                end
+              within "div.widget_save_v2" do
+                click_button "Save"
               end
-
-              assert has_message? "Project updated correctly."
-              within ".g_popup" do
-                click_link "1 - "
-              end
-
-              within "form" do
-                within "div.widget_save_v2" do
-                  click_button "Publish"
-                end
-              end
-
-              assert has_button? "Publish"
-              assert has_content? "Editing version\n2"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\n1"
-              assert has_content? "Click on Publish to make this version publicly visible."
-
-
-              unpublished_project.reload
-
-              assert unpublished_project.published?
             end
+
+            assert has_message? "Project updated correctly."
+            within ".g_popup" do
+              click_link "1 - "
+            end
+
+            within "form" do
+              within "div.widget_save_v2" do
+                click_button "Publish"
+              end
+            end
+
+            assert has_button? "Publish"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+
+            unpublished_project.reload
+
+            assert unpublished_project.published?
           end
         end
 
@@ -497,48 +479,46 @@ module GobiertoAdmin
           allow_regular_admin_edit_project(unpublished_project)
           unpublished_project.moderation.approved!
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
-              within "form" do
-                fill_in "project_name_translations_en", with: "Updated project"
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
 
-                fill_in "project_starts_at", with: "2020-01-01"
-                fill_in "project_ends_at", with: "2021-01-01"
-                select "3%", from: "project_progress"
+              fill_in "project_starts_at", with: "2020-01-01"
+              fill_in "project_ends_at", with: "2021-01-01"
+              select "3%", from: "project_progress"
 
-                within "div.widget_save_v2" do
-                  click_button "Save"
-                end
+              within "div.widget_save_v2" do
+                click_button "Save"
               end
-
-              assert has_message? "Project updated correctly."
-              within ".g_popup" do
-                click_link "1 - "
-              end
-
-              within "form" do
-                fill_in "project_name_translations_en", with: "Changed version"
-
-                fill_in "project_starts_at", with: "2050-01-01"
-                fill_in "project_ends_at", with: "2051-01-01"
-                select "3%", from: "project_progress"
-
-                within "div.widget_save_v2.editor" do
-                  click_button "Publish"
-                end
-              end
-
-              assert has_link? "Unpublish"
-              assert has_content? "Editing version\n3"
-              assert has_content? "Status\nPublished"
-              assert has_content? "Published version\n3"
-              assert has_content? "Current version is the published one."
-
-              unpublished_project.reload
-
-              assert unpublished_project.published?
             end
+
+            assert has_message? "Project updated correctly."
+            within ".g_popup" do
+              click_link "1 - "
+            end
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Changed version"
+
+              fill_in "project_starts_at", with: "2050-01-01"
+              fill_in "project_ends_at", with: "2051-01-01"
+              select "3%", from: "project_progress"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Publish"
+              end
+            end
+
+            assert has_link? "Unpublish"
+            assert has_content? "Editing version\n3"
+            assert has_content? "Status\nPublished"
+            assert has_content? "Published version\n3"
+            assert has_content? "Current version is the published one."
+
+            unpublished_project.reload
+
+            assert unpublished_project.published?
           end
         end
 
@@ -582,30 +562,28 @@ module GobiertoAdmin
           unpublished_project.update_attribute(:progress, 20)
           unpublished_project.update_attribute(:progress, 50)
 
-          with_signed_in_admin(regular_admin) do
-            with_current_site(site) do
-              visit unpublished_path
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
 
-              within ".g_popup" do
-                click_link "1 - "
-              end
-
-              within "form" do
-                within "div.widget_save_v2" do
-                  click_button "Publish"
-                end
-              end
-
-              assert has_button? "Publish"
-              assert has_content? "Editing version\n4"
-              assert has_content? "Status\nNot published"
-              assert has_content? "Published version\n1"
-              assert has_content? "Click on Publish to make this version publicly visible."
-
-              unpublished_project.reload
-
-              assert unpublished_project.published?
+            within ".g_popup" do
+              click_link "1 - "
             end
+
+            within "form" do
+              within "div.widget_save_v2" do
+                click_button "Publish"
+              end
+            end
+
+            assert has_button? "Publish"
+            assert has_content? "Editing version\n4"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "Click on Publish to make this version publicly visible."
+
+            unpublished_project.reload
+
+            assert unpublished_project.published?
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -204,6 +204,31 @@ module GobiertoAdmin
           end
         end
 
+        def test_edit_not_allowed_project_as_regular_editor
+          allow_regular_admin_edit_plans
+
+          with(site: site, admin: regular_admin) do
+            visit unpublished_path
+
+            assert_equal 404, page.status_code
+          end
+        end
+
+        def test_edit_disabled_on_approved_project_as_regular_editor
+          allow_regular_admin_edit_plans
+
+          with(site: site, admin: regular_admin) do
+            visit path
+            assert has_field?("project_name_translations_en", disabled: true)
+            assert has_field?("project_status_id", disabled: true)
+            assert has_field?("project_starts_at", disabled: true)
+            assert has_field?("project_ends_at", disabled: true)
+            assert has_field?("project_progress", disabled: true)
+            assert has_no_button? "Save"
+            assert has_no_link? "Unpublish"
+          end
+        end
+
         def test_edit_project_as_regular_editor
           allow_regular_admin_edit_project(published_project)
 

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -125,11 +125,11 @@ module GobiertoAdmin
             visit path
 
             within "form" do
-              assert has_field?("project_name_translations_en", disabled: true)
-              assert has_field?("project_status_id", disabled: true)
-              assert has_field?("project_starts_at", disabled: true)
-              assert has_field?("project_ends_at", disabled: true)
-              assert has_field?("project_progress", disabled: true)
+              fill_in "project_name_translations_en", with: "Updated project"
+              fill_in "project_starts_at", with: "2020-01-01"
+              fill_in "project_ends_at", with: "2021-01-01"
+              select "Active", from: "project_status_id"
+              select "3%", from: "project_progress"
 
               within "div.widget_save_v2" do
                 assert has_button? "Save"
@@ -140,7 +140,18 @@ module GobiertoAdmin
                 find(".js-admin-widget-save .i_p_status a", text: "Approved")
                 assert has_button? "Save"
               end
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
             end
+
+            assert has_message? "Project updated correctly."
+            assert has_content? "Updated project"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "Click on Publish to make this version publicly visible."
           end
         end
 

--- a/test/support/integration/admin_groups_concern.rb
+++ b/test/support/integration/admin_groups_concern.rb
@@ -9,12 +9,27 @@ module Integration
         @regular_admin ||= gobierto_admin_admins(:steve)
       end
 
+      def edit_project_group
+        @edit_project_group ||= gobierto_admin_admin_groups(:political_agendas_permissions_group)
+      end
+
+      def edit_project_permission
+        @edit_project_permission ||= gobierto_admin_group_permissions(:edit_political_agendas)
+      end
+
       def allow_regular_admin_manage_plans
         regular_admin.admin_groups << gobierto_admin_admin_groups(:madrid_manage_plans_group)
       end
 
       def allow_regular_admin_edit_plans
         regular_admin.admin_groups << gobierto_admin_admin_groups(:madrid_edit_plans_group)
+      end
+
+      def allow_regular_admin_edit_project(project)
+        edit_project_group.update_attribute(:resource, project)
+        edit_project_permission.update_attribute(:resource, project)
+        regular_admin.admin_groups << gobierto_admin_admin_groups(:madrid_edit_plans_group)
+        regular_admin.admin_groups << edit_project_group
       end
 
       def allow_regular_admin_moderate_plans


### PR DESCRIPTION
Closes #2379


## :v: What does this PR do?


* Hides config tab link unless admin is able to manage plans
* Changes permissions for editors:
  * An editor will see a project in the index of projects if belongs to the list of editors of the project or it's approved. Any other project will be unavailable. 
  * An editor will be able to edit a project if is included in the list of editors of the plan. If the project is approved, the admin will see the edition form but won't be able to submit changes.
* Moderators permissions remain the same, a moderator can see all projects, regardless the moderation stage and change moderation stage but if the moderator is added as an editor to a project, she also acquires editing permissions on the project.

### Caution

This PR is built on top of #2452. Don't merge before #2452 merge.
 
## :mag: How should this be manually tested?

Visit a plan with different roles and check the list of projects

## :eyes: Screenshots

### Before this PR

![2379-before](https://user-images.githubusercontent.com/446459/61279383-4e3cba80-a7b6-11e9-8206-c24ef5f6034b.gif)

### After this PR

![2379-after](https://user-images.githubusercontent.com/446459/61364101-71826b00-a885-11e9-8dbe-43227a2dfaeb.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No