### PR TITLE
2419 projects site activities

### DIFF
--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -41,6 +41,7 @@ module GobiertoAdmin
         options = options.to_h.with_indifferent_access
         ordered_options = options.slice(:id, :plan_id, :admin).merge!(options)
         @passed_attributes = ordered_options.keys
+        @publication_updated = false
         super(ordered_options)
         set_publication_version
       end
@@ -144,6 +145,10 @@ module GobiertoAdmin
         nodes_attributes_differ?(set_node_attributes, versioned_node)
       end
 
+      def publication_updated?
+        @publication_updated
+      end
+
       def version_index
         return unless @version && @version.to_i < node.versions.length
 
@@ -226,6 +231,7 @@ module GobiertoAdmin
 
           attributes.visibility_level = visibility_level
           attributes.published_version = @published_version
+          @publication_updated = attributes.visibility_level_changed?
         end
       end
 

--- a/app/publishers/gobierto_plans_project_activity.rb
+++ b/app/publishers/gobierto_plans_project_activity.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Publishers
+  class GobiertoPlansProjectActivity
+    include Publisher
+    self.pub_sub_namespace = "activities/gobierto_plans_projects"
+  end
+end

--- a/app/subscribers/gobierto_plans_project_activity.rb
+++ b/app/subscribers/gobierto_plans_project_activity.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class GobiertoPlansProjectActivity < ::Subscribers::Base
+
+    def progresses_updated(event)
+      create_activity_from_event(event, "gobierto_plans.progresses_updated")
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      Activity.create! subject: event.payload[:subject],
+                       author: event.payload[:author],
+                       subject_ip: event.payload[:ip],
+                       action: action,
+                       site_id: event.payload[:site_id],
+                       admin_activity: true
+    end
+  end
+end

--- a/app/subscribers/gobierto_plans_project_activity.rb
+++ b/app/subscribers/gobierto_plans_project_activity.rb
@@ -2,6 +2,17 @@
 
 module Subscribers
   class GobiertoPlansProjectActivity < ::Subscribers::Base
+    def project_created(event)
+      create_activity_from_event(event, "gobierto_plans.project_created")
+    end
+
+    def project_updated(event)
+      create_activity_from_event(event, "gobierto_plans.project_updated")
+    end
+
+    def project_destroyed(event)
+      create_activity_from_event(event, "gobierto_plans.project_destroyed")
+    end
 
     def progresses_updated(event)
       create_activity_from_event(event, "gobierto_plans.progresses_updated")
@@ -11,6 +22,7 @@ module Subscribers
 
     def create_activity_from_event(event, action)
       Activity.create! subject: event.payload[:subject],
+                       recipient: event.payload[:recipient],
                        author: event.payload[:author],
                        subject_ip: event.payload[:ip],
                        action: action,

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -24,6 +24,7 @@ Subscribers::GobiertoParticipationProcessActivity.attach_to("activities/gobierto
 Subscribers::GobiertoParticipationPollActivity.attach_to("activities/gobierto_participation_polls")
 Subscribers::GobiertoParticipationContributionContainerActivity.attach_to("activities/gobierto_participation_contribution_containers")
 Subscribers::GobiertoPlansPlanActivity.attach_to("activities/gobierto_plans_plans")
+Subscribers::GobiertoPlansProjectActivity.attach_to("activities/gobierto_plans_projects")
 Subscribers::GobiertoIndicatorsIndicatorActivity.attach_to("activities/gobierto_indicators_indicators")
 Subscribers::GobiertoPlansPlanTypeActivity.attach_to("activities/gobierto_plans_plan_types")
 Subscribers::UserActivity.attach_to("activities/users")

--- a/config/locales/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_plans/views/ca.yml
@@ -9,6 +9,9 @@ ca:
       gobierto_plans_plan_type_updated: Tipus de pla actualitzat
       gobierto_plans_plan_updated: Pla actualitzat
       gobierto_plans_progresses_updated: Progressos de projectes actualitzats
+      gobierto_plans_project_created: Projecte creat
+      gobierto_plans_project_destroyed: Projecte eliminat del pla
+      gobierto_plans_project_updated: Projecte actualitzat
     layouts:
       application:
         plans: Plans

--- a/config/locales/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_plans/views/ca.yml
@@ -8,6 +8,7 @@ ca:
       gobierto_plans_plan_type_created: Tipus de pla creat
       gobierto_plans_plan_type_updated: Tipus de pla actualitzat
       gobierto_plans_plan_updated: Pla actualitzat
+      gobierto_plans_progresses_updated: Progressos de projectes actualitzats
     layouts:
       application:
         plans: Plans

--- a/config/locales/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_plans/views/en.yml
@@ -7,6 +7,7 @@ en:
       gobierto_plans_plan_type_created: Plan type created
       gobierto_plans_plan_type_updated: Plan type updated
       gobierto_plans_plan_updated: Plan updated
+      gobierto_plans_progresses_updated: Projects progresses updated
     layouts:
       application:
         plans: Plans

--- a/config/locales/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_plans/views/en.yml
@@ -8,6 +8,9 @@ en:
       gobierto_plans_plan_type_updated: Plan type updated
       gobierto_plans_plan_updated: Plan updated
       gobierto_plans_progresses_updated: Projects progresses updated
+      gobierto_plans_project_created: Project created
+      gobierto_plans_project_destroyed: Project deleted from plan
+      gobierto_plans_project_updated: Project updated
     layouts:
       application:
         plans: Plans

--- a/config/locales/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_plans/views/es.yml
@@ -8,6 +8,7 @@ es:
       gobierto_plans_plan_type_created: Tipo de plan creado
       gobierto_plans_plan_type_updated: Tipo de plan actualizado
       gobierto_plans_plan_updated: Plan actualizado
+      gobierto_plans_progresses_updated: Progresos de proyectos actualizados
     layouts:
       application:
         plans: Planes

--- a/config/locales/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_plans/views/es.yml
@@ -9,6 +9,9 @@ es:
       gobierto_plans_plan_type_updated: Tipo de plan actualizado
       gobierto_plans_plan_updated: Plan actualizado
       gobierto_plans_progresses_updated: Progresos de proyectos actualizados
+      gobierto_plans_project_created: Proyecto creado
+      gobierto_plans_project_destroyed: Proyecto eliminado del plan
+      gobierto_plans_project_updated: Proyecto actualizado
     layouts:
       application:
         plans: Planes

--- a/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/create_project_test.rb
@@ -106,21 +106,28 @@ module GobiertoAdmin
                 click_button "Save"
 
                 assert has_content? "Project created correctly."
-
-                project = plan.nodes.last
-                assert_equal regular_admin, project.author
-                assert_equal "New project", project.name
-                assert_equal "Not started", project.status.name
-                assert_equal "Nuevo proyecto", project.name_es
-                assert_equal 1.0, project.progress
-                assert_equal Date.parse("2020-01-01"), project.starts_at
-                assert_equal Date.parse("2021-01-01"), project.ends_at
-                assert project.draft?
-                assert project.moderation.not_sent?
                 assert has_link? "Permissions"
               end
             end
           end
+
+          project = plan.nodes.last
+          assert_equal regular_admin, project.author
+          assert_equal "New project", project.name
+          assert_equal "Not started", project.status.name
+          assert_equal "Nuevo proyecto", project.name_es
+          assert_equal 1.0, project.progress
+          assert_equal Date.parse("2020-01-01"), project.starts_at
+          assert_equal Date.parse("2021-01-01"), project.ends_at
+          assert project.draft?
+          assert project.moderation.not_sent?
+
+          activity = Activity.last
+          assert_equal project, activity.subject
+          assert_equal plan, activity.recipient
+          assert_equal regular_admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_plans.project_created", activity.action
         end
 
         def test_regular_editor_default_progress_on_create_is_zero

--- a/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/delete_project_test.rb
@@ -76,6 +76,11 @@ module GobiertoAdmin
 
               assert has_content? "Project deleted correctly."
 
+              activity = Activity.last
+              assert_equal plan, activity.subject
+              assert_equal regular_admin, activity.author
+              assert_equal site.id, activity.site_id
+              assert_equal "gobierto_plans.project_destroyed", activity.action
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -116,6 +116,13 @@ module GobiertoAdmin
             assert_equal Date.parse("2021-01-01"), published_project.ends_at
             assert published_project.published?
             assert published_project.moderation.approved?
+
+            activity = Activity.last
+            assert_equal published_project, activity.subject
+            assert_equal plan, activity.recipient
+            assert_equal admin, activity.author
+            assert_equal site.id, activity.site_id
+            assert_equal "gobierto_plans.project_updated", activity.action
           end
         end
 

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/lib/tasks/custom_field_plugins/progress/calculate_progress.rake
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/lib/tasks/custom_field_plugins/progress/calculate_progress.rake
@@ -5,14 +5,21 @@ namespace :custom_field_plugins do
     desc "Calculate total progress of plugin custom field records of type progress based on the other configured fields"
     task calculate_progress: :environment do
 
+      sites_list = []
+
       GobiertoCommon::CustomField.with_plugin_type("progress").where.not(instance: nil).each do |custom_field|
+        sites_list << custom_field.site unless sites_list.include?(custom_field.site) || custom_field.instance.nodes.empty?
+
         custom_field.instance.nodes.each do |node|
           custom_field.records.find_or_initialize_by(item: node).functions.update_progress!
         end
       end
 
       GobiertoPlans::Plan.where.not(id: GobiertoCommon::CustomField.with_plugin_type("progress").where.not(instance: nil)).each do |plan|
-        plan.site.custom_fields.with_plugin_type("progress").where(instance: nil).each do |custom_field|
+        custom_fields = plan.site.custom_fields.with_plugin_type("progress").where(instance: nil)
+        sites_list << plan.site unless sites_list.include?(plan.site) || custom_fields.empty?
+
+        custom_fields.each do |custom_field|
           plan.nodes.each do |node|
             custom_field.records.find_or_initialize_by(item: node).functions.update_progress!
           end
@@ -20,6 +27,11 @@ namespace :custom_field_plugins do
       end
 
       GobiertoPlans::Plan.all.each(&:touch)
+
+      sites_list.each do |site|
+        Publishers::GobiertoPlansProjectActivity.broadcast_event("progresses_updated", ip: "127.0.0.1", subject: site, site_id: site.id)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Closes #2419
Closes #2431


## :v: What does this PR do?

Adds some site activities related with projects:

* Create, update and delete projects
* Update progresses of projects executed by a task

## :mag: How should this be manually tested?

Visit a plan, create, update and destroy projects

## :eyes: Screenshots

### Before this PR
![2419-before](https://user-images.githubusercontent.com/446459/61319046-b0251080-a806-11e9-81fc-d53cda32214a.gif)

### After this PR

![2419-after](https://user-images.githubusercontent.com/446459/61331298-f8056100-a821-11e9-95c8-8e2ce7b3eaf6.gif)

<img width="1081" alt="Screen Shot 2019-07-16 at 23 30 42" src="https://user-images.githubusercontent.com/446459/61331333-0bb0c780-a822-11e9-9141-807828698020.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
