### PR TITLE
2363 fix export plans status

### DIFF
--- a/app/decorators/gobierto_plans/row_node_decorator.rb
+++ b/app/decorators/gobierto_plans/row_node_decorator.rb
@@ -23,7 +23,7 @@ module GobiertoPlans
       elsif object.is_a? GobiertoCommon::Term
         @category = CategoryTermDecorator.new(object)
         @plan = @category.plan
-        @node = Node.new
+        @node = Node.new(progress: nil)
         @object = CSV::Row.new(plan_csv_columns, node_csv_values)
       end
     end

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -15,7 +15,7 @@ module GobiertoPlans
     has_vocabulary :statuses
     belongs_to :status, class_name: "GobiertoCommon::Term"
 
-    delegate :name, to: :status, prefix: true
+    delegate :name, to: :status, prefix: true, allow_nil: true
 
     scope :with_name, ->(name) { where("gplan_nodes.name_translations ->> 'en' ILIKE :name OR gplan_nodes.name_translations ->> 'es' ILIKE :name OR gplan_nodes.name_translations ->> 'ca' ILIKE :name", name: "%#{name}%") }
     scope :with_status, ->(status) { where(status_id: status) }

--- a/test/controllers/gobierto_admin/gobierto_plans/plans_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_plans/plans_controller_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPlans
+    class PlansControllerTest < GobiertoControllerTest
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def plan
+        @plan ||= gobierto_plans_plans(:strategic_plan)
+      end
+
+      def empty_plan
+        @empty_plan ||= gobierto_plans_plans(:government_plan)
+      end
+
+      def plan_with_projects_with_blank_status
+        @plan_with_projects_with_blank_status ||= gobierto_plans_plans(:economic_plan)
+      end
+
+      def project
+        @project ||= gobierto_plans_nodes(:political_agendas)
+      end
+
+      def test_export_csv
+        with(site: site, admin: admin) do
+          get admin_plans_plan_export_csv_url(plan)
+
+          assert_response :success
+          assert_equal "text/csv", response.content_type
+
+          parsed_response = CSV.parse(response.body, headers: true)
+          assert_equal 2, parsed_response.length
+          last_row = parsed_response[1]
+
+          assert_equal project.categories.first.parent_term.parent_term.name, last_row["Level 0"]
+          assert_equal project.categories.first.parent_term.name, last_row["Level 1"]
+          assert_equal project.categories.first.name, last_row["Level 2"]
+          assert_equal project.name, last_row["Node.Title"]
+          assert_equal project.status.name, last_row["Node.Status"]
+          assert_equal project.progress, last_row["Node.Progress"].to_f
+          assert_equal project.starts_at, Date.parse(last_row["Node.Start"])
+          assert_equal project.ends_at, Date.parse(last_row["Node.End"])
+          assert_equal project.options["objetivos"], last_row["Node.objetivos"]
+          assert_equal project.options["temporality"], last_row["Node.temporality"]
+        end
+      end
+
+      def test_export_csv_empty_plan
+        with(site: site, admin: admin) do
+          get admin_plans_plan_export_csv_url(empty_plan)
+
+          assert_response :success
+          assert_equal "text/csv", response.content_type
+
+          parsed_response = CSV.parse(response.body, headers: true)
+          assert_equal 3, parsed_response.length
+          parsed_response.each do |row|
+            assert_nil row["Node.Progress"]
+          end
+        end
+      end
+
+      def test_export_csv_plan_with_projects_with_blank_status
+        with(site: site, admin: admin) do
+          get admin_plans_plan_export_csv_url(plan_with_projects_with_blank_status)
+
+          assert_response :success
+          assert_equal "text/csv", response.content_type
+
+          parsed_response = CSV.parse(response.body, headers: true)
+          assert_equal 1, parsed_response.length
+          assert_equal "0.0", parsed_response[0]["Node.Progress"]
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Closes #2363


## :v: What does this PR do?

* Fixes a bug which raises an exception when a plan contains projects with blank status or categories without projects
* Avoids the presence of "0.0" value for progress for rows of csv export containing categories without projects (In these cases, the columns for projects/nodes must be empty)
* Adds controller tests checking success response and csv data generated calling the url to export to csv. 

## :mag: How should this be manually tested?

From admin visit a plan, select configuration tab and click on "Export to CSV" link

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
