### PR TITLE
2470 plan without vocabulary

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/categories_controller.rb
@@ -3,8 +3,6 @@
 module GobiertoAdmin
   module GobiertoPlans
     class CategoriesController < GobiertoAdmin::GobiertoCommon::OrderedTermsController
-      skip_before_action :check_permissions!
-
       before_action -> { module_allowed_action!(current_admin, current_admin_module, :manage) }
       before_action :set_leaf_terms
       after_action :expire_plan_cache, only: [:update]
@@ -13,6 +11,11 @@ module GobiertoAdmin
 
       def index
         find_vocabulary
+        unless @vocabulary.present?
+          redirect_to edit_admin_plans_plan_path(@plan)
+          return
+        end
+
         calculate_accumulated_values
 
         @global_progress = @plan.global_progress

--- a/test/integration/gobierto_admin/gobierto_plans/categories/categories_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/categories/categories_index_test.rb
@@ -49,6 +49,31 @@ module GobiertoAdmin
             end
           end
         end
+
+        def test_index_without_categories_vocabulary
+          plan.update_attribute(:vocabulary_id, nil)
+          with(site: site, admin: admin, js: false) do
+            visit @path
+
+            within "div.tabs" do
+              assert has_no_content? "Categories"
+              within "li.active" do
+                assert has_content? "Configuration"
+              end
+            end
+
+          end
+        end
+
+        def test_regular_admin_index_without_categories_vocabulary
+          plan.update_attribute(:vocabulary_id, nil)
+          with(site: site, admin: regular_admin) do
+            visit @path
+
+            assert has_content? "You are not authorized to perform this action"
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
Closes #2470


## :v: What does this PR do?

Redirects admins to plan configuration tab from categories path of a plan with no categories vocabulary defined yet.

## :mag: How should this be manually tested?

Visit the index of plans and click on a plan without categories vocabulary. The admin should be redirected to configuration tab.

## :eyes: Screenshots

### Before this PR

![2480-before](https://user-images.githubusercontent.com/446459/61541106-493e6c00-aa3f-11e9-807a-092ab88596b6.gif)

### After this PR

![2480-after](https://user-images.githubusercontent.com/446459/61541118-522f3d80-aa3f-11e9-8bae-cccceece94c2.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
