### PR TITLE
Use the same order criteria for editions in front as in admin

### DIFF
--- a/app/views/gobierto_citizens_charters/charters/show.html.erb
+++ b/app/views/gobierto_citizens_charters/charters/show.html.erb
@@ -69,7 +69,7 @@
   </div>
 
   <div class="charter-container">
-    <% @charter.editions.each do |edition| %>
+    <% @charter.editions.order(id: :asc).each do |edition| %>
       <div class="charter">
         <div class="charter-inner">
           <div class="m_b_2"><%= edition.commitment.description %></div>


### PR DESCRIPTION
Related with #2355


## :v: What does this PR do?

Uses the same order criteria for editions in front as in admin

## :mag: How should this be manually tested?

Update editions in admin. The editions should be displayed with the same order in admin jsgrid and front

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No