### PR TITLE
Avoid data per inhabitant in budgets guide if population data is empty

### DIFF
--- a/app/views/gobierto_budgets/budgets/guide.html.erb
+++ b/app/views/gobierto_budgets/budgets/guide.html.erb
@@ -65,10 +65,12 @@
         <h3><%= t('.expenses') %></h3>
         <p><%= t('.expenses_how') %></p>
 
-        <div class="number">
-          <p><%= t('.expenses_per_inhabitant') %></p>
-          <div><%= format_currency @site_stats.total_budget_per_inhabitant %>/hab</div>
-        </div>
+        <% if @site_stats.population_data? %>
+          <div class="number">
+            <p><%= t('.expenses_per_inhabitant') %></p>
+            <div><%= format_currency @site_stats.total_budget_per_inhabitant %>/hab</div>
+          </div>
+        <% end %>
 
         <hr class="separator_responsive" />
 


### PR DESCRIPTION
Closes #2486


## :v: What does this PR do?

* Checks if there is population data and hides total budget per inhabitant from expenses section in budgets guide if population is not available

## :mag: How should this be manually tested?

Visit budgets guide for an organisation without population data.

## :eyes: Screenshots

### Before this PR

<img width="1257" alt="Screen Shot 2019-07-22 at 16 19 35" src="https://user-images.githubusercontent.com/446459/61639843-881d2d80-ac9c-11e9-87f4-21c57af0fb1a.png">

### After this PR

<img width="1231" alt="Screen Shot 2019-07-22 at 16 26 00" src="https://user-images.githubusercontent.com/446459/61640343-70927480-ac9d-11e9-89df-efdb59b0b31c.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
