### PR TITLE
2471 gobierto investments module

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_investments/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_investments/base_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    class BaseController < GobiertoAdmin::BaseController
+      before_action { module_enabled!(current_site, "GobiertoInvestments") }
+      before_action { module_allowed!(current_admin, "GobiertoInvestments") }
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_investments/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_investments/projects_controller.rb
@@ -9,19 +9,19 @@ module GobiertoAdmin
       end
 
       def new
-        @project_form = ProjectForm.new(site_id: current_site.id)
+        @project_form = ProjectForm.new(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
       end
 
       def edit
         @project = find_project
 
         @project_form = ProjectForm.new(
-          @project.attributes.except(*ignored_project_attributes).merge(site_id: current_site.id)
+          @project.attributes.except(*ignored_project_attributes).merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
         )
       end
 
       def create
-        @project_form = ProjectForm.new(project_params.merge(site_id: current_site.id))
+        @project_form = ProjectForm.new(project_params.merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip))
 
         if @project_form.save
           redirect_to(
@@ -37,7 +37,7 @@ module GobiertoAdmin
         @project = find_project
 
         @project_form = ProjectForm.new(
-          project_params.merge(id: params[:id], site_id: current_site.id)
+          project_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
         )
 
         if @project_form.save

--- a/app/controllers/gobierto_admin/gobierto_investments/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_investments/projects_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    class ProjectsController < GobiertoAdmin::GobiertoInvestments::BaseController
+
+      def index
+        @projects = current_site.projects.order(id: :desc)
+      end
+
+      def new
+        @project_form = ProjectForm.new(site_id: current_site.id)
+      end
+
+      def edit
+        @project = find_project
+
+        @project_form = ProjectForm.new(
+          @project.attributes.except(*ignored_project_attributes).merge(site_id: current_site.id)
+        )
+      end
+
+      def create
+        @project_form = ProjectForm.new(project_params.merge(site_id: current_site.id))
+
+        if @project_form.save
+          redirect_to(
+            edit_admin_investments_project_path(@project_form.project),
+            notice: t(".success")
+          )
+        else
+          render :new
+        end
+      end
+
+      def update
+        @project = find_project
+
+        @project_form = ProjectForm.new(
+          project_params.merge(id: params[:id], site_id: current_site.id)
+        )
+
+        if @project_form.save
+          redirect_to(
+            edit_admin_investments_project_path(@project),
+            notice: t(".success")
+          )
+        else
+          render :edit
+        end
+      end
+
+      def destroy
+        @project = find_project
+
+        @project.destroy
+
+        redirect_to admin_investments_projects_path, notice: t(".success")
+      end
+
+      private
+
+      def project_params
+        params.require(:project).permit(
+          :external_id,
+          title_translations: [*I18n.available_locales]
+        )
+      end
+
+      def ignored_project_attributes
+        %w(created_at updated_at site_id)
+      end
+
+      def find_project
+        current_site.projects.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/extensions/gobierto_common/trackable_grouped_attributes.rb
+++ b/app/extensions/gobierto_common/trackable_grouped_attributes.rb
@@ -3,7 +3,7 @@
 module GobiertoCommon
   module TrackableGroupedAttributes
     module ClassMethods
-      attr_reader :trackable, :publisher, :subject
+      attr_reader :trackable, :publisher, :subject, :event_prefix
 
       def notify_changed(*attribute_names, **opts)
         changed_attributes_to_notify.push(*attribute_names)
@@ -22,6 +22,10 @@ module GobiertoCommon
 
       def use_trackable_subject(subject)
         @subject = subject
+      end
+
+      def use_event_prefix(prefix)
+        @event_prefix = "#{prefix}_"
       end
 
       private
@@ -146,11 +150,12 @@ module GobiertoCommon
     end
 
     def event_prefix
-      @event_prefix ||= if subject != trackable
-                          trackable.class.name.demodulize.tableize + "_"
-                        else
-                          ""
-                        end
+      self.class.event_prefix ||
+        @event_prefix ||= if subject != trackable
+                            trackable.class.name.demodulize.tableize + "_"
+                          else
+                            ""
+                          end
     end
 
     def store_changes

--- a/app/extensions/gobierto_common/trackable_grouped_attributes.rb
+++ b/app/extensions/gobierto_common/trackable_grouped_attributes.rb
@@ -137,7 +137,12 @@ module GobiertoCommon
     end
 
     def event_payload
-      { gid: subject.to_gid, site_id: trackable.site_id, admin_id: (trackable.admin_id if trackable.respond_to?(:admin_id)) }
+      {
+        gid: subject.to_gid,
+        site_id: trackable.site_id,
+        admin_id: (trackable.try(:admin_id) || try(:admin_id)),
+        ip: try(:ip)
+      }
     end
 
     def event_prefix

--- a/app/forms/gobierto_admin/gobierto_investments/project_form.rb
+++ b/app/forms/gobierto_admin/gobierto_investments/project_form.rb
@@ -8,7 +8,9 @@ module GobiertoAdmin
         :id,
         :site_id,
         :title_translations,
-        :external_id
+        :external_id,
+        :admin_id,
+        :ip
       )
 
       validates :site_id, presence: true

--- a/app/forms/gobierto_admin/gobierto_investments/project_form.rb
+++ b/app/forms/gobierto_admin/gobierto_investments/project_form.rb
@@ -3,6 +3,7 @@
 module GobiertoAdmin
   module GobiertoInvestments
     class ProjectForm < BaseForm
+      prepend ::GobiertoCommon::TrackableGroupedAttributes
 
       attr_accessor(
         :id,
@@ -16,6 +17,12 @@ module GobiertoAdmin
       validates :site_id, presence: true
 
       delegate :persisted?, to: :project
+
+      trackable_on :project
+      use_event_prefix :project
+      notify_changed :title_translations, :external_id, as: :attribute
+      use_publisher Publishers::AdminGobiertoInvestmentsActivity
+      use_trackable_subject :project
 
       def save
         save_project if valid?
@@ -47,7 +54,9 @@ module GobiertoAdmin
         end
 
         if @project.valid?
-          @project.save
+          run_callbacks(:save) do
+            @project.save
+          end
 
           @project
         else

--- a/app/forms/gobierto_admin/gobierto_investments/project_form.rb
+++ b/app/forms/gobierto_admin/gobierto_investments/project_form.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    class ProjectForm < BaseForm
+
+      attr_accessor(
+        :id,
+        :site_id,
+        :title_translations,
+        :external_id
+      )
+
+      validates :site_id, presence: true
+
+      delegate :persisted?, to: :project
+
+      def save
+        save_project if valid?
+      end
+
+      def site
+        @site ||= Site.find_by(id: site_id)
+      end
+
+      def project
+        @project ||= project_class.find_by(id: id).presence || build_project
+      end
+
+      private
+
+      def build_project
+        project_class.new
+      end
+
+      def project_class
+        ::GobiertoInvestments::Project
+      end
+
+      def save_project
+        @project = project.tap do |attributes|
+          attributes.site_id = site_id
+          attributes.title_translations = title_translations
+          attributes.external_id = external_id.blank? ? nil : external_id
+        end
+
+        if @project.valid?
+          @project.save
+
+          @project
+        else
+          promote_errors(@project.errors)
+
+          false
+        end
+      end
+
+    end
+  end
+end

--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -30,6 +30,7 @@ module GobiertoAdmin
     has_many :gobierto_observatory_permissions, through: :admin_groups, class_name: "Permission::GobiertoObservatory", source: :permissions
     has_many :gobierto_participation_permissions, through: :admin_groups, class_name: "Permission::GobiertoParticipation", source: :permissions
     has_many :gobierto_citizens_charters_permissions, through: :admin_groups, class_name: "Permission::GobiertoCitizensCharters", source: :permissions
+    has_many :gobierto_investments_permissions, through: :admin_groups, class_name: "Permission::GobiertoInvestments", source: :permissions
     has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"
 
     has_many :census_imports

--- a/app/models/gobierto_admin/permission/gobierto_investments.rb
+++ b/app/models/gobierto_admin/permission/gobierto_investments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class Permission::GobiertoInvestments < GroupPermission
+    default_scope -> { for_class_module }
+  end
+end

--- a/app/models/gobierto_investments.rb
+++ b/app/models/gobierto_investments.rb
@@ -8,4 +8,8 @@ module GobiertoInvestments
   def self.classes_with_custom_fields
     [GobiertoInvestments::Project]
   end
+
+  def self.doc_url
+    "https://gobierto.readme.io/docs/inversiones"
+  end
 end

--- a/app/models/gobierto_investments.rb
+++ b/app/models/gobierto_investments.rb
@@ -6,6 +6,6 @@ module GobiertoInvestments
   end
 
   def self.classes_with_custom_fields
-    []
+    [GobiertoInvestments::Project]
   end
 end

--- a/app/models/gobierto_investments.rb
+++ b/app/models/gobierto_investments.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GobiertoInvestments
+  def self.table_name_prefix
+    "ginv_"
+  end
+
+  def self.classes_with_custom_fields
+    []
+  end
+end

--- a/app/models/gobierto_investments/project.rb
+++ b/app/models/gobierto_investments/project.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_investments"
+
+module GobiertoInvestments
+  class Project < ApplicationRecord
+    belongs_to :site
+
+    translates :title
+
+    validates :site, :title, presence: true
+    validates :external_id, uniqueness: { scope: :site_id, allow_nil: true }
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -84,6 +84,9 @@ class Site < ApplicationRecord
   has_many :commitments, through: :charters, class_name: "GobiertoCitizensCharters::Commitment"
   has_many :editions, through: :commitments, class_name: "GobiertoCitizensCharters::Edition"
 
+  # Gobierto Investments integration
+  has_many :projects, dependent: :destroy, class_name: "GobiertoInvestments::Project"
+
   serialize :configuration_data
 
   before_save :store_configuration

--- a/app/publishers/admin_gobierto_investments_activity.rb
+++ b/app/publishers/admin_gobierto_investments_activity.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Publishers
+  class AdminGobiertoInvestmentsActivity
+    include Publisher
+
+    self.pub_sub_namespace = "activities/admin_gobierto_investments"
+  end
+end

--- a/app/subscribers/admin_gobierto_investments_activity.rb
+++ b/app/subscribers/admin_gobierto_investments_activity.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class AdminGobiertoInvestmentsActivity < ::Subscribers::Base
+
+    def project_attribute_changed(event)
+      create_activity_from_event(event, "project_updated")
+    end
+
+    def project_created(event)
+      create_activity_from_event(event, "project_created")
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      subject = GlobalID::Locator.locate event.payload[:gid]
+
+      return unless subject.class.parent == GobiertoInvestments
+
+      author = GobiertoAdmin::Admin.find_by id: event.payload[:admin_id]
+
+      # When the author is nil, we can asume the action has been performed by an integration
+      return unless author.present?
+
+      action = subject.class.name.underscore.tr("/", ".") + "." + action
+
+      Activity.create! subject: subject,
+                       author: author,
+                       subject_ip: event.payload[:ip] || author.last_sign_in_ip,
+                       action: action,
+                       admin_activity: true,
+                       site_id: event.payload[:site_id]
+    end
+  end
+end

--- a/app/views/gobierto_admin/gobierto_investments/projects/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_investments/projects/_form.html.erb
@@ -1,0 +1,44 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @project_form %>
+
+<%= form_for(@project_form, as: :project, url: @project_form.persisted? ? admin_investments_project_path(@project_form) : admin_investments_projects_path(@project), data: { 'globalized-form-container' => true }) do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+      <div class="globalized_fields">
+        <%= render "gobierto_admin/shared/form_locale_switchers" %>
+
+        <% current_site.configuration.available_locales.each do |locale| %>
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "project[title_translations][#{locale}]" do %>
+              <%= f.object.class.human_attribute_name(:title) %>
+              <%= attribute_indication_tag required: true %>
+            <% end %>
+            <%= text_field_tag "project[title_translations][#{locale}]", f.object.title_translations && f.object.title_translations[locale], placeholder: t('.placeholders.title', locale: locale) %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="form_item input_text">
+        <%= f.label :external_id %>
+        <%= f.text_field :external_id, placeholder: t('.placeholders.external_id') %>
+      </div>
+
+    </div>
+
+    <div class="pure-u-1 pure-u-md-2-24"></div>
+
+    <div class="pure-u-1 pure-u-md-1-4 ">
+
+      <div class="stick_in_parent">
+
+        <div class="widget_save ">
+
+          <%= f.submit class: "button" %>
+
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_investments/projects/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_investments/projects/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_investments.projects.index.title"), admin_investments_projects_path %> »
+  <%= @project.title %>
+</div>
+
+<h1><%= @project.title %></h1>
+
+<%= render 'form' %>

--- a/app/views/gobierto_admin/gobierto_investments/projects/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_investments/projects/index.html.erb
@@ -1,0 +1,53 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= t('.title') %>
+</div>
+
+<h1><%= t('.title') %></h1>
+
+<div class="admin_tools right">
+  <%= link_to t(".new"), new_admin_investments_project_path, class: "button" %>
+</div>
+
+<table id="projects">
+  <thead>
+    <tr>
+      <th class="icon_col"></th>
+      <th><%= t(".header.external_id") %></th>
+      <th><%= t(".header.title") %></th>
+      <th></th>
+      <th class="icon_col"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @projects.each do |project| %>
+    <tr id="project-item-<%= project.id %>">
+      <td>
+        <%= link_to edit_admin_investments_project_path(project) do %>
+          <i class="fas fa-edit"></i>
+        <% end %>
+      </td>
+      <td>
+        <%= project.external_id %>
+      </td>
+      <td>
+        <%= link_to project.title, edit_admin_investments_project_path(project) %>
+      </td>
+      <td>
+        <%= link_to edit_admin_investments_project_path(project), target: "_blank", class: "view_item" do %>
+          <i class="fas fa-eye"></i>
+          <%= t(".view_project") %>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to admin_investments_project_path(project.id),
+                    title: t("gobierto_admin.shared.archive.element"),
+                    method: :delete,
+                    data: { confirm: t("views.delete_confirm") } do %>
+          <i class="fas fa-trash"></i>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/gobierto_admin/gobierto_investments/projects/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_investments/projects/new.html.erb
@@ -1,0 +1,9 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_investments.projects.index.title"), admin_investments_projects_path %> »
+  <%= t(".title") %>
+</div>
+
+<h1><%= t('.title') %></h1>
+
+<%= render 'form' %>

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -165,6 +165,12 @@
             </li>
             <% end %>
 
+            <% if show_module_link?("GobiertoInvestments") %>
+              <li>
+                <%= link_to t(".investments"), admin_investments_projects_path %>
+              </li>
+            <% end %>
+
             <li class="sep"></li>
 
             <li>

--- a/config/application.yml
+++ b/config/application.yml
@@ -32,6 +32,9 @@ default: &default
     -
       name: Gobierto Citizens Charters
       namespace: GobiertoCitizensCharters
+    -
+      name: Gobierto Investments
+      namespace: GobiertoInvestments
   site_modules_with_root_path:
     -
       name: Gobierto Budgets

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -30,6 +30,7 @@ Subscribers::UserActivity.attach_to("activities/users")
 Subscribers::SiteActivity.attach_to("activities/sites")
 Subscribers::AdminGobiertoCalendarsActivity.attach_to("activities/admin_gobierto_calendars")
 Subscribers::AdminGobiertoCitizensChartersActivity.attach_to("activities/admin_gobierto_citizens_charters")
+Subscribers::AdminGobiertoInvestmentsActivity.attach_to("activities/admin_gobierto_investments")
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|

--- a/config/locales/gobierto_admin/gobierto_investments/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/controllers/ca.yml
@@ -1,0 +1,11 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_investments:
+      projects:
+        create:
+          success: El projecte s'ha creat correctament.
+        destroy:
+          success: El projecte s'ha esborrat correctament.
+        update:
+          success: El projecte s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_investments/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/controllers/en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  gobierto_admin:
+    gobierto_investments:
+      projects:
+        create:
+          success: Project created correctly.
+        destroy:
+          success: Project deleted correctly.
+        update:
+          success: Project updated correctly.

--- a/config/locales/gobierto_admin/gobierto_investments/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/controllers/es.yml
@@ -1,0 +1,11 @@
+---
+es:
+  gobierto_admin:
+    gobierto_investments:
+      projects:
+        create:
+          success: El proyecto ha sido creado correctamente.
+        destroy:
+          success: El proyecto ha sido eliminado correctamente.
+        update:
+          success: El proyecto ha sido actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_investments/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/models/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  activemodel:
+    attributes:
+      gobierto_admin/gobierto_investments/project_form:
+        external_id: ID extern
+        title: Títol

--- a/config/locales/gobierto_admin/gobierto_investments/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/models/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  activemodel:
+    attributes:
+      gobierto_admin/gobierto_investments/project_form:
+        external_id: External ID
+        title: Title

--- a/config/locales/gobierto_admin/gobierto_investments/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/models/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  activemodel:
+    attributes:
+      gobierto_admin/gobierto_investments/project_form:
+        external_id: ID externo
+        title: Título

--- a/config/locales/gobierto_admin/gobierto_investments/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/views/ca.yml
@@ -1,0 +1,18 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_investments:
+      projects:
+        form:
+          placeholders:
+            external_id: ID001
+            title: Centre esportiu
+        index:
+          header:
+            external_id: ID extern
+            title: Títol
+          new: Nou
+          title: Projectes
+          view_project: Veure projecte
+        new:
+          title: Nou projecte

--- a/config/locales/gobierto_admin/gobierto_investments/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/views/en.yml
@@ -1,0 +1,18 @@
+---
+en:
+  gobierto_admin:
+    gobierto_investments:
+      projects:
+        form:
+          placeholders:
+            external_id: ID001
+            title: Sports center
+        index:
+          header:
+            external_id: External ID
+            title: Title
+          new: New
+          title: Projects
+          view_project: See project
+        new:
+          title: New project

--- a/config/locales/gobierto_admin/gobierto_investments/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_investments/views/es.yml
@@ -1,0 +1,18 @@
+---
+es:
+  gobierto_admin:
+    gobierto_investments:
+      projects:
+        form:
+          placeholders:
+            external_id: ID001
+            title: Centro deportivo
+        index:
+          header:
+            external_id: ID externo
+            title: Título
+          new: Nuevo
+          title: Proyectos
+          view_project: Ver proyecto
+        new:
+          title: Nuevo proyecto

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -18,6 +18,7 @@ ca:
         edit_site: Personalitzar site
         file_attachments: Documents
         hey_admin: Hola, %{admin_name}
+        investments: Inversions
         manage_sites: Gestionar sites
         notifications: Notificacions
         participation: Participació

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -18,6 +18,7 @@ en:
         edit_site: Customize site
         file_attachments: Documents
         hey_admin: Hey, %{admin_name}
+        investments: Investments
         manage_sites: Manage sites
         notifications: Notifications
         participation: Participation

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -18,6 +18,7 @@ es:
         edit_site: Personalizar sitio
         file_attachments: Documentos
         hey_admin: Hola, %{admin_name}
+        investments: Inversiones
         manage_sites: Gestionar sites
         notifications: Notificaciones
         participation: Participación

--- a/config/locales/gobierto_investments/models/ca.yml
+++ b/config/locales/gobierto_investments/models/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  activerecord:
+    models:
+      gobierto_investments/project:
+        one: Projecte
+        other: Projectes

--- a/config/locales/gobierto_investments/models/en.yml
+++ b/config/locales/gobierto_investments/models/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  activerecord:
+    models:
+      gobierto_investments/project:
+        one: Project
+        other: Projects

--- a/config/locales/gobierto_investments/models/es.yml
+++ b/config/locales/gobierto_investments/models/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  activerecord:
+    models:
+      gobierto_investments/project:
+        one: Proyecto
+        other: Proyectos

--- a/config/locales/gobierto_investments/views/ca.yml
+++ b/config/locales/gobierto_investments/views/ca.yml
@@ -1,0 +1,6 @@
+---
+ca:
+  gobierto_investments:
+    events:
+      gobierto_investments_project_project_created: Projecte d'inversió creat
+      gobierto_investments_project_project_updated: Projecte d'inversió actualitzat

--- a/config/locales/gobierto_investments/views/en.yml
+++ b/config/locales/gobierto_investments/views/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  gobierto_investments:
+    events:
+      gobierto_investments_project_project_created: Investment project created
+      gobierto_investments_project_project_updated: Investment project updated

--- a/config/locales/gobierto_investments/views/es.yml
+++ b/config/locales/gobierto_investments/views/es.yml
@@ -1,0 +1,6 @@
+---
+es:
+  gobierto_investments:
+    events:
+      gobierto_investments_project_project_created: Proyecto de inversión creado
+      gobierto_investments_project_project_updated: Proyecto de inversión actualizado

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,6 +230,10 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      namespace :gobierto_investments, as: :investments do
+        resources :projects
+      end
     end
 
     # User module

--- a/db/migrate/20190722154502_create_ginv_projects.rb
+++ b/db/migrate/20190722154502_create_ginv_projects.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateGinvProjects < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ginv_projects do |t|
+      t.references :site, index: true
+      t.jsonb :title_translations
+      t.string :external_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_10_130540) do
+ActiveRecord::Schema.define(version: 2019_07_22_154502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -530,6 +530,15 @@ ActiveRecord::Schema.define(version: 2019_07_10_130540) do
     t.datetime "updated_at", null: false
     t.integer "year"
     t.index ["site_id"], name: "index_gi_indicators_on_site_id"
+  end
+
+  create_table "ginv_projects", force: :cascade do |t|
+    t.bigint "site_id"
+    t.jsonb "title_translations"
+    t.string "external_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id"], name: "index_ginv_projects_on_site_id"
   end
 
   create_table "gobierto_module_settings", id: :serial, force: :cascade do |t|

--- a/test/fixtures/gobierto_admin/group_permissions.yml
+++ b/test/fixtures/gobierto_admin/group_permissions.yml
@@ -71,3 +71,9 @@ moderate_plans_madrid:
   namespace: site_module
   resource_type: gobierto_plans
   action_name: moderate
+
+madrid_manage_investments:
+  admin_group: madrid_group
+  namespace: site_module
+  resource_type: gobierto_investments
+  action_name: manage

--- a/test/fixtures/gobierto_investments/projects.yml
+++ b/test/fixtures/gobierto_investments/projects.yml
@@ -1,0 +1,18 @@
+public_pool_project:
+  site: madrid
+  title_translations: <%= {
+    en: "Public pool",
+    es: "Piscina municipal"
+    }.to_json %>
+  external_id: EE022
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+sports_center_project:
+  site: madrid
+  title_translations: <%= {
+    en: "Sports center",
+    es: "Centro deportivo"
+    }.to_json %>
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -15,6 +15,7 @@ madrid:
       "GobiertoPlans",
       "GobiertoCitizensCharters",
       "GobiertoObservatory",
+      "GobiertoInvestments"
     ],
     "default_locale" => "en",
     "available_locales" => ["en", "es"],

--- a/test/forms/gobierto_admin/admin_group_form_test.rb
+++ b/test/forms/gobierto_admin/admin_group_form_test.rb
@@ -92,19 +92,20 @@ module GobiertoAdmin
       form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage],
                                                                       gobierto_budget_consultations: [:manage],
                                                                       gobierto_participation: [:manage],
-                                                                      gobierto_plans: [:manage] }))
+                                                                      gobierto_plans: [:manage],
+                                                                      gobierto_investments: [:manage] }))
 
-      assert_equal 3, tony.modules_permissions.size
+      assert_equal 4, tony.modules_permissions.size
 
       assert form.save
 
-      assert_equal 4, tony.modules_permissions.size
+      assert_equal 5, tony.modules_permissions.size
     end
 
     def test_revoke_module_permissions
       form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage] }))
 
-      assert_equal 3, tony.modules_permissions.size
+      assert_equal 4, tony.modules_permissions.size
 
       assert form.save
 

--- a/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
+++ b/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
@@ -142,7 +142,7 @@ module GobiertoAdmin
               refute find("#admin_group_people_#{richard.id}", visible: false).checked?
             end
 
-            assert_equal 9, madrid_group.permissions.count
+            assert_equal 10, madrid_group.permissions.count
             assert GobiertoAdmin::Permission::GobiertoPlans.where(admin_group: madrid_group, action_name: "moderate").exists?
             assert madrid_group.permissions.for_people.where(action_name: "manage_all").exists?
           end

--- a/test/integration/gobierto_admin/gobierto_investments/projects/create_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/create_project_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    module Projects
+      class CreateProjectTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = new_admin_investments_project_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_regular_admin
+          @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def test_regular_admin_permissions_not_authorized
+          with(site: site, admin: unauthorized_regular_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+
+        def test_regular_admin_permissions_authorized
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+            assert has_no_content?("You are not authorized to perform this action")
+            assert_equal @path, current_path
+          end
+        end
+
+        def test_create_project_errors
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            click_button "Create"
+
+            assert has_alert?("Title can't be blank")
+          end
+        end
+
+        def test_create_project
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            fill_in "project_title_translations_en", with: "Concert hall"
+
+            switch_locale "ES"
+            fill_in "project_title_translations_es", with: "Sala de conciertos"
+
+            fill_in "project_external_id", with: "ID002"
+
+            click_button "Create"
+
+            assert has_message?("Project created correctly.")
+
+            assert has_field?("project_title_translations_en", with: "Concert hall")
+
+            switch_locale "ES"
+
+            assert has_field?("project_title_translations_es", with: "Sala de conciertos")
+          end
+
+          activity = Activity.last
+          new_project = ::GobiertoInvestments::Project.last
+          assert_equal new_project, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_investments.project.project_created", activity.action
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_investments/projects/delete_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/delete_project_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    module Projects
+      class DeleteProjectTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_investments_projects_path
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def project
+          @project ||= gobierto_investments_projects(:public_pool_project)
+        end
+
+        def test_delete_project
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+
+            within "#project-item-#{project.id}" do
+              find("a[data-method='delete']").click
+            end
+
+            assert has_message?("Project deleted correctly.")
+
+            refute site.projects.exists?(id: project.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_investments/projects/projects_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/projects_index_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    module Projects
+      class ProjectsIndexTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_investments_projects_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_regular_admin
+          @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def projects
+          @projects ||= site.projects
+        end
+
+        def test_regular_admin_permissions_not_authorized
+          with(site: site, admin: unauthorized_regular_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+
+        def test_regular_admin_permissions_authorized
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+            assert has_no_content?("You are not authorized to perform this action")
+            assert_equal @path, current_path
+          end
+        end
+
+        def test_projects_index
+          with_signed_in_admin(admin) do
+            with_current_site(site) do
+              visit @path
+
+              within "table tbody" do
+                assert has_selector?("tr", count: projects.size)
+
+                projects.each do |project|
+                  assert has_selector?("tr#project-item-#{ project.id }")
+
+                  within "tr#project-item-#{ project.id }" do
+                    assert has_link?(project.title)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_investments/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/update_project_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoInvestments
+    module Projects
+      class UpdateProjectTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = edit_admin_investments_project_path(project)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_regular_admin
+          @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def project
+          @project ||= gobierto_investments_projects(:public_pool_project)
+        end
+
+        def test_regular_admin_permissions_not_authorized
+          with(site: site, admin: unauthorized_regular_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal admin_root_path, current_path
+          end
+        end
+
+        def test_regular_admin_permissions_authorized
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+            assert has_no_content?("You are not authorized to perform this action")
+            assert_equal @path, current_path
+          end
+        end
+
+        def test_update_project
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            fill_in "project_title_translations_en", with: "Public pool updated"
+
+            switch_locale "ES"
+            fill_in "project_title_translations_es", with: "Piscina pública actualizada"
+
+            fill_in "project_external_id", with: "ID004"
+
+            click_button "Update"
+
+            assert has_message?("Project updated correctly.")
+
+            visit @path
+
+            assert has_field? "project_title_translations_en", with: "Public pool updated"
+
+            switch_locale "ES"
+
+            assert has_field?("project_title_translations_es", with: "Piscina pública actualizada")
+            assert has_field?("project_external_id", with: "ID004")
+          end
+
+          activity = Activity.last
+          assert_equal project, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_investments.project.project_updated", activity.action
+        end
+
+        def test_update_project_error
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                fill_in "project_title_translations_en", with: ""
+                switch_locale "ES"
+                fill_in "project_title_translations_es", with: ""
+
+                click_button "Update"
+
+                assert has_alert?("can't be blank")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/models/gobierto_investments/project_test.rb
+++ b/test/models/gobierto_investments/project_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoInvestments
+  class ProjectTest < ActiveSupport::TestCase
+    def project
+      @project ||= gobierto_investments_projects(:public_pool_project)
+    end
+
+    def project_without_external_id
+      @project_without_external_id ||= gobierto_investments_projects(:sports_center_project)
+    end
+
+    def test_valid
+      assert project.valid?
+    end
+
+    def test_valid_without_external_id
+      assert project_without_external_id.valid?
+    end
+  end
+end


### PR DESCRIPTION
Closes #2471


## :v: What does this PR do?
* Adds a new Investments module to gobierto:
  * Adds module in models and sets table_name_prefix
  * Defines module permissions for admins
  * Adds a new `GobiertoInvestments::Project` model, with custom fields enabled (in module configuration, the integration with admin views is pending)
  * Adds controller and views in admin to create, update and delete projects
  * Adds site activities for creation and update of projects
  * Adds some model and integration tests and fixtures for projects
  * Adds a link in module admin to documentation

 
## :mag: How should this be manually tested?

Enable investments in a site and visit the "Investments" side menu element

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![2471-after-2](https://user-images.githubusercontent.com/446459/61749240-8c337300-ada2-11e9-977f-1f406edb4160.gif)


## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [x] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

New initial documentation has been added in https://gobierto.readme.io/docs/inversiones. The documentation should be improved.