### PR TITLE
2473 numeric custom field

### DIFF
--- a/app/decorators/gobierto_common/custom_field_record_decorator.rb
+++ b/app/decorators/gobierto_common/custom_field_record_decorator.rb
@@ -82,6 +82,12 @@ module GobiertoCommon
             }
           }
         }
+      },
+      numeric: {
+        class_names: "form_item input_text",
+        field_tag: :number_field_tag,
+        partial: "item",
+        tag_attributes: { step: :any }
       }
     }.freeze
 

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -20,7 +20,8 @@ module GobiertoCommon
                        image: 7,
                        date: 8,
                        vocabulary_options: 9,
-                       plugin: 10 }
+                       plugin: 10,
+                       numeric: 11 }
 
     scope :sorted, -> { order(position: :asc) }
     scope :localized, -> { where(field_type: [:localized_string, :localized_paragraph]) }

--- a/app/models/gobierto_common/custom_field_record.rb
+++ b/app/models/gobierto_common/custom_field_record.rb
@@ -14,6 +14,7 @@ module GobiertoCommon
       image: CustomFieldValue::Image,
       vocabulary_options: CustomFieldValue::VocabularyOptions,
       plugin: CustomFieldValue::Plugin,
+      numeric: CustomFieldValue::Numeric,
       default: CustomFieldValue::Base
     }.freeze
 

--- a/app/models/gobierto_common/custom_field_value/numeric.rb
+++ b/app/models/gobierto_common/custom_field_value/numeric.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module GobiertoCommon::CustomFieldValue
+  class Numeric < Base
+    def value=(value)
+      if custom_field
+        record.payload = { custom_field.uid => value.to_f }
+      end
+    end
+
+    def value_string
+      raw_value.to_s
+    end
+  end
+end

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -18,6 +18,7 @@ ca:
         localized_string: Text (línia)
         multiple_options: Selecció múltiple
         name: Nom
+        numeric: Nombre
         options: Opcions
         paragraph: Text llarg sense traduccions
         single_option: Selecció única

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -18,6 +18,7 @@ en:
         localized_string: Text (line)
         multiple_options: Multiple selections
         name: Name
+        numeric: Number
         options: Options
         paragraph: Long text without translations
         single_option: One selection

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -18,6 +18,7 @@ es:
         localized_string: Texto (línea)
         multiple_options: Selección múltiple
         name: Nombre
+        numeric: Número
         options: Opciones
         paragraph: Texto largo sin traducciones
         single_option: Selección única

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -33,6 +33,11 @@ neil_custom_field_record_date_of_birth:
   custom_field: madrid_custom_field_date_of_birth
   payload: <%= { "date-of-birth" => "2019-07-19 12:29" }.to_json %>
 
+neil_custom_field_record_weight:
+  item: neil (GobiertoPeople::Person)
+  custom_field: madrid_custom_field_weight
+  payload: <%= { "weight" => 72.3 }.to_json %>
+
 madrid_custom_field_record_population:
   item: madrid (Site)
   custom_field: madrid_site_custom_field

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -221,3 +221,12 @@ madrid_custom_field_progress_plugin:
       plugin_configuration: { custom_field_uids: ["human-resources"] }
     }
   }.to_json %>
+
+madrid_custom_field_weight:
+  site: madrid
+  class_name: "GobiertoPeople::Person"
+  mandatory: false
+  position: 6
+  name_translations: <%= { en: "Weight (kg)", es: "Peso (kg)" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:numeric] %>
+  uid: weight

--- a/test/models/gobierto_common/custom_field_value/numeric_test.rb
+++ b/test/models/gobierto_common/custom_field_value/numeric_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon::CustomFieldValue
+  class NumericTest < ActiveSupport::TestCase
+
+    def record
+      gobierto_common_custom_field_records(:neil_custom_field_record_weight)
+    end
+
+    def test_value
+      assert_equal 72.3, record.value
+    end
+
+    def test_value_assign
+      record.value = 66.6
+      record.save
+
+      record.reload
+
+      assert_equal 66.6, record.value
+    end
+
+    def test_value_assign_numeric_string
+      record.value = "66.6"
+      record.save
+
+      record.reload
+
+      assert_equal 66.6, record.value
+    end
+
+    def test_value_assign_not_numeric_string
+      record.value = "wadus"
+      record.save
+
+      record.reload
+
+      assert_equal 0.0, record.value
+    end
+
+  end
+end


### PR DESCRIPTION
Closes #2473


## :v: What does this PR do?

* Adds a new numeric custom field type
* Includes a `number_field_tag` for custom field records of this type in forms

## :mag: How should this be manually tested?

Add a custom field of this type to a class which admits custom fields and edit an item of the class  

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![2473-after](https://user-images.githubusercontent.com/446459/61799620-c006ab00-ae2b-11e9-8577-2c851373660f.gif)


## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

A new entry in documentation has been suggested in https://gobierto.readme.io/docs/campos-personalizados