### PR TITLE
2474 extend image custom field with multiple items

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -30,8 +30,7 @@ module GobiertoAdmin
             instance_id: params[:instance_id]
           )
           @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
-          @types_with_options = @custom_field_form.types_with_options
-          @types_with_vocabulary = @custom_field_form.types_with_vocabulary
+          set_options
         end
 
         def create
@@ -46,8 +45,7 @@ module GobiertoAdmin
               notice: t(".success")
             )
           else
-            @types_with_options = @custom_field_form.types_with_options
-            @types_with_vocabulary = @custom_field_form.types_with_vocabulary
+            set_options
             @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
             render :new
           end
@@ -64,8 +62,7 @@ module GobiertoAdmin
 
           @custom_field_form = form_class.new(@custom_field.attributes.except(*ignored_custom_field_attributes).merge(site_id: current_site.id))
           @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
-          @types_with_options = @custom_field_form.types_with_options
-          @types_with_vocabulary = @custom_field_form.types_with_vocabulary
+          set_options
         end
 
         def update
@@ -82,8 +79,7 @@ module GobiertoAdmin
               notice: t(".success")
             )
           else
-            @types_with_options = @custom_field_form.types_with_options
-            @types_with_vocabulary = @custom_field_form.types_with_vocabulary
+            set_options
             @decorated_instance = ::GobiertoAdmin::BaseResourceDecorator.new(@custom_field_form.instance) if @custom_field_form.instance
             render :edit
           end
@@ -133,6 +129,7 @@ module GobiertoAdmin
             :instance_class_name,
             :instance_id,
             :plugin_configuration,
+            :multiple,
             name_translations: [*I18n.available_locales],
             options_translations: {}
           )
@@ -160,6 +157,12 @@ module GobiertoAdmin
 
         def form_class
           ::GobiertoAdmin::GobiertoCommon::CustomFieldForm
+        end
+
+        def set_options
+          @types_with_options = @custom_field_form.types_with_options
+          @types_with_vocabulary = @custom_field_form.types_with_vocabulary
+          @types_with_multiple_setting = @custom_field_form.types_with_multiple_setting
         end
 
         def check_class

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -80,7 +80,7 @@ module GobiertoAdmin
       end
 
       def available_vocabulary_options
-        ::GobiertoCommon::CustomField.available_options
+        ::GobiertoCommon::CustomField.available_vocabulary_options
       end
 
       def available_date_options

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -21,10 +21,11 @@ module GobiertoAdmin
         :vocabulary_type,
         :plugin_type,
         :date_type,
-        :plugin_configuration
+        :plugin_configuration,
+        :multiple
       )
 
-      delegate :persisted?, :has_vocabulary?, to: :custom_field
+      delegate :persisted?, :has_vocabulary?, :allow_multiple?, to: :custom_field
 
       validates :name_translations, :site, :klass, :field_type, presence: true
       validate :instance_type_is_enabled
@@ -102,6 +103,9 @@ module GobiertoAdmin
             opts[:configuration][:plugin_type] = plugin_type
             opts[:configuration][:plugin_configuration] = plugin_configuration_format
           end
+          if allow_multiple?
+            opts[:configuration][:multiple] = multiple?
+          end
         end
       end
 
@@ -115,6 +119,10 @@ module GobiertoAdmin
 
       def types_with_vocabulary
         @types_with_vocabulary ||= ::GobiertoCommon::CustomField.field_types_with_vocabulary.keys
+      end
+
+      def types_with_multiple_setting
+        @types_with_multiple_setting ||= ::GobiertoCommon::CustomField.field_types_with_multiple_setting
       end
 
       def has_options?
@@ -163,6 +171,14 @@ module GobiertoAdmin
 
       def site
         @site ||= Site.find_by(id: site_id)
+      end
+
+      def multiple
+        @multiple ||= custom_field.configuration.multiple || false
+      end
+
+      def multiple?
+        multiple == "1" || multiple == true
       end
 
       private

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -62,11 +62,11 @@ module GobiertoAdmin
                                          item: item
                                        )
                                        if record.custom_field_id == value["custom_field_id"].to_i
-                                         if record.custom_field.image?
-                                           record.value = upload_file(uid, value) if value["value"].present?
-                                         else
-                                           record.value = value["value"]
-                                         end
+                                         record.value = if record.custom_field.configuration.multiple
+                                                          extract_multiple_values(value, record)
+                                                        else
+                                                          extract_single_value(value, record, default_value: record.value)
+                                                        end
                                        end
                                        ::GobiertoCommon::CustomFieldRecordDecorator.new(record)
                                      end
@@ -75,6 +75,26 @@ module GobiertoAdmin
 
       def save
         save_custom_fields if valid?
+      end
+
+      def extract_multiple_values(value, record)
+        new_values = value.values.map do |item|
+          extract_single_value(item, record)
+        end.compact
+        current_values = record.value
+        current_values = [current_values] unless current_values.is_a? Array
+        values = (value["existing"]&.values || []) & current_values
+        values + new_values
+      end
+
+      def extract_single_value(value, record, default_value: nil)
+        if record.custom_field.image?
+          return default_value unless value["value"].present?
+
+          upload_file(record.custom_field.uid, value)
+        else
+          value["value"]
+        end
       end
 
       def changed?

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -47,7 +47,7 @@ module GobiertoAdmin
       end
 
       def image_fields_options
-        site.custom_fields.pluck(:uid, :options).map do |uid, options|
+        site.custom_fields.pluck(:uid).map do |uid|
           { uid: uid,
             max_width: 500,
             max_height: 500 }

--- a/app/javascript/gobierto_admin/modules/gobierto_common_custom_field_records_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_common_custom_field_records_controller.js
@@ -8,6 +8,26 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsController = (function() {
       _cropImage(image_field)
     }
     _handleSelectBehaviors()
+    _handleMultipleElementsBehaviors()
+  }
+
+  function _handleMultipleElementsBehaviors() {
+    $(document).on("click", "[data-behavior]", function handler(e) {
+      if ($(this).data("behavior") === "delete_item") {
+        e.preventDefault();
+        _deleteItem($(this).data("index"), $(this).data("uid"));
+      } else if ($(this).data("behavior") === "new_item") {
+        e.preventDefault();
+        _showNewItem();
+      } else if ($(this).data("behavior") === "cancel_new") {
+        e.preventDefault();
+        if ($(this).parents("span#new-item-form").length > 0 ) {
+          _hideNewItem();
+        } else {
+          $(this).parents("span").remove();
+        }
+      }
+    })
   }
 
   function _cropImage(image_field) {
@@ -35,7 +55,28 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsController = (function() {
       $crop_y.val(output.cropper.getData()["y"]);
       $crop_w.val(output.cropper.getData()["width"]);
       $crop_h.val(output.cropper.getData()["height"]);
+      _createNewItem(image_field)
     });
+  }
+
+  function _createNewItem(image_field) {
+    if ($("#new-item-form").length == 0) retun
+
+    let uid = image_field.uid
+    let index = $(".new_item").last().data("index") === undefined ? 0 : $(".new_item").last().data("index") + 1
+    let item_uid = `${uid}_${index}`
+
+    let addItemForm = $("#new-item-form").clone().prop("id", `new-item-form-${index}`).addClass("new_item")
+    addItemForm.find("input").each(function(i){
+      $(this).prop('name', $(this).prop("name").replace("add_item", index))
+      $(this).prop('id', $(this).prop("id").replace(uid, item_uid))
+    });
+    addItemForm.find(".add_item").removeClass("add_item")
+    addItemForm.data("index", index)
+
+    $("#new-item-form").before(addItemForm)
+    _hideNewItem()
+    $('.add_item').val('');
   }
 
   function openCropModal(loaded_image, image_field) {
@@ -87,10 +128,28 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsController = (function() {
         if ((height > image_field.max_height || width > image_field.max_width)) {
           openCropModal(loaded_image, image_field);
         } else {
+          _createNewItem(image_field)
           $(`#saved_image_${ image_field.uid }`).hide();
         }
       };
     };
+  }
+
+  function _deleteItem(index, uid) {
+    if (confirm(I18n.t("gobierto_admin.gobierto_common.custom_fields.custom_fields.form.confirm"))) {
+      $(`div[data-index=${index}][data-uid=${uid}]`).remove()
+    }
+  }
+
+  function _showNewItem() {
+    $("div#add-item").hide()
+    $("#new-item-form").show()
+    $("#new-item-form").find(".add_item").click()
+  }
+
+  function _hideNewItem() {
+    $("#new-item-form").hide()
+    $("div#add-item").show()
   }
 
   function _handleSelectBehaviors() {

--- a/app/javascript/gobierto_admin/modules/gobierto_common_custom_fields_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_common_custom_fields_controller.js
@@ -21,6 +21,10 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldsController = (function() {
         $("#options").show();
       }
 
+      if ($(this).data().hasMultiple) {
+        $("#multiple").show();
+      }
+
       if ($(this).data().type === "plugin") {
         _handlePluginOptionsVisibility($('.js-plugin-type-option[checked="checked"]'));
         _handlePluginOptionsDefault();

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -44,8 +44,16 @@ module GobiertoCommon
       [:single_select, :multiple_select, :tags]
     end
 
+    def self.field_types_with_multiple_setting
+      %w(image)
+    end
+
     def self.date_options
       [:date, :datetime]
+    end
+
+    def allow_multiple?
+      self.class.field_types_with_multiple_setting.include? field_type
     end
 
     def long_text?

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -40,7 +40,7 @@ module GobiertoCommon
       field_types.select { |key, _| /vocabulary/.match(key) }
     end
 
-    def self.available_options
+    def self.available_vocabulary_options
       [:single_select, :multiple_select, :tags]
     end
 

--- a/app/models/gobierto_common/custom_field_value/base.rb
+++ b/app/models/gobierto_common/custom_field_value/base.rb
@@ -12,7 +12,7 @@ module GobiertoCommon
       end
 
       def value
-        return unless custom_field && payload.present?
+        return default_value unless custom_field && payload.present?
 
         raw_value
       end
@@ -29,6 +29,10 @@ module GobiertoCommon
         @raw_value ||= if custom_field && payload.present?
                          payload[custom_field.uid]
                        end
+      end
+
+      def default_value
+        custom_field.configuration.multiple ? [] : nil
       end
 
       def value=(value)

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
@@ -42,7 +42,8 @@
                       data: {
                         type: b.text,
                         has_options: @types_with_options.include?(b.text),
-                        has_vocabulary: @types_with_vocabulary.include?(b.text)
+                        has_vocabulary: @types_with_vocabulary.include?(b.text),
+                        has_multiple: @types_with_multiple_setting.include?(b.text)
                       }
                     ) %>
                 <%= b.label do %>
@@ -56,6 +57,16 @@
       </div>
 
       <div class="configuration">
+        <%= content_tag :div, class: "form_block" do %>
+          <%= content_tag :div, id: "multiple", class: "form_item", style: @custom_field_form.allow_multiple? ? nil : "display: none;" do %>
+            <h4 class="options compact"><%= t(".type") %></h4>
+            <%= f.check_box(:multiple) %>
+            <%= f.label :multiple do %>
+              <span></span>
+              <%= t('.multiple') %>
+            <% end %>
+          <% end %>
+        <% end %>
         <%= content_tag :div, class: "form_block" do %>
           <%= content_tag :div, id: "plugin", class: "form_item", style: @custom_field_form.custom_field.plugin? ? nil : "display: none;" do %>
             <%= render partial: "plugin", locals: { f: f } %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_custom_fields.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_custom_fields.html.erb
@@ -26,6 +26,7 @@
       f: f,
       record: record,
       input_base_name: input_base_name,
+      multiple: record.custom_field.configuration.multiple && record.value.is_a?(Array)
     }
   ) %>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_gallery_image.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_gallery_image.html.erb
@@ -1,0 +1,15 @@
+<%= content_tag :div, class: "user_field_container pure-g", data: { index: index, uid: record.uid, input_base_name: input_base_name } do %>
+  <div class="pure-u-1">
+    <div class="f_right">
+      <%= link_to "#",
+        class: "tipsit",
+        title: t("views.delete"),
+        data: { behavior: "delete_item", index: index, uid: record.uid } do %>
+        <i class="fas fa-trash"></i>
+      <% end %>
+    </div>
+  </div>
+
+  <%= image_tag content, height: 150, id: "saved_image_#{record.uid}_#{index}" %>
+  <%= hidden_field_tag "#{ input_base_name }[#{record.uid}][existing][#{index}]", content %>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_image.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_image.html.erb
@@ -1,3 +1,5 @@
+<% multiple ||= false %>
+
 <div class="<%= record.class_names %>">
   <%= label_tag "#{ input_base_name }[#{ record.uid }][value]" do %>
     <%= record.name %>
@@ -14,14 +16,40 @@
     </div>
   </div>
 
-  <% if record.input_content.present? %>
-    <%= image_tag record.input_content, height: 150, id: "saved_image_#{ record.uid }" %>
+  <% if multiple %>
+    <% (record.input_content || []).each_with_index do |content, index| %>
+      <%= render(
+            partial: "gobierto_admin/gobierto_common/custom_fields/forms/gallery_image",
+            locals: {
+              record: record,
+              content: content,
+              index: index,
+              input_base_name: input_base_name,
+              f: f
+            }
+          ) %>
+    <% end %>
+  <% else %>
+    <% if record.input_content.present? %>
+      <%= image_tag record.input_content, height: 150, id: "saved_image_#{ record.uid }" %>
+    <% end %>
   <% end %>
 
-  <%= f.file_field "[custom_records][#{record.uid}][value]", id: record.uid %>
-  <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][custom_field_id]", record.custom_field_id %>
+  <% if multiple %>
+    <%= render(
+      partial: "gobierto_admin/gobierto_common/custom_fields/forms/new_gallery_image",
+      locals: {
+        record: record,
+        input_base_name: input_base_name,
+        f: f
+      }
+    ) %>
+  <% else %>
+    <%= f.file_field "[custom_records][#{record.uid}][value]", id: record.uid %>
+    <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][custom_field_id]", record.custom_field_id %>
 
-  <% %w[x y w h].each do |attribute| %>
-    <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][crop][#{ attribute }]", nil, id: "#{ record.uid }_crop_#{ attribute }" %>
+    <% %w[x y w h].each do |attribute| %>
+      <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][crop][#{ attribute }]", nil, id: "#{ record.uid }_crop_#{ attribute }" %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_new_gallery_image.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_new_gallery_image.html.erb
@@ -1,0 +1,30 @@
+<%= content_tag :span,
+  id: "new-item-form",
+  style: "display: none;" do %>
+
+  <div class="user_field_container pure-g" data-option="new_option">
+    <div class="pure-u-1">
+      <div class="f_right">
+        <%= link_to "#",
+          class: "tipsit",
+          title: t(".cancel_new_item"),
+          data: { behavior: "cancel_new" } do %>
+          <i class="fas fa-times"></i>
+        <% end %>
+      </div>
+    </div>
+
+    <%= f.file_field "[custom_records][#{record.uid}][add_item][value]", id: record.uid, class: "add_item" %>
+    <% %w[x y w h].each do |attribute| %>
+      <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][add_item][crop][#{ attribute }]", nil, id: "#{ record.uid }_crop_#{ attribute }" %>
+    <% end %>
+  </div>
+<% end %>
+
+<%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][custom_field_id]", record.custom_field_id %>
+<div class="m_2" id="add-item">
+  <%= link_to "#", data: { behavior: "new_item" } do %>
+    <i class="fas fa-plus-circle"></i>
+    <%= t(".add_item") %>
+  <% end %>
+</div>

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
@@ -42,6 +42,10 @@ ca:
             single_select: Selecció única
             tags: Tags
             type: Tipus
+        forms:
+          new_gallery_image:
+            add_item: Afegir imatge
+            cancel_new_item: Cancel
         module_resources:
           index:
             custom_fields_for_instances_of: Camps personalitzats per a instàncies

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
@@ -14,6 +14,8 @@ ca:
           form:
             confirm: Estàs segur?
             crop: Retallar
+            multiple: Múltiple
+            type: Opcions de contingut
           index:
             instance_title: Camps personalitzats de %{instance_name}
             localized_custom_fields: Camps traduïbles

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
@@ -42,6 +42,10 @@ en:
             single_select: Single select
             tags: Tags
             type: Type
+        forms:
+          new_gallery_image:
+            add_item: Add image
+            cancel_new_item: Cancel
         module_resources:
           index:
             custom_fields_for_instances_of: Custom fields for instances of %{name}

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
@@ -14,6 +14,8 @@ en:
           form:
             confirm: Are you sure?
             crop: Crop
+            multiple: Multiple
+            type: Content options
           index:
             instance_title: Custom fields of %{instance_name}
             localized_custom_fields: Translatable fields

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
@@ -14,6 +14,8 @@ es:
           form:
             confirm: "¿Estás seguro?"
             crop: Recortar
+            multiple: Múltiple
+            type: Opciones de contenido
           index:
             instance_title: Campos personalizados de %{instance_name}
             localized_custom_fields: Campos traducibles

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
@@ -42,6 +42,10 @@ es:
             single_select: Selección única
             tags: Tags
             type: Tipo
+        forms:
+          new_gallery_image:
+            add_item: Añadir imagen
+            cancel_new_item: Cancelar
         module_resources:
           index:
             custom_fields_for_instances_of: Campos personalizados para instancias

--- a/test/integration/gobierto_admin/gobierto_common/custom_field_records/image_gallery_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_field_records/image_gallery_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module CustomFieldRecord
+      class ImageGallertTest < ActionDispatch::IntegrationTest
+
+        attr_reader :plan, :project, :path
+
+        def setup
+          super
+          @plan = gobierto_plans_plans(:strategic_plan)
+          @project = gobierto_plans_nodes(:political_agendas)
+
+          remove_custom_fields_and_create_gallery
+
+          @path = edit_admin_plans_plan_project_path(plan, project)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def remove_custom_fields_and_create_gallery
+          ::GobiertoCommon::CustomField.destroy_all
+          ::GobiertoCommon::CustomField.image.create(
+            site: site,
+            class_name: "GobiertoPlans::Node",
+            name_translations: { en: "Image gallery", es: "Galería de imágenes" },
+            uid: "image_gallery",
+            options: { configuration: { multiple: true } }
+          )
+        end
+
+        def test_update_project_as_manager
+          with(site: site, admin: admin, js: true) do
+            visit path
+
+            within "form" do
+              click_link "Add image"
+              attach_file "image_gallery", Rails.root.join("test/fixtures/files/sites/logo-madrid.png")
+              click_link "Add image"
+              attach_file "image_gallery", Rails.root.join("test/fixtures/files/gobierto_people/people/avatar-small.jpg")
+
+              has_css?(".new_item", count: 2)
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            assert has_message? "Project updated correctly."
+
+            custom_field_record = ::GobiertoCommon::CustomFieldRecord.find_by(item: project)
+
+            assert_equal 2, custom_field_record.value.count
+
+            within "form" do
+              find("[data-index='0'][data-behavior='delete_item']").click
+              page.accept_alert
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            custom_field_record.reload
+
+            assert_equal 1, custom_field_record.value.count
+          end
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2474


## :v: What does this PR do?

* Adds a setting to image custom field allowing multiple images
* Changes admin custom fields records form to manage multiple image
* Adds some integration tests

## :mag: How should this be manually tested?

Create image custom fields enabling multiple option, visit resources with this type of custom field

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![2474-after](https://user-images.githubusercontent.com/446459/61994513-744a4080-b07b-11e9-941f-ae485580a46f.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [x] Suggestion submitted to https://gobierto.readme.io/docs/campos-personalizados
