### PR TITLE
Add custom fields to investments projects admin controller and form

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_investments/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_investments/projects_controller.rb
@@ -10,6 +10,7 @@ module GobiertoAdmin
 
       def new
         @project_form = ProjectForm.new(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
+        initialize_custom_field_form
       end
 
       def edit
@@ -18,12 +19,15 @@ module GobiertoAdmin
         @project_form = ProjectForm.new(
           @project.attributes.except(*ignored_project_attributes).merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
         )
+        initialize_custom_field_form
       end
 
       def create
         @project_form = ProjectForm.new(project_params.merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip))
+        initialize_custom_field_form
 
         if @project_form.save
+          custom_fields_save
           redirect_to(
             edit_admin_investments_project_path(@project_form.project),
             notice: t(".success")
@@ -39,8 +43,9 @@ module GobiertoAdmin
         @project_form = ProjectForm.new(
           project_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
         )
+        initialize_custom_field_form
 
-        if @project_form.save
+        if @project_form.save && custom_fields_save
           redirect_to(
             edit_admin_investments_project_path(@project),
             notice: t(".success")
@@ -74,6 +79,22 @@ module GobiertoAdmin
       def find_project
         current_site.projects.find(params[:id])
       end
+
+      def initialize_custom_field_form
+        @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(
+          site_id: current_site.id,
+          item: @project_form.project
+        )
+        custom_params_key = self.class.name.demodulize.gsub("Controller", "").underscore.singularize
+        return if request.get? || !params.has_key?(custom_params_key)
+
+        @custom_fields_form.custom_field_records = params.require(custom_params_key).permit(custom_records: {})
+      end
+
+      def custom_fields_save
+        @custom_fields_form.save
+      end
+
     end
   end
 end

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_new_gallery_image.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_new_gallery_image.html.erb
@@ -22,7 +22,7 @@
 <% end %>
 
 <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][custom_field_id]", record.custom_field_id %>
-<div class="m_2" id="add-item">
+<div id="add-item">
   <%= link_to "#", data: { behavior: "new_item" } do %>
     <i class="fas fa-plus-circle"></i>
     <%= t(".add_item") %>

--- a/app/views/gobierto_admin/gobierto_investments/projects/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_investments/projects/_form.html.erb
@@ -22,6 +22,15 @@
         <%= f.text_field :external_id, placeholder: t('.placeholders.external_id') %>
       </div>
 
+      <%= render(
+        partial: "gobierto_admin/gobierto_common/custom_fields/forms/custom_fields",
+        locals: {
+          f: f,
+          item: @custom_fields_form,
+          form_name: "project"
+        }
+      ) %>
+
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>


### PR DESCRIPTION
Related with #2476


## :v: What does this PR do?

Adds custom fields to investments projects forms

## :mag: How should this be manually tested?

Define some custom fields for projects of investments module and create/edit a project

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
