### PR TITLE
2477 custom fields api

### DIFF
--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -19,6 +19,10 @@ class ApiBaseController < ActionController::API
     end
   end
 
+  def api_errors_render(item, options = {})
+    render({ json: item, status: :unprocessable_entity, serializer: ActiveModel::Serializer::ErrorSerializer }.merge(options))
+  end
+
   protected
 
   def raise_module_not_enabled(_redirect)

--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -1,9 +1,28 @@
 # frozen_string_literal: true
 
-class ApiBaseController < ApplicationController
+class ApiBaseController < ActionController::API
+  include SubmodulesHelper
+  include ::GobiertoCommon::ModuleHelper
+  include ApplicationConcern
 
-  respond_to :json
+  def preferred_locale
+    @preferred_locale ||= begin
+                            locale_param = params[:locale]
+                            site_locale = current_site.configuration.default_locale if current_site.present?
+                            (locale_param || site_locale || I18n.default_locale).to_s
+                          end
+  end
 
-  skip_before_action :verify_authenticity_token
+  def set_locale
+    if available_locales.include?(preferred_locale)
+      I18n.locale = preferred_locale.to_sym
+    end
+  end
+
+  protected
+
+  def raise_module_not_enabled(_redirect)
+    head :forbidden
+  end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   include SubmodulesHelper
   include ::GobiertoCommon::ModuleHelper
   include ::GobiertoCommon::FileUploadHelper
   include ::GobiertoCms::GlobalNavigation
+  include ApplicationConcern
 
   protect_from_forgery with: :exception
 
@@ -20,7 +23,7 @@ class ApplicationController < ActionController::Base
     :cache_key_preffix
   )
 
-  before_action :set_current_site, :authenticate_user_in_site, :set_locale, :apply_engines_overrides
+  before_action :authenticate_user_in_site, :apply_engines_overrides
 
   def render_404
     render file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]
@@ -30,68 +33,30 @@ class ApplicationController < ActionController::Base
     ActionController::Base.helpers
   end
 
-  def current_site
-    @current_site ||= begin
-      site = if request.env['gobierto_site'].present?
-        request.env['gobierto_site']
-      else
-        Site.first if Rails.env.test?
-      end
-      ::GobiertoCore::CurrentScope.current_site = site
-      site
-    end
-  end
-
   private
-
-  def current_module?
-    current_module.present?
-  end
-
-  def current_module
-    @current_module ||= if params[:controller].include?('/')
-                          params[:controller].split('/').first
-                        end
-  end
-
-  def current_module_class
-    @current_module_class ||= current_module&.camelize&.constantize
-  end
-
-  def set_current_site
-    @site = current_site
-  end
 
   def authenticate_user_in_site
     if (Rails.env.production? || Rails.env.staging?) && @site && @site.password_protected?
-      authenticate_or_request_with_http_basic('Gobierto') do |username, password|
+      authenticate_or_request_with_http_basic("Gobierto") do |username, password|
         username == @site.configuration.password_protection_username && password == @site.configuration.password_protection_password
       end
     end
   end
 
   def set_locale
-    locale_param = params[:locale]
-    locale_cookie = cookies.signed[:locale]
-    site_locale = current_site.configuration.default_locale if current_site.present?
-
-    preferred_locale = (locale_param || locale_cookie || site_locale || I18n.default_locale).to_s
-
     if available_locales.include?(preferred_locale)
       I18n.locale = cookies.permanent.signed[:locale] = preferred_locale.to_sym
     end
   end
 
-  def available_locales
-    @available_locales ||= if current_site
-                             current_site.configuration.available_locales
-                           else
-                             I18n.available_locales
-                           end
-  end
+  def preferred_locale
+    @preferred_locale ||= begin
+                            locale_param = params[:locale]
+                            locale_cookie = cookies.signed[:locale]
+                            site_locale = current_site.configuration.default_locale if current_site.present?
 
-  def algoliasearch_configured?
-    ::GobiertoCommon::Search.algoliasearch_configured?
+                            (locale_param || locale_cookie || site_locale || I18n.default_locale).to_s
+                          end
   end
 
   def engine_overrides
@@ -104,20 +69,13 @@ class ApplicationController < ActionController::Base
 
   def apply_engines_overrides
     return unless engine_overrides?
+
     engine_overrides.each do |engine|
       prepend_view_path Rails.root.join("vendor/gobierto_engines/#{ engine }/app/views")
     end
   end
 
-  def cache_key_preffix
-    "site-#{current_site.id}-#{params.to_unsafe_h.sort.flatten.join('-')}"
-  end
-
   protected
-
-  def remote_ip
-    request.env['action_dispatch.remote_ip'].try(:calculate_ip) || request.remote_ip
-  end
 
   def raise_module_not_enabled(redirect = true)
     if redirect

--- a/app/controllers/concerns/application_concern.rb
+++ b/app/controllers/concerns/application_concern.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ApplicationConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_current_site, :set_locale
+  end
+
+  def current_site
+    @current_site ||= begin
+                        site = if request.env["gobierto_site"].present?
+                                 request.env["gobierto_site"]
+                               elsif Rails.env.test?
+                                 Site.first
+                               end
+                        ::GobiertoCore::CurrentScope.current_site = site
+                        site
+                      end
+  end
+
+  private
+
+  def current_module?
+    current_module.present?
+  end
+
+  def current_module
+    @current_module ||= if params[:controller].include?("/")
+                          params[:controller].split("/").first
+                        end
+  end
+
+  def current_module_class
+    @current_module_class ||= current_module&.camelize&.constantize
+  end
+
+  def set_current_site
+    @site = current_site
+  end
+
+  def available_locales
+    @available_locales ||= if current_site
+                             current_site.configuration.available_locales
+                           else
+                             I18n.available_locales
+                           end
+  end
+
+  def algoliasearch_configured?
+    ::GobiertoCommon::Search.algoliasearch_configured?
+  end
+
+  def cache_key_preffix
+    "site-#{current_site.id}-#{params.to_unsafe_h.sort.flatten.join("-")}"
+  end
+
+  protected
+
+  def remote_ip
+    request.env["action_dispatch.remote_ip"].try(:calculate_ip) || request.remote_ip
+  end
+
+end

--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module CustomFieldsApi
+    extend ActiveSupport::Concern
+
+    included do
+      attr_reader :resource
+
+      serialization_scope :current_site
+    end
+
+    def save_with_custom_fields
+      return unless resource.save
+
+      initialize_custom_fields_form
+      custom_fields_save
+    end
+
+    private
+
+    def custom_fields_save
+      @custom_fields_form.save
+    end
+
+    def initialize_custom_fields_form
+      @custom_fields_form = GobiertoCommon::CustomFieldRecordsForm.new(
+        site_id: current_site.id,
+        item: resource
+      )
+
+      return if request.get?
+
+      @custom_fields_form.custom_field_records = params.require(:data).require(:attributes).slice(*custom_field_keys).permit!
+    end
+
+    def custom_field_keys
+      current_site.custom_fields.where(class_name: resource.class.name).map(&:uid)
+    end
+
+  end
+end

--- a/app/controllers/gobierto_investments/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/base_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GobiertoInvestments
+  module Api
+    module V1
+      class BaseController < ApiBaseController
+
+        before_action { module_enabled!(current_site, "GobiertoInvestments", false) }
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module GobiertoInvestments
+  module Api
+    module V1
+      class ProjectsController < ApiBaseController
+
+        include ::GobiertoCommon::CustomFieldsApi
+
+        # GET /gobierto_investments/api/v1/projects
+        # GET /gobierto_investments/api/v1/projects.json
+        def index
+          render json: base_relation, adapter: :json_api
+        end
+
+        # GET /gobierto_investments/api/v1/projects/1
+        # GET /gobierto_investments/api/v1/projects/1.json
+        def show
+          find_resource
+
+          render json: @resource, adapter: :json_api
+        end
+
+        # GET /gobierto_investments/api/v1/projects/new
+        # GET /gobierto_investments/api/v1/projects/new.json
+        def new
+          @resource = base_relation.new
+
+          render json: @resource, adapter: :json_api
+        end
+
+        # POST /gobierto_investments/api/v1/projects
+        # POST /gobierto_investments/api/v1/projects.json
+        def create
+          @resource = if (external_id = params.dig(:data, :attributes, :external_id)).present?
+                        base_relation.find_or_initialize_by(external_id: external_id)
+                      else
+                        base_relation.new
+                      end
+          @resource.assign_attributes(resource_params)
+
+          save_with_custom_fields
+
+          render json: @resource, adapter: :json_api
+        end
+
+        # PATCH/PUT /gobierto_investments/api/v1/projects/1
+        # PATCH/PUT /gobierto_investments/api/v1/projects/1
+        def update
+          find_resource
+
+          @resource.assign_attributes(resource_params)
+
+          save_with_custom_fields
+
+          render json: @resource, adapter: :json_api
+        end
+
+        private
+
+        def find_resource
+          @resource = base_relation.find(params[:id])
+        end
+
+        def base_relation
+          current_site.projects
+        end
+
+        def resource_params
+          params.require(:data).require(:attributes).permit(:external_id, title_translations: {})
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -39,9 +39,11 @@ module GobiertoInvestments
                       end
           @resource.assign_attributes(resource_params)
 
-          save_with_custom_fields
-
-          render json: @resource, adapter: :json_api
+          if save_with_custom_fields
+            render json: @resource, adapter: :json_api
+          else
+            api_errors_render(@resource, adapter: :json_api)
+          end
         end
 
         # PATCH/PUT /gobierto_investments/api/v1/projects/1
@@ -53,7 +55,11 @@ module GobiertoInvestments
 
           save_with_custom_fields
 
-          render json: @resource, adapter: :json_api
+          if save_with_custom_fields
+            render json: @resource, adapter: :json_api
+          else
+            api_errors_render(@resource, adapter: :json_api)
+          end
         end
 
         private

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -62,6 +62,16 @@ module GobiertoInvestments
           end
         end
 
+        # DELETE /gobierto_investments/api/v1/projects/1
+        # DELETE /gobierto_investments/api/v1/projects/1.json
+        def destroy
+          find_resource
+
+          @resource.destroy
+
+          head :no_content
+        end
+
         private
 
         def find_resource

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_records_form.rb
@@ -2,37 +2,7 @@
 
 module GobiertoAdmin
   module GobiertoCommon
-    class CustomFieldRecordsForm < BaseForm
-
-      attr_accessor(
-        :site_id,
-        :item,
-        :instance,
-        :with_version,
-        :force_new_version,
-        :version_index
-      )
-
-      delegate :persisted?, to: :item
-
-      validates :site, presence: true
-
-      def available_custom_fields
-        if instance # GobiertoPlans
-          ::GobiertoPlans::Node.node_custom_fields(instance, item).sorted
-        else # GobiertoCitizensCharters
-          site.custom_fields.sorted.where(class_name: item.class.name, instance_type: instance_type_options, instance_id: instance_id_options)
-        end
-      end
-
-      def custom_field_records
-        @custom_field_records ||= available_custom_fields.map do |custom_field|
-          record = site.custom_field_records.find_or_initialize_by(item: item, custom_field: custom_field)
-          record = record.versions[version_index].reify if version_index && !(record.versions.count + version_index).negative? && record.versions[version_index].reify.present?
-
-          ::GobiertoCommon::CustomFieldRecordDecorator.new(record)
-        end
-      end
+    class CustomFieldRecordsForm < ::GobiertoCommon::CustomFieldRecordsForm
 
       def has_localized_records?
         custom_field_records.any?(&:has_localized_value?)
@@ -73,10 +43,6 @@ module GobiertoAdmin
                                    end
       end
 
-      def save
-        save_custom_fields if valid?
-      end
-
       def extract_multiple_values(value, record)
         new_values = value.values.map do |item|
           extract_single_value(item, record)
@@ -97,35 +63,7 @@ module GobiertoAdmin
         end
       end
 
-      def changed?
-        custom_field_records.any? { |custom_field| version_changed?(custom_field) }
-      end
-
       private
-
-      def version_changed?(custom_field)
-        if with_version && version_index.present?
-          (custom_field.versions[version_index]&.reify || custom_field.clone.reload).slice(*attributes_for_new_version) != custom_field.slice(*attributes_for_new_version)
-        else
-          custom_field.changed?
-        end
-      end
-
-      def instance_type_options
-        return [nil] unless instance
-
-        [nil, instance.class.name]
-      end
-
-      def instance_id_options
-        return [nil] unless instance
-
-        [nil, instance.id]
-      end
-
-      def site
-        @site ||= Site.find_by(id: site_id || item.try(:site_id))
-      end
 
       def upload_file(uid, value)
         return nil unless value["value"].present?
@@ -142,24 +80,6 @@ module GobiertoAdmin
         ).upload!
       end
 
-      def save_custom_fields
-        return custom_field_records if with_version && !force_new_version && !changed?
-
-        custom_field_records.each do |record|
-          record.item_has_versions = with_version
-
-          save_success = with_version && force_new_version && !record.changed? ? record.paper_trail.save_with_version : record.save
-          unless save_success
-            promote_errors(record.errors)
-            return false
-          end
-        end
-        custom_field_records
-      end
-
-      def attributes_for_new_version
-        %w(item_type item_id custom_field_id payload)
-      end
     end
   end
 end

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class CustomFieldRecordsForm < BaseForm
+
+    attr_accessor(
+      :site_id,
+      :item,
+      :instance,
+      :with_version,
+      :force_new_version,
+      :version_index
+    )
+
+    delegate :persisted?, to: :item
+
+    validates :site, presence: true
+
+    def available_custom_fields
+      if instance # GobiertoPlans
+        ::GobiertoPlans::Node.node_custom_fields(instance, item).sorted
+      else # GobiertoCitizensCharters
+        site.custom_fields.sorted.where(class_name: item.class.name, instance_type: instance_type_options, instance_id: instance_id_options)
+      end
+    end
+
+    def custom_field_records
+      @custom_field_records ||= available_custom_fields.map do |custom_field|
+        record = site.custom_field_records.find_or_initialize_by(item: item, custom_field: custom_field)
+        record = record.versions[version_index].reify if version_index && !(record.versions.count + version_index).negative? && record.versions[version_index].reify.present?
+
+        ::GobiertoCommon::CustomFieldRecordDecorator.new(record)
+      end
+    end
+
+    def custom_field_records=(attributes)
+      @custom_field_records ||= begin
+                                  attributes.to_h.map do |attribute, value|
+                                    custom_field = site.custom_fields.find_by(uid: attribute)
+
+                                    next unless custom_field.present?
+
+                                    record = site.custom_field_records.find_or_initialize_by(
+                                      custom_field: custom_field,
+                                      item: item
+                                    )
+                                    record.value = single_value(value, record)
+                                    ::GobiertoCommon::CustomFieldRecordDecorator.new(record)
+                                  end.compact
+                                end
+    end
+
+    def save
+      save_custom_fields if valid?
+    end
+
+    def single_value(value, record, default_value: nil)
+      record.custom_field.plugin? ? { record.custom_field.uid => (value || default_value) } : (value || default_value)
+    end
+
+    def changed?
+      custom_field_records.any? { |custom_field| version_changed?(custom_field) }
+    end
+
+    private
+
+    def version_changed?(custom_field)
+      if with_version && version_index.present?
+        (custom_field.versions[version_index]&.reify || custom_field.clone.reload).slice(*attributes_for_new_version) != custom_field.slice(*attributes_for_new_version)
+      else
+        custom_field.changed?
+      end
+    end
+
+    def instance_type_options
+      return [nil] unless instance
+
+      [nil, instance.class.name]
+    end
+
+    def instance_id_options
+      return [nil] unless instance
+
+      [nil, instance.id]
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id || item.try(:site_id))
+    end
+
+    def save_custom_fields
+      return custom_field_records if with_version && !force_new_version && !changed?
+
+      custom_field_records.each do |record|
+        record.item_has_versions = with_version
+
+        save_success = with_version && force_new_version && !record.changed? ? record.paper_trail.save_with_version : record.save
+        unless save_success
+          promote_errors(record.errors)
+          return false
+        end
+      end
+      custom_field_records
+    end
+
+    def attributes_for_new_version
+      %w(item_type item_id custom_field_id payload)
+    end
+  end
+end

--- a/app/models/gobierto_common/custom_field_value/plugin.rb
+++ b/app/models/gobierto_common/custom_field_value/plugin.rb
@@ -12,7 +12,12 @@ module GobiertoCommon::CustomFieldValue
     def raw_value
       payload.present? ? payload : {}.with_indifferent_access
     end
-    alias value raw_value
+
+    def value
+      return raw_value unless raw_value.is_a?(Hash) && raw_value.has_key?(custom_field.uid)
+
+      raw_value[custom_field.uid]
+    end
 
     def plugin_name
       custom_field.options.plugin_name

--- a/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
+++ b/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module HasCustomFieldsAttributes
+
+    extend ActiveSupport::Concern
+
+    def attributes(*args)
+      data = super
+
+      custom_fields_attributes = current_site.custom_fields.where(class_name: object.class.name).inject({}) do |attrs, custom_field|
+        attrs.update(
+          custom_field.uid => ::GobiertoCommon::CustomFieldRecord.find_or_initialize_by(
+            item: object,
+            custom_field: custom_field
+          ).value
+        )
+      end
+      data.merge(custom_fields_attributes)
+    end
+
+  end
+end

--- a/app/serializers/gobierto_investments/project_serializer.rb
+++ b/app/serializers/gobierto_investments/project_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GobiertoInvestments
+  class ProjectSerializer < ActiveModel::Serializer
+
+    include ::GobiertoCommon::HasCustomFieldsAttributes
+
+    attributes :id, :external_id, :title_translations
+
+  end
+end

--- a/app/services/gobierto_plans/plan_tree.rb
+++ b/app/services/gobierto_plans/plan_tree.rb
@@ -75,7 +75,7 @@ class GobiertoPlans::PlanTree
       end
 
       attributes[:children_count] = subtree.blank? ? category.nodes.count : subtree.count
-      attributes[:nodes_list_path] = url_helper.gobierto_plans_api_plan_projects_path(plan_id: @plan.id, category_id: category.id)
+      attributes[:nodes_list_path] = url_helper.gobierto_plans_api_plan_projects_path(plan_id: @plan.id, category_id: category.id, locale: I18n.locale)
 
       { id: category.id,
         uid: category.uid,

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActiveModelSerializers.config.key_transform = :unaltered

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -523,6 +523,19 @@ Rails.application.routes.draw do
       end
     end
 
+    # Gobierto Investments module
+    namespace :gobierto_investments do
+      constraints GobiertoSiteConstraint.new do
+
+        # API
+        namespace :api do
+          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true) do
+            resources :projects, except: [:edit]
+          end
+        end
+      end
+    end
+
     # Sidekiq Web UI
     mount Sidekiq::Web => "/sidekiq", as: :sidekiq_console
   end

--- a/lib/constraints/api_constraint.rb
+++ b/lib/constraints/api_constraint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ApiConstraint
+  def initialize(options)
+    @version = options[:version]
+    @default = options[:default]
+    @domain = options[:domain] || :gobierto
+  end
+
+  def matches?(req)
+    @default || req.headers["Accept"].include?("application/vnd.#{ @domain }+json; version=#{ @version }")
+  end
+end

--- a/test/services/gobierto_plans/plan_tree_test.rb
+++ b/test/services/gobierto_plans/plan_tree_test.rb
@@ -44,7 +44,7 @@ class GobiertoPlans::PlanTreeTest < ActiveSupport::TestCase
         img: "http://gobierto.es/assets/v2/logo-gobierto.svg",
         counter: true,
         children_count: 0,
-        nodes_list_path: "/planes/gobierto_plans/api/plan_projects/28856268/184796018"
+        nodes_list_path: "/planes/gobierto_plans/api/plan_projects/28856268/184796018?locale=en"
       },
       children: []
     }.with_indifferent_access
@@ -67,7 +67,7 @@ class GobiertoPlans::PlanTreeTest < ActiveSupport::TestCase
         img: "http://gobierto.es/assets/v2/logo-gobierto.svg",
         counter: true,
         children_count: 0,
-        nodes_list_path: "/planes/gobierto_plans/api/plan_projects/28856268/344799082"
+        nodes_list_path: "/planes/gobierto_plans/api/plan_projects/28856268/344799082?locale=en"
       },
       children: []
     }.with_indifferent_access

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -29,10 +29,12 @@ def stub_current_site(site)
 
   GobiertoSiteConstraint.stub_any_instance(:matches?, true) do
     ApplicationController.stub_any_instance(:current_site, site) do
-      GobiertoAdmin::BaseController.stub_any_instance(:current_site, SiteDecorator.new(site)) do
-        ::GobiertoCore::CurrentScope.current_site = site
-        yield
-        ::GobiertoCore::CurrentScope.current_site = nil
+      ApiBaseController.stub_any_instance(:current_site, site) do
+        GobiertoAdmin::BaseController.stub_any_instance(:current_site, SiteDecorator.new(site)) do
+          ::GobiertoCore::CurrentScope.current_site = site
+          yield
+          ::GobiertoCore::CurrentScope.current_site = nil
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #2477


## :v: What does this PR do?

* Adds API CRUD actions for investments projects using an adapter which implements JSON:API specification
* The custom fields defined for projects are treated as normal attributes, using the custom field uid as key for the attribute
* The create action with POST verb creates a new project but if an external_id is provided and there is a project with the external_id, the attributes sent are used to update the existing project.
* Currently the API is open for all actions, but an authentication step will be added with #2478

## :mag: How should this be manually tested?

* Some routes are available:
  * index: `GET /gobierto_investments/api/v1/projects` or `GET /gobierto_investments/api/v1/projects.json`
  * show: `GET /gobierto_investments/api/v1/projects/1`, `GET /gobierto_investments/api/v1/projects/1.json`
  * new: (a project with empty attributes is returned) `GET /gobierto_investments/api/v1/projects/new`, `GET /gobierto_investments/api/v1/projects/new.json`
  * create: `POST /gobierto_investments/api/v1/projects`, `POST /gobierto_investments/api/v1/projects.json`
  * update: `PATCH/PUT /gobierto_investments/api/v1/projects/1`, `PATCH/PUT /gobierto_investments/api/v1/projects/1`
  * delete: `DELETE /gobierto_investments/api/v1/projects/1`, `DELETE /gobierto_investments/api/v1/projects/1.json`

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![2477-after](https://user-images.githubusercontent.com/446459/62720924-5aa9e100-ba0b-11e9-86dc-494f50fcdf3c.gif)


## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No
