### PR TITLE
Change PopulateData::ApiMock.stub_endpoint to avoid session timeouts

### DIFF
--- a/test/integration/gobierto_observatory/observatory/index_test.rb
+++ b/test/integration/gobierto_observatory/observatory/index_test.rb
@@ -29,27 +29,29 @@ module GobiertoObservatory
 
       def test_index
         with(site: site, js: true) do
-          PopulateData::ApiMock.stub_endpoint
+          PopulateData::ApiMock.stub_endpoint do
 
-          visit gobierto_observatory_root_path
+            visit gobierto_observatory_root_path
 
-          assert_equal "Inhabitants", first_card_front.find("h3").text
-          assert first_card_front.text.include?("INE")
-          assert first_card_back.text.include?("Indicator description")
+            assert_equal "Inhabitants", first_card_front.find("h3").text
+            assert first_card_front.text.include?("INE")
+            assert first_card_back.text.include?("Indicator description")
+          end
         end
       end
 
       def test_flip_card
         with(site: site, js: true) do
-          PopulateData::ApiMock.stub_endpoint
+          PopulateData::ApiMock.stub_endpoint do
 
-          visit gobierto_observatory_root_path
+            visit gobierto_observatory_root_path
 
-          refute first_card_back_visible?
+            refute first_card_back_visible?
 
-          first_card.find(".fa-question-circle").click
+            first_card.find(".fa-question-circle").click
 
-          assert first_card_back_visible?
+            assert first_card_back_visible?
+          end
         end
       end
 

--- a/test/support/populate_data/api_mock.rb
+++ b/test/support/populate_data/api_mock.rb
@@ -4,7 +4,12 @@ module PopulateData
   class ApiMock
 
     def self.stub_endpoint
+      old_config = APP_CONFIG["populate_data"]["endpoint"]
       APP_CONFIG["populate_data"]["endpoint"] = "http://localhost:#{Capybara.current_session.server.port}/populate_data_mock"
+      yield
+    ensure
+      Capybara.current_session.quit
+      APP_CONFIG["populate_data"]["endpoint"] = old_config
     end
 
     def self.generic_indicator_data


### PR DESCRIPTION
## :v: What does this PR do?

* Fixes `PopulateData::ApiMock.stub_endpoint` which was failing with a timeout error in observatory index integration test when called for second time. Now the method ensures the Capybara session is finished

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
