### PR TITLE
Plugins migration

### DIFF
--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -178,6 +178,65 @@ political_agendas_table_custom_field_record:
   item: political_agendas (GobiertoPlans::Node)
   custom_field: madrid_custom_field_table_plugin
 
+political_agendas_human_resources_table_custom_field_record:
+  item: political_agendas (GobiertoPlans::Node)
+  custom_field: madrid_custom_field_human_resources_table_plugin
+  payload: <%= {
+    human_resources_table: [
+       {
+        human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
+        cost: 35_000,
+        start_date: "2018-01-01",
+        end_date: "2018-12-31"
+      },
+      {
+        human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+        cost: 25_000,
+        start_date: "2018-01-01",
+        end_date: "2018-12-31"
+      },
+      {
+        human_resource: ActiveRecord::FixtureSet.identify(:human_resources_employee),
+        cost: 20_000,
+        start_date: "2018-01-01",
+        end_date: "2018-06-15"
+      }
+    ]
+  }.to_json %>
+
+political_agendas_indicators_table_custom_field_record:
+  item: political_agendas (GobiertoPlans::Node)
+  custom_field: madrid_custom_field_indicators_table_plugin
+  payload: <%= {
+    indicators_table: [
+      {
+        indicator: ActiveRecord::FixtureSet.identify(:indicators_raw_savings),
+        objective: 100,
+        value_reached: 92.5,
+        date: "2018-12"
+      },
+      {
+        indicator: ActiveRecord::FixtureSet.identify(:indicators_raw_savings),
+        objective: 100,
+        value_reached: 85,
+        date: "2018-11"
+      },
+      {
+        indicator: ActiveRecord::FixtureSet.identify(:indicators_net_savings),
+        objective: 200,
+        value_reached: 210,
+        date: "2019"
+      },
+      {
+        indicator: ActiveRecord::FixtureSet.identify(:indicators_births),
+        objective: 50
+      },
+      {
+        indicator: ActiveRecord::FixtureSet.identify(:indicators_deaths)
+      }
+    ]
+  }.to_json %>
+
 ## Economic Plan Nodes
 
 scholarships_in_school_cateens_custom_field_instance_level:

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -298,3 +298,107 @@ madrid_custom_field_table_plugin:
       }
     }
   }.to_json %>
+
+madrid_custom_field_human_resources_table_plugin:
+  site: madrid
+  class_name: GobiertoPlans::Node
+  mandatory: false
+  position: 8
+  name_translations: <%= { en: "Human Resources (table)", es: "Recursos Humanos (tabla)" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:plugin] %>
+  uid: human_resources_table
+  options: <%= {
+    configuration: {
+            plugin_type: "table",
+            plugin_configuration: {
+        "columns": [
+          {
+            "id": "human_resource",
+            "type": "vocabulary",
+            "dataSource": "/admin/api/vocabularies/#{ ActiveRecord::FixtureSet.identify(:human_resources_vocabulary) }",
+            "name_translations": {
+              "en": "Human resource",
+              "es": "Recurso humano"
+            }
+          },
+          {
+            "id": "cost",
+            "type": "text",
+            "name_translations": {
+              "en": "Cost",
+              "es": "Coste"
+            }
+          },
+          {
+            "id": "start_date",
+            "type": "date",
+            "name_translations": {
+              "en": "Start date",
+              "es": "Fecha inicio"
+            }
+          },
+          {
+            "id": "end_date",
+            "type": "date",
+            "name_translations": {
+              "en": "End date",
+              "es": "Fecha de fin"
+            }
+          }
+        ],
+        "category_term_decorator": "human_resources"
+      }
+    }
+  }.to_json %>
+
+madrid_custom_field_indicators_table_plugin:
+  site: madrid
+  class_name: GobiertoPlans::Node
+  mandatory: false
+  position: 9
+  name_translations: <%= { en: "Indicator (table)", es: "Indicador (tabla)" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:plugin] %>
+  uid: indicators_table
+  options: <%= {
+    configuration: {
+      plugin_type: "table",
+      plugin_configuration: {
+        "columns": [
+          {
+            "id": "indicator",
+            "type": "vocabulary",
+            "dataSource": "/admin/api/vocabularies/#{ ActiveRecord::FixtureSet.identify(:indicators_vocabulary) }",
+            "name_translations": {
+              "en": "Indicator",
+              "es": "Indicador"
+            }
+          },
+          {
+            "id": "objective",
+            "type": "float",
+            "name_translations": {
+              "en": "Objective",
+              "es": "Objetivo"
+            }
+          },
+          {
+            "id": "value_reached",
+            "type": "float",
+            "name_translations": {
+              "en": "Value reached",
+              "es": "Valor alcanzado"
+            }
+          },
+          {
+            "id": "date",
+            "type": "text",
+            "name_translations": {
+              "en": "Date",
+              "es": "Fecha"
+            }
+          }
+        ],
+        "category_term_decorator": "indicators"
+      }
+    }
+  }.to_json %>

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -58,7 +58,9 @@ module GobiertoAdmin
             political_agendas_custom_field_record_color: unpublished_project,
             political_agendas_custom_field_record_image: unpublished_project,
             political_agendas_custom_field_record_localized_description: unpublished_project,
-            political_agendas_table_custom_field_record: unpublished_project
+            political_agendas_table_custom_field_record: unpublished_project,
+            political_agendas_human_resources_table_custom_field_record: unpublished_project,
+            political_agendas_indicators_table_custom_field_record: unpublished_project
           }.each do |fixture_key, project|
             ::GobiertoCommon::CustomFieldRecord.create(
               gobierto_common_custom_field_records(fixture_key).attributes.except("id", "item_id").merge(

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/models/gobierto_common/custom_field_functions/human_resource.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/models/gobierto_common/custom_field_functions/human_resource.rb
@@ -30,7 +30,7 @@ module GobiertoCommon::CustomFieldFunctions
 
     def data
       @data ||= begin
-                  resources = value.dig("human_resources") || []
+                  resources = value.is_a?(Array) ? value : value.dig("human_resources") || value.dig(custom_field.uid) || []
 
                   resources.map do |resource|
                     OpenStruct.new(

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/models/gobierto_common/custom_field_functions/indicator.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/models/gobierto_common/custom_field_functions/indicator.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module GobiertoCommon::CustomFieldFunctions
+  class Indicator < Base
+    delegate :latest_value_reached_row, to: :class
+
+    def self.latest_indicators(rows)
+      rows.group_by(&:id).map { |_id, rows_group| latest_value_reached_row(rows_group) }.compact
+    end
+
+    def self.latest_value_reached_row(rows)
+      versioned_rows = rows.select { |row| row.value_reached.present? && row.date.present? }
+
+      if versioned_rows.count < 2
+        versioned_rows.first
+      else
+        versioned_rows.max_by(&:date)
+      end
+    end
+
+    def indicators(_options = {})
+      data
+    end
+
+    def latest_indicators(_options = {})
+      data.group_by(&:id).map { |_id, rows| latest_value_reached_row(rows) }.compact
+    end
+
+    private
+
+    def data
+      @data ||= begin
+                  resources = value.is_a?(Array) ? value : value.dig(custom_field.uid) || []
+
+                  resources.map do |resource|
+                    indicator = ::GobiertoCommon::Term.find_by(id: resource["indicator"])
+                    next unless indicator.present?
+
+                    OpenStruct.new(
+                      id: indicator.id,
+                      indicator: indicator,
+                      objective: resource["objective"],
+                      value_reached: resource["value_reached"],
+                      date_string: resource["date"] || "",
+                      date: parse_date(resource["date"] || "")
+                    )
+                  end.compact
+                end
+    end
+
+    def parse_date(date, fallback = nil)
+      Date.strptime(date, "%Y-%m")
+    rescue ArgumentError
+      begin
+        Date.strptime(date, "%Y")
+      rescue ArgumentError
+        fallback
+      end
+    end
+  end
+end

--- a/vendor/gobierto_engines/custom-fields-table-plugin/app/decorators/gobierto_plans/category_term_decorator_table_attachment.rb
+++ b/vendor/gobierto_engines/custom-fields-table-plugin/app/decorators/gobierto_plans/category_term_decorator_table_attachment.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  module CategoryTermDecoratorTableAttachment
+
+    extend ActiveSupport::Concern
+
+    private
+
+    def node_plugins_data(plan, node)
+      super_result = super(plan, node)
+
+      table_records = GobiertoCommon::CustomFieldRecord.where(
+        item: node
+      ).joins(
+        :custom_field
+      ).where(
+        "custom_fields.options @> ?",
+        { configuration: { plugin_type: "table" } }.to_json
+      )
+
+      human_resources_condition = { configuration: { plugin_configuration: { category_term_decorator: "human_resources" } } }.to_json
+      indicators_condition = { configuration: { plugin_configuration: { category_term_decorator: "indicators" } } }.to_json
+
+      if (human_resources_records = table_records.where("custom_fields.options @> ?", human_resources_condition)).exists?
+        super_result[:human_resources] = human_resources_data(human_resources_records, version: node.published_version)
+      end
+
+      if (indicators_records = table_records.where("custom_fields.options @> ?", indicators_condition)).exists?
+        super_result[:indicators] = indicators_data(indicators_records, version: node.published_version)
+      end
+
+      super_result
+    end
+
+    def human_resources_data(records, version: nil)
+      totals = human_resources_data_template
+
+      if records.present?
+        functions = records.map do |record|
+          GobiertoCommon::CustomFieldFunctions::HumanResource.new(record, version: version)
+        end
+
+        total_cost = functions.map(&:planned_cost).compact.sum
+        total_executed = functions.map(&:executed_cost).compact.sum
+
+        totals[:budgeted_amount] = total_cost.round
+        totals[:executed_amount] = total_executed.round
+        if total_cost.positive?
+          totals[:executed_percentage] = "#{((total_executed * 100) / total_cost).round} %"
+        end
+      end
+
+      totals
+    end
+
+    def indicators_data(records, version: nil)
+      totals = indicators_data_template
+
+      if records.present?
+        combined_table = records.map do |record|
+          ::GobiertoCommon::CustomFieldFunctions::Indicator.new(record, version: version).indicators
+        end.flatten
+
+        totals[:data] = ::GobiertoCommon::CustomFieldFunctions::Indicator.latest_indicators(combined_table).map do |row|
+          { id: row.id,
+            name_translations: row.indicator.name_translations,
+            description_translations: row.indicator.description_translations,
+            last_value: row.value_reached,
+            date: row.date_string }
+        end
+      end
+
+      totals
+    end
+
+    def indicators_data_template
+      {
+        title_translations: Hash[I18n.available_locales.map do |locale|
+          [locale, I18n.t("gobierto_plans.custom_fields_plugins.indicators.title", locale: locale)]
+        end],
+        data: []
+      }
+    end
+
+    def human_resources_data_template
+      {
+        title_translations: Hash[I18n.available_locales.map do |locale|
+          [locale, I18n.t("gobierto_plans.custom_fields_plugins.human_resources.title", locale: locale)]
+        end],
+        budgeted_amount: nil,
+        executed_amount: nil,
+        executed_percentage: nil
+      }
+    end
+
+  end
+end

--- a/vendor/gobierto_engines/custom-fields-table-plugin/lib/custom_fields_table_plugin/railtie.rb
+++ b/vendor/gobierto_engines/custom-fields-table-plugin/lib/custom_fields_table_plugin/railtie.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../app/decorators/gobierto_plans/category_term_decorator_table_attachment"
+
 def attach_module(config, origin, module_class)
   if config.plugins_attached_modules[origin]
     config.plugins_attached_modules[origin].append(module_class)
@@ -27,6 +29,9 @@ else
         conf.custom_field_plugins_packs += %w(table)
         conf.autoload_paths += Dir[Pathname.new(base_path).join("app", "models")]
         conf.eager_load_paths += Dir[Pathname.new(base_path).join("app", "models")]
+
+        attach_module(conf, "::GobiertoPlans::CategoryTermDecorator", ::GobiertoPlans::CategoryTermDecoratorTableAttachment)
+
         conf.i18n.load_path += Dir[File.join(base_path, "config", "locales", "**", "*.{rb,yml}")]
       end
 


### PR DESCRIPTION
Closes #2508


## :v: What does this PR do?

* Adds a `category_term_decorator` configuration attribute on plugins of type table to render the data in front of plans as expected for a plugin of other type. There are two available types: `indicators` and `human_resources`. The tabled
* Adds a decorator class to be used in plans containing the logic to decorate tables for plans front with the defined types.
* Refactors the indicators and human resources decorators to use the same functions used in tables decorators for each type of table.
* Adds some fixtures of tables with human resources and indicators.

The columns defined in a custom field plugin of type table which is expected to behave like other type plugin must have at least the same columns as defined in the corresponding plugin, with the same id and a type compatible. For example:

* To have a table of Human resources, a valid table configuration would be (note the `category_term_decorator` setting as `human_resources`):

```json
{
  "columns": [
    {
      "id": "human_resource",
      "type": "vocabulary",
      "dataSource": "/admin/api/vocabularies/XXXX",
      "name_translations": {
        "en": "Human resource",
        "es": "Recurso humano"
      }
    },
    {
      "id": "cost",
      "type": "text",
      "name_translations": {
        "en": "Cost",
        "es": "Coste"
      }
    },
    {
      "id": "start_date",
      "type": "date",
      "name_translations": {
        "en": "Start date",
        "es": "Fecha inicio"
      }
    },
    {
      "id": "end_date",
      "type": "date",
      "name_translations": {
        "en": "End date",
        "es": "Fecha de fin"
      }
    }
  ],
  "category_term_decorator": "human_resources"
}
```
* To have a table of indicators, a valid table configuration would be (note the `category_term_decorator` setting as `indicators`):
```json
{
  "columns": [
    {
      "id": "indicator",
      "type": "vocabulary",
      "dataSource": "/admin/api/vocabularies/XXXX",
      "name_translations": {
        "en": "Indicator",
        "es": "Indicador"
      }
    },
    {
      "id": "objective",
      "type": "float",
      "name_translations": {
        "en": "Objective",
        "es": "Objetivo"
      }
    },
    {
      "id": "value_reached",
      "type": "float",
      "name_translations": {
        "en": "Value reached",
        "es": "Valor alcanzado"
      }
    },
    {
      "id": "date",
      "type": "text",
      "name_translations": {
        "en": "Date",
        "es": "Fecha"
      }
    }
  ],
  "category_term_decorator": "indicators"
}
```

If a resource has defined custom fields both as table decorated with a plugin or with the plugin itself, the plan in front only will display the data of one type of plugin, depending on the order the related engines are loaded, so it's recommended to define custom fields of only a type, tables with decorator setting or human resources / indicators plugins. 

## :mag: How should this be manually tested?

Define some custom fields for plans projects of type table with configuration described as above. There is an example project with all custom fields defined as plugin tables in http://talavan.gobify.net/admin/plans/34/projects/10552/edit

## :eyes: Screenshots

### Before this PR

![2508-before](https://user-images.githubusercontent.com/446459/63216575-4d8da000-c137-11e9-977f-60a4880ad2c0.gif)


### After this PR

![2508-after](https://user-images.githubusercontent.com/446459/63216579-5c745280-c137-11e9-88e1-6136bf1535c1.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No