### PR TITLE
Change confirm messsage when a project is sent to moderation

### DIFF
--- a/app/decorators/gobierto_admin/moderated_resource_decorator.rb
+++ b/app/decorators/gobierto_admin/moderated_resource_decorator.rb
@@ -98,6 +98,14 @@ module GobiertoAdmin
       end][staus_text.to_sym] || :in_revision
     end
 
+    def publish_step_action_confirm_message
+      if @object.is_a?(::GobiertoPlans::Node)
+        I18n.t("gobierto_admin.gobierto_plans.projects.#{publish_step_action}.confirm")
+      else
+        I18n.t("gobierto_admin.shared.moderation_save_widget.confirm")
+      end
+    end
+
     private
 
     def publish_moderation_status

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -110,7 +110,7 @@
                       class: "bl",
                       name: "#{f.object_name}[visibility_level]",
                       value: [moderated_resource.step_visibility_value, versioned_resource.current_version].compact.join("-"),
-                      data: { confirm: versioned_resource.first_publication_confirm_message }
+                      data: { confirm: moderated_resource.publish_step_action_confirm_message }
                     ) %>
               </div>
             <% end %>

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/projects/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/projects/ca.yml
@@ -14,6 +14,8 @@ ca:
             podrà veure-ho.
           error: El projecte no s'ha pogut publicar.
           success: El projecte s'ha publicat correctament.
+        send:
+          confirm: Vas a enviar aquest projecte a un moderador per a la seva validació.
         unpublish:
           error: El projecte no s'ha pogut despublicar.
           success: El projecte s'ha despublicat correctament.

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/projects/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/projects/en.yml
@@ -14,6 +14,8 @@ en:
             to see it in the front-end.
           error: Project couldn't be published.
           success: Project published correctly.
+        send:
+          confirm: You are going to send this project to be validated by a moderator.
         unpublish:
           error: Project couldn't be unpublished.
           success: Project unpublished correctly.

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/projects/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/projects/es.yml
@@ -14,6 +14,8 @@ es:
             verlo.
           error: El proyecto no se ha podido publicar.
           success: El proyecto ha sido publicado correctamente.
+        send:
+          confirm: Vas a enviar este proyecto a un moderador para su validación.
         unpublish:
           error: El proyecto no se ha podido despublicar.
           success: El proyecto ha sido despublicado correctamente.


### PR DESCRIPTION
Closes #2536


## :v: What does this PR do?

* Uses a different confirm message when an admin send a project for moderation or publish an accepted project.

## :mag: How should this be manually tested?

Create a project as editor admin and send it to moderation. Once accepted, click on publish button.

## :eyes: Screenshots

### Before this PR

![2536-before](https://user-images.githubusercontent.com/446459/64240390-14f51100-cf02-11e9-9fba-8cf5de11965f.gif)

### After this PR

![2536-after](https://user-images.githubusercontent.com/446459/64241714-8f269500-cf04-11e9-99b9-e1587f7c090b.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
