### PR TITLE
2537 regular admins site activities

### DIFF
--- a/app/controllers/gobierto_admin/activities_controller.rb
+++ b/app/controllers/gobierto_admin/activities_controller.rb
@@ -1,6 +1,8 @@
 module GobiertoAdmin
   class ActivitiesController < BaseController
     def index
+      raise_action_not_allowed unless current_admin.managing_user?
+
       @activities = ActivityCollectionDecorator.new(Activity.global_admin_activities.page(params[:page]))
     end
   end

--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -12,7 +12,7 @@ module GobiertoAdmin
 
     helper_method :current_admin, :admin_signed_in?, :current_site, :managing_site?,
                   :managed_sites, :can_manage_sites?, :gobierto_cms_page_preview_path,
-                  :preview_item_url, :module_doc_url
+                  :preview_item_url, :module_doc_url, :default_modules_home_paths
 
     rescue_from Errors::NotAuthorized, with: :raise_admin_not_authorized
 
@@ -62,6 +62,18 @@ module GobiertoAdmin
       rescue NameError
         default_doc_url
       end
+    end
+
+    def default_modules_home_paths
+      @default_modules_home_paths ||= {
+        gobierto_budgets: admin_gobierto_budgets_options_path,
+        gobierto_budget_consultations: admin_budget_consultations_path,
+        gobierto_people: admin_people_people_path,
+        gobierto_participation: admin_participation_path,
+        gobierto_plans: admin_plans_plans_path,
+        gobierto_citizens_charters: admin_citizens_charters_path,
+        gobierto_investments: admin_investments_projects_path
+      }.with_indifferent_access
     end
 
     protected

--- a/app/controllers/gobierto_admin/welcome_controller.rb
+++ b/app/controllers/gobierto_admin/welcome_controller.rb
@@ -1,12 +1,21 @@
+# frozen_string_literal: true
+
 module GobiertoAdmin
   class WelcomeController < BaseController
     def index
-      @activities = if current_admin.managing_user?
-                      ActivityCollectionDecorator.new(Activity.where(site_id: current_site).or(Activity.where(site_id: nil)).sorted.includes(:subject, :author, :recipient).page(params[:page]))
-                    else
-                      ActivityCollectionDecorator.new(Activity.in_site(current_site).sorted.includes(:subject, :author, :recipient).page(params[:page]))
-                    end
-      render 'gobierto_admin/activities/index'
+      unless current_admin.managing_user?
+        module_path = if (available_modules = current_admin.modules_permissions.where(resource_type: default_modules_home_paths.keys).on_site(current_site)).exists?
+                        default_modules_home_paths[available_modules.first.resource_type]
+                      else
+                        edit_admin_admin_settings_path
+                      end
+        redirect_to module_path and return
+      end
+
+      @activities = ActivityCollectionDecorator.new(
+        Activity.where(site_id: current_site).or(Activity.where(site_id: nil)).sorted.includes(:subject, :author, :recipient).page(params[:page])
+      )
+      render "gobierto_admin/activities/index"
     end
   end
 end

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -129,46 +129,12 @@
         <div class="menu_content">
 
           <ul>
-            <% if show_module_link?("GobiertoBudgets") %>
-            <li>
-              <%= link_to t(".budgets"), admin_gobierto_budgets_options_path %>
-            </li>
-            <% end %>
-
-            <% if show_module_link?("GobiertoBudgetConsultations") %>
-            <li>
-              <%= link_to t(".budget_consultations"), admin_budget_consultations_path %>
-            </li>
-            <% end %>
-
-            <% if show_module_link?("GobiertoPeople") %>
-            <li>
-              <%= link_to t(".people"), admin_people_people_path %>
-            </li>
-            <% end %>
-
-            <% if show_module_link?("GobiertoParticipation") %>
-            <li>
-              <%= link_to t(".participation"), admin_participation_path %>
-            </li>
-            <% end %>
-
-            <% if show_module_link?("GobiertoPlans") %>
-            <li>
-              <%= link_to t(".plans"), admin_plans_plans_path %>
-            </li>
-            <% end %>
-
-            <% if show_module_link?("GobiertoCitizensCharters") %>
-            <li>
-              <%= link_to t(".citizens_charters"), admin_citizens_charters_path %>
-            </li>
-            <% end %>
-
-            <% if show_module_link?("GobiertoInvestments") %>
-              <li>
-                <%= link_to t(".investments"), admin_investments_projects_path %>
-              </li>
+            <% default_modules_home_paths.each do |module_name, path| %>
+              <% if show_module_link?(module_name.camelize) %>
+                <li>
+                  <%= link_to t(".modules.#{module_name.gsub(/\Agobierto_/,"")}"), path %>
+                </li>
+              <% end %>
             <% end %>
 
             <li class="sep"></li>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -114,6 +114,7 @@ ignore_unused:
   - 'gobierto_admin.custom_fields_plugins.*'
   - 'gobierto_plans.plan_types.show.read_less'
   - 'gobierto_plans.plan_types.show.read_more'
+  - 'gobierto_admin.layouts.application.modules.*'
 
 translation:
   api_key: ''

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -6,8 +6,6 @@ ca:
         admin_dropdown:
           account: El teu compte
           sign_out: Tancar sessió
-        budget_consultations: Consultes de pressupostos
-        budgets: Pressupostos
         calendars: Agendes
         citizens_charters: Serveis i cartes de serveis
         cms: CMS
@@ -18,12 +16,16 @@ ca:
         edit_site: Personalitzar site
         file_attachments: Documents
         hey_admin: Hola, %{admin_name}
-        investments: Inversions
         manage_sites: Gestionar sites
+        modules:
+          budget_consultations: Consultes de pressupostos
+          budgets: Pressupostos
+          citizens_charters: Serveis i cartes de serveis
+          investments: Inversions
+          participation: Participació
+          people: Alts càrrecs i Agendes
+          plans: Plans
         notifications: Notificacions
-        participation: Participació
-        people: Alts càrrecs i Agendes
-        plans: Plans
         site_network: Xarxa
         templates: Plantilles
         users: Usuaris

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -6,8 +6,6 @@ en:
         admin_dropdown:
           account: Account
           sign_out: Sign out
-        budget_consultations: Budget consultations
-        budgets: Budgets
         calendars: Calendars
         citizens_charters: Services and services charters
         cms: CMS
@@ -18,12 +16,16 @@ en:
         edit_site: Customize site
         file_attachments: Documents
         hey_admin: Hey, %{admin_name}
-        investments: Investments
         manage_sites: Manage sites
+        modules:
+          budget_consultations: Budget consultations
+          budgets: Budgets
+          citizens_charters: Services and services charters
+          investments: Investments
+          participation: Participation
+          people: Officers and Agendas
+          plans: Plans
         notifications: Notifications
-        participation: Participation
-        people: Officers and Agendas
-        plans: Plans
         site_network: Network
         templates: Templates
         users: Users

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -6,8 +6,6 @@ es:
         admin_dropdown:
           account: Tu cuenta
           sign_out: Cerrar sesión
-        budget_consultations: Consultas de presupuestos
-        budgets: Presupuestos
         calendars: Agendas
         citizens_charters: Servicios y cartas de servicios
         cms: CMS
@@ -18,12 +16,16 @@ es:
         edit_site: Personalizar sitio
         file_attachments: Documentos
         hey_admin: Hola, %{admin_name}
-        investments: Inversiones
         manage_sites: Gestionar sites
+        modules:
+          budget_consultations: Consultas de presupuestos
+          budgets: Presupuestos
+          citizens_charters: Servicios y cartas de servicios
+          investments: Inversiones
+          participation: Participación
+          people: Altos cargos y Agendas
+          plans: Planes
         notifications: Notificaciones
-        participation: Participación
-        people: Altos cargos y Agendas
-        plans: Planes
         site_network: Red
         templates: Plantillas
         users: Usuarios

--- a/test/integration/gobierto_admin/activities_test.rb
+++ b/test/integration/gobierto_admin/activities_test.rb
@@ -9,14 +9,31 @@ module GobiertoAdmin
       @path = admin_activities_path
     end
 
-    def admin
-      @admin ||= gobierto_admin_admins(:tony)
+    def manager_admin
+      @manager_admin ||= gobierto_admin_admins(:nick)
     end
 
-    def test_view_activities
-      with_signed_in_admin(admin) do
+    def regular_admin
+      @regular_admin ||= gobierto_admin_admins(:steve)
+    end
+
+    def test_regular_view_activities
+      with_signed_in_admin(regular_admin) do
         visit @path
 
+        assert has_alert?("You are not authorized to perform this action")
+        assert has_no_content?("Activity log")
+        assert has_no_content?("Site updated")
+        assert has_no_content?("1.2.3.4")
+        assert_equal edit_admin_admin_settings_path, current_path
+      end
+    end
+
+    def test_manager_view_activities
+      with_signed_in_admin(manager_admin) do
+        visit @path
+
+        assert has_content?("Activity log")
         assert has_content?("Site updated")
         assert has_content?("Ayuntamiento de Madrid")
         assert has_content?("Tony Stark")

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/charters_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/charters_index_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/create_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/create_charter_test.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/delete_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/delete_charter_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/charters/update_charter_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/charters/update_charter_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/commitments_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/commitments_index_test.rb
@@ -36,7 +36,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/create_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/create_commitment_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/delete_commitment_test.rb
@@ -36,7 +36,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/commitments/update_commitment_test.rb
@@ -41,7 +41,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/create_service_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/create_service_test.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/delete_service_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/delete_service_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/services_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/services_index_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_citizens_charters/services/update_service_test.rb
+++ b/test/integration/gobierto_admin/gobierto_citizens_charters/services/update_service_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/create_custom_field_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/create_custom_field_test.rb
@@ -60,7 +60,7 @@ module GobiertoAdmin
           with(site: site, admin: unauthorized_admin) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
 

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/custom_fields_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/custom_fields_index_test.rb
@@ -43,7 +43,7 @@ module GobiertoCommon
         with(site: site, admin: unauthorized_admin) do
           visit path
           assert has_content?("You are not authorized to perform this action")
-          assert_equal admin_root_path, current_path
+          assert_equal edit_admin_admin_settings_path, current_path
         end
       end
 

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/update_custom_field_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/update_custom_field_test.rb
@@ -34,7 +34,7 @@ module GobiertoCommon
         with(site: site, admin: unauthorized_admin) do
           visit @path
           assert has_content?("You are not authorized to perform this action")
-          assert_equal admin_root_path, current_path
+          assert_equal edit_admin_admin_settings_path, current_path
         end
       end
 

--- a/test/integration/gobierto_admin/gobierto_common/terms/create_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/create_term_test.rb
@@ -32,7 +32,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/terms/delete_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/delete_term_test.rb
@@ -56,7 +56,7 @@ module GobiertoCommon
           with_current_site(site) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_common/terms/terms_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/terms_index_test.rb
@@ -40,7 +40,7 @@ module GobiertoCommon
           with_current_site(site) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
@@ -39,7 +39,7 @@ module GobiertoCommon
           with_current_site(site) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/create_vocabulary_test.rb
@@ -28,7 +28,7 @@ module GobiertoAdmin
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/delete_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/delete_vocabulary_test.rb
@@ -37,7 +37,7 @@ module GobiertoCommon
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/update_vocabulary_test.rb
@@ -32,7 +32,7 @@ module GobiertoCommon
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/vocabularies/vocabularies_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/vocabularies/vocabularies_index_test.rb
@@ -33,7 +33,7 @@ module GobiertoCommon
             with_current_site(site) do
               visit @path
               assert has_content?("You are not authorized to perform this action")
-              assert_equal admin_root_path, current_path
+              assert_equal edit_admin_admin_settings_path, current_path
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_core/templates/index_templates_test.rb
+++ b/test/integration/gobierto_admin/gobierto_core/templates/index_templates_test.rb
@@ -15,7 +15,7 @@ module GobiertoAdmin
       end
 
       def unauthorized_admin
-        @unauthorized_admin ||= gobierto_admin_admins(:tony)
+        @unauthorized_admin ||= gobierto_admin_admins(:steve)
       end
 
       def site
@@ -46,7 +46,7 @@ module GobiertoAdmin
             visit @path
 
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_core/templates/site_templates_test.rb
+++ b/test/integration/gobierto_admin/gobierto_core/templates/site_templates_test.rb
@@ -37,7 +37,7 @@ module GobiertoAdmin
             click_button "Save"
 
             assert has_content? "You are not authorized to perform this action"
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end
@@ -54,7 +54,7 @@ module GobiertoAdmin
             click_link "application"
 
             assert has_content? "You are not authorized to perform this action"
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end
@@ -71,7 +71,7 @@ module GobiertoAdmin
             click_button "Reset"
 
             assert has_content? "You are not authorized to perform this action"
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_investments/projects/create_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/create_project_test.rb
@@ -31,7 +31,7 @@ module GobiertoAdmin
           with(site: site, admin: unauthorized_regular_admin) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
 

--- a/test/integration/gobierto_admin/gobierto_investments/projects/projects_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/projects_index_test.rb
@@ -35,7 +35,7 @@ module GobiertoAdmin
           with(site: site, admin: unauthorized_regular_admin) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
 

--- a/test/integration/gobierto_admin/gobierto_investments/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/update_project_test.rb
@@ -35,7 +35,7 @@ module GobiertoAdmin
           with(site: site, admin: unauthorized_regular_admin) do
             visit @path
             assert has_content?("You are not authorized to perform this action")
-            assert_equal admin_root_path, current_path
+            assert_equal edit_admin_admin_settings_path, current_path
           end
         end
 

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -192,6 +192,7 @@ YAML
 
     def test_authorized_regular_admin_access
       with_signed_in_admin(regular_admin) do
+        revoke_modules_permission(regular_admin)
         visit admin_root_path
 
         click_link "Customize site"
@@ -208,6 +209,7 @@ YAML
         click_link "Customize site"
 
         revoke_customize_site_permission(regular_admin)
+        revoke_modules_permission(regular_admin)
 
         # HACK: https://github.com/PopulateTools/gobierto/blob/master/app/controllers/concerns/user/session_helper.rb#L67
         # causes infinite redirects, since referer in not authorized either. Since it's
@@ -217,7 +219,7 @@ YAML
         click_button "Update"
 
         assert has_content?("You are not authorized to perform this action")
-        assert_equal admin_root_path, current_path
+        assert_equal edit_admin_admin_settings_path, current_path
       end
     end
 

--- a/test/support/permission_helpers.rb
+++ b/test/support/permission_helpers.rb
@@ -88,4 +88,8 @@ module PermissionHelpers
     ).each(&:destroy)
   end
 
+  def revoke_modules_permission(admin)
+    admin.modules_permissions.each(&:destroy)
+  end
+
 end


### PR DESCRIPTION
Closes #2537


## :v: What does this PR do?

* Avoid not manager admins to access site activities and redirects them from admin root path to the first module with permissions or admin settings if no modules are available.

## :mag: How should this be manually tested?

Sign in as regular admin

## :eyes: Screenshots

### Before this PR

![2537-before](https://user-images.githubusercontent.com/446459/64354917-97fc9100-d000-11e9-9d34-2a657f520cc4.gif)

### After this PR

![2537-after](https://user-images.githubusercontent.com/446459/64355291-3be63c80-d001-11e9-8da3-b565fe725178.gif)

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No