### PR TITLE
Change links to projects from plans index for editors

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/base_controller.rb
@@ -6,12 +6,16 @@ module GobiertoAdmin
       before_action { module_enabled!(current_site, "GobiertoPlans") }
       before_action { module_allowed!(current_admin, "GobiertoPlans") }
 
-      helper_method :gobierto_plans_plan_type_preview_url, :current_admin_can_manage_plans?
+      helper_method :gobierto_plans_plan_type_preview_url, :current_admin_can_manage_plans?, :current_admin_can_edit_plans?
 
       protected
 
       def current_admin_can_manage_plans?
         @can_manage_plans = current_admin.module_allowed_action?(current_admin_module, current_site, :manage)
+      end
+
+      def current_admin_can_edit_plans?
+        @can_manage_plans = current_admin.module_allowed_action?(current_admin_module, current_site, :edit)
       end
 
       def gobierto_plans_plan_type_preview_url(plan, options = {})

--- a/app/views/gobierto_admin/gobierto_plans/plans/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/index.html.erb
@@ -38,7 +38,11 @@
         <%= plan.plan_type.name %>
       </td>
       <td>
-        <%= link_to plan.title, current_admin_can_manage_plans? ? admin_plans_plan_categories_path(plan) : admin_plans_plan_projects_path(plan) %>
+        <% if current_admin_can_manage_plans? %>
+          <%= link_to plan.title, admin_plans_plan_categories_path(plan) %>
+        <% else %>
+          <%= link_to plan.title, current_admin_can_edit_plans? ? admin_plans_plan_projects_path(plan, projects_filter: { admin_actions: current_admin.id }) : admin_plans_plan_projects_path(plan) %>
+        <% end %>
       </td>
       <td>
         <%=  plan.year %>


### PR DESCRIPTION
Closes #2545

## :v: What does this PR do?

* Changes links to projects from plans index when the admin is only editor to include a filter to list only the projects owned by the editor

## :mag: How should this be manually tested?

As regular admin with only edit permissions go to the plans list and click on a plan. The projects list should filter the projects owned by the editor

## :eyes: Screenshots

### Before this PR

![2545-before](https://user-images.githubusercontent.com/446459/64361052-0a26a300-d00c-11e9-9486-7e93885cfa9b.gif)

### After this PR

![2545-after](https://user-images.githubusercontent.com/446459/64361719-6a6a1480-d00d-11e9-93dc-2e54fc5358b2.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
