### PR TITLE
2540 filter complex queries

### DIFF
--- a/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
+++ b/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
@@ -17,20 +17,14 @@ module GobiertoCommon::CustomFieldValue
     def value=(value)
       value = value.id if value.is_a?(GobiertoCommon::Term)
 
-      if custom_field.configuration.vocabulary_type == "tags"
-        if value&.any?
-          existing_ids = vocabulary.terms.where(id: value).pluck(:id).map(&:to_s)
-          new_tags = value - existing_ids
-          start_position = vocabulary.terms.maximum(:position).to_i + 1
-
-          new_terms_ids = new_tags.map.with_index do |new_term, i|
-            vocabulary.terms.create(name: new_term, position: start_position + i).id
-          end.compact
-          value = existing_ids + new_terms_ids
-        else
-          value = []
-        end
-      end
+      value = if custom_field.configuration.vocabulary_type == "tags"
+                create_tags(value)
+              elsif value.is_a?(Array)
+                ids = value.map { |val| string_term_id(val) }.compact
+                custom_field.configuration.vocabulary_type == "single_select" ? ids.first : ids
+              else
+                string_term_id(value)
+              end
 
       super
     end
@@ -39,6 +33,27 @@ module GobiertoCommon::CustomFieldValue
       return unless custom_field.options.present?
 
       GobiertoCommon::Vocabulary.find_by(id: custom_field.options["vocabulary_id"])
+    end
+
+    protected
+
+    def create_tags(value)
+      return [] unless value&.any?
+
+      existing_ids = vocabulary.terms.where(id: value).pluck(:id).map(&:to_s)
+      new_tags = value - existing_ids
+      start_position = vocabulary.terms.maximum(:position).to_i + 1
+
+      new_terms_ids = new_tags.map.with_index do |new_term, i|
+        vocabulary.terms.create(name: new_term, position: start_position + i).id
+      end.compact
+      existing_ids + new_terms_ids
+    end
+
+    def string_term_id(id)
+      return unless vocabulary.terms.exists?(id)
+
+      id.to_s
     end
   end
 end

--- a/app/queries/gobierto_common/custom_fields_query.rb
+++ b/app/queries/gobierto_common/custom_fields_query.rb
@@ -126,8 +126,8 @@ module GobiertoCommon
     end
 
     def filter_comparison_condition(custom_field, operator, value)
-      value = if operator == "in" && value.is_a?(Array)
-                "(#{value.map { |v| "'#{v}'" }.join(", ")})"
+      value = if operator == "IN" && value.is_a?(Array)
+                "(#{value.map { |v| "'#{v.inspect}'" }.join(", ")})"
               else
                 "'#{value}'"
               end

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -268,6 +268,11 @@ sports_center_political_group_custom_field_record:
     "political-group" => ActiveRecord::FixtureSet.identify(:marvel_term).to_s
   }.to_json %>
 
+sports_center_start_date_custom_field_record:
+  item: sports_center_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "2018-01-01" }.to_json %>
+
 public_pool_cost_custom_field_record:
   item: public_pool_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_cost
@@ -279,3 +284,42 @@ public_pool_political_group_custom_field_record:
   payload: <%= {
     "political-group" => ActiveRecord::FixtureSet.identify(:dc_term).to_s
   }.to_json %>
+
+public_pool_start_date_custom_field_record:
+  item: public_pool_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "2018-07-15" }.to_json %>
+
+public_library_cost_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_cost
+  payload: <%= { "cost" => 500000.0 }.to_json %>
+
+public_library_political_group_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_political_group
+  payload: <%= {
+    "political-group" => ActiveRecord::FixtureSet.identify(:marvel_term).to_s
+  }.to_json %>
+
+public_library_start_date_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "2010-12-31" }.to_json %>
+
+art_gallery_cost_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_cost
+  payload: <%= { "cost" => 1000000.0 }.to_json %>
+
+art_gallery_political_group_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_political_group
+  payload: <%= {
+    "political-group" => ActiveRecord::FixtureSet.identify(:dc_term).to_s
+  }.to_json %>
+
+art_gallery_start_date_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "1819-11-19" }.to_json %>

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -273,6 +273,11 @@ sports_center_start_date_custom_field_record:
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "2018-01-01" }.to_json %>
 
+sports_center_text_code_custom_field_record:
+  item: sports_center_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "sport-01" }.to_json %>
+
 public_pool_cost_custom_field_record:
   item: public_pool_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_cost
@@ -289,6 +294,11 @@ public_pool_start_date_custom_field_record:
   item: public_pool_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "2018-07-15" }.to_json %>
+
+public_pool_text_code_custom_field_record:
+  item: public_pool_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "sport-02" }.to_json %>
 
 public_library_cost_custom_field_record:
   item: public_library_project (GobiertoInvestments::Project)
@@ -307,6 +317,11 @@ public_library_start_date_custom_field_record:
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "2010-12-31" }.to_json %>
 
+public_library_text_code_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "culture-01" }.to_json %>
+
 art_gallery_cost_custom_field_record:
   item: art_gallery_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_cost
@@ -323,3 +338,8 @@ art_gallery_start_date_custom_field_record:
   item: art_gallery_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "1819-11-19" }.to_json %>
+
+art_gallery_text_code_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "culture-02" }.to_json %>

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -321,6 +321,17 @@ madrid_investments_projects_custom_field_political_group:
     vocabulary_id: ActiveRecord::FixtureSet.identify(:madrid_political_groups_vocabulary)
   }.to_json %>
 
+madrid_investments_projects_custom_field_start_date:
+  site: madrid
+  class_name: GobiertoInvestments::Project
+  position: 3
+  name_translations: <%= { en: "Start date", es: "Fecha de inicio" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:date] %>
+  uid: start-date
+  options: <%= {
+    configuration: { "date_type" => "date" },
+  }.to_json %>
+
 madrid_custom_field_human_resources_table_plugin:
   site: madrid
   class_name: GobiertoPlans::Node

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -332,6 +332,14 @@ madrid_investments_projects_custom_field_start_date:
     configuration: { "date_type" => "date" },
   }.to_json %>
 
+madrid_investments_projects_custom_field_text_code:
+  site: madrid
+  class_name: GobiertoInvestments::Project
+  position: 4
+  name_translations: <%= { en: "Text code", es: "Código de texto" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:string] %>
+  uid: text-code
+
 madrid_custom_field_human_resources_table_plugin:
   site: madrid
   class_name: GobiertoPlans::Node

--- a/test/fixtures/gobierto_investments/projects.yml
+++ b/test/fixtures/gobierto_investments/projects.yml
@@ -13,6 +13,26 @@ sports_center_project:
   title_translations: <%= {
     en: "Sports center",
     es: "Centro deportivo"
-    }.to_json %>
+     }.to_json %>
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+public_library_project:
+  site: madrid
+  title_translations: <%= {
+    en: "Public library",
+    es: "Biblioteca pública"
+     }.to_json %>
+  external_id: EE001
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+art_gallery_project:
+  site: madrid
+  title_translations: <%= {
+    en: "Art gallery",
+    es: "Pinacoteca"
+     }.to_json %>
+  external_id: EE002
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>

--- a/test/models/gobierto_common/custom_field_value/vocabulary_options_test.rb
+++ b/test/models/gobierto_common/custom_field_value/vocabulary_options_test.rb
@@ -5,28 +5,118 @@ require "test_helper"
 module GobiertoCommon::CustomFieldValue
   class VocabularyOptionsTest < ActiveSupport::TestCase
 
-    def test_vocabulary_single_select_value_string
-      record = gobierto_common_custom_field_records(
+    def single_select_record
+      @single_select_record ||= gobierto_common_custom_field_records(
         :political_agendas_custom_field_record_vocabulary_single_select
       )
+    end
 
-      assert_equal ["Mammal"], record.value_string
+    def multiple_select_record
+      @multiple_select_record ||= gobierto_common_custom_field_records(
+        :political_agendas_custom_field_record_vocabulary_multiple_select
+      )
+    end
+
+    def multiple_tags_select_record
+      @multiple_tags_select_record ||= gobierto_common_custom_field_records(
+        :political_agendas_custom_field_record_vocabulary_tags
+      )
+    end
+
+    def mammal_term
+      gobierto_common_terms(:mammal)
+    end
+
+    def dog_term
+      gobierto_common_terms(:dog)
+    end
+
+    def vocabulary_term
+      gobierto_common_terms(:cat)
+    end
+
+    def other_vocabulary_term
+      gobierto_common_terms(:marvel_term)
+    end
+
+    def test_vocabulary_single_select_value_string
+      assert_equal [mammal_term.name], single_select_record.value_string
     end
 
     def test_vocabulary_multiple_select_value_string
-      record = gobierto_common_custom_field_records(
-        :political_agendas_custom_field_record_vocabulary_multiple_select
-      )
-
-      assert_equal %w(Mammal Dog), record.value_string
+      assert_equal [mammal_term.name, dog_term.name], multiple_select_record.value_string
     end
 
     def test_vocabulary_tags_value_string
-      record = gobierto_common_custom_field_records(
-        :political_agendas_custom_field_record_vocabulary_tags
-      )
+      assert_equal [mammal_term.name, dog_term.name], multiple_tags_select_record.value_string
+    end
 
-      assert_equal %w(Mammal Dog), record.value_string
+    def test_vocabulary_single_select_filter_value
+      assert_equal mammal_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_multiple_select_filter_value
+      assert_equal [mammal_term.id.to_s, dog_term.id.to_s].to_s, multiple_select_record.filter_value
+    end
+
+    def test_vocabulary_tags_filter_value
+      assert_equal [mammal_term.id.to_s, dog_term.id.to_s].to_s, multiple_tags_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_vocabulary_term
+      single_select_record.value = vocabulary_term
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_other_vocabulary_term
+      single_select_record.value = other_vocabulary_term
+
+      assert_equal [], single_select_record.value_string
+      refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_term_integer_id
+      single_select_record.value = vocabulary_term.id
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_other_vocabulary_integer_id
+      single_select_record.value = other_vocabulary_term.id
+
+      assert_equal [], single_select_record.value_string
+      refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_term_string_id
+      single_select_record.value = vocabulary_term.id.to_s
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_other_vocabulary_string_id
+      single_select_record.value = other_vocabulary_term.id.to_s
+
+      assert_equal [], single_select_record.value_string
+      refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_array_of_integer_ids
+      single_select_record.value = [vocabulary_term.id, mammal_term.id]
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_array_of_string_ids
+      single_select_record.value = [vocabulary_term.id.to_s, mammal_term.id.to_s]
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
   end


### PR DESCRIPTION
Closes #2540


## :v: What does this PR do?

* Allows the use of a notation in the query params of API index request including operators such as `lt`, `lteq`, `gt`, `gteq`, `in` and `like`
* Parses operators provided in the request to build the appropriate query in the `GobiertoCommon::CustomFieldQuery` `filter` action.

## :mag: How should this be manually tested?

Visit API index project path. The old notation of filters in the query string with the form: `/?filter[uid]=value&filter[uid2]=1000` or adding to the body the JSON:

```json
{
    "filter": {
        "uid": "value",
        "uid2": 1000
    }
}
```
assumes that the operator is `eq`. To use other operators, as `lt`, use a LHS brackets notation:
`/?filter[uid][lt]=value&filter[uid][gt]=value2&filter[uid2][gteq]=1000`, or in JSON format:

```json
{
    "filter": {
        "uid": {
            "lt": "value",
            "gt": "value2"
        },
        "uid2": {
            "gteq": 1000
        }
    }
}
```
The `in` operator expects a string formed by the concatenation of values separated by commas.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No