### PR TITLE
2541 api custom fields meta data

### DIFF
--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -47,9 +47,9 @@ module GobiertoCommon
 
     def filterable_custom_fields
       @filterable_custom_fields ||= if (filterable_custom_fields_uids = current_site.settings_for_module(current_module)&.filterable_custom_fields).present?
-                                      custom_fields.where(uid: filterable_custom_fields_uids)
+                                      custom_fields.where(uid: filterable_custom_fields_uids).sorted
                                     else
-                                      custom_fields.where(field_type: [:date, :vocabulary_options, :numeric])
+                                      custom_fields.where(field_type: [:date, :vocabulary_options, :numeric]).sorted
                                     end
     end
 

--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -24,6 +24,11 @@ module GobiertoCommon
       custom_fields_save
     end
 
+    def meta
+      @resource = base_relation.new
+      render json: custom_fields, adapter: :json_api
+    end
+
     private
 
     def custom_fields_save

--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -27,6 +27,8 @@ module GobiertoCommon
     def meta
       @resource = base_relation.new
 
+      return unless stale?(base_relation)
+
       meta_stats = if params[:stats] == "true"
                      filterable_custom_fields.inject({}) do |stats, custom_field|
                        stats.update(

--- a/app/controllers/concerns/gobierto_common/secured_with_token.rb
+++ b/app/controllers/concerns/gobierto_common/secured_with_token.rb
@@ -20,7 +20,7 @@ module GobiertoCommon
       if decoded_data && decoded_data["sub"] == "login" && decoded_data["api_token"].present? && (admin = ::GobiertoAdmin::Admin.find_by(api_token: decoded_data["api_token"]))
         @current_admin = admin
       else
-        send_unauthorized
+        render(json: { message: "Unauthorized" }, status: :unauthorized, adapter: :json_api) && return
       end
     end
 

--- a/app/controllers/gobierto_admin/api/base_controller.rb
+++ b/app/controllers/gobierto_admin/api/base_controller.rb
@@ -33,6 +33,9 @@ module GobiertoAdmin
         render json: { error: error_message }, status: 400
       end
 
+      def set_admin_by_session_or_token
+        set_admin_with_token unless (@current_admin = find_current_admin).present?
+      end
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -4,6 +4,9 @@ module GobiertoAdmin
   module GobiertoAttachments
     module Api
       class AttachmentsController < ::GobiertoAdmin::Api::BaseController
+        include ::GobiertoCommon::SecuredWithToken
+        skip_before_action :authenticate_admin!, :set_admin_with_token
+        before_action :set_admin_by_session_or_token
 
         before_action :find_attachable, only: [:index]
         before_action :find_attachment, only: [:show, :destroy]

--- a/app/controllers/gobierto_admin/gobierto_common/api/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/vocabularies_controller.rb
@@ -4,9 +4,12 @@ module GobiertoAdmin
   module GobiertoCommon
     module Api
       class VocabulariesController < ::GobiertoAdmin::Api::BaseController
+        include ::GobiertoCommon::SecuredWithToken
 
-        def index
-        end
+        skip_before_action :authenticate_admin!, :set_admin_with_token
+        before_action :set_admin_by_session_or_token
+
+        def index; end
 
         def show
           load_vocabulary
@@ -17,6 +20,10 @@ module GobiertoAdmin
 
         def load_vocabulary
           @vocabulary = current_site.vocabularies.find(params[:id])
+        end
+
+        def set_admin_by_session_or_token
+          set_admin_with_token unless (@current_admin = find_current_admin).present?
         end
 
       end

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -8,8 +8,8 @@ module GobiertoInvestments
         include ::GobiertoCommon::CustomFieldsApi
         include ::GobiertoCommon::SecuredWithToken
 
-        skip_before_action :set_admin_with_token, only: [:index, :show, :new]
-        before_action :module_allowed, except: [:index, :show, :new]
+        skip_before_action :set_admin_with_token, only: [:index, :show, :new, :meta]
+        before_action :module_allowed, except: [:index, :show, :new, :meta]
 
         # GET /gobierto_investments/api/v1/projects
         # GET /gobierto_investments/api/v1/projects.json

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -15,7 +15,11 @@ module GobiertoInvestments
         # GET /gobierto_investments/api/v1/projects.json
         def index
           @resource = GobiertoInvestments::Project.new
-          render json: filtered_relation, adapter: :json_api
+          relation = filtered_relation
+
+          if stale?(relation)
+            render json: relation, adapter: :json_api
+          end
         end
 
         # GET /gobierto_investments/api/v1/projects/1

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -96,7 +96,7 @@ module GobiertoAdmin
           opts[:configuration] ||= {}
           opts.merge!(options_translations.except("new_option")) if has_options? && options_translations
           if has_vocabulary?
-            opts[:vocabulary_id] = vocabulary_id if vocabulary_id
+            opts[:vocabulary_id] = vocabulary_id.to_i if vocabulary_id
             opts[:configuration][:vocabulary_type] = vocabulary_type if vocabulary_type.present?
           end
           if custom_field.date?

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -28,6 +28,7 @@ module GobiertoCommon
     scope :not_localized, -> { where.not(field_type: [:localized_string, :localized_paragraph]) }
     scope :with_plugin_type, ->(plugin_type) { plugin.where("options @> ?", { configuration: { plugin_type: plugin_type } }.to_json) }
     scope :for_class, ->(klass) { klass.present? ? where(class_name: klass.name).all : all }
+    scope :for_vocabulary, ->(vocabulary) { where("options @> ?", { vocabulary_id: vocabulary.id.to_s }.to_json) }
 
     translates :name
 

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -28,7 +28,7 @@ module GobiertoCommon
     scope :not_localized, -> { where.not(field_type: [:localized_string, :localized_paragraph]) }
     scope :with_plugin_type, ->(plugin_type) { plugin.where("options @> ?", { configuration: { plugin_type: plugin_type } }.to_json) }
     scope :for_class, ->(klass) { klass.present? ? where(class_name: klass.name).all : all }
-    scope :for_vocabulary, ->(vocabulary) { where("options @> ?", { vocabulary_id: vocabulary.id.to_s }.to_json) }
+    scope :for_vocabulary, ->(vocabulary) { where("options @> ?", { vocabulary_id: vocabulary.id }.to_json) }
 
     translates :name
 

--- a/app/models/gobierto_common/custom_field_record.rb
+++ b/app/models/gobierto_common/custom_field_record.rb
@@ -28,7 +28,7 @@ module GobiertoCommon
 
     attr_accessor :item_has_versions
 
-    belongs_to :item, polymorphic: true, touch: true
+    belongs_to :item, polymorphic: true
     belongs_to :custom_field
 
     validates :custom_field, presence: true
@@ -43,7 +43,7 @@ module GobiertoCommon
 
     delegate :value, :value_string, :raw_value, :value=, :filter_value, :searchable_value, to: :value_processor
 
-    after_save :check_plugin_callbacks
+    after_save :check_plugin_callbacks, :touch_item
 
     def value_processor
       key = VALUE_PROCESSORS.has_key?(custom_field&.field_type&.to_sym) ? custom_field.field_type.to_sym : :default
@@ -69,6 +69,12 @@ module GobiertoCommon
     end
 
     private
+
+    def touch_item
+      return if item_has_versions
+
+      item.touch
+    end
 
     def check_plugin_callbacks
       plugin_types_with_callbacks = GobiertoCommon::CustomFieldPlugin.with_callbacks.map(&:type)

--- a/app/models/gobierto_common/custom_field_record.rb
+++ b/app/models/gobierto_common/custom_field_record.rb
@@ -26,7 +26,7 @@ module GobiertoCommon
       end
     end
 
-    attr_accessor :item_has_versions
+    attr_accessor :item_has_versions, :callback_update
 
     belongs_to :item, polymorphic: true
     belongs_to :custom_field
@@ -71,7 +71,7 @@ module GobiertoCommon
     private
 
     def touch_item
-      return if item_has_versions
+      return if item_has_versions || callback_update
 
       item.touch
     end

--- a/app/models/gobierto_common/custom_field_record.rb
+++ b/app/models/gobierto_common/custom_field_record.rb
@@ -28,7 +28,7 @@ module GobiertoCommon
 
     attr_accessor :item_has_versions
 
-    belongs_to :item, polymorphic: true
+    belongs_to :item, polymorphic: true, touch: true
     belongs_to :custom_field
 
     validates :custom_field, presence: true

--- a/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
+++ b/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
@@ -17,20 +17,14 @@ module GobiertoCommon::CustomFieldValue
     def value=(value)
       value = value.id if value.is_a?(GobiertoCommon::Term)
 
-      if custom_field.configuration.vocabulary_type == "tags"
-        if value&.any?
-          existing_ids = vocabulary.terms.where(id: value).pluck(:id).map(&:to_s)
-          new_tags = value - existing_ids
-          start_position = vocabulary.terms.maximum(:position).to_i + 1
-
-          new_terms_ids = new_tags.map.with_index do |new_term, i|
-            vocabulary.terms.create(name: new_term, position: start_position + i).id
-          end.compact
-          value = existing_ids + new_terms_ids
-        else
-          value = []
-        end
-      end
+      value = if custom_field.configuration.vocabulary_type == "tags"
+                create_tags(value)
+              elsif value.is_a?(Array)
+                ids = value.map { |val| string_term_id(val) }.compact
+                custom_field.configuration.vocabulary_type == "single_select" ? ids.first : ids
+              else
+                string_term_id(value)
+              end
 
       super
     end
@@ -39,6 +33,27 @@ module GobiertoCommon::CustomFieldValue
       return unless custom_field.options.present?
 
       GobiertoCommon::Vocabulary.find_by(id: custom_field.options["vocabulary_id"])
+    end
+
+    protected
+
+    def create_tags(value)
+      return [] unless value&.any?
+
+      existing_ids = vocabulary.terms.where(id: value).pluck(:id).map(&:to_s)
+      new_tags = value - existing_ids
+      start_position = vocabulary.terms.maximum(:position).to_i + 1
+
+      new_terms_ids = new_tags.map.with_index do |new_term, i|
+        vocabulary.terms.create(name: new_term, position: start_position + i).id
+      end.compact
+      existing_ids + new_terms_ids
+    end
+
+    def string_term_id(id)
+      return unless vocabulary.terms.exists?(id)
+
+      id.to_s
     end
   end
 end

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -11,7 +11,7 @@ module GobiertoCommon
     before_destroy :free_children
     before_validation :clear_parent_if_itself
 
-    belongs_to :vocabulary
+    belongs_to :vocabulary, touch: true
 
     has_many :terms, dependent: :nullify
     belongs_to :parent_term, class_name: name, foreign_key: :term_id

--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -27,9 +27,7 @@ module GobiertoCommon
     end
 
     def ordered_flatten_terms_tree
-      terms.order(position: :asc).where(level: minimum_level).map do |term|
-        term.ordered_self_and_descendants
-      end.flatten
+      terms.order(position: :asc).where(level: minimum_level).map(&:ordered_self_and_descendants).flatten
     end
 
     def update_terms_positions(sort_params)

--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -10,6 +10,8 @@ module GobiertoCommon
     validates :site, :name, :slug, presence: true
     validates :slug, uniqueness: { scope: :site_id }
 
+    after_touch :touch_associated_custom_field_items
+
     translates :name
 
     def attributes_for_slug
@@ -34,6 +36,12 @@ module GobiertoCommon
       sort_params.values.each do |term_attributes|
         term_attributes[:class].constantize.where(id: term_attributes[:id]).update_all(position: term_attributes[:position])
       end
+    end
+
+    private
+
+    def touch_associated_custom_field_items
+      CustomFieldRecord.where(custom_field: CustomField.vocabulary_options.for_vocabulary(self)).each { |record| record.item.touch }
     end
   end
 end

--- a/app/queries/gobierto_common/custom_fields_query.rb
+++ b/app/queries/gobierto_common/custom_fields_query.rb
@@ -126,8 +126,8 @@ module GobiertoCommon
     end
 
     def filter_comparison_condition(custom_field, operator, value)
-      value = if operator == "in" && value.is_a?(Array)
-                "(#{value.map { |v| "'#{v}'" }.join(", ")})"
+      value = if operator == "IN" && value.is_a?(Array)
+                "(#{value.map { |v| "'#{v.inspect}'" }.join(", ")})"
               else
                 "'#{value}'"
               end

--- a/app/queries/gobierto_common/custom_fields_query.rb
+++ b/app/queries/gobierto_common/custom_fields_query.rb
@@ -127,7 +127,7 @@ module GobiertoCommon
         "jsonb_extract_path",
         [custom_fields_subqueries[custom_field.id][:payload], Arel::Nodes::SqlLiteral.new("'#{custom_field.uid}'")]
       )
-      Arel::Nodes::SqlLiteral.new("#{extraction_function.to_sql}#{cast_function(custom_field)}")
+      Arel::Nodes::SqlLiteral.new("CASE #{extraction_function.to_sql}::text WHEN 'null' THEN NULL WHEN '\"\"' THEN NULL ELSE #{extraction_function.to_sql}#{cast_function(custom_field)} END")
     end
 
     def filtered_query(filters, join_manager, *select_attributes)

--- a/app/queries/gobierto_common/custom_fields_query.rb
+++ b/app/queries/gobierto_common/custom_fields_query.rb
@@ -85,7 +85,7 @@ module GobiertoCommon
     def histogram(custom_field, filters, stats)
       return unless stats.min != stats.max && stats.count > 1
 
-      separations = Math.log(stats.count, 2).floor
+      separations = [stats.count, 9].min
       interval_width = (stats.max - stats.min).to_f / (1 + separations)
       bucket_attributes = Arel::Nodes::SqlLiteral.new(
         "width_bucket(#{extracted_attribute(custom_field)}, #{stats.min}, #{stats.max}, #{separations}) as bucket, count(*)"
@@ -97,11 +97,11 @@ module GobiertoCommon
         bucket_attributes
       ).group(:bucket).order(bucket: :asc)
 
-      histogram_query.map do |bin_data|
-        { bucket: bin_data.bucket,
-          start: stats.min + interval_width * (bin_data.bucket - 1),
-          end: stats.min + interval_width * bin_data.bucket,
-          count: bin_data.count }
+      (1..separations + 1).map do |bucket|
+        { bucket: bucket,
+          start: stats.min + interval_width * (bucket - 1),
+          end: stats.min + interval_width * bucket,
+          count: histogram_query.find { |bin_data| bin_data.bucket == bucket }&.count || 0 }
       end
     end
 

--- a/app/queries/gobierto_common/custom_fields_query.rb
+++ b/app/queries/gobierto_common/custom_fields_query.rb
@@ -99,8 +99,8 @@ module GobiertoCommon
 
       (1..separations + 1).map do |bucket|
         { bucket: bucket,
-          start: stats.min + interval_width * (bucket - 1),
-          end: stats.min + interval_width * bucket,
+          start: (stats.min + interval_width * (bucket - 1)).ceil,
+          end: (stats.min + interval_width * bucket).floor,
           count: histogram_query.find { |bin_data| bin_data.bucket == bucket }&.count || 0 }
       end
     end

--- a/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
+++ b/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
@@ -9,7 +9,7 @@ module GobiertoCommon
       data = super
 
       if data[:id].present?
-        ::GobiertoCommon::CustomFieldRecord.includes(:custom_field).where(custom_field: custom_fields, item: object).each do |record|
+        ::GobiertoCommon::CustomFieldRecord.includes(:custom_field).where(custom_field: custom_fields, item: object).sorted.each do |record|
           data[record.custom_field.uid] = record.value
         end
       else
@@ -22,7 +22,7 @@ module GobiertoCommon
     end
 
     def custom_fields
-      @custom_fields ||= current_site.custom_fields.where(class_name: object.class.name)
+      @custom_fields ||= current_site.custom_fields.where(class_name: object.class.name).sorted
     end
 
   end

--- a/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
+++ b/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
@@ -8,15 +8,21 @@ module GobiertoCommon
     def attributes(*args)
       data = super
 
-      custom_fields_attributes = current_site.custom_fields.where(class_name: object.class.name).inject({}) do |attrs, custom_field|
-        attrs.update(
-          custom_field.uid => ::GobiertoCommon::CustomFieldRecord.find_or_initialize_by(
-            item: object,
-            custom_field: custom_field
-          ).value
-        )
+      if data[:id].present?
+        ::GobiertoCommon::CustomFieldRecord.includes(:custom_field).where(custom_field: custom_fields, item: object).each do |record|
+          data[record.custom_field.uid] = record.value
+        end
+      else
+        custom_fields.each do |custom_field|
+          data[custom_field.uid] = custom_field.records.new.value
+        end
       end
-      data.merge(custom_fields_attributes)
+
+      data
+    end
+
+    def custom_fields
+      @custom_fields ||= current_site.custom_fields.where(class_name: object.class.name)
     end
 
   end

--- a/app/serializers/gobierto_common/custom_field_serializer.rb
+++ b/app/serializers/gobierto_common/custom_field_serializer.rb
@@ -8,7 +8,7 @@ module GobiertoCommon
     def vocabulary_terms
       return unless object.has_vocabulary?
 
-      ActiveModelSerializers::SerializableResource.new(object.vocabulary.terms).as_json
+      ActiveModelSerializers::SerializableResource.new(object.vocabulary.terms.sorted).as_json
     end
 
   end

--- a/app/serializers/gobierto_common/custom_field_serializer.rb
+++ b/app/serializers/gobierto_common/custom_field_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class CustomFieldSerializer < ActiveModel::Serializer
+
+    attributes :id, :uid, :name_translations, :field_type, :options, :vocabulary_terms
+
+    def vocabulary_terms
+      return unless object.has_vocabulary?
+
+      ActiveModelSerializers::SerializableResource.new(object.vocabulary.terms).as_json
+    end
+
+  end
+end

--- a/app/serializers/gobierto_common/term_serializer.rb
+++ b/app/serializers/gobierto_common/term_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class TermSerializer < ActiveModel::Serializer
+
+    attributes(
+      :id,
+      :name_translations,
+      :description_translations,
+      :slug,
+      :position,
+      :level,
+      :term_id
+    )
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -530,7 +530,11 @@ Rails.application.routes.draw do
         # API
         namespace :api do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true) do
-            resources :projects, except: [:edit]
+            resources :projects, except: [:edit] do
+              collection do
+                get :meta
+              end
+            end
           end
         end
       end

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -268,6 +268,11 @@ sports_center_political_group_custom_field_record:
     "political-group" => ActiveRecord::FixtureSet.identify(:marvel_term).to_s
   }.to_json %>
 
+sports_center_start_date_custom_field_record:
+  item: sports_center_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "2018-01-01" }.to_json %>
+
 public_pool_cost_custom_field_record:
   item: public_pool_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_cost
@@ -279,3 +284,42 @@ public_pool_political_group_custom_field_record:
   payload: <%= {
     "political-group" => ActiveRecord::FixtureSet.identify(:dc_term).to_s
   }.to_json %>
+
+public_pool_start_date_custom_field_record:
+  item: public_pool_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "2018-07-15" }.to_json %>
+
+public_library_cost_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_cost
+  payload: <%= { "cost" => 500000.0 }.to_json %>
+
+public_library_political_group_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_political_group
+  payload: <%= {
+    "political-group" => ActiveRecord::FixtureSet.identify(:marvel_term).to_s
+  }.to_json %>
+
+public_library_start_date_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "2010-12-31" }.to_json %>
+
+art_gallery_cost_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_cost
+  payload: <%= { "cost" => 1000000.0 }.to_json %>
+
+art_gallery_political_group_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_political_group
+  payload: <%= {
+    "political-group" => ActiveRecord::FixtureSet.identify(:dc_term).to_s
+  }.to_json %>
+
+art_gallery_start_date_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_start_date
+  payload: <%= { "start-date" => "1819-11-19" }.to_json %>

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -273,6 +273,11 @@ sports_center_start_date_custom_field_record:
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "2018-01-01" }.to_json %>
 
+sports_center_text_code_custom_field_record:
+  item: sports_center_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "sport-01" }.to_json %>
+
 public_pool_cost_custom_field_record:
   item: public_pool_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_cost
@@ -289,6 +294,11 @@ public_pool_start_date_custom_field_record:
   item: public_pool_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "2018-07-15" }.to_json %>
+
+public_pool_text_code_custom_field_record:
+  item: public_pool_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "sport-02" }.to_json %>
 
 public_library_cost_custom_field_record:
   item: public_library_project (GobiertoInvestments::Project)
@@ -307,6 +317,11 @@ public_library_start_date_custom_field_record:
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "2010-12-31" }.to_json %>
 
+public_library_text_code_custom_field_record:
+  item: public_library_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "culture-01" }.to_json %>
+
 art_gallery_cost_custom_field_record:
   item: art_gallery_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_cost
@@ -323,3 +338,8 @@ art_gallery_start_date_custom_field_record:
   item: art_gallery_project (GobiertoInvestments::Project)
   custom_field: madrid_investments_projects_custom_field_start_date
   payload: <%= { "start-date" => "1819-11-19" }.to_json %>
+
+art_gallery_text_code_custom_field_record:
+  item: art_gallery_project (GobiertoInvestments::Project)
+  custom_field: madrid_investments_projects_custom_field_text_code
+  payload: <%= { "text-code" => "culture-02" }.to_json %>

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -321,6 +321,17 @@ madrid_investments_projects_custom_field_political_group:
     vocabulary_id: ActiveRecord::FixtureSet.identify(:madrid_political_groups_vocabulary)
   }.to_json %>
 
+madrid_investments_projects_custom_field_start_date:
+  site: madrid
+  class_name: GobiertoInvestments::Project
+  position: 3
+  name_translations: <%= { en: "Start date", es: "Fecha de inicio" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:date] %>
+  uid: start-date
+  options: <%= {
+    configuration: { "date_type" => "date" },
+  }.to_json %>
+
 madrid_custom_field_human_resources_table_plugin:
   site: madrid
   class_name: GobiertoPlans::Node

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -332,6 +332,14 @@ madrid_investments_projects_custom_field_start_date:
     configuration: { "date_type" => "date" },
   }.to_json %>
 
+madrid_investments_projects_custom_field_text_code:
+  site: madrid
+  class_name: GobiertoInvestments::Project
+  position: 4
+  name_translations: <%= { en: "Text code", es: "Código de texto" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:string] %>
+  uid: text-code
+
 madrid_custom_field_human_resources_table_plugin:
   site: madrid
   class_name: GobiertoPlans::Node

--- a/test/fixtures/gobierto_investments/projects.yml
+++ b/test/fixtures/gobierto_investments/projects.yml
@@ -13,6 +13,26 @@ sports_center_project:
   title_translations: <%= {
     en: "Sports center",
     es: "Centro deportivo"
-    }.to_json %>
+     }.to_json %>
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+public_library_project:
+  site: madrid
+  title_translations: <%= {
+    en: "Public library",
+    es: "Biblioteca pública"
+     }.to_json %>
+  external_id: EE001
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+art_gallery_project:
+  site: madrid
+  title_translations: <%= {
+    en: "Art gallery",
+    es: "Pinacoteca"
+     }.to_json %>
+  external_id: EE002
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
@@ -45,7 +45,7 @@ module GobiertoAdmin
       def test_requests_need_authentication
         get admin_attachments_api_attachments_path(site_id: site.id)
 
-        assert_response :redirect
+        assert_response :unauthorized
       end
 
       def test_attachments_index

--- a/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
@@ -14,6 +14,14 @@ module GobiertoCommon
         gobierto_common_vocabularies(:animals)
       end
 
+      def vocabulary_associated_to_custom_fields
+        gobierto_common_vocabularies(:madrid_political_groups_vocabulary)
+      end
+
+      def item_related_with_vocabulary
+        @item_related_with_vocabulary ||= gobierto_investments_projects(:public_pool_project)
+      end
+
       def admin
         @admin ||= gobierto_admin_admins(:tony)
       end
@@ -83,6 +91,28 @@ module GobiertoCommon
           end
         end
       end
+
+      def test_update_term_updates_items_with_custom_fields
+        with(site: site, admin: admin) do
+          visit admin_common_vocabulary_terms_path(vocabulary_associated_to_custom_fields)
+
+          within("#v_el_actions_#{vocabulary_associated_to_custom_fields.terms.first.id}") do
+            click_link("Edit")
+          end
+
+          assert_changes "item_related_with_vocabulary.reload.updated_at" do
+            within "form.edit_term" do
+              fill_in "term_name_translations_en", with: "WADUS"
+              fill_in "term_slug", with: "wadus-updated"
+
+              click_button "Update"
+            end
+
+            assert has_message?("Term updated successfully.")
+          end
+        end
+      end
+
     end
   end
 end

--- a/test/integration/gobierto_admin/gobierto_investments/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_investments/projects/update_project_test.rb
@@ -96,6 +96,18 @@ module GobiertoAdmin
             end
           end
         end
+
+        def test_update_custom_field_updates_project
+          with(site: site, admin: admin) do
+            visit @path
+
+            assert_changes "project.reload.updated_at" do
+              fill_in "project_custom_records_text-code_value", with: "test changed"
+              click_button "Update"
+              assert has_message?("Project updated correctly.")
+            end
+          end
+        end
       end
     end
   end

--- a/test/models/gobierto_common/custom_field_value/vocabulary_options_test.rb
+++ b/test/models/gobierto_common/custom_field_value/vocabulary_options_test.rb
@@ -5,28 +5,118 @@ require "test_helper"
 module GobiertoCommon::CustomFieldValue
   class VocabularyOptionsTest < ActiveSupport::TestCase
 
-    def test_vocabulary_single_select_value_string
-      record = gobierto_common_custom_field_records(
+    def single_select_record
+      @single_select_record ||= gobierto_common_custom_field_records(
         :political_agendas_custom_field_record_vocabulary_single_select
       )
+    end
 
-      assert_equal ["Mammal"], record.value_string
+    def multiple_select_record
+      @multiple_select_record ||= gobierto_common_custom_field_records(
+        :political_agendas_custom_field_record_vocabulary_multiple_select
+      )
+    end
+
+    def multiple_tags_select_record
+      @multiple_tags_select_record ||= gobierto_common_custom_field_records(
+        :political_agendas_custom_field_record_vocabulary_tags
+      )
+    end
+
+    def mammal_term
+      gobierto_common_terms(:mammal)
+    end
+
+    def dog_term
+      gobierto_common_terms(:dog)
+    end
+
+    def vocabulary_term
+      gobierto_common_terms(:cat)
+    end
+
+    def other_vocabulary_term
+      gobierto_common_terms(:marvel_term)
+    end
+
+    def test_vocabulary_single_select_value_string
+      assert_equal [mammal_term.name], single_select_record.value_string
     end
 
     def test_vocabulary_multiple_select_value_string
-      record = gobierto_common_custom_field_records(
-        :political_agendas_custom_field_record_vocabulary_multiple_select
-      )
-
-      assert_equal %w(Mammal Dog), record.value_string
+      assert_equal [mammal_term.name, dog_term.name], multiple_select_record.value_string
     end
 
     def test_vocabulary_tags_value_string
-      record = gobierto_common_custom_field_records(
-        :political_agendas_custom_field_record_vocabulary_tags
-      )
+      assert_equal [mammal_term.name, dog_term.name], multiple_tags_select_record.value_string
+    end
 
-      assert_equal %w(Mammal Dog), record.value_string
+    def test_vocabulary_single_select_filter_value
+      assert_equal mammal_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_multiple_select_filter_value
+      assert_equal [mammal_term.id.to_s, dog_term.id.to_s].to_s, multiple_select_record.filter_value
+    end
+
+    def test_vocabulary_tags_filter_value
+      assert_equal [mammal_term.id.to_s, dog_term.id.to_s].to_s, multiple_tags_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_vocabulary_term
+      single_select_record.value = vocabulary_term
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_other_vocabulary_term
+      single_select_record.value = other_vocabulary_term
+
+      assert_equal [], single_select_record.value_string
+      refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_term_integer_id
+      single_select_record.value = vocabulary_term.id
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_other_vocabulary_integer_id
+      single_select_record.value = other_vocabulary_term.id
+
+      assert_equal [], single_select_record.value_string
+      refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_term_string_id
+      single_select_record.value = vocabulary_term.id.to_s
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_other_vocabulary_string_id
+      single_select_record.value = other_vocabulary_term.id.to_s
+
+      assert_equal [], single_select_record.value_string
+      refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_array_of_integer_ids
+      single_select_record.value = [vocabulary_term.id, mammal_term.id]
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
+    end
+
+    def test_vocabulary_single_select_value_assign_with_array_of_string_ids
+      single_select_record.value = [vocabulary_term.id.to_s, mammal_term.id.to_s]
+
+      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
   end

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/models/gobierto_common/custom_field_functions/progress.rb
@@ -32,6 +32,8 @@ module GobiertoCommon::CustomFieldFunctions
     def update_progress!
       current_progress = progress
       record.value = current_progress
+      record.callback_update = true
+
       record.save!
 
       return unless record.item&.has_attribute? :progress


### PR DESCRIPTION
Closes #2541


## :v: What does this PR do?

Adds a meta endpoint to projects API:
* Lists all custom fields defined for projects with attributes: `uid`, `name_translations`, `field_type`, `options` (extra configuration attributes of custom field) and `vocabulary_terms` (if the custom field has a vocabulary the terms are listed in this field)
* If the request includes `?stats=true` in the url, statistics of fields are included to build filters
* By default the stats are sent for all fields of type `date`, `numeric` or `vocabulary_options`, but the fields can be set at site and module level under the key `filterable_custom_fields` (the application looks if there is a `current_site.settings_for_module(current_module).filterable_custom_fields` containing an array of custom fields uids)

Makes changes on admin/attachments API:
* Allows both session and JWT authentication for attachments controller actions. With this, an external ETL can upload images as attachments using the appropriate credentials.

Other changes:
* Adds callbacks to update timestamps of an item when a belonging custom field record is changed or a vocabulary related with an associated custom field is changed, with two exceptions:
  * The item has versions enabled
  * The custom field record is updated by a method which declares a `callback_update` attribute as `true`
* Changes custom field form to store `vocabulary_id` as integer in configuration JSON

## :mag: How should this be manually tested?



## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
