### PR TITLE
Avoid duplicated uploads of files in the same collection

### DIFF
--- a/app/forms/gobierto_admin/file_attachment_form.rb
+++ b/app/forms/gobierto_admin/file_attachment_form.rb
@@ -7,13 +7,13 @@ module GobiertoAdmin
       :id,
       :site_id,
       :collection_id,
-      :file,
       :description,
       :slug
     )
 
     attr_writer(
       :admin_id,
+      :file,
       :file_name,
       :file_size,
       :file_digest,
@@ -49,7 +49,9 @@ module GobiertoAdmin
     end
 
     def file_attachment
-      @file_attachment ||= file_attachment_class.find_by(id: id).presence || build_file_attachment
+      @file_attachment ||= file_attachment_class.find_by(id: id).presence ||
+                           file && file_attachment_class.find_by(collection: collection, file_digest: file_digest).presence ||
+                           build_file_attachment
     end
     alias content_context file_attachment
 
@@ -73,7 +75,7 @@ module GobiertoAdmin
     def current_version
       @current_version ||= begin
         if persisted?
-          persisted_attachment = file_attachment_class.find(id) # don't access memoized version, since its digest may already be updated
+          persisted_attachment = file_attachment_class.find(file_attachment.id) # don't access memoized version, since its digest may already be updated
           if persisted_attachment.file_digest != file_digest
             persisted_attachment.current_version + 1
           else

--- a/test/forms/gobierto_admin/gobierto_attachments/file_attachment_form_tests/create_test.rb
+++ b/test/forms/gobierto_admin/gobierto_attachments/file_attachment_form_tests/create_test.rb
@@ -42,10 +42,22 @@ module GobiertoAdmin
           assert_equal "http://www.domain.com/logo-madrid.png", file_attachment.url
         end
 
+        def test_create_when_file_exists
+          form = ::GobiertoAdmin::FileAttachmentForm.new(file_attachment_attributes)
+          form.save
+
+          new_form = ::GobiertoAdmin::FileAttachmentForm.new(file_attachment_attributes.merge(name: "Duplicated file"))
+          new_form.save
+
+          file_attachment = file_attachment_class.find(form.file_attachment.id)
+          assert_equal form.file_attachment.id, new_form.file_attachment.id
+          assert_equal "Duplicated file", file_attachment.name
+        end
+
         def test_create_attachment_on_collection
           form = ::GobiertoAdmin::FileAttachmentForm.new(file_attachment_attributes.merge(
                                                            collection_id: collection.id
-          ))
+                                                         ))
 
           assert form.save
 

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
@@ -167,6 +167,31 @@ module GobiertoAdmin
         assert_equal 1, attachment["current_version"]
       end
 
+      def test_attachments_create_twice_success
+        login_admin_for_api(admin)
+
+        payload = {
+          attachment: {
+            collection_id: collection.id,
+            name: "New attachment name",
+            description: "New attachment description",
+            file_name: "new-pdf-attachment.pdf",
+            file: ::Base64.strict_encode64(new_pdf_file.read)
+          }
+        }
+
+        ::GobiertoAdmin::FileUploadService.any_instance.stubs(:upload!).returns("http://host.com/attachments/super-long-and-ugly-aws-id/new-pdf-attachment.pdf")
+        assert_difference "::GobiertoAttachments::Attachment.count", 1 do
+          post admin_attachments_api_attachments_path(payload)
+          assert_response :success
+        end
+
+        assert_no_difference "::GobiertoAttachments::Attachment.count" do
+          post admin_attachments_api_attachments_path(payload)
+          assert_response :success
+        end
+      end
+
       def test_attachments_create_error
         login_admin_for_api(admin)
 


### PR DESCRIPTION
Closes #2565

## :v: What does this PR do?

* Checks if a file has been already uploaded to a collection and avoids repeated uploads.
* When an existing file is uploaded the API and form uses the existing attachments and updates their attributes

## :mag: How should this be manually tested?

Visit documents and upload a file twice.

## :eyes: Screenshots

### Before this PR

![2565-before](https://user-images.githubusercontent.com/446459/65320280-cc944f00-dba1-11e9-8f7e-afbf24220978.gif)

### After this PR

![2565-after](https://user-images.githubusercontent.com/446459/65320289-d453f380-dba1-11e9-8cbf-c82ac76c3f8d.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?
No
