### PR TITLE
Set published version of projects on csv import of plans

### DIFF
--- a/app/decorators/gobierto_plans/row_node_decorator.rb
+++ b/app/decorators/gobierto_plans/row_node_decorator.rb
@@ -58,6 +58,7 @@ module GobiertoPlans
                     node.progress = progress_from_status(node.status.name) unless has_progress_column?
                     node.progress ||= 0.0
                     node.visibility_level = :published
+                    node.published_version = 1
                     node.build_moderation(stage: :approved)
                     node.categories << category unless node.categories.include?(category)
                   end

--- a/test/decorators/gobierto_plans/plan_data_decorator_test.rb
+++ b/test/decorators/gobierto_plans/plan_data_decorator_test.rb
@@ -71,6 +71,7 @@ module GobiertoPlans
       assert_equal csv_input.by_row[0]["Node.Priority"], first_node.options["Priority"]
       assert_equal csv_input.by_row[0]["Node.Custom Field 1"], first_node.options["Custom Field 1"]
       assert first_node.published?
+      assert first_node.published_version.present?
       assert first_node.moderation.approved?
      end
 

--- a/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
@@ -50,33 +50,40 @@ module GobiertoAdmin
       end
 
       def test_import_csv_file
-        with_signed_in_admin(admin) do
-          with_current_site(site) do
-            visit path
+        with(site: site, admin: admin) do
+          visit path
 
-            click_link "Import from CSV"
+          click_link "Import from CSV"
 
-            attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan2.csv")
-            within "form" do
-              with_stubbed_s3_file_upload do
-                click_button "Import from CSV file"
-              end
+          attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan2.csv")
+          within "form" do
+            with_stubbed_s3_file_upload do
+              click_button "Import from CSV file"
             end
-
-            within ".flash-message", match: :first do
-              assert has_content? "Data imported successfully"
-            end
-
-            assert has_content? "5 axes"
-            assert has_content? "39 lines of action"
-            assert has_content? "119 actions"
-            assert has_content? "247 projects/actions"
-
-            plan.reload
-            assert_equal 247, plan.nodes.count
-            assert_equal "eix-1-economia-emprenedoria-i-ocupacio", plan.categories_vocabulary.terms.first.slug
-            assert_equal 1, plan.nodes.where(status: blank_status_term).count
           end
+
+          within ".flash-message", match: :first do
+            assert has_content? "Data imported successfully"
+          end
+
+          assert has_content? "5 axes"
+          assert has_content? "39 lines of action"
+          assert has_content? "119 actions"
+          assert has_content? "247 projects/actions"
+
+          plan.reload
+          assert_equal 247, plan.nodes.count
+          assert_equal "eix-1-economia-emprenedoria-i-ocupacio", plan.categories_vocabulary.terms.first.slug
+          assert_equal 1, plan.nodes.where(status: blank_status_term).count
+        end
+
+        with(site: site, js: true) do
+          visit gobierto_plans_plan_path(slug: plan.plan_type.slug, year: plan.year)
+
+          assert has_content? "5 axes"
+          assert has_content? "39 lines of action"
+          assert has_content? "119 actions"
+          assert has_content? "247 projects/actions"
         end
       end
 


### PR DESCRIPTION
Closes #2573


## :v: What does this PR do?

* Sets first as published version on projects imported from CSV

## :mag: How should this be manually tested?

Import a new plan from CSV in admin and visit the plan front

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
