### PR TITLE
685 census edition permissions

### DIFF
--- a/app/assets/stylesheets/admin/application.scss
+++ b/app/assets/stylesheets/admin/application.scss
@@ -302,4 +302,12 @@ ul.jqtree-tree {
   }
 }
 
+.pointer-events-none {
+  pointer-events: none;
+
+  * {
+    pointer-events: auto;
+  }
+}
+
 @import "responsive";

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -507,4 +507,12 @@ body.sessions_new {
   }
 }
 
+.pointer-events-none {
+  pointer-events: none;
+
+  * {
+    pointer-events: auto;
+  }
+}
+
 @import "responsive";

--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -738,14 +738,6 @@ select {
 .form_item {
   position: relative;
 
-  label {
-    pointer-events: none;
-  }
-
-  i {
-    pointer-events: auto;
-  }
-
   .options {
     .option {
       display: block;

--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -724,6 +724,7 @@ select {
     text-transform: uppercase;
     font-size: 0.75em;
     font-weight: 700;
+    pointer-events: none;
   }
 }
 
@@ -812,6 +813,10 @@ select {
   .fas {
     margin: 0 0.5em;
     opacity: 0.5;
+  }
+
+  > i {
+    pointer-events: auto;
   }
 
   .fa-question-circle {

--- a/app/assets/stylesheets/comp-forms.scss
+++ b/app/assets/stylesheets/comp-forms.scss
@@ -724,7 +724,6 @@ select {
     text-transform: uppercase;
     font-size: 0.75em;
     font-weight: 700;
-    pointer-events: none;
   }
 }
 
@@ -738,6 +737,14 @@ select {
 
 .form_item {
   position: relative;
+
+  label {
+    pointer-events: none;
+  }
+
+  i {
+    pointer-events: auto;
+  }
 
   .options {
     .option {
@@ -813,10 +820,6 @@ select {
   .fas {
     margin: 0 0.5em;
     opacity: 0.5;
-  }
-
-  > i {
-    pointer-events: auto;
   }
 
   .fa-question-circle {

--- a/app/controllers/user/base_controller.rb
+++ b/app/controllers/user/base_controller.rb
@@ -3,4 +3,14 @@ class User::BaseController < ApplicationController
   include User::VerificationHelper
 
   layout "user/layouts/application"
+
+  private
+
+  def read_only_user_attributes
+    return [] unless auth_modules_present?
+
+    @read_only_user_attributes ||= current_site.configuration.auth_modules_data.inject([]) do |attributes, auth_module|
+      attributes | (auth_module.read_only_user_attributes || [])
+    end
+  end
 end

--- a/app/controllers/user/base_controller.rb
+++ b/app/controllers/user/base_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User::BaseController < ApplicationController
   include User::SessionHelper
   include User::VerificationHelper

--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -8,7 +8,8 @@ class User::ConfirmationsController < User::BaseController
       confirmation_token: params[:confirmation_token],
       creation_ip: remote_ip,
       site: current_site,
-      password_enabled: password_enabled
+      password_enabled: password_enabled,
+      read_only_user_attributes: read_only_user_attributes
     )
 
     @user_genders = get_user_genders
@@ -25,7 +26,8 @@ class User::ConfirmationsController < User::BaseController
         date_of_birth_day: user_confirmation_params["date_of_birth(3i)"],
         creation_ip: remote_ip,
         site: current_site,
-        password_enabled: password_enabled
+        password_enabled: password_enabled,
+        read_only_user_attributes: read_only_user_attributes
       )
     )
 
@@ -47,9 +49,10 @@ class User::ConfirmationsController < User::BaseController
   private
 
   def user_confirmation_params
-    permitted_params = [:confirmation_token, :name, :password, :password_confirmation, :date_of_birth, :gender, :document_number]
+    permitted_params = [:confirmation_token, :name, :password, :password_confirmation, :date_of_birth, :gender, :document_number] - read_only_user_attributes
     if params[:user_confirmation] && params[:user_confirmation][:custom_records]
-      permitted_params << {custom_records: Hash[params[:user_confirmation][:custom_records].keys.map{ |k| [k, [:custom_user_field_id, :value]] }]}
+      custom_keys = params[:user_confirmation][:custom_records].except(*read_only_user_attributes).keys
+      permitted_params << { custom_records: Hash[custom_keys.map { |k| [k, [:custom_user_field_id, :value]] }] } unless custom_keys.blank?
     end
 
     params.require(:user_confirmation).permit(permitted_params)

--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User::ConfirmationsController < User::BaseController
   before_action :require_no_authentication
 
@@ -20,7 +22,9 @@ class User::ConfirmationsController < User::BaseController
 
   def create
     @user_confirmation_form = User::ConfirmationForm.new(
-      user_confirmation_params.except(*ignored_user_confirmation_params).merge(
+      user_confirmation_params.except(
+        *ignored_user_confirmation_params
+      ).merge(
         date_of_birth_year: user_confirmation_params["date_of_birth(1i)"],
         date_of_birth_month: user_confirmation_params["date_of_birth(2i)"],
         date_of_birth_day: user_confirmation_params["date_of_birth(3i)"],
@@ -63,7 +67,7 @@ class User::ConfirmationsController < User::BaseController
   end
 
   def password_enabled
-    @password_enabled ||= !auth_modules_present? || current_site.configuration.auth_modules_data.any? { |auth_module| auth_module.password_enabled }
+    @password_enabled ||= !auth_modules_present? || current_site.configuration.auth_modules_data.any?(&:password_enabled)
   end
 
   def ignored_user_confirmation_params

--- a/app/controllers/user/settings_controller.rb
+++ b/app/controllers/user/settings_controller.rb
@@ -8,13 +8,14 @@ class User::SettingsController < User::BaseController
       date_of_birth_year: current_user.date_of_birth.year,
       date_of_birth_month: current_user.date_of_birth.month,
       date_of_birth_day: current_user.date_of_birth.day,
-      password_enabled: password_enabled
+      password_enabled: password_enabled,
+      read_only_user_attributes: read_only_user_attributes
     })
     @user_genders = get_user_genders
   end
 
   def update
-    @user_settings_form = User::SettingsForm.new(user_id: current_user.id, password_enabled: password_enabled)
+    @user_settings_form = User::SettingsForm.new(user_id: current_user.id, password_enabled: password_enabled, read_only_user_attributes: read_only_user_attributes)
     @user_settings_form.assign_attributes(user_settings_params.except(*ignored_user_settings_params).merge(
       date_of_birth_year: user_settings_params["date_of_birth(1i)"],
       date_of_birth_month: user_settings_params["date_of_birth(2i)"],
@@ -34,9 +35,10 @@ class User::SettingsController < User::BaseController
   private
 
   def user_settings_params
-    permitted_params = [:name, :password, :password_confirmation, :date_of_birth, :gender]
+    permitted_params = [:name, :password, :password_confirmation, :date_of_birth, :gender] - read_only_user_attributes
     if params[:user_settings] && params[:user_settings][:custom_records]
-      permitted_params << {custom_records: Hash[params[:user_settings][:custom_records].keys.map{ |k| [k, [:custom_user_field_id, :value]] }]}
+      custom_keys = params[:user_settings][:custom_records].except(*read_only_user_attributes).keys
+      permitted_params << { custom_records: Hash[custom_keys.map { |k| [k, [:custom_user_field_id, :value]] }] } unless custom_keys.blank?
     end
 
     params.require(:user_settings).permit(permitted_params)

--- a/app/controllers/user/settings_controller.rb
+++ b/app/controllers/user/settings_controller.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class User::SettingsController < User::BaseController
   before_action :authenticate_user!
 
   def show
-    @user_settings_form = User::SettingsForm.new({
+    @user_settings_form = User::SettingsForm.new(
       user_id: current_user.id, name: current_user.name,
       email: current_user.email, gender: current_user.gender,
       date_of_birth_year: current_user.date_of_birth.year,
@@ -10,17 +12,21 @@ class User::SettingsController < User::BaseController
       date_of_birth_day: current_user.date_of_birth.day,
       password_enabled: password_enabled,
       read_only_user_attributes: read_only_user_attributes
-    })
+    )
     @user_genders = get_user_genders
   end
 
   def update
     @user_settings_form = User::SettingsForm.new(user_id: current_user.id, password_enabled: password_enabled, read_only_user_attributes: read_only_user_attributes)
-    @user_settings_form.assign_attributes(user_settings_params.except(*ignored_user_settings_params).merge(
-      date_of_birth_year: user_settings_params["date_of_birth(1i)"],
-      date_of_birth_month: user_settings_params["date_of_birth(2i)"],
-      date_of_birth_day: user_settings_params["date_of_birth(3i)"],
-    ))
+    @user_settings_form.assign_attributes(
+      user_settings_params.except(
+        *ignored_user_settings_params
+      ).merge(
+        date_of_birth_year: user_settings_params["date_of_birth(1i)"],
+        date_of_birth_month: user_settings_params["date_of_birth(2i)"],
+        date_of_birth_day: user_settings_params["date_of_birth(3i)"]
+      )
+    )
 
     if @user_settings_form.save
       flash[:notice] = t(".success")
@@ -28,7 +34,7 @@ class User::SettingsController < User::BaseController
     else
       @user_genders = get_user_genders
       flash[:alert] = t(".error")
-      render 'show'
+      render "show"
     end
   end
 
@@ -49,7 +55,7 @@ class User::SettingsController < User::BaseController
   end
 
   def password_enabled
-    @password_enabled ||= !auth_modules_present? || current_site.configuration.auth_modules_data.any? { |auth_module| auth_module.password_enabled }
+    @password_enabled ||= !auth_modules_present? || current_site.configuration.auth_modules_data.any?(&:password_enabled)
   end
 
   def ignored_user_settings_params

--- a/app/forms/user/confirmation_form.rb
+++ b/app/forms/user/confirmation_form.rb
@@ -6,21 +6,23 @@ class User::ConfirmationForm < BaseForm
 
   attr_accessor(
     :confirmation_token,
-    :name,
-    :password_enabled,
     :password,
     :password_confirmation,
     :read_only_user_attributes,
-    :date_of_birth_year,
-    :date_of_birth_month,
-    :date_of_birth_day,
-    :date_of_birth,
-    :gender,
     :creation_ip,
     :site,
     :document_number
   )
-  attr_reader :user
+  attr_writer(
+    :user,
+    :password_enabled,
+    :name,
+    :gender,
+    :date_of_birth_year,
+    :date_of_birth_month,
+    :date_of_birth_day,
+    :date_of_birth
+  )
 
   validates :user, presence: true
   [:name, :date_of_birth, :gender].each do |attribute|
@@ -81,12 +83,12 @@ class User::ConfirmationForm < BaseForm
 
   def date_of_birth
     @date_of_birth ||= if date_of_birth_year && date_of_birth_month && date_of_birth_day
-      Date.new(
-        date_of_birth_year.to_i,
-        date_of_birth_month.to_i,
-        date_of_birth_day.to_i
-      )
-    end
+                         Date.new(
+                           date_of_birth_year.to_i,
+                           date_of_birth_month.to_i,
+                           date_of_birth_day.to_i
+                         )
+                       end
   rescue ArgumentError
     nil
   end
@@ -110,7 +112,7 @@ class User::ConfirmationForm < BaseForm
       user_attributes.custom_records = custom_records
     end
 
-    if !@user.valid?
+    unless @user.valid?
       promote_errors(@user.errors)
       return false
     end
@@ -118,13 +120,13 @@ class User::ConfirmationForm < BaseForm
     if require_user_verification?
       @census_verification = build_census_verification
 
-      if !@census_verification.valid?
+      unless @census_verification.valid?
         promote_errors(@census_verification.errors)
         return false
       end
 
-      if !@census_verification.will_verify?
-        errors[:base] << "#{I18n.t('activemodel.models.user/census_verification_form')} #{I18n.t('errors.messages.invalid')}"
+      unless @census_verification.will_verify?
+        errors[:base] << "#{I18n.t("activemodel.models.user/census_verification_form")} #{I18n.t("errors.messages.invalid")}"
         return false
       end
 
@@ -133,12 +135,11 @@ class User::ConfirmationForm < BaseForm
         @census_verification.save
         @census_verification.verify!
       end
-
-      return @user
     else
       @user.save
-      return @user
     end
+
+    @user
   end
 
   def confirm_user
@@ -149,7 +150,7 @@ class User::ConfirmationForm < BaseForm
 
   def user_verification
     if require_user_verification? && document_number.blank?
-      errors.add(:document_number, I18n.t('errors.messages.blank'))
+      errors.add(:document_number, I18n.t("errors.messages.blank"))
     end
   end
 

--- a/app/forms/user/confirmation_form.rb
+++ b/app/forms/user/confirmation_form.rb
@@ -8,7 +8,6 @@ class User::ConfirmationForm < BaseForm
     :confirmation_token,
     :password,
     :password_confirmation,
-    :read_only_user_attributes,
     :creation_ip,
     :site,
     :document_number
@@ -16,6 +15,7 @@ class User::ConfirmationForm < BaseForm
   attr_writer(
     :user,
     :password_enabled,
+    :read_only_user_attributes,
     :name,
     :gender,
     :date_of_birth_year,
@@ -99,6 +99,10 @@ class User::ConfirmationForm < BaseForm
 
   def disabled_user_attribute?(attribute)
     read_only_user_attributes.include? attribute.to_s
+  end
+
+  def read_only_user_attributes
+    @read_only_user_attributes ||= []
   end
 
   private

--- a/app/forms/user/settings_form.rb
+++ b/app/forms/user/settings_form.rb
@@ -8,7 +8,6 @@ class User::SettingsForm < BaseForm
     :user_id,
     :name,
     :password,
-    :read_only_user_attributes,
     :password_confirmation,
     :date_of_birth_year,
     :date_of_birth_month,
@@ -18,7 +17,8 @@ class User::SettingsForm < BaseForm
   )
   attr_writer(
     :user,
-    :password_enabled
+    :password_enabled,
+    :read_only_user_attributes
   )
 
   validates :user, presence: true
@@ -54,6 +54,10 @@ class User::SettingsForm < BaseForm
 
   def disabled_user_attribute?(attribute)
     read_only_user_attributes.include? attribute.to_s
+  end
+
+  def read_only_user_attributes
+    @read_only_user_attributes ||= []
   end
 
   private

--- a/app/forms/user/settings_form.rb
+++ b/app/forms/user/settings_form.rb
@@ -7,7 +7,6 @@ class User::SettingsForm < BaseForm
   attr_accessor(
     :user_id,
     :name,
-    :password_enabled,
     :password,
     :read_only_user_attributes,
     :password_confirmation,
@@ -17,8 +16,10 @@ class User::SettingsForm < BaseForm
     :gender,
     :email
   )
-
-  attr_reader :user
+  attr_writer(
+    :user,
+    :password_enabled
+  )
 
   validates :user, presence: true
   [:name, :date_of_birth, :gender].each do |attribute|
@@ -45,8 +46,8 @@ class User::SettingsForm < BaseForm
 
   def date_of_birth
     @date_of_birth ||= if date_of_birth_year && date_of_birth_month && date_of_birth_day
-      Date.new(date_of_birth_year.to_i, date_of_birth_month.to_i, date_of_birth_day.to_i)
-    end
+                         Date.new(date_of_birth_year.to_i, date_of_birth_month.to_i, date_of_birth_day.to_i)
+                       end
   rescue ArgumentError
     nil
   end

--- a/app/views/user/confirmations/_form.html.erb
+++ b/app/views/user/confirmations/_form.html.erb
@@ -16,7 +16,7 @@
     <%= label_tag "user_confirmation[name]" do %>
       <%= t("activemodel.attributes.gobierto_admin/confirmation_form.name") %>
       <% if @user_confirmation_form.disabled_user_attribute?(:name) %>
-        <i class="fas fa-lock tipsit"></i>
+        <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>
       <% end %>
     <% end %>
     <%= f.text_field :name, disabled: @user_confirmation_form.disabled_user_attribute?(:name) %>
@@ -45,7 +45,7 @@
     <%= label_tag "user_confirmation[date_of_birth]" do %>
       <%= t("activemodel.attributes.user/confirmation_form.date_of_birth") %>
       <% if @user_confirmation_form.disabled_user_attribute?(:date_of_birth) %>
-        <i class="fas fa-lock tipsit"></i>
+        <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>
       <% end %>
     <% end %>
     <i class="fas fa-question-circle tipsit" title="<%= t(".hints.date_of_birth") %>"></i>
@@ -62,7 +62,7 @@
       <%= label_tag "user_confirmation[gender]" do %>
         <%= t(".your_gender_is") %>
         <% if @user_confirmation_form.disabled_user_attribute?(:gender) %>
-          <i class="fas fa-lock tipsit"></i>
+          <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>
         <% end %>
       <% end %>
       <i class="fas fa-question-circle tipsit" title="<%= t(".hints.gender") %>"></i>

--- a/app/views/user/confirmations/_form.html.erb
+++ b/app/views/user/confirmations/_form.html.erb
@@ -13,8 +13,13 @@
   </div>
 
   <div class="form_item input_text">
-    <%= f.label :name %>
-    <%= f.text_field :name %>
+    <%= label_tag "user_confirmation[name]" do %>
+      <%= t("activemodel.attributes.gobierto_admin/confirmation_form.name") %>
+      <% if @user_confirmation_form.disabled_user_attribute?(:name) %>
+        <i class="fas fa-lock tipsit"></i>
+      <% end %>
+    <% end %>
+    <%= f.text_field :name, disabled: @user_confirmation_form.disabled_user_attribute?(:name) %>
   </div>
 
   <% if @user_confirmation_form.password_enabled %>
@@ -37,22 +42,33 @@
   <% end %>
 
   <div class="form_item select_control selects_inline">
-    <%= f.label :date_of_birth %>
+    <%= label_tag "user_confirmation[date_of_birth]" do %>
+      <%= t("activemodel.attributes.user/confirmation_form.date_of_birth") %>
+      <% if @user_confirmation_form.disabled_user_attribute?(:date_of_birth) %>
+        <i class="fas fa-lock tipsit"></i>
+      <% end %>
+    <% end %>
     <i class="fas fa-question-circle tipsit" title="<%= t(".hints.date_of_birth") %>"></i>
     <%= f.date_select(
       :date_of_birth,
       prompt: true,
       end_year: 100.years.ago.year,
-      start_year: Date.current.year) %>
+      start_year: Date.current.year,
+      disabled: @user_confirmation_form.disabled_user_attribute?(:date_of_birth)) %>
   </div>
 
   <div class="form_item">
     <div class="options options_cont">
-      <%= f.label :gender, t(".your_gender_is") %>
+      <%= label_tag "user_confirmation[gender]" do %>
+        <%= t(".your_gender_is") %>
+        <% if @user_confirmation_form.disabled_user_attribute?(:gender) %>
+          <i class="fas fa-lock tipsit"></i>
+        <% end %>
+      <% end %>
       <i class="fas fa-question-circle tipsit" title="<%= t(".hints.gender") %>"></i>
 
       <div class="pure-g">
-        <%= f.collection_radio_buttons(:gender, @user_genders, :first, :first) do |b| %>
+        <%= f.collection_radio_buttons(:gender, @user_genders, :first, :first, {}, {disabled: @user_confirmation_form.disabled_user_attribute?(:gender)}) do |b| %>
           <div class="pure-u-1-2">
             <div class="option ">
               <%= b.radio_button %>
@@ -67,7 +83,7 @@
     </div>
   </div>
 
-  <%= render partial: 'user/shared/custom_fields', locals: {custom_records: f.object.custom_records, form_name: "user_confirmation"} %>
+  <%= render partial: 'user/shared/custom_fields', locals: {custom_records: f.object.custom_records, disabled_attributes: @user_confirmation_form.read_only_user_attributes, form_name: "user_confirmation"} %>
 
   <%= f.submit t(".submit"), class: "button" %>
 

--- a/app/views/user/confirmations/_form.html.erb
+++ b/app/views/user/confirmations/_form.html.erb
@@ -42,7 +42,7 @@
   <% end %>
 
   <div class="form_item select_control selects_inline">
-    <%= label_tag "user_confirmation[date_of_birth]" do %>
+    <%= label_tag "user_confirmation[date_of_birth]", class: "pointer-events-none" do %>
       <%= t("activemodel.attributes.user/confirmation_form.date_of_birth") %>
       <% if @user_confirmation_form.disabled_user_attribute?(:date_of_birth) %>
         <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>

--- a/app/views/user/settings/_form.html.erb
+++ b/app/views/user/settings/_form.html.erb
@@ -14,7 +14,7 @@
     <%= label_tag "user_settings[name]" do %>
       <%= t("activemodel.attributes.gobierto_admin/admin_form.name") %>
       <% if @user_settings_form.disabled_user_attribute?(:name) %>
-        <i class="fas fa-lock tipsit"></i>
+        <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>
       <% end %>
       <%= attribute_indication_tag required: true %>
     <% end %>
@@ -37,7 +37,7 @@
     <%= label_tag "user_settings[date_of_birth]" do %>
       <%= t("activemodel.attributes.user/settings_form.date_of_birth") %>
       <% if @user_settings_form.disabled_user_attribute?(:date_of_birth) %>
-        <i class="fas fa-lock tipsit"></i>
+        <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>
       <% end %>
     <% end %>
     <i class="fas fa-question-circle tipsit" title="<%= t(".hints.date_of_birth") %>"></i>
@@ -55,7 +55,7 @@
       <%= label_tag "user_settings[gender]" do %>
         <%= t(".your_gender_is") %>
         <% if @user_settings_form.disabled_user_attribute?(:gender) %>
-          <i class="fas fa-lock tipsit"></i>
+          <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>
         <% end %>
       <% end %>
       <i class="fas fa-question-circle tipsit" title="<%= t(".hints.gender") %>"></i>

--- a/app/views/user/settings/_form.html.erb
+++ b/app/views/user/settings/_form.html.erb
@@ -13,9 +13,12 @@
   <div class="form_item input_text">
     <%= label_tag "user_settings[name]" do %>
       <%= t("activemodel.attributes.gobierto_admin/admin_form.name") %>
+      <% if @user_settings_form.disabled_user_attribute?(:name) %>
+        <i class="fas fa-lock tipsit"></i>
+      <% end %>
       <%= attribute_indication_tag required: true %>
     <% end %>
-    <%= f.text_field :name %>
+    <%= f.text_field :name, disabled: @user_settings_form.disabled_user_attribute?(:name) %>
   </div>
 
   <% if @user_settings_form.password_enabled %>
@@ -31,24 +34,34 @@
   <% end %>
 
   <div class="form_item select_control selects_inline">
-    <%= f.label :date_of_birth %>
+    <%= label_tag "user_settings[date_of_birth]" do %>
+      <%= t("activemodel.attributes.user/settings_form.date_of_birth") %>
+      <% if @user_settings_form.disabled_user_attribute?(:date_of_birth) %>
+        <i class="fas fa-lock tipsit"></i>
+      <% end %>
+    <% end %>
     <i class="fas fa-question-circle tipsit" title="<%= t(".hints.date_of_birth") %>"></i>
     <%= f.date_select(
       :date_of_birth,
       prompt: true,
       end_year: 100.years.ago.year,
-      start_year: Date.current.year) %>
+      start_year: Date.current.year,
+      disabled: @user_settings_form.disabled_user_attribute?(:date_of_birth)) %>
   </div>
 
   <div class="form_item">
 
     <div class="options options_cont">
-
-      <%= f.label :gender, t(".your_gender_is") %>
+      <%= label_tag "user_settings[gender]" do %>
+        <%= t(".your_gender_is") %>
+        <% if @user_settings_form.disabled_user_attribute?(:gender) %>
+          <i class="fas fa-lock tipsit"></i>
+        <% end %>
+      <% end %>
       <i class="fas fa-question-circle tipsit" title="<%= t(".hints.gender") %>"></i>
 
       <div class="pure-g">
-        <%= f.collection_radio_buttons(:gender, @user_genders, :first, :first) do |b| %>
+        <%= f.collection_radio_buttons(:gender, @user_genders, :first, :first, {}, {disabled: @user_settings_form.disabled_user_attribute?(:gender)}) do |b| %>
           <div class="pure-u-1-2">
             <div class="option ">
               <%= b.radio_button %>
@@ -65,7 +78,7 @@
 
   </div>
 
-  <%= render partial: 'user/shared/custom_fields', locals: {custom_records: f.object.custom_records, form_name: "user_settings"} %>
+  <%= render partial: 'user/shared/custom_fields', locals: {custom_records: f.object.custom_records, disabled_attributes: @user_settings_form.read_only_user_attributes, form_name: "user_settings"} %>
 
   <%= f.submit t(".submit"), class: "button" %>
 

--- a/app/views/user/settings/_form.html.erb
+++ b/app/views/user/settings/_form.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 
   <div class="form_item select_control selects_inline">
-    <%= label_tag "user_settings[date_of_birth]" do %>
+    <%= label_tag "user_settings[date_of_birth]", class: "pointer-events-none" do %>
       <%= t("activemodel.attributes.user/settings_form.date_of_birth") %>
       <% if @user_settings_form.disabled_user_attribute?(:date_of_birth) %>
         <i class="fas fa-lock tipsit" title="<%= t(".hints.census_locked") %>"></i>

--- a/app/views/user/shared/_custom_fields.html.erb
+++ b/app/views/user/shared/_custom_fields.html.erb
@@ -4,7 +4,7 @@
     <%= label_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]" do %>
       <%= custom_record.custom_user_field.localized_title %>
       <% if disabled %>
-        <i class="fas fa-lock tipsit"></i>
+        <i class="fas fa-lock tipsit" title="<%= t("user.settings.form.hints.census_locked") %>"></i>
       <% end %>
     <% end %>
     <%= hidden_field_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][custom_user_field_id]", custom_record.custom_user_field_id %>

--- a/app/views/user/shared/_custom_fields.html.erb
+++ b/app/views/user/shared/_custom_fields.html.erb
@@ -1,16 +1,22 @@
 <% custom_records.each do |custom_record| %>
+  <% disabled = local_assigns[:disabled_attributes]&.include?(custom_record.custom_user_field.name) %>
   <div class="form_item input_text">
-    <%= label_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", custom_record.custom_user_field.localized_title %>
+    <%= label_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]" do %>
+      <%= custom_record.custom_user_field.localized_title %>
+      <% if disabled %>
+        <i class="fas fa-lock tipsit"></i>
+      <% end %>
+    <% end %>
     <%= hidden_field_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][custom_user_field_id]", custom_record.custom_user_field_id %>
 
     <% if custom_record.custom_user_field.string? %>
-      <%= text_field_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", custom_record.value %>
+      <%= text_field_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", custom_record.value, disabled: disabled %>
     <% elsif custom_record.custom_user_field.paragraph? %>
-      <%= text_area_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", custom_record.value %>
+      <%= text_area_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", custom_record.value, disabled: disabled %>
     <% elsif custom_record.custom_user_field.single_option? %>
-      <%= select_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", options_for_custom_user_record(custom_record), include_blank: !custom_record.custom_user_field.mandatory? %>
+      <%= select_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", options_for_custom_user_record(custom_record), include_blank: !custom_record.custom_user_field.mandatory?, disabled: disabled %>
     <% elsif custom_record.custom_user_field.multiple_options? %>
-      <%= select_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", options_for_custom_user_record(custom_record), include_blank: !custom_record.custom_user_field.mandatory?, multiple: true %>
+      <%= select_tag "#{form_name}[custom_records][#{custom_record.custom_user_field.name}][value]", options_for_custom_user_record(custom_record), include_blank: !custom_record.custom_user_field.mandatory?, multiple: true, disabled: disabled %>
     <% end %>
   </div>
 <% end %>

--- a/config/locales/user/views/confirmations/ca.yml
+++ b/config/locales/user/views/confirmations/ca.yml
@@ -8,6 +8,7 @@ ca:
           female: Dona
           male: Home
         hints:
+          census_locked: Aquesta informació prové del cens, de manera que no és editable.
           date_of_birth: Aquesta informació serà privada, i mai se t'identificarà
             amb el teu perfil. La dada serà anonimitzada, i te la demanem només per
             poder obtindre informació segmentada i entendre millor les opinions i

--- a/config/locales/user/views/confirmations/en.yml
+++ b/config/locales/user/views/confirmations/en.yml
@@ -8,6 +8,8 @@ en:
           female: Female
           male: Male
         hints:
+          census_locked: This information has been provided by the census, so it is
+            not editable.
           date_of_birth: This information will be considered private at all times.
           email: Your email address will be considered private at all times.
           gender: This information will be considered private at all times.

--- a/config/locales/user/views/confirmations/es.yml
+++ b/config/locales/user/views/confirmations/es.yml
@@ -8,6 +8,7 @@ es:
           female: Mujer
           male: Hombre
         hints:
+          census_locked: Esta información proviene del censo, por lo que no es editable.
           date_of_birth: Esta información será privada, y nunca se identificará con
             tu perfil. El dato será anonimizado, y te lo pedimos para poder obtener
             información segmentada para entender mejor las opiniones y preferencias

--- a/config/locales/user/views/settings/ca.yml
+++ b/config/locales/user/views/settings/ca.yml
@@ -7,6 +7,7 @@ ca:
           female: Dona
           male: Home
         hints:
+          census_locked: Aquesta informació prové del cens, de manera que no és editable.
           date_of_birth: Aquesta informació serà privada, i nunca s'identificarà amb
             el teu perfil. La dada serà anonimitzada, i te la demanem només per a
             poder obtindre informació segmentada i entendre millor les opinions i

--- a/config/locales/user/views/settings/en.yml
+++ b/config/locales/user/views/settings/en.yml
@@ -7,6 +7,8 @@ en:
           female: Female
           male: Male
         hints:
+          census_locked: This information has been provided by the census, so it is
+            not editable.
           date_of_birth: This information will be considered private at all times.
           email: Your email address will be considered private at all times.
           gender: This information will be considered private at all times.

--- a/config/locales/user/views/settings/es.yml
+++ b/config/locales/user/views/settings/es.yml
@@ -7,6 +7,7 @@ es:
           female: Mujer
           male: Hombre
         hints:
+          census_locked: Esta información proviene del censo, por lo que no es editable.
           date_of_birth: Esta información será privada, y nunca se identificará con
             tu perfil. El dato será anonimizado, y te lo pedimos para poder obtener
             información segmentada para entender mejor las opiniones y preferencias

--- a/test/integration/user/settings_test.rb
+++ b/test/integration/user/settings_test.rb
@@ -62,6 +62,32 @@ class User::SettingsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_settings_page_with_read_only_attributes
+    auth_strategy_site.configuration.stubs(:auth_modules_data).returns(
+      [OpenStruct.new(
+        name: "null_strategy",
+        read_only_user_attributes: %w(name gender date_of_birth)
+      )]
+    )
+
+    with(site: auth_strategy_site) do
+      with_current_user(auth_strategy_site_user) do
+        visit @path
+
+        assert has_field?("user_settings_name", disabled: true)
+        assert has_field?("user_settings_date_of_birth_1i", disabled: true)
+        assert has_field?("user_settings_date_of_birth_2i", disabled: true)
+        assert has_field?("user_settings_date_of_birth_3i", disabled: true)
+        assert has_field?("user_settings_gender_male", disabled: true)
+        assert has_field?("user_settings_gender_female", disabled: true)
+
+        click_on "Save"
+        assert has_message?("Settings saved successfully")
+        assert has_field?("user_settings_name", disabled: true, with: auth_strategy_site_user.name)
+      end
+    end
+  end
+
   def test_settings_page_update_custom_fields
     with_signed_in_user(user) do
       visit @path


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/685


## :v: What does this PR do?

* Allows to define from an auth provider which attributes (including custom user fields) a user won't have permissions to edit. These attributes are expected to be assigned with the auth provider mechanism.
* If more than one auth provider defines read only attributes, the locked attributes will be the union of all sets
* To define a list of attributes edit `config/application.yml` and add, for example:

```yaml
  auth_modules:
    -
      name: null_strategy
      description: Null Strategy
      session_form: NullStrategySessionForm
      default: false
      read_only_user_attributes:
        - name
        - gender
        - date_of_birth
        - custom_user_field_name
```

## :mag: How should this be manually tested?

Update application.yml and add to the auth strategy in use a list of `read_only_user_attributes`. Sign in and go to the settings form. The read only attributtes should be disabled with a lock icon

## :eyes: Screenshots

### Before this PR

![685-before](https://user-images.githubusercontent.com/446459/65969046-6b536200-e464-11e9-9f4b-30934f91fbdc.gif)

### After this PR

![685-after](https://user-images.githubusercontent.com/446459/65971644-c6875380-e468-11e9-876d-c564fc28e581.gif)


## :shipit: Does this PR changes any configuration file?

- [x] new entry in `config/application.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new module/submodule settings?
