### PR TITLE
766 blank localized custom fields

### DIFF
--- a/app/models/gobierto_common/custom_field_value/localized_markdown_text.rb
+++ b/app/models/gobierto_common/custom_field_value/localized_markdown_text.rb
@@ -15,6 +15,7 @@ module GobiertoCommon::CustomFieldValue
 
         return markdown(value) if value.present?
       end
+      ""
     end
 
   end

--- a/app/models/gobierto_common/custom_field_value/localized_text.rb
+++ b/app/models/gobierto_common/custom_field_value/localized_text.rb
@@ -5,10 +5,13 @@ module GobiertoCommon::CustomFieldValue
     def value
       value = raw_value[I18n.locale.to_s] || raw_value[I18n.default_locale.to_s]
       return value if value.present?
+
       I18n.available_locales.each do |locale|
         value = raw_value[locale.to_s]
+
         return value if value.present?
       end
+      ""
     end
 
     def searchable_value

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -38,6 +38,15 @@ neil_custom_field_record_weight:
   custom_field: madrid_custom_field_weight
   payload: <%= { "weight" => 72.3 }.to_json %>
 
+juana_custom_field_record_blank_localized_bio:
+  item: juana (GobiertoPeople::Person)
+  custom_field: madrid_custom_field_localized_bio
+  payload: <%= {
+    "localized-bio" => {
+      "es" => ""
+    }
+  }.to_json %>
+
 madrid_custom_field_record_population:
   item: madrid (Site)
   custom_field: madrid_site_custom_field

--- a/test/models/gobierto_common/custom_field_value/localized_markdown_text_test.rb
+++ b/test/models/gobierto_common/custom_field_value/localized_markdown_text_test.rb
@@ -9,8 +9,19 @@ module GobiertoCommon::CustomFieldValue
       gobierto_common_custom_field_records(:neil_custom_field_record_localized_bio)
     end
 
+    def blank_record
+      gobierto_common_custom_field_records(:juana_custom_field_record_blank_localized_bio)
+    end
+
     def test_value
       assert_equal "<p><strong>Neil</strong> has a long bio</p>\n", record.value
+    end
+
+    def test_value_with_blank_payload
+      assert_equal "", blank_record.value
+
+      blank_record.update_attribute(:payload, nil)
+      assert_equal "", blank_record.value
     end
 
   end


### PR DESCRIPTION
Closes PopulateTools/issues#766


## :v: What does this PR do?

* Fixes the value returned on localized custom fields (`localized_string` and `localized_paragraph`) when the payload is blank to return an empty string. This fix changes also the response provided by API for these type of fields.

## :mag: How should this be manually tested?

Visit plans projects or investments projects with empty localized fields. The values shown in front should be blank instead of an array of locale keys. 

## :eyes: Screenshots

### Before this PR

<img width="704" alt="Screen Shot 2019-10-07 at 15 26 01" src="https://user-images.githubusercontent.com/446459/66316437-f676a100-e917-11e9-9d13-0bb6697a2780.png">
<img width="179" alt="Screen Shot 2019-10-07 at 15 28 06" src="https://user-images.githubusercontent.com/446459/66316438-f70f3780-e917-11e9-9316-e56fe0657ac2.png">


### After this PR

<img width="742" alt="Screen Shot 2019-10-07 at 15 47 16" src="https://user-images.githubusercontent.com/446459/66317467-db0c9580-e919-11e9-9c5b-84645ec60ab7.png">
<img width="259" alt="Screen Shot 2019-10-07 at 15 47 22" src="https://user-images.githubusercontent.com/446459/66317468-db0c9580-e919-11e9-8866-72af9a231453.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
