### PR TITLE
752 categories custom names

### DIFF
--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -36,7 +36,7 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
   def treemap
     respond_to do |format|
       format.json do
-        data_line = GobiertoBudgets::Data::Treemap.new organization_id: current_site.organization_id, year: @year, kind: @kind, type: @area_name, parent_code: params[:parent_code], level: params[:level]
+        data_line = GobiertoBudgets::Data::Treemap.new site: current_site, organization_id: current_site.organization_id, year: @year, kind: @kind, type: @area_name, parent_code: params[:parent_code], level: params[:level]
         render json: data_line.generate_json
       end
       format.js

--- a/app/models/gobierto_budgets/data/treemap.rb
+++ b/app/models/gobierto_budgets/data/treemap.rb
@@ -5,6 +5,7 @@ module GobiertoBudgets
     class Treemap
       def initialize(options)
         @organization_id = options[:organization_id]
+        @site = options[:site] || Site.find_by(organization_id: @organization_id)
         @kind = options[:kind]
         @type = options[:type]
         @year = options[:year]

--- a/app/models/gobierto_budgets/data/treemap.rb
+++ b/app/models/gobierto_budgets/data/treemap.rb
@@ -18,7 +18,7 @@ module GobiertoBudgets
 
         children_json = budget_lines_hits.map do |h|
           {
-            name: areas.all_items[@kind][h["_source"]["code"]],
+            name: BudgetLinePresenter.load("#{h["_id"]}/#{h["_type"]}", @site).name,
             code: h["_source"]["code"],
             budget: h["_source"]["amount"],
             budget_per_inhabitant: h["_source"]["amount_per_inhabitant"]


### PR DESCRIPTION
Closes #752


## :v: What does this PR do?

* Fixes the treemap in gobierto budgets main page to use custom category names if present.

## :mag: How should this be manually tested?

Visit a site with custom budget lines categories defined. The budget lines names should be the custom names.

## :eyes: Screenshots

### Before this PR

<img width="629" alt="Screen Shot 2019-10-09 at 16 00 34" src="https://user-images.githubusercontent.com/446459/66492590-f52eab00-eab4-11e9-825d-c83be8dfca31.png">


### After this PR

<img width="652" alt="Screen Shot 2019-10-09 at 16 40 39" src="https://user-images.githubusercontent.com/446459/66492601-fa8bf580-eab4-11e9-9e91-3c0d72892f69.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
