### PR TITLE
Fix two rollbars

### DIFF
--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -60,7 +60,7 @@
 
               <div class="explanation explanation_bar">
                 <% percentage = @budgets_execution_summary.expenses_execution_percentage %>
-                <% percentage_bar_width = percentage > 100 ? 100 : percentage %>
+                <% percentage_bar_width = (percentage.nil? || percentage > 100) ? 100 : percentage %>
                 <div class="bar"><div class="line" style="width: <%= percentage_bar_width %>%"></div></div>
                 <span><%= t('.executed_percent', percentage: percentage) %></span>
               </div>

--- a/lib/middlewares/override_welcome_action.rb
+++ b/lib/middlewares/override_welcome_action.rb
@@ -18,7 +18,7 @@ class OverrideWelcomeAction
     end
 
     # If the path is the homepage, the route should be the site root path
-    if env["PATH_INFO"] == "/"
+    if env["PATH_INFO"] == "/" && env["gobierto_site"].present?
       # A CMS page is handled by meta welcome controller
       if env["gobierto_site"].configuration.home_page != "GobiertoCms"
         env["PATH_INFO"] = env["gobierto_site"].root_path


### PR DESCRIPTION
Fixes two Rollbars:

- https://rollbar.com/Populate/gobierto/items/2507/?item_page=0&item_count=100&#traceback
- https://rollbar.com/Populate/gobierto/items/2450/

## :v: What does this PR do?

1. When the main host was loaded (i.e gobify.net) the middleware that redirected to the main module was raising an error

2. When there's no execution data the width of a box was returning an error.
