### PR TITLE
Allow definition of session_store key using an environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ SECRET_KEY_BASE=
 RACK_ENV=development
 RAILS_ENV=development
 TLD_LENGTH=2
+GOBIERTO_SESSION_KEY=_gobierto_session
 HOST=gobierto.test
 BASE_HOST=gobierto.test
 PORT=3000

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,6 +3,6 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store,
-                                       key: "_gobierto_session",
+                                       key: ENV.fetch("GOBIERTO_SESSION_KEY") { "_gobierto_session" },
                                        domain: :all,
                                        tld_length: ENV.fetch("TLD_LENGTH") { "2" }.to_i


### PR DESCRIPTION
## :v: What does this PR do?

Allows configure a key for session_store configuration using an environment variable.

Define an environment variable `GOBIERTO_SESSION_KEY` to override the default `_gobierto_session` value for session store key.

This is useful when staging and production environments share the same domain but use different machines and databases. For example, if we have `production.gobierto.test` and `staging.gobierto.test` the `tld_length` argument can't be used because a `tld_length` of value 3 would generate errors since the expected domain names should have the form: `something.production.gobierto.test`


## :mag: How should this be manually tested?

Visit staging and production environments deployed with this domain name problem and log in as admin in both environments. The session in one application shouldn't affect the other one.


## :shipit: Does this PR changes any configuration file?

- [x] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`? NO
- [ ] new entry in `config/secrets.yml`? NO

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No