### PR TITLE
Fix integration tests with signed in users

### DIFF
--- a/test/integration/gobierto_admin/session_test.rb
+++ b/test/integration/gobierto_admin/session_test.rb
@@ -73,12 +73,12 @@ module GobiertoAdmin
     end
 
     def test_sign_in_mantains_session_across_sites
-      with_current_site_with_host(site) do
+      with_current_site(site, include_host: true) do
         sign_in_admin(admin)
         assert_equal site.name, find('div#current-site-name').text
       end
 
-      with_current_site_with_host(other_site) do
+      with_current_site(other_site, include_host: true) do
         visit @sign_in_path
 
         assert has_message?("You are already signed in")
@@ -112,11 +112,11 @@ module GobiertoAdmin
     end
 
     def test_sign_out
-      with_current_site_with_host(site) do
+      with_current_site(site, include_host: true) do
         sign_in_admin(admin)
       end
 
-      with_current_site_with_host(site) do
+      with_current_site(site, include_host: true) do
         visit admin_root_path
         click_link "admin-sign-out"
         visit @sign_in_path
@@ -124,7 +124,7 @@ module GobiertoAdmin
         assert has_content?("Log in")
       end
 
-      with_current_site_with_host(other_site) do
+      with_current_site(other_site, include_host: true) do
         visit @sign_in_path
 
         assert has_content?("Log in")

--- a/test/integration/gobierto_participation/processes/process_contribution_create_test.rb
+++ b/test/integration/gobierto_participation/processes/process_contribution_create_test.rb
@@ -43,7 +43,7 @@ module GobiertoParticipation
 
     def test_contribution_create
       with_javascript do
-        with_signed_in_user(user, logout=false) do
+        with_signed_in_user(user, logout: false) do
           visit container_path
 
           assert_equal 4, contributions.size
@@ -70,7 +70,7 @@ module GobiertoParticipation
 
     def test_contribution_errors
       with_javascript do
-        with_signed_in_user(user, logout=false) do
+        with_signed_in_user(user, logout: false) do
           visit container_path
 
           assert_equal contributions.size, 4

--- a/test/integration/gobierto_participation/welcome/welcome_index_test.rb
+++ b/test/integration/gobierto_participation/welcome/welcome_index_test.rb
@@ -135,7 +135,7 @@ module GobiertoParticipation
 
     def test_show_poll
       with_javascript do
-        with_signed_in_user(user) do
+        with_signed_in_user(user, include_host: true) do
           visit @path
 
           assert has_link? poll.title

--- a/test/integration/gobierto_participation/welcome/welcome_index_test.rb
+++ b/test/integration/gobierto_participation/welcome/welcome_index_test.rb
@@ -134,13 +134,11 @@ module GobiertoParticipation
     end
 
     def test_show_poll
-      with_javascript do
-        with_signed_in_user(user, include_host: true) do
-          visit @path
+      with_signed_in_user(user) do
+        visit @path
 
-          assert has_link? poll.title
-          assert has_content? poll.questions.first.title
-        end
+        assert has_link? poll.title
+        assert has_content? poll.questions.first.title
       end
     end
 

--- a/test/integration/user/session_test.rb
+++ b/test/integration/user/session_test.rb
@@ -105,7 +105,7 @@ class User::SessionTest < ActionDispatch::IntegrationTest
   end
 
   def test_session_is_shared_between_hosts
-    with_current_site_with_host(site) do
+    with_current_site(site, include_host: true) do
       visit @sign_in_path
 
       fill_in :user_session_email, with: user.email
@@ -114,7 +114,7 @@ class User::SessionTest < ActionDispatch::IntegrationTest
     end
 
     # The session is replaced with the new one
-    with_current_site_with_host(other_site) do
+    with_current_site(other_site, include_host: true) do
       visit @sign_in_path
 
       fill_in :user_session_email, with: other_site_user.email
@@ -122,13 +122,13 @@ class User::SessionTest < ActionDispatch::IntegrationTest
       click_on "Log in"
     end
 
-    with_current_site_with_host(site) do
+    with_current_site(site, include_host: true) do
       visit @sign_in_path
 
       assert has_content?("Log in")
     end
 
-    with_current_site_with_host(other_site) do
+    with_current_site(other_site, include_host: true) do
       visit @sign_in_path
 
       assert has_message?("You are already signed in.")

--- a/test/support/app_host_helpers.rb
+++ b/test/support/app_host_helpers.rb
@@ -2,6 +2,16 @@
 
 module AppHostHelpers
   def with_site_host(site)
+    if javascript_driver?
+      message = <<-MESSAGE
+ Capybara current driver is javascript_driver. This would make the browser to send a
+            request to a remote application with host #{site.domain} instead of the Capybara's
+            rack server. Avoid the use of with_site_host or include_host: true option combined
+            with javascript driver.
+      MESSAGE
+      raise(Exception, message)
+    end
+
     original_host = Capybara.app_host
     Capybara.app_host = root_url(host: site.domain).gsub(/\/$/, '')
     yield

--- a/test/support/contexts.rb
+++ b/test/support/contexts.rb
@@ -3,6 +3,8 @@
 require "support/site_session_helpers"
 
 def with_javascript
+  ensure_app_host_blank
+
   Capybara.current_driver = Capybara.javascript_driver
   yield
   Capybara.reset_session!
@@ -23,6 +25,8 @@ def with(params = {})
   admin = params[:admin]
 
   if params[:js]
+    ensure_app_host_blank
+
     Capybara.current_driver = Capybara.javascript_driver
 
     if params[:window_size] == :xl
@@ -50,4 +54,16 @@ ensure
     page.driver.resize_window_to(window_handle, *default_size) if params[:window_size]
     Capybara.current_driver = Capybara.default_driver
   end
+end
+
+def ensure_app_host_blank
+  return if Capybara.app_host.blank?
+
+  message = <<-MESSAGE
+ Capybara current driver is javascript_driver. This would make the browser to send a
+            request to a remote application with host #{site.domain} instead of the Capybara's
+            rack server. Avoid the use of with_site_host or include_host: true option combined
+            with javascript driver.
+  MESSAGE
+  raise(Exception, message)
 end

--- a/test/support/integration/authentication_helpers.rb
+++ b/test/support/integration/authentication_helpers.rb
@@ -8,8 +8,10 @@ module Integration
       sign_out_admin
     end
 
-    def with_signed_in_user(user, logout=true)
-      with_current_site(user.site) do
+    def with_signed_in_user(user, opts = {})
+      logout = opts.has_key?(:logout) ? opts[:logout] : true
+
+      with_current_site(user.site, opts.slice(:include_host)) do
         sign_in_user(user)
         yield
         # permits skipping logout on some pages that don't have layout, thus no logout link

--- a/test/support/site_session_helpers.rb
+++ b/test/support/site_session_helpers.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
 module SiteSessionHelpers
-  def with_current_site(site)
-    stub_current_site(site) { yield }
+  def with_current_site(site, opts = {})
+    if opts[:include_host]
+      with_site_host(site) do
+        yield
+      end
+    else
+      stub_current_site(site) { yield }
+    end
   end
 
   def with_each_current_site(*sites)
     sites.each do |site|
       with_current_site(site) do
         yield(site)
-      end
-    end
-  end
-
-  def with_current_site_with_host(site)
-    with_current_site(site) do
-      with_site_host(site) do
-        yield
       end
     end
   end


### PR DESCRIPTION
Related with PopulateTools/issues#795


## :v: What does this PR do?

* Fixes a failing test due to the combination of external `Capybara.app_host` with `javascript_driver`. The use of javascript is not required for this test.
* Refactors some tests helper methods
* Adds exceptions in tests which use tests helpers methods setting both Capybara with an `app_host` and driver with `javascript_driver`.

## :mag: How should this be manually tested?

Just run the test: `test/integration/gobierto_participation/welcome/welcome_index_test.rb#test_show_poll` 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No