### PR TITLE
Resize event throws error

### DIFF
--- a/app/javascript/lib/visualizations/modules/age_distribution.js
+++ b/app/javascript/lib/visualizations/modules/age_distribution.js
@@ -11,7 +11,7 @@ export class VisAgeDistribution {
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
-    this.margin = {top: 25, right: 10, bottom: 25, left: 15};
+    this.margin = { top: 25, right: 10, bottom: 25, left: 15 };
     this.width = this._width() - this.margin.left - this.margin.right;
     this.height = this._height() - this.margin.top - this.margin.bottom;
 
@@ -49,7 +49,11 @@ export class VisAgeDistribution {
     this.svg.append('g').attr('class','x axis');
     this.svg.append('g').attr('class','y axis');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -171,11 +175,11 @@ export class VisAgeDistribution {
     // We only want multiples of 10 in the x axis
     if (this.isMobile) {
       this.svg.selectAll(".x.axis .tick")
-        .filter(function (d) { return d % 20 !== 0;  })
+        .filter(function (d) { return d % 20 !== 0; })
         .remove();
     } else {
       this.svg.selectAll(".x.axis .tick")
-        .filter(function (d) { return d % 10 !== 0;  })
+        .filter(function (d) { return d % 10 !== 0; })
         .remove();
     }
 
@@ -191,7 +195,7 @@ export class VisAgeDistribution {
 
     // Remove the zero
     this.svg.selectAll(".y.axis .tick")
-      .filter(function (d) { return d === 0;  })
+      .filter(function (d) { return d === 0; })
       .remove();
   }
 

--- a/app/javascript/lib/visualizations/modules/age_report.js
+++ b/app/javascript/lib/visualizations/modules/age_report.js
@@ -10,7 +10,7 @@ export class VisAgeReport {
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
-    this.margin = {top: 25, right: 10, bottom: 25, left: 15};
+    this.margin = { top: 25, right: 10, bottom: 25, left: 15 };
     this.width = this._width() - this.margin.left - this.margin.right;
     this.height = this._height() - this.margin.top - this.margin.bottom;
 
@@ -43,7 +43,11 @@ export class VisAgeReport {
     this.svg.append('g').attr('class','x axis');
     this.svg.append('g').attr('class','y axis');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -169,7 +173,7 @@ export class VisAgeReport {
 
     // Remove the zero
     this.svg.selectAll(".y.axis .tick")
-      .filter(function (d) { return d === 0;  })
+      .filter(function (d) { return d === 0; })
       .remove();
   }
 

--- a/app/javascript/lib/visualizations/modules/evo_line.js
+++ b/app/javascript/lib/visualizations/modules/evo_line.js
@@ -9,7 +9,7 @@ export class VisEvoLine {
     this.classed = "evoline"
 
     // Chart dimensions
-    this.margin = {top: 5, right: 50, bottom: 25, left: 0};
+    this.margin = { top: 5, right: 50, bottom: 25, left: 0 };
     this.width = this._width();
     this.height = 60 + this.margin.top + this.margin.bottom;
 
@@ -47,7 +47,7 @@ export class VisEvoLine {
       .datum(this.data)
       .attr("class", "line")
 
-    if(this.currentYear != null) {
+    if (this.currentYear != null) {
       this.svg.selectAll('.year_marker')
             .data([this.currentYear])
             .enter()
@@ -55,7 +55,11 @@ export class VisEvoLine {
             .attr('class', 'year_marker');
     }
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -140,7 +144,7 @@ export class VisEvoLine {
         return Math.abs(e.deviation);
       })));
     var edge, lower_edge;
-    if(max_abs > 100) {
+    if (max_abs > 100) {
       edge = ((max_abs % 100) < 50) ? Math.floor(max_abs/100) * 100 : (Math.floor(max_abs/100) + 1) * 100;
       lower_edge = -100;
     } else if (max_abs < 10) {

--- a/app/javascript/lib/visualizations/modules/rent_distribution.js
+++ b/app/javascript/lib/visualizations/modules/rent_distribution.js
@@ -335,15 +335,7 @@ export class VisRentDistribution {
 
       this.voronoiGroup.selectAll('.voronoiPath')
         .data(this.voronoi(this.data))
-        .attr("d", function(d, i, _) {
-          if (!d) {
-            console.log(d, i, _);
-
-            return
-          }
-
-          return d.path;
-         });
+        .attr("d", function(d) { return (d || {}).path; });
     }
   }
 

--- a/app/javascript/lib/visualizations/modules/rent_distribution.js
+++ b/app/javascript/lib/visualizations/modules/rent_distribution.js
@@ -335,7 +335,15 @@ export class VisRentDistribution {
 
       this.voronoiGroup.selectAll('.voronoiPath')
         .data(this.voronoi(this.data))
-        .attr("d", function(d) { return d.path; });
+        .attr("d", function(d, i, _) {
+          if (!d) {
+            console.log(d, i, _);
+
+            return
+          }
+
+          return d.path;
+         });
     }
   }
 

--- a/app/javascript/lib/visualizations/modules/rent_distribution.js
+++ b/app/javascript/lib/visualizations/modules/rent_distribution.js
@@ -21,7 +21,7 @@ export class VisRentDistribution {
     d3.formatDefaultLocale(d3locale[I18n.locale]);
 
     // Chart dimensions
-    this.margin = {top: 25, right: 15, bottom: 30, left: 15};
+    this.margin = { top: 25, right: 15, bottom: 30, left: 15 };
     this.width = this._width() - this.margin.left - this.margin.right;
     this.height = this._height() - this.margin.top - this.margin.bottom;
 
@@ -56,7 +56,11 @@ export class VisRentDistribution {
       .append('div')
       .attr('class', 'tooltip');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -150,7 +154,7 @@ export class VisRentDistribution {
   }
 
   _renderVoronoi() {
-    
+
     // Create voronoi
     this.voronoi = d3.distanceLimitedVoronoi()
       .x(function(d) { return this.xScale(d.value); }.bind(this))
@@ -265,7 +269,7 @@ export class VisRentDistribution {
 
     // Remove the zero on the y axis
     this.svg.selectAll('.y.axis .tick')
-      .filter(function (d) { return d === 0;  })
+      .filter(function (d) { return d === 0; })
       .remove();
   }
 

--- a/app/javascript/lib/visualizations/modules/sparkline.js
+++ b/app/javascript/lib/visualizations/modules/sparkline.js
@@ -10,7 +10,7 @@ export class Sparkline {
     this.trend = options.trend;
     this.axes = options.axes || false;
     this.aspectRatio = options.aspectRatio || 5
-    this.margin = options.margins || {top: 5, right: 5, bottom: 5, left: 5};
+    this.margin = options.margins || { top: 5, right: 5, bottom: 5, left: 5 };
 
     // Chart dimensions
     this.width = this._width() - this.margin.left - this.margin.right;
@@ -30,7 +30,11 @@ export class Sparkline {
       .attr('class', 'chart-container')
       .attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   render() {

--- a/app/javascript/lib/visualizations/modules/unemployment_age.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_age.js
@@ -9,7 +9,7 @@ export class VisUnemploymentAge {
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
-    this.margin = {top: 25, right: 20, bottom: 25, left: 50};
+    this.margin = { top: 25, right: 20, bottom: 25, left: 50 };
     this.width = this._width() - this.margin.left - this.margin.right;
     this.height = this._height() - this.margin.top - this.margin.bottom;
 
@@ -39,7 +39,11 @@ export class VisUnemploymentAge {
     this.svg.append('g').attr('class','x axis');
     this.svg.append('g').attr('class','y axis');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -149,7 +153,7 @@ export class VisUnemploymentAge {
 
     this.focus.attr('transform', 'translate(' + this.xScale(d.data.date) + ',' + this.yScale(d.data.pct) + ')');
     this.focus.select('text').attr('text-anchor', d.data.date >= this.parseTime('2014-01') ? 'end' : 'start');
-    this.focus.select('tspan').text(`${this._getAgeRange(d.data.age_range)}: ${this.pctFormat(d.data.pct)} (${d.data.date.toLocaleString(I18n.locale, {month: 'short'})} ${d.data.date.getFullYear()})`);
+    this.focus.select('tspan').text(`${this._getAgeRange(d.data.age_range)}: ${this.pctFormat(d.data.pct)} (${d.data.date.toLocaleString(I18n.locale, { month: 'short' })} ${d.data.date.getFullYear()})`);
   }
 
   _mouseout() {
@@ -188,7 +192,7 @@ export class VisUnemploymentAge {
 
     // Remove the zero
     this.svg.selectAll(".y.axis .tick")
-      .filter(function (d) { return d === 0;  })
+      .filter(function (d) { return d === 0; })
       .remove();
 
     // Move y axis ticks on top of the chart

--- a/app/javascript/lib/visualizations/modules/unemployment_rate.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_rate.js
@@ -13,7 +13,7 @@ export class VisUnemploymentRate {
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
-    this.margin = {top: 25, right: 80, bottom: 25, left: 0};
+    this.margin = { top: 25, right: 80, bottom: 25, left: 0 };
     this.width = this._width() - this.margin.left - this.margin.right;
     this.height = this._height() - this.margin.top - this.margin.bottom;
 
@@ -43,7 +43,11 @@ export class VisUnemploymentRate {
     this.svg.append('g').attr('class','x axis');
     this.svg.append('g').attr('class','y axis');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -191,7 +195,7 @@ export class VisUnemploymentRate {
 
     this.focus.attr('transform', 'translate(' + this.xScale(d.data.date) + ',' + this.yScale(d.data.value) + ')');
     this.focus.select('text').attr('text-anchor', d.data.date >= this.parseTime('2014-01') ? 'end' : 'start');
-    this.focus.select('tspan').text(`${this._getPlaceType(d.data.location_type)}: ${d.data.value}% (${d.data.date.toLocaleString(I18n.locale, {month: 'short'})} ${d.data.date.getFullYear()})`);
+    this.focus.select('tspan').text(`${this._getPlaceType(d.data.location_type)}: ${d.data.value}% (${d.data.date.toLocaleString(I18n.locale, { month: 'short' })} ${d.data.date.getFullYear()})`);
   }
 
   _mouseout() {
@@ -220,7 +224,7 @@ export class VisUnemploymentRate {
 
     // Remove the zero
     this.svg.selectAll('.y.axis .tick')
-      .filter(function (d) { return d === 0;  })
+      .filter(function (d) { return d === 0; })
       .remove();
 
     // Move y axis ticks on top of the chart

--- a/app/javascript/lib/visualizations/modules/unemployment_sex.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_sex.js
@@ -14,7 +14,7 @@ export class VisUnemploymentSex {
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
-    this.margin = {top: 25, right: 50, bottom: 25, left: 20};
+    this.margin = { top: 25, right: 50, bottom: 25, left: 20 };
     this.width = this._width() - this.margin.left - this.margin.right;
     this.height = this._height() - this.margin.top - this.margin.bottom;
 
@@ -44,7 +44,11 @@ export class VisUnemploymentSex {
     this.svg.append('g').attr('class','x axis');
     this.svg.append('g').attr('class','y axis');
 
-    d3.select(window).on('resize.' + this.container, this._resize.bind(this));
+    d3.select(window).on('resize.' + this.container, () => {
+      if (this.data) {
+        this._resize()
+      }
+    });
   }
 
   getData() {
@@ -60,7 +64,7 @@ export class VisUnemploymentSex {
       .await(function (error, population, unemployment) {
         if (error) throw error;
 
-        if(this.location_id === 8077) {
+        if (this.location_id === 8077) {
           let factor = 0.7786712568;
           population.forEach((d) => {
             d.value = d.value * factor;
@@ -84,9 +88,9 @@ export class VisUnemploymentSex {
         unemployment.forEach(function(d) {
           var year = d.date.slice(0,4);
 
-          if(nested.hasOwnProperty(year)) {
+          if (Object.prototype.hasOwnProperty.call(nested, year)) {
             d.pct = d.value / nested[year]
-          } else if(year === lastYear) {
+          } else if (year === lastYear) {
             // If we are in the last year, divide the unemployment by last year's population
             d.pct = d.value / nested[year - 1]
           } else {
@@ -208,7 +212,7 @@ export class VisUnemploymentSex {
     this.focus.select('circle').attr('stroke', this.color(d.data.sex));
     this.focus.attr('transform', 'translate(' + this.xScale(d.data.date) + ',' + this.yScale(d.data.pct) + ')');
     this.focus.select('text').attr('text-anchor', d.data.date >= this.parseTime('2014-01') ? 'end' : 'start');
-    this.focus.select('tspan').text(`${this._getLabel(d.data.sex)}: ${this.pctFormat(d.data.pct)} (${d.data.date.toLocaleString(I18n.locale, {month: 'short'})} ${d.data.date.getFullYear()})`);
+    this.focus.select('tspan').text(`${this._getLabel(d.data.sex)}: ${this.pctFormat(d.data.pct)} (${d.data.date.toLocaleString(I18n.locale, { month: 'short' })} ${d.data.date.getFullYear()})`);
   }
 
   _mouseout() {
@@ -247,7 +251,7 @@ export class VisUnemploymentSex {
 
     // Remove the zero
     this.svg.selectAll(".y.axis .tick")
-      .filter(function (d) { return d === 0;  })
+      .filter(function (d) { return d === 0; })
       .remove();
 
     // Move y axis ticks on top of the chart


### PR DESCRIPTION
closes #2630 and closes #2631 and closes #2632 

## :v: What does this PR do?
Triggers the resize function for charts only when there's data to depict.
Fixes https://rollbar.com/Populate/gobierto/items/2660/ and also it's possible fixes https://rollbar.com/Populate/gobierto/items/2696 and fixes https://rollbar.com/Populate/gobierto/items/2700

## :mag: How should this be manually tested?
This is quite tricky. The issue comes up once you open a new tab and forces a resize event. It's more likely to appear in mobile environments, as you may spin the device, creating a resize event.
In desktop, that could be achieved opening the devtools quickly. 
