### PR TITLE
Set initialization vars AFTER footer

### DIFF
--- a/app/views/layouts/_gobierto_footer.html.erb
+++ b/app/views/layouts/_gobierto_footer.html.erb
@@ -2,3 +2,35 @@
 
 <!-- generic content hook -->
 <%= yield(:gobierto_footer_content) %>
+
+<!-- site js variables -->
+<script type="text/javascript">
+  I18n.defaultLocale = "<%= I18n.default_locale %>";
+  I18n.locale = "<%= I18n.locale %>";
+
+  <% if algoliasearch_configured? %>
+  window.searchClient = {
+    client: algoliasearch('<%= Rails.application.secrets.algolia_application_id %>', '<%= Rails.application.secrets.algolia_search_api_key %>'),
+    indexes: [<%= algolia_search_client.search_in_indexes.html_safe %>],
+    filters: "site_id:<%= algolia_search_client.site.id %>"
+  };
+  <% end %>
+  window.populateData = {
+    token: "<%= current_site.configuration.populate_data_api_token %>",
+    <% if current_site.place %>
+      municipalityId: "<%= current_site.place.id %>",
+      municipalityName: "<%= current_site.place.name %>",
+      provinceId: "<%= current_site.place.province.id %>",
+      provinceName: "<%= current_site.place.province.name %>",
+      ccaaId: "<%= current_site.place.province.autonomous_region.id %>",
+      ccaaName: "<%= current_site.place.province.autonomous_region.name(I18n.locale) %>",
+    <% else %>
+      municipalityId: "<%= current_site.organization_id %>",
+    <% end %>
+    year: <%= APP_CONFIG["gobierto_observatory"]["year"] %>,
+    endpoint: "<%= APP_CONFIG["populate_data"]["endpoint"] %>"
+  }
+  window.populateDataYear = {
+    currentYear: <%= @selected_year || Date.current.year %>
+  }
+</script>

--- a/app/views/layouts/_gobierto_head.html.erb
+++ b/app/views/layouts/_gobierto_head.html.erb
@@ -31,37 +31,6 @@
 <!-- generic content hook -->
 <%= yield(:gobierto_head_content) %>
 
-<script type="text/javascript">
-  I18n.defaultLocale = "<%= I18n.default_locale %>";
-  I18n.locale = "<%= I18n.locale %>";
-
-  <% if algoliasearch_configured? %>
-  window.searchClient = {
-    client: algoliasearch('<%= Rails.application.secrets.algolia_application_id %>', '<%= Rails.application.secrets.algolia_search_api_key %>'),
-    indexes: [<%= algolia_search_client.search_in_indexes.html_safe %>],
-    filters: "site_id:<%= algolia_search_client.site.id %>"
-  };
-  <% end %>
-  window.populateData = {
-    token: "<%= current_site.configuration.populate_data_api_token %>",
-    <% if current_site.place %>
-      municipalityId: "<%= current_site.place.id %>",
-      municipalityName: "<%= current_site.place.name %>",
-      provinceId: "<%= current_site.place.province.id %>",
-      provinceName: "<%= current_site.place.province.name %>",
-      ccaaId: "<%= current_site.place.province.autonomous_region.id %>",
-      ccaaName: "<%= current_site.place.province.autonomous_region.name(I18n.locale) %>",
-    <% else %>
-      municipalityId: "<%= current_site.organization_id %>",
-    <% end %>
-    year: <%= APP_CONFIG["gobierto_observatory"]["year"] %>,
-    endpoint: "<%= APP_CONFIG["populate_data"]["endpoint"] %>"
-  }
-  window.populateDataYear = {
-    currentYear: <%= @selected_year || Date.current.year %>
-  }
-</script>
-
 <%= csrf_meta_tags %>
 
 <%= render 'layouts/analytics_header_site' %>


### PR DESCRIPTION
## :v: What does this PR do?
**This PR is just an HYPOTHESIS** to test the behaviour of the following rollbar errors:
- https://rollbar.com/Populate/gobierto/items/1460/
- https://rollbar.com/Populate/gobierto/items/1459/
- https://rollbar.com/Populate/gobierto/items/1527/
- Perhaps this also: https://rollbar.com/Populate/gobierto/items/2705/

Looking the rollbar error times, they are triggered at startup. That's quite odd and difficult to replay, as the missing variables are defined in the `window` scope, so this hypothesis tries to delay when these variables are called, moving the script beneath the footer.