### PR TITLE
798 gobierto data

### DIFF
--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class BaseController < ApiBaseController
+
+        before_action { module_enabled!(current_site, "GobiertoData", false) }
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -5,7 +5,7 @@ module GobiertoData
     module V1
       class QueryController < ApiBaseController
 
-        # GET /gobierto_data/api/v1?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/data?sql=SELECT%20%2A%20FROM%20table_name
         def index
           render json: { data: execute_query(params[:sql]) }, adapter: :json_api
         end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class QueryController < ApiBaseController
+
+        # GET /gobierto-data/api/v1
+        # GET /gobierto_investments/api/v1.json
+        def index
+          render json: { data: nil }, adapter: :json_api
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -5,10 +5,15 @@ module GobiertoData
     module V1
       class QueryController < ApiBaseController
 
-        # GET /gobierto-data/api/v1
-        # GET /gobierto_investments/api/v1.json
+        # GET /gobierto_data/api/v1?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          render json: { data: nil }, adapter: :json_api
+          render json: { data: execute_query(params[:sql]) }, adapter: :json_api
+        end
+
+        private
+
+        def execute_query(sql)
+          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql))
         end
 
       end

--- a/app/controllers/gobierto_data/application_controller.rb
+++ b/app/controllers/gobierto_data/application_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class GobiertoData::ApplicationController < ApplicationController
+  include User::SessionHelper
+
+  layout "gobierto_data/layouts/application"
+end

--- a/app/models/gobierto_data.rb
+++ b/app/models/gobierto_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  def self.table_name_prefix
+    "gdata_"
+  end
+end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  class Connection < ActiveRecord::Base
+    self.abstract_class = true
+
+    class << self
+      def execute_query(site, query)
+        base_connection_config = connection_config
+        return null_query unless (db_config = site&.gobierto_data_settings&.db_config&.dig(Rails.env)).present?
+
+        establish_connection(db_config)
+        connection.execute(query)
+      rescue ActiveRecord::StatementInvalid => e
+        failed_query(e.message)
+      ensure
+        establish_connection(base_connection_config)
+      end
+
+      private
+
+      def null_query
+        []
+      end
+
+      def failed_query(message)
+        { error: message }
+      end
+    end
+  end
+end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -9,7 +9,7 @@ module GobiertoData
     class << self
       def execute_query(site, query)
         base_connection_config = connection_config
-        return null_query unless (db_config = site&.gobierto_data_settings&.db_config&.dig(Rails.env)).present?
+        return null_query unless (db_config = site&.gobierto_data_settings&.db_config).present?
 
         establish_connection(db_config)
         connection.execute(query)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -149,6 +149,12 @@ class Site < ApplicationRecord
                                              end
   end
 
+  def gobierto_data_settings
+    @gobierto_data_settings ||= if configuration.available_module?("GobiertoData") && configuration.gobierto_data_enabled?
+                                  module_settings.find_by(module_name: "GobiertoData")
+                                end
+  end
+
   def settings_for_module(module_name)
     return unless respond_to?(method = "#{ module_name.underscore }_settings")
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -35,6 +35,9 @@ default: &default
     -
       name: Gobierto Investments
       namespace: GobiertoInvestments
+    -
+      name: Gobierto Data
+      namespace: GobiertoData
   site_modules_with_root_path:
     -
       name: Gobierto Budgets

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -548,6 +548,8 @@ Rails.application.routes.draw do
       end
     end
 
+    # Add new modules before this line
+
     # Sidekiq Web UI
     mount Sidekiq::Web => "/sidekiq", as: :sidekiq_console
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -549,11 +549,11 @@ Rails.application.routes.draw do
     end
 
     # Gobierto Data module
-    namespace :gobierto_data, path: "gobierto_data" do
+    namespace :gobierto_data, path: "/" do
       constraints GobiertoSiteConstraint.new do
         # API
-        namespace :api, path: "/api" do
-          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true) do
+        namespace :api, path: "/" do
+          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "/" => "query#index", as: :root
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -548,6 +548,18 @@ Rails.application.routes.draw do
       end
     end
 
+    # Gobierto Data module
+    namespace :gobierto_data, path: "gobierto_data" do
+      constraints GobiertoSiteConstraint.new do
+        # API
+        namespace :api, path: "/api" do
+          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true) do
+            get "/" => "query#index", as: :root
+          end
+        end
+      end
+    end
+
     # Add new modules before this line
 
     # Sidekiq Web UI

--- a/lib/generators/gobierto_module/USAGE
+++ b/lib/generators/gobierto_module/USAGE
@@ -1,0 +1,18 @@
+Description:
+    Generator to start a new gobierto module
+
+Example:
+    rails generate gobierto_module GobiertoData
+
+    This will do:
+        insert  config/application.yml
+        insert  config/routes.rb
+        create  app/models/gobierto_test.rb
+        create  app/controllers/gobierto_test/application_controller.rb
+        create  app/controllers/gobierto_test/welcome_controller.rb
+        create  app/views/gobierto_test/layouts/_navigation.main.html.erb
+        create  app/views/gobierto_test/layouts/application.html.erb
+        create  app/views/gobierto_test/welcome/index.html.erb
+        create  config/locales/gobierto_test/views/ca.yml
+        create  config/locales/gobierto_test/views/en.yml
+        create  config/locales/gobierto_test/views/es.yml

--- a/lib/generators/gobierto_module/gobierto_module_generator.rb
+++ b/lib/generators/gobierto_module/gobierto_module_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails/generators"
+
 class GobiertoModuleGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 

--- a/lib/generators/gobierto_module/gobierto_module_generator.rb
+++ b/lib/generators/gobierto_module/gobierto_module_generator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class GobiertoModuleGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+
+  class_option :title, type: :string, desc: "String to identify the module. If not present TITLE will be inferred with titleize inflection from module class name"
+  class_option :fron_path, type: :string, desc: "String for the base path of module in front. If not present FRONT_PATH will be inferred with parameterize inflection from TITLE"
+  class_option :table_prefix, type: :string, desc: "Table prefix. It not present it will be inferred from module name. For example: 'gobierto_test' will generate 'gtest_'"
+
+  attr_reader :module_name, :module_class_name, :module_title, :module_front_path, :table_prefix
+  def initialize_names
+    @module_class_name = name
+    @module_name = name.underscore
+    @module_title = options["title"] || name.titleize
+    @module_front_path = (options["front_path"] || module_title).parameterize
+    @table_prefix = options["table_prefix"] || module_name.gsub(/^gobierto_/, "g")[0, 5]
+    @table_prefix = "#{@table_prefix}_" if @table_prefix.last != "_"
+  end
+
+  def insert_into_application_site_modules
+    inject_into_file "config/application.yml", before: "  site_modules_with_root_path:\n" do
+      <<-YAML
+    -
+      name: #{module_title}
+      namespace: #{module_class_name}
+      YAML
+    end
+  end
+
+  def add_root_path
+    inject_into_file "config/routes.rb", before: "    # Add new modules before this line" do
+      <<-RUBY
+    # #{module_title} module
+    namespace :#{module_name}, path: "#{module_front_path}" do
+      constraints GobiertoSiteConstraint.new do
+        get "/" => "welcome#index", as: :root
+      end
+    end
+
+      RUBY
+    end
+  end
+
+  def create_lib_file
+    template("models/module_model.rb.tt", "app/models/#{module_name}.rb")
+  end
+
+  def create_controllers
+    template("controllers/application_controller.rb.tt", "app/controllers/#{module_name}/application_controller.rb")
+    template("controllers/welcome_controller.rb.tt", "app/controllers/#{module_name}/welcome_controller.rb")
+  end
+
+  def create_layout_and_views
+    template("views/layouts/_navigation.main.html.erb.tt", "app/views/#{module_name}/layouts/_navigation.main.html.erb")
+    template("views/layouts/application.html.erb.tt", "app/views/#{module_name}/layouts/application.html.erb")
+    template("views/welcome/index.html.erb.tt", "app/views/#{module_name}/welcome/index.html.erb")
+  end
+
+  def create_locale_files
+    template("locales/views/ca.yml.tt", "config/locales/#{module_name}/views/ca.yml")
+    template("locales/views/en.yml.tt", "config/locales/#{module_name}/views/en.yml")
+    template("locales/views/es.yml.tt", "config/locales/#{module_name}/views/es.yml")
+  end
+end

--- a/lib/generators/gobierto_module/templates/controllers/application_controller.rb.tt
+++ b/lib/generators/gobierto_module/templates/controllers/application_controller.rb.tt
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class <%= module_class_name %>::ApplicationController < ApplicationController
+  include User::SessionHelper
+
+  layout "<%= module_name %>/layouts/application"
+end

--- a/lib/generators/gobierto_module/templates/controllers/welcome_controller.rb.tt
+++ b/lib/generators/gobierto_module/templates/controllers/welcome_controller.rb.tt
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class <%= module_class_name %>::WelcomeController < <%= module_class_name %>::ApplicationController
+  def index; end
+end

--- a/lib/generators/gobierto_module/templates/locales/views/ca.yml.tt
+++ b/lib/generators/gobierto_module/templates/locales/views/ca.yml.tt
@@ -1,0 +1,6 @@
+---
+ca:
+  <%= module_name %>:
+    layouts:
+      application:
+        <%= module_name %>: <%= module_title %>

--- a/lib/generators/gobierto_module/templates/locales/views/en.yml.tt
+++ b/lib/generators/gobierto_module/templates/locales/views/en.yml.tt
@@ -1,0 +1,6 @@
+---
+en:
+  <%= module_name %>:
+    layouts:
+      application:
+        <%= module_name %>: <%= module_title %>

--- a/lib/generators/gobierto_module/templates/locales/views/es.yml.tt
+++ b/lib/generators/gobierto_module/templates/locales/views/es.yml.tt
@@ -1,0 +1,6 @@
+---
+es:
+  <%= module_name %>:
+    layouts:
+      application:
+        <%= module_name %>: <%= module_title %>

--- a/lib/generators/gobierto_module/templates/models/module_model.rb.tt
+++ b/lib/generators/gobierto_module/templates/models/module_model.rb.tt
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module <%= module_class_name %>
+  def self.table_name_prefix
+    "<%= table_prefix %>"
+  end
+end

--- a/lib/generators/gobierto_module/templates/views/layouts/_navigation.main.html.erb.tt
+++ b/lib/generators/gobierto_module/templates/views/layouts/_navigation.main.html.erb.tt
@@ -1,0 +1,3 @@
+<div class="main-nav-item<%%= class_if(" active", current_module == "<%= module_name %>") %>">
+  <%%= link_to t("<%= module_name %>.layouts.application.<%= module_name %>"), <%= module_name %>_root_path, data: { turbolinks: false } %>
+</div>

--- a/lib/generators/gobierto_module/templates/views/layouts/application.html.erb.tt
+++ b/lib/generators/gobierto_module/templates/views/layouts/application.html.erb.tt
@@ -1,0 +1,1 @@
+<%%= render template: "layouts/application" %>

--- a/lib/generators/gobierto_module/templates/views/welcome/index.html.erb.tt
+++ b/lib/generators/gobierto_module/templates/views/welcome/index.html.erb.tt
@@ -1,0 +1,11 @@
+<%% title t("<%= module_name %>.layouts.application.<%= module_name %>") %>
+
+<div class="column">
+  <div class="pure-g block header_block_inline m_b_1">
+    <div class="pure-u-1 pure-u-md-12-24">
+      <h2 class="with_description">
+        <%%= I18n.t("<%= module_name %>.layouts.application.<%= module_name %>") %>
+      </h2>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Closes PopulateTools/issues#798


## :v: What does this PR do?

#### Implements a new module: GobiertoData

The module configuration accepts a `db_config` setting with an `ActiveRecord::Base` connection configuration and has a `GobiertoData::Connection` model with an `execute_query` method able to send sql to the database configured in the module for the site
Adds an API endpoint at `api/v1/data` accepting requests with an `sql` param to perform queries

#### Adds an initializer to create new modules generating the initial files required in a module

The initializer can be called using:
```
rails generate gobierto_module GobiertoData
```

The branch of this PR is included in https://github.com/PopulateTools/gobierto/pull/2679 branch

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [x] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [x] new module/submodule settings?
- [ ] significant changes in some feature?
