### PR TITLE
811 gobierto data datasets

### DIFF
--- a/app/controllers/gobierto_admin/base_controller.rb
+++ b/app/controllers/gobierto_admin/base_controller.rb
@@ -72,7 +72,8 @@ module GobiertoAdmin
         gobierto_participation: admin_participation_path,
         gobierto_plans: admin_plans_plans_path,
         gobierto_citizens_charters: admin_citizens_charters_path,
-        gobierto_investments: admin_investments_projects_path
+        gobierto_investments: admin_investments_projects_path,
+        gobierto_data: admin_data_datasets_path
       }.with_indifferent_access
     end
 

--- a/app/controllers/gobierto_admin/gobierto_data/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/base_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoData
+    class BaseController < GobiertoAdmin::BaseController
+      before_action { module_enabled!(current_site, "GobiertoData") }
+      before_action { module_allowed!(current_admin, "GobiertoData") }
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoData
+    class DatasetsController < GobiertoAdmin::GobiertoData::BaseController
+      include CustomFieldsHelper
+
+      def index
+        @datasets = current_site.datasets.order(id: :desc)
+      end
+
+      def new
+        @dataset_form = DatasetForm.new(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
+        @dataset = @dataset_form.dataset
+        initialize_custom_field_form
+      end
+
+      def edit
+        @dataset = find_dataset
+
+        @dataset_form = DatasetForm.new(
+          @dataset.attributes.except(*ignored_dataset_attributes).merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
+        )
+        initialize_custom_field_form
+      end
+
+      def create
+        @dataset_form = DatasetForm.new(dataset_params.merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip))
+        @dataset = @dataset_form.dataset
+        initialize_custom_field_form
+
+        if @dataset_form.save
+          custom_fields_save
+          redirect_to(
+            edit_admin_data_dataset_path(@dataset_form.dataset),
+            notice: t(".success")
+          )
+        else
+          render :new
+        end
+      end
+
+      def update
+        @dataset = find_dataset
+
+        @dataset_form = DatasetForm.new(
+          dataset_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
+        )
+        initialize_custom_field_form
+
+        if @dataset_form.save && custom_fields_save
+          redirect_to(
+            edit_admin_data_dataset_path(@dataset),
+            notice: t(".success")
+          )
+        else
+          render :edit
+        end
+      end
+
+      def destroy
+        @dataset = find_dataset
+
+        @dataset.destroy
+
+        redirect_to admin_data_datasets_path, notice: t(".success")
+      end
+
+      private
+
+      def dataset_params
+        params.require(:dataset).permit(
+          :table_name,
+          :slug,
+          name_translations: [*I18n.available_locales]
+        )
+      end
+
+      def ignored_dataset_attributes
+        %w(created_at updated_at site_id)
+      end
+
+      def find_dataset
+        current_site.datasets.find(params[:id])
+      end
+
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class BaseController < ApiBaseController
+
+        before_action { module_enabled!(current_site, "GobiertoData", false) }
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -5,7 +5,7 @@ module GobiertoData
     module V1
       class QueryController < ApiBaseController
 
-        # GET /gobierto_data/api/v1?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/data?sql=SELECT%20%2A%20FROM%20table_name
         def index
           render json: { data: execute_query(params[:sql]) }, adapter: :json_api
         end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class QueryController < ApiBaseController
+
+        # GET /gobierto-data/api/v1
+        # GET /gobierto_investments/api/v1.json
+        def index
+          render json: { data: nil }, adapter: :json_api
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -5,10 +5,15 @@ module GobiertoData
     module V1
       class QueryController < ApiBaseController
 
-        # GET /gobierto-data/api/v1
-        # GET /gobierto_investments/api/v1.json
+        # GET /gobierto_data/api/v1?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          render json: { data: nil }, adapter: :json_api
+          render json: { data: execute_query(params[:sql]) }, adapter: :json_api
+        end
+
+        private
+
+        def execute_query(sql)
+          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql))
         end
 
       end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -7,7 +7,7 @@ module GobiertoData
 
         # GET /api/v1/data?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          render json: { data: execute_query(params[:sql]) }, adapter: :json_api
+          render json: { data: execute_query(params[:sql] || "") }, adapter: :json_api
         end
 
         private

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -3,11 +3,17 @@
 module GobiertoData
   module Api
     module V1
-      class QueryController < ApiBaseController
+      class QueryController < BaseController
 
         # GET /api/v1/data?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          render json: { data: execute_query(params[:sql] || "") }, adapter: :json_api
+          query_result = execute_query(params[:sql] || "")
+
+          if query_result.is_a?(Hash) && query_result.has_key?(:errors)
+            render json: query_result, status: :bad_request, adapter: :json_api
+          else
+            render json: { data: query_result }, adapter: :json_api
+          end
         end
 
         private

--- a/app/controllers/gobierto_data/application_controller.rb
+++ b/app/controllers/gobierto_data/application_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class GobiertoData::ApplicationController < ApplicationController
+  include User::SessionHelper
+
+  layout "gobierto_data/layouts/application"
+end

--- a/app/controllers/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_data/datasets_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class GobiertoData::DatasetsController < GobiertoData::ApplicationController
+  def index
+    @datasets = current_site.datasets
+  end
+
+  def show
+    @dataset = current_site.datasets.find_by(slug: params[:slug])
+
+    @rows_count = @dataset.rails_model.count
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoData
+    class DatasetForm < BaseForm
+
+      attr_accessor(
+        :id,
+        :site_id,
+        :name_translations,
+        :table_name,
+        :slug,
+        :admin_id,
+        :ip
+      )
+
+      validates :site_id, presence: true
+
+      delegate :persisted?, to: :dataset
+
+      def save
+        save_dataset if valid?
+      end
+
+      def site
+        @site ||= Site.find_by(id: site_id)
+      end
+
+      def dataset
+        @dataset ||= dataset_class.find_by(id: id).presence || build_dataset
+      end
+
+      private
+
+      def build_dataset
+        dataset_class.new
+      end
+
+      def dataset_class
+        ::GobiertoData::Dataset
+      end
+
+      def save_dataset
+        @dataset = dataset.tap do |attributes|
+          attributes.site_id = site_id
+          attributes.name_translations = name_translations
+          attributes.table_name = table_name
+          attributes.slug = slug.blank? ? nil : slug
+        end
+
+        if @dataset.valid?
+          @dataset.save
+
+          @dataset
+        else
+          promote_errors(@dataset.errors)
+
+          false
+        end
+      end
+
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -16,6 +16,7 @@ module GobiertoAdmin
       )
 
       validates :site_id, presence: true
+      validate :table_reachable
 
       delegate :persisted?, to: :dataset
 
@@ -68,6 +69,11 @@ module GobiertoAdmin
         end
       end
 
+      def table_reachable
+        query_result = ::GobiertoData::Connection.execute_query(site, Arel.sql("SELECT COUNT(*) FROM #{table_name} LIMIT 1"))
+
+        errors.add(:table_name, :invalid_table, error_message: query_result[:error]) if query_result.is_a?(Hash) && query_result.has_key?(:error)
+      end
     end
   end
 end

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -3,6 +3,7 @@
 module GobiertoAdmin
   module GobiertoData
     class DatasetForm < BaseForm
+      prepend ::GobiertoCommon::TrackableGroupedAttributes
 
       attr_accessor(
         :id,
@@ -17,6 +18,12 @@ module GobiertoAdmin
       validates :site_id, presence: true
 
       delegate :persisted?, to: :dataset
+
+      trackable_on :dataset
+      use_event_prefix :dataset
+      notify_changed :name_translations, :table_name, :slug, as: :attribute
+      use_publisher Publishers::AdminGobiertoDataActivity
+      use_trackable_subject :dataset
 
       def save
         save_dataset if valid?
@@ -49,7 +56,9 @@ module GobiertoAdmin
         end
 
         if @dataset.valid?
-          @dataset.save
+          run_callbacks(:save) do
+            @dataset.save
+          end
 
           @dataset
         else

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -38,6 +38,10 @@ module GobiertoAdmin
         @dataset ||= dataset_class.find_by(id: id).presence || build_dataset
       end
 
+      def available_table_names
+        ::GobiertoData::Connection.tables(site)
+      end
+
       private
 
       def build_dataset

--- a/app/models/gobierto_admin/admin.rb
+++ b/app/models/gobierto_admin/admin.rb
@@ -31,6 +31,7 @@ module GobiertoAdmin
     has_many :gobierto_participation_permissions, through: :admin_groups, class_name: "Permission::GobiertoParticipation", source: :permissions
     has_many :gobierto_citizens_charters_permissions, through: :admin_groups, class_name: "Permission::GobiertoCitizensCharters", source: :permissions
     has_many :gobierto_investments_permissions, through: :admin_groups, class_name: "Permission::GobiertoInvestments", source: :permissions
+    has_many :gobierto_data_permissions, through: :admin_groups, class_name: "Permission::GobiertoData", source: :permissions
     has_many :contribution_containers, dependent: :destroy, class_name: "GobiertoParticipation::ContributionContainer"
 
     has_many :census_imports

--- a/app/models/gobierto_admin/permission/gobierto_data.rb
+++ b/app/models/gobierto_admin/permission/gobierto_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  class Permission::GobiertoData < GroupPermission
+    default_scope -> { for_class_module }
+  end
+end

--- a/app/models/gobierto_data.rb
+++ b/app/models/gobierto_data.rb
@@ -4,4 +4,8 @@ module GobiertoData
   def self.table_name_prefix
     "gdata_"
   end
+
+  def self.classes_with_custom_fields
+    [GobiertoData::Dataset]
+  end
 end

--- a/app/models/gobierto_data.rb
+++ b/app/models/gobierto_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  def self.table_name_prefix
+    "gdata_"
+  end
+end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -7,16 +7,19 @@ module GobiertoData
     self.abstract_class = true
 
     class << self
-      def execute_query(site, query)
-        base_connection_config = connection_config
-        return null_query unless (db_conf = db_config(site)).present?
 
-        establish_connection(db_conf)
-        connection.execute(query)
+      def execute_query(site, query)
+        with_connection(site, fallback: null_query) do
+          connection.execute(query) || null_query
+        end
       rescue ActiveRecord::StatementInvalid => e
         failed_query(e.message)
-      ensure
-        establish_connection(base_connection_config)
+      end
+
+      def tables(site)
+        with_connection(site) do
+          connection.tables
+        end
       end
 
       def db_config(site)
@@ -25,6 +28,16 @@ module GobiertoData
 
       private
 
+      def with_connection(site, fallback: nil)
+        base_connection_config = connection_config
+        return fallback unless (db_conf = db_config(site)).present?
+
+        establish_connection(db_conf)
+        yield
+      ensure
+        establish_connection(base_connection_config)
+      end
+
       def null_query
         []
       end
@@ -32,6 +45,7 @@ module GobiertoData
       def failed_query(message)
         { errors: [{ sql: message }] }
       end
+
     end
   end
 end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -9,14 +9,18 @@ module GobiertoData
     class << self
       def execute_query(site, query)
         base_connection_config = connection_config
-        return null_query unless (db_config = site&.gobierto_data_settings&.db_config).present?
+        return null_query unless (db_conf = db_config(site)).present?
 
-        establish_connection(db_config)
+        establish_connection(db_conf)
         connection.execute(query)
       rescue ActiveRecord::StatementInvalid => e
         failed_query(e.message)
       ensure
         establish_connection(base_connection_config)
+      end
+
+      def db_config(site)
+        site&.gobierto_data_settings&.db_config
       end
 
       private

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  class Connection < ActiveRecord::Base
+    self.abstract_class = true
+
+    class << self
+      def execute_query(site, query)
+        base_connection_config = connection_config
+        return null_query unless (db_config = site&.gobierto_data_settings&.db_config&.dig(Rails.env)).present?
+
+        establish_connection(db_config)
+        connection.execute(query)
+      rescue ActiveRecord::StatementInvalid => e
+        failed_query(e.message)
+      ensure
+        establish_connection(base_connection_config)
+      end
+
+      private
+
+      def null_query
+        []
+      end
+
+      def failed_query(message)
+        { error: message }
+      end
+    end
+  end
+end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -9,7 +9,7 @@ module GobiertoData
     class << self
       def execute_query(site, query)
         base_connection_config = connection_config
-        return null_query unless (db_config = site&.gobierto_data_settings&.db_config&.dig(Rails.env)).present?
+        return null_query unless (db_config = site&.gobierto_data_settings&.db_config).present?
 
         establish_connection(db_config)
         connection.execute(query)

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -30,7 +30,7 @@ module GobiertoData
       end
 
       def failed_query(message)
-        { error: message }
+        { errors: [{ sql: message }] }
       end
     end
   end

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  class Dataset < ApplicationRecord
+    include GobiertoCommon::Sluggable
+
+    belongs_to :site
+
+    translates :name
+
+    validates :site, :name, :slug, :table_name, presence: true
+    validates :slug, uniqueness: { scope: :site_id }
+
+    def attributes_for_slug
+      [name]
+    end
+  end
+end

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -16,5 +16,26 @@ module GobiertoData
     def attributes_for_slug
       [name]
     end
+
+    def rails_model
+      @rails_model ||= begin
+                         return Connection.const_get(internal_rails_class_name) if Connection.const_defined?(internal_rails_class_name)
+
+                         db_config = Connection.db_config(site)
+                         return if db_config.blank?
+
+                         Class.new(Connection).tap do |connection_model|
+                           Connection.const_set(internal_rails_class_name, connection_model)
+                           connection_model.establish_connection(connection_model.db_config(site))
+                           connection_model.table_name = table_name
+                         end
+                       end
+    end
+
+    private
+
+    def internal_rails_class_name
+      @internal_rails_class_name ||= "site_id_#{site.id}_table_#{table_name}".classify
+    end
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -87,6 +87,9 @@ class Site < ApplicationRecord
   # Gobierto Investments integration
   has_many :projects, dependent: :destroy, class_name: "GobiertoInvestments::Project"
 
+  # GobiertoData integration
+  has_many :datasets, dependent: :destroy, class_name: "GobiertoData::Dataset"
+
   serialize :configuration_data
 
   before_save :store_configuration

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -149,6 +149,12 @@ class Site < ApplicationRecord
                                              end
   end
 
+  def gobierto_data_settings
+    @gobierto_data_settings ||= if configuration.available_module?("GobiertoData") && configuration.gobierto_data_enabled?
+                                  module_settings.find_by(module_name: "GobiertoData")
+                                end
+  end
+
   def settings_for_module(module_name)
     return unless respond_to?(method = "#{ module_name.underscore }_settings")
 

--- a/app/publishers/admin_gobierto_data_activity.rb
+++ b/app/publishers/admin_gobierto_data_activity.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Publishers
+  class AdminGobiertoDataActivity
+    include Publisher
+
+    self.pub_sub_namespace = "activities/admin_gobierto_data"
+  end
+end

--- a/app/subscribers/admin_gobierto_data_activity.rb
+++ b/app/subscribers/admin_gobierto_data_activity.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Subscribers
+  class AdminGobiertoDataActivity < ::Subscribers::Base
+
+    def dataset_attribute_changed(event)
+      create_activity_from_event(event, "dataset_updated")
+    end
+
+    def dataset_created(event)
+      create_activity_from_event(event, "dataset_created")
+    end
+
+    private
+
+    def create_activity_from_event(event, action)
+      subject = GlobalID::Locator.locate event.payload[:gid]
+
+      return unless subject.class.parent == GobiertoData
+
+      author = GobiertoAdmin::Admin.find_by id: event.payload[:admin_id]
+
+      # When the author is nil, we can asume the action has been performed by an integration
+      return unless author.present?
+
+      action = subject.class.name.underscore.tr("/", ".") + "." + action
+
+      Activity.create! subject: subject,
+                       author: author,
+                       subject_ip: event.payload[:ip] || author.last_sign_in_ip,
+                       action: action,
+                       admin_activity: true,
+                       site_id: event.payload[:site_id]
+    end
+  end
+end

--- a/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
@@ -1,0 +1,65 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @dataset_form %>
+
+<%= form_for(@dataset_form, as: :dataset, url: @dataset_form.persisted? ? admin_data_dataset_path(@dataset_form) : admin_data_datasets_path(@dataset), data: { "globalized-form-container" => true }) do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+      <div class="globalized_fields">
+        <%= render "gobierto_admin/shared/form_locale_switchers" %>
+
+        <% current_site.configuration.available_locales.each do |locale| %>
+          <div class="form_item input_text" data-locale="<%= locale %>">
+            <%= label_tag "dataset[name_translations][#{locale}]" do %>
+              <%= f.object.class.human_attribute_name(:name) %>
+              <%= attribute_indication_tag required: true %>
+            <% end %>
+            <%= text_field_tag "dataset[name_translations][#{locale}]", f.object.name_translations && f.object.name_translations[locale], placeholder: t(".placeholders.name", locale: locale) %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="form_item input_text">
+        <%= label_tag "dataset[table_name]" do %>
+          <%= t("activemodel.attributes.gobierto_admin/gobierto_data/dataset_form.table_name") %>
+          <%= attribute_indication_tag required: true %>
+        <% end %>
+
+        <%= f.text_field :table_name, placeholder: t(".placeholders.table_name") %>
+      </div>
+
+      <div class="form_item input_text">
+        <%= label_tag "dataset[slug]" do %>
+          <%= t("activemodel.attributes.gobierto_admin/gobierto_data/dataset_form.slug") %>
+          <%= attribute_indication_tag required: @dataset_form.persisted? %>
+        <% end %>
+        <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
+      </div>
+
+      <%= render(
+        partial: "gobierto_admin/gobierto_common/custom_fields/forms/custom_fields",
+        locals: {
+          f: f,
+          item: @custom_fields_form,
+          form_name: "dataset"
+        }
+      ) %>
+
+    </div>
+
+    <div class="pure-u-1 pure-u-md-2-24"></div>
+
+    <div class="pure-u-1 pure-u-md-1-4 ">
+
+      <div class="stick_in_parent">
+
+        <div class="widget_save ">
+
+          <%= f.submit class: "button" %>
+
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
@@ -17,13 +17,13 @@
         <% end %>
       </div>
 
-      <div class="form_item input_text">
+      <div class="form_item select_control">
         <%= label_tag "dataset[table_name]" do %>
           <%= t("activemodel.attributes.gobierto_admin/gobierto_data/dataset_form.table_name") %>
           <%= attribute_indication_tag required: true %>
         <% end %>
 
-        <%= f.text_field :table_name, placeholder: t(".placeholders.table_name") %>
+        <%= f.select(:table_name, @dataset_form.available_table_names) %>
       </div>
 
       <div class="form_item input_text">

--- a/app/views/gobierto_admin/gobierto_data/datasets/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_data.datasets.index.title"), admin_data_datasets_path %> »
+  <%= @dataset.name %>
+</div>
+
+<h1><%= @dataset.name %></h1>
+
+<%= render "form" %>

--- a/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
@@ -34,7 +34,7 @@
         <%= dataset.table_name %>
       </td>
       <td>
-        <%= link_to edit_admin_data_dataset_path(dataset), target: "_blank", class: "view_item" do %>
+        <%= link_to gobierto_data_dataset_path(dataset.slug), target: "_blank", class: "view_item" do %>
           <i class="fas fa-eye"></i>
           <%= t(".view_dataset") %>
         <% end %>

--- a/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
@@ -1,0 +1,53 @@
+<div class='admin_breadcrumb'>
+  <%= link_to t('gobierto_admin.welcome.index.title'), admin_root_path %> »
+  <%= t('.title') %>
+</div>
+
+<h1><%= t('.title') %></h1>
+
+<div class="admin_tools right">
+  <%= link_to t(".new"), new_admin_data_dataset_path, class: "button" %>
+</div>
+
+<table id="datasets">
+  <thead>
+    <tr>
+      <th class="icon_col"></th>
+      <th><%= t(".header.name") %></th>
+      <th><%= t(".header.table_name") %></th>
+      <th></th>
+      <th class="icon_col"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @datasets.each do |dataset| %>
+    <tr id="dataset-item-<%= dataset.id %>">
+      <td>
+        <%= link_to edit_admin_data_dataset_path(dataset) do %>
+          <i class="fas fa-edit"></i>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to dataset.name, edit_admin_data_dataset_path(dataset) %>
+      </td>
+      <td>
+        <%= dataset.table_name %>
+      </td>
+      <td>
+        <%= link_to edit_admin_data_dataset_path(dataset), target: "_blank", class: "view_item" do %>
+          <i class="fas fa-eye"></i>
+          <%= t(".view_dataset") %>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to admin_data_dataset_path(dataset.id),
+                    title: t("gobierto_admin.shared.archive.element"),
+                    method: :delete,
+                    data: { confirm: t("views.delete_confirm") } do %>
+          <i class="fas fa-trash"></i>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/gobierto_admin/gobierto_data/datasets/new.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/new.html.erb
@@ -1,0 +1,9 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_data.datasets.index.title"), admin_data_datasets_path %> »
+  <%= t(".title") %>
+</div>
+
+<h1><%= t('.title') %></h1>
+
+<%= render 'form' %>

--- a/app/views/gobierto_data/datasets/index.html.erb
+++ b/app/views/gobierto_data/datasets/index.html.erb
@@ -1,0 +1,21 @@
+<% title t(".title") %>
+
+<div class="column">
+  <div class="pure-g block header_block_inline m_b_1">
+    <div class="pure-u-1 pure-u-md-12-24">
+      <h2 class="with_description">
+        <%= I18n.t("gobierto_data.layouts.application.gobierto_data") %>
+      </h2>
+    </div>
+
+  </div>
+    <div class="m_b_2">
+    <div class="container sandbox">
+      <div class="column inner_cols one_col">
+        <% @datasets.each do |dataset| %>
+            <%= link_to(dataset.name, gobierto_data_dataset_path(dataset.slug)) %>
+        <% end %>
+      </div>
+    </div>
+    </div>
+</div>

--- a/app/views/gobierto_data/datasets/show.html.erb
+++ b/app/views/gobierto_data/datasets/show.html.erb
@@ -1,0 +1,13 @@
+<% title t(".title", dataset_name: @dataset.name) %>
+
+<div class="column">
+  <div class="pure-g block header_block_inline m_b_1">
+    <div class="pure-u-1 pure-u-md-12-24">
+      <h2 class="with_description">
+        <%= @dataset.name %>
+      </h2>
+    </div>
+
+  </div>
+      <%= "Rows count: #{@rows_count}" %>
+</div>

--- a/app/views/gobierto_data/layouts/_navigation.main.html.erb
+++ b/app/views/gobierto_data/layouts/_navigation.main.html.erb
@@ -1,0 +1,3 @@
+<div class="main-nav-item<%= class_if(" active", current_module == "gobierto_data") %>">
+  <%= link_to t("gobierto_data.layouts.application.gobierto_data"), gobierto_data_root_path, data: { turbolinks: false } %>
+</div>

--- a/app/views/gobierto_data/layouts/application.html.erb
+++ b/app/views/gobierto_data/layouts/application.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "layouts/application" %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -35,6 +35,9 @@ default: &default
     -
       name: Gobierto Investments
       namespace: GobiertoInvestments
+    -
+      name: Gobierto Data
+      namespace: GobiertoData
   site_modules_with_root_path:
     -
       name: Gobierto Budgets

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -32,6 +32,7 @@ Subscribers::SiteActivity.attach_to("activities/sites")
 Subscribers::AdminGobiertoCalendarsActivity.attach_to("activities/admin_gobierto_calendars")
 Subscribers::AdminGobiertoCitizensChartersActivity.attach_to("activities/admin_gobierto_citizens_charters")
 Subscribers::AdminGobiertoInvestmentsActivity.attach_to("activities/admin_gobierto_investments")
+Subscribers::AdminGobiertoDataActivity.attach_to("activities/admin_gobierto_data")
 
 # Custom subscribers
 ActiveSupport::Notifications.subscribe(/trackable/) do |*args|

--- a/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
@@ -1,0 +1,11 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_data:
+      datasets:
+        create:
+          success: El dataset s'ha creat correctament.
+        destroy:
+          success: El dataset s'ha esborrat correctament.
+        update:
+          success: El dataset s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
@@ -4,8 +4,8 @@ ca:
     gobierto_data:
       datasets:
         create:
-          success: El dataset s'ha creat correctament.
+          success: El conjunt de dades s'ha creat correctament.
         destroy:
-          success: El dataset s'ha esborrat correctament.
+          success: El conjunt de dades s'ha esborrat correctament.
         update:
-          success: El dataset s'ha actualitzat correctament.
+          success: El conjunt de dades s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_data/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  gobierto_admin:
+    gobierto_data:
+      datasets:
+        create:
+          success: Dataset created correctly.
+        destroy:
+          success: Dataset deleted correctly.
+        update:
+          success: Dataset updated correctly.

--- a/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
@@ -1,0 +1,11 @@
+---
+es:
+  gobierto_admin:
+    gobierto_data:
+      datasets:
+        create:
+          success: El dataset ha sido creado correctamente.
+        destroy:
+          success: El dataset ha sido eliminado correctamente.
+        update:
+          success: El dataset ha sido actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
@@ -4,8 +4,8 @@ es:
     gobierto_data:
       datasets:
         create:
-          success: El dataset ha sido creado correctamente.
+          success: El conjunto de datos ha sido creado correctamente.
         destroy:
-          success: El dataset ha sido eliminado correctamente.
+          success: El conjunto de datos ha sido eliminado correctamente.
         update:
-          success: El dataset ha sido actualizado correctamente.
+          success: El conjunto de datos ha sido actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/ca.yml
@@ -1,0 +1,8 @@
+---
+ca:
+  activemodel:
+    attributes:
+      gobierto_admin/gobierto_data/dataset_form:
+        name: Nom
+        slug: Slug
+        table_name: Nom de la taula

--- a/config/locales/gobierto_admin/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/ca.yml
@@ -6,3 +6,9 @@ ca:
         name: Nom
         slug: Slug
         table_name: Nom de la taula
+    errors:
+      models:
+        gobierto_admin/gobierto_data/dataset_form:
+          attributes:
+            table_name:
+              invalid_table: 'No es pot accedir a la taula. Missatge d''error: "%{error_message}"'

--- a/config/locales/gobierto_admin/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  activemodel:
+    attributes:
+      gobierto_admin/gobierto_data/dataset_form:
+        name: Name
+        slug: Slug
+        table_name: Table name

--- a/config/locales/gobierto_admin/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/en.yml
@@ -6,3 +6,9 @@ en:
         name: Name
         slug: Slug
         table_name: Table name
+    errors:
+      models:
+        gobierto_admin/gobierto_data/dataset_form:
+          attributes:
+            table_name:
+              invalid_table: 'Unable to access the table. Error message: "%{error_message}"'

--- a/config/locales/gobierto_admin/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/es.yml
@@ -6,3 +6,9 @@ es:
         name: Nombre
         slug: Slug
         table_name: Nombre de la tabla
+    errors:
+      models:
+        gobierto_admin/gobierto_data/dataset_form:
+          attributes:
+            table_name:
+              invalid_table: 'No se puede acceder a la tabla. Mensaje de error: "%{error_message}"'

--- a/config/locales/gobierto_admin/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/es.yml
@@ -1,0 +1,8 @@
+---
+es:
+  activemodel:
+    attributes:
+      gobierto_admin/gobierto_data/dataset_form:
+        name: Nombre
+        slug: Slug
+        table_name: Nombre de la tabla

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -1,0 +1,19 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_data:
+      datasets:
+        form:
+          placeholders:
+            name: Habitants
+            slug: habitants
+            table_name: population_census
+        index:
+          header:
+            name: Nom
+            table_name: Nom de la taula
+          new: Nou
+          title: Datasets
+          view_dataset: Veure dataset
+        new:
+          title: Nou dataset

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -12,7 +12,7 @@ ca:
             name: Nom
             table_name: Nom de la taula
           new: Nou
-          title: Datasets
-          view_dataset: Veure dataset
+          title: Conjunts de dades
+          view_dataset: Veure conjunt de dades
         new:
-          title: Nou dataset
+          title: Nou conjunt de dades

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -7,7 +7,6 @@ ca:
           placeholders:
             name: Habitants
             slug: habitants
-            table_name: population_census
         index:
           header:
             name: Nom

--- a/config/locales/gobierto_admin/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/en.yml
@@ -1,0 +1,19 @@
+---
+en:
+  gobierto_admin:
+    gobierto_data:
+      datasets:
+        form:
+          placeholders:
+            name: Population
+            slug: population
+            table_name: population_census
+        index:
+          header:
+            name: Name
+            table_name: Table name
+          new: New
+          title: Datasets
+          view_dataset: See dataset
+        new:
+          title: New dataset

--- a/config/locales/gobierto_admin/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/en.yml
@@ -7,7 +7,6 @@ en:
           placeholders:
             name: Population
             slug: population
-            table_name: population_census
         index:
           header:
             name: Name

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -12,7 +12,7 @@ es:
             name: Nombre
             table_name: Nombre de la tabla
           new: Nuevo
-          title: Datasets
-          view_dataset: Ver dataset
+          title: Conjuntos de datos
+          view_dataset: Ver conjunto de datos
         new:
-          title: Nuevo dataset
+          title: Nuevo conjunto de datos

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -7,7 +7,6 @@ es:
           placeholders:
             name: Habitantes
             slug: habitantes
-            table_name: population_census
         index:
           header:
             name: Nombre

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -1,0 +1,19 @@
+---
+es:
+  gobierto_admin:
+    gobierto_data:
+      datasets:
+        form:
+          placeholders:
+            name: Habitantes
+            slug: habitantes
+            table_name: population_census
+        index:
+          header:
+            name: Nombre
+            table_name: Nombre de la tabla
+          new: Nuevo
+          title: Datasets
+          view_dataset: Ver dataset
+        new:
+          title: Nuevo dataset

--- a/config/locales/gobierto_admin/views/layouts/ca.yml
+++ b/config/locales/gobierto_admin/views/layouts/ca.yml
@@ -22,6 +22,7 @@ ca:
           budget_consultations: Consultes de pressupostos
           budgets: Pressupostos
           citizens_charters: Serveis i cartes de serveis
+          data: Dades
           investments: Inversions
           participation: Participació
           people: Alts càrrecs i Agendes

--- a/config/locales/gobierto_admin/views/layouts/en.yml
+++ b/config/locales/gobierto_admin/views/layouts/en.yml
@@ -22,6 +22,7 @@ en:
           budget_consultations: Budget consultations
           budgets: Budgets
           citizens_charters: Services and services charters
+          data: Data
           investments: Investments
           participation: Participation
           people: Officers and Agendas

--- a/config/locales/gobierto_admin/views/layouts/es.yml
+++ b/config/locales/gobierto_admin/views/layouts/es.yml
@@ -22,6 +22,7 @@ es:
           budget_consultations: Consultas de presupuestos
           budgets: Presupuestos
           citizens_charters: Servicios y cartas de servicios
+          data: Datos
           investments: Inversiones
           participation: Participación
           people: Altos cargos y Agendas

--- a/config/locales/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_data/models/ca.yml
@@ -3,5 +3,5 @@ ca:
   activerecord:
     models:
       gobierto_data/dataset:
-        one: Dataset
-        other: Datasets
+        one: Conjunt de dades
+        other: Conjunts de dades

--- a/config/locales/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_data/models/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  activerecord:
+    models:
+      gobierto_data/dataset:
+        one: Dataset
+        other: Datasets

--- a/config/locales/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_data/models/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  activerecord:
+    models:
+      gobierto_data/dataset:
+        one: Dataset
+        other: Datasets

--- a/config/locales/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_data/models/es.yml
@@ -3,5 +3,5 @@ es:
   activerecord:
     models:
       gobierto_data/dataset:
-        one: Dataset
-        other: Datasets
+        one: Conjunto de datos
+        other: Conjuntos de datos

--- a/config/locales/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_data/models/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  activerecord:
+    models:
+      gobierto_data/dataset:
+        one: Dataset
+        other: Datasets

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -3,12 +3,12 @@ ca:
   gobierto_data:
     datasets:
       index:
-        title: Datasets
+        title: Conjunts de dades
       show:
-        title: Dataset %{dataset_name}
+        title: Conjunt de dades %{dataset_name}
     events:
-      gobierto_data_dataset_dataset_created: Dataset creat
-      gobierto_data_dataset_dataset_updated: Dataset actualitzat
+      gobierto_data_dataset_dataset_created: Conjunt de dades creat
+      gobierto_data_dataset_dataset_updated: Conjunt de dades actualitzat
     layouts:
       application:
         gobierto_data: Dades

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -1,0 +1,6 @@
+---
+ca:
+  gobierto_data:
+    events:
+      gobierto_data_dataset_dataset_created: Dataset creat
+      gobierto_data_dataset_dataset_updated: Dataset actualitzat

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -1,6 +1,14 @@
 ---
 ca:
   gobierto_data:
+    datasets:
+      index:
+        title: Datasets
+      show:
+        title: Dataset %{dataset_name}
     events:
       gobierto_data_dataset_dataset_created: Dataset creat
       gobierto_data_dataset_dataset_updated: Dataset actualitzat
+    layouts:
+      application:
+        gobierto_data: Dades

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -1,6 +1,14 @@
 ---
 en:
   gobierto_data:
+    datasets:
+      index:
+        title: Datasets
+      show:
+        title: Dataset %{dataset_name}
     events:
       gobierto_data_dataset_dataset_created: Dataset created
       gobierto_data_dataset_dataset_updated: Dataset updated
+    layouts:
+      application:
+        gobierto_data: Data

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  gobierto_data:
+    events:
+      gobierto_data_dataset_dataset_created: Dataset created
+      gobierto_data_dataset_dataset_updated: Dataset updated

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -1,6 +1,14 @@
 ---
 es:
   gobierto_data:
+    datasets:
+      index:
+        title: Datasets
+      show:
+        title: Dataset %{dataset_name}
     events:
       gobierto_data_dataset_dataset_created: Dataset creado
       gobierto_data_dataset_dataset_updated: Dataset actualizado
+    layouts:
+      application:
+        gobierto_data: Datos

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -1,0 +1,6 @@
+---
+es:
+  gobierto_data:
+    events:
+      gobierto_data_dataset_dataset_created: Dataset creado
+      gobierto_data_dataset_dataset_updated: Dataset actualizado

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -3,12 +3,12 @@ es:
   gobierto_data:
     datasets:
       index:
-        title: Datasets
+        title: Conjuntos de datos
       show:
-        title: Dataset %{dataset_name}
+        title: Conjunto de datos %{dataset_name}
     events:
-      gobierto_data_dataset_dataset_created: Dataset creado
-      gobierto_data_dataset_dataset_updated: Dataset actualizado
+      gobierto_data_dataset_dataset_created: Conjunto de datos creado
+      gobierto_data_dataset_dataset_updated: Conjunto de datos actualizado
     layouts:
       application:
         gobierto_data: Datos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,6 +237,10 @@ Rails.application.routes.draw do
       namespace :gobierto_investments, as: :investments do
         resources :projects
       end
+
+      namespace :gobierto_data, as: :data do
+        resources :datasets
+      end
     end
 
     # User module

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -548,6 +548,8 @@ Rails.application.routes.draw do
       end
     end
 
+    # Add new modules before this line
+
     # Sidekiq Web UI
     mount Sidekiq::Web => "/sidekiq", as: :sidekiq_console
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -555,6 +555,9 @@ Rails.application.routes.draw do
     # Gobierto Data module
     namespace :gobierto_data, path: "/" do
       constraints GobiertoSiteConstraint.new do
+        resources :datasets, only: [:index, :show], param: :slug, path: "datasets"
+        get "/datasets" => "datasets#index", as: :root
+
         # API
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -549,11 +549,11 @@ Rails.application.routes.draw do
     end
 
     # Gobierto Data module
-    namespace :gobierto_data, path: "gobierto_data" do
+    namespace :gobierto_data, path: "/" do
       constraints GobiertoSiteConstraint.new do
         # API
-        namespace :api, path: "/api" do
-          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true) do
+        namespace :api, path: "/" do
+          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "/" => "query#index", as: :root
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -548,6 +548,18 @@ Rails.application.routes.draw do
       end
     end
 
+    # Gobierto Data module
+    namespace :gobierto_data, path: "gobierto_data" do
+      constraints GobiertoSiteConstraint.new do
+        # API
+        namespace :api, path: "/api" do
+          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true) do
+            get "/" => "query#index", as: :root
+          end
+        end
+      end
+    end
+
     # Add new modules before this line
 
     # Sidekiq Web UI

--- a/db/migrate/20191114152643_create_gdata_datasets.rb
+++ b/db/migrate/20191114152643_create_gdata_datasets.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGdataDatasets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :gdata_datasets do |t|
+      t.references :site, index: true
+      t.jsonb :name_translations
+      t.string :table_name
+      t.string :slug
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_142501) do
+ActiveRecord::Schema.define(version: 2019_11_14_152643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -521,6 +521,16 @@ ActiveRecord::Schema.define(version: 2019_09_30_142501) do
     t.string "template_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "gdata_datasets", force: :cascade do |t|
+    t.bigint "site_id"
+    t.jsonb "name_translations"
+    t.string "table_name"
+    t.string "slug"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id"], name: "index_gdata_datasets_on_site_id"
   end
 
   create_table "gi_indicators", force: :cascade do |t|

--- a/lib/generators/gobierto_module/USAGE
+++ b/lib/generators/gobierto_module/USAGE
@@ -1,0 +1,18 @@
+Description:
+    Generator to start a new gobierto module
+
+Example:
+    rails generate gobierto_module GobiertoData
+
+    This will do:
+        insert  config/application.yml
+        insert  config/routes.rb
+        create  app/models/gobierto_test.rb
+        create  app/controllers/gobierto_test/application_controller.rb
+        create  app/controllers/gobierto_test/welcome_controller.rb
+        create  app/views/gobierto_test/layouts/_navigation.main.html.erb
+        create  app/views/gobierto_test/layouts/application.html.erb
+        create  app/views/gobierto_test/welcome/index.html.erb
+        create  config/locales/gobierto_test/views/ca.yml
+        create  config/locales/gobierto_test/views/en.yml
+        create  config/locales/gobierto_test/views/es.yml

--- a/lib/generators/gobierto_module/gobierto_module_generator.rb
+++ b/lib/generators/gobierto_module/gobierto_module_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails/generators"
+
 class GobiertoModuleGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 

--- a/lib/generators/gobierto_module/gobierto_module_generator.rb
+++ b/lib/generators/gobierto_module/gobierto_module_generator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class GobiertoModuleGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+
+  class_option :title, type: :string, desc: "String to identify the module. If not present TITLE will be inferred with titleize inflection from module class name"
+  class_option :fron_path, type: :string, desc: "String for the base path of module in front. If not present FRONT_PATH will be inferred with parameterize inflection from TITLE"
+  class_option :table_prefix, type: :string, desc: "Table prefix. It not present it will be inferred from module name. For example: 'gobierto_test' will generate 'gtest_'"
+
+  attr_reader :module_name, :module_class_name, :module_title, :module_front_path, :table_prefix
+  def initialize_names
+    @module_class_name = name
+    @module_name = name.underscore
+    @module_title = options["title"] || name.titleize
+    @module_front_path = (options["front_path"] || module_title).parameterize
+    @table_prefix = options["table_prefix"] || module_name.gsub(/^gobierto_/, "g")[0, 5]
+    @table_prefix = "#{@table_prefix}_" if @table_prefix.last != "_"
+  end
+
+  def insert_into_application_site_modules
+    inject_into_file "config/application.yml", before: "  site_modules_with_root_path:\n" do
+      <<-YAML
+    -
+      name: #{module_title}
+      namespace: #{module_class_name}
+      YAML
+    end
+  end
+
+  def add_root_path
+    inject_into_file "config/routes.rb", before: "    # Add new modules before this line" do
+      <<-RUBY
+    # #{module_title} module
+    namespace :#{module_name}, path: "#{module_front_path}" do
+      constraints GobiertoSiteConstraint.new do
+        get "/" => "welcome#index", as: :root
+      end
+    end
+
+      RUBY
+    end
+  end
+
+  def create_lib_file
+    template("models/module_model.rb.tt", "app/models/#{module_name}.rb")
+  end
+
+  def create_controllers
+    template("controllers/application_controller.rb.tt", "app/controllers/#{module_name}/application_controller.rb")
+    template("controllers/welcome_controller.rb.tt", "app/controllers/#{module_name}/welcome_controller.rb")
+  end
+
+  def create_layout_and_views
+    template("views/layouts/_navigation.main.html.erb.tt", "app/views/#{module_name}/layouts/_navigation.main.html.erb")
+    template("views/layouts/application.html.erb.tt", "app/views/#{module_name}/layouts/application.html.erb")
+    template("views/welcome/index.html.erb.tt", "app/views/#{module_name}/welcome/index.html.erb")
+  end
+
+  def create_locale_files
+    template("locales/views/ca.yml.tt", "config/locales/#{module_name}/views/ca.yml")
+    template("locales/views/en.yml.tt", "config/locales/#{module_name}/views/en.yml")
+    template("locales/views/es.yml.tt", "config/locales/#{module_name}/views/es.yml")
+  end
+end

--- a/lib/generators/gobierto_module/templates/controllers/application_controller.rb.tt
+++ b/lib/generators/gobierto_module/templates/controllers/application_controller.rb.tt
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class <%= module_class_name %>::ApplicationController < ApplicationController
+  include User::SessionHelper
+
+  layout "<%= module_name %>/layouts/application"
+end

--- a/lib/generators/gobierto_module/templates/controllers/welcome_controller.rb.tt
+++ b/lib/generators/gobierto_module/templates/controllers/welcome_controller.rb.tt
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class <%= module_class_name %>::WelcomeController < <%= module_class_name %>::ApplicationController
+  def index; end
+end

--- a/lib/generators/gobierto_module/templates/locales/views/ca.yml.tt
+++ b/lib/generators/gobierto_module/templates/locales/views/ca.yml.tt
@@ -1,0 +1,6 @@
+---
+ca:
+  <%= module_name %>:
+    layouts:
+      application:
+        <%= module_name %>: <%= module_title %>

--- a/lib/generators/gobierto_module/templates/locales/views/en.yml.tt
+++ b/lib/generators/gobierto_module/templates/locales/views/en.yml.tt
@@ -1,0 +1,6 @@
+---
+en:
+  <%= module_name %>:
+    layouts:
+      application:
+        <%= module_name %>: <%= module_title %>

--- a/lib/generators/gobierto_module/templates/locales/views/es.yml.tt
+++ b/lib/generators/gobierto_module/templates/locales/views/es.yml.tt
@@ -1,0 +1,6 @@
+---
+es:
+  <%= module_name %>:
+    layouts:
+      application:
+        <%= module_name %>: <%= module_title %>

--- a/lib/generators/gobierto_module/templates/models/module_model.rb.tt
+++ b/lib/generators/gobierto_module/templates/models/module_model.rb.tt
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module <%= module_class_name %>
+  def self.table_name_prefix
+    "<%= table_prefix %>"
+  end
+end

--- a/lib/generators/gobierto_module/templates/views/layouts/_navigation.main.html.erb.tt
+++ b/lib/generators/gobierto_module/templates/views/layouts/_navigation.main.html.erb.tt
@@ -1,0 +1,3 @@
+<div class="main-nav-item<%%= class_if(" active", current_module == "<%= module_name %>") %>">
+  <%%= link_to t("<%= module_name %>.layouts.application.<%= module_name %>"), <%= module_name %>_root_path, data: { turbolinks: false } %>
+</div>

--- a/lib/generators/gobierto_module/templates/views/layouts/application.html.erb.tt
+++ b/lib/generators/gobierto_module/templates/views/layouts/application.html.erb.tt
@@ -1,0 +1,1 @@
+<%%= render template: "layouts/application" %>

--- a/lib/generators/gobierto_module/templates/views/welcome/index.html.erb.tt
+++ b/lib/generators/gobierto_module/templates/views/welcome/index.html.erb.tt
@@ -1,0 +1,11 @@
+<%% title t("<%= module_name %>.layouts.application.<%= module_name %>") %>
+
+<div class="column">
+  <div class="pure-g block header_block_inline m_b_1">
+    <div class="pure-u-1 pure-u-md-12-24">
+      <h2 class="with_description">
+        <%%= I18n.t("<%= module_name %>.layouts.application.<%= module_name %>") %>
+      </h2>
+    </div>
+  </div>
+</div>

--- a/test/controllers/gobierto_data/api/v1/query_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/query_controller_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class QueryControllerTest < GobiertoControllerTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def test_index
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM users"), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal 1, response_data["data"].count
+            assert_equal 7, response_data["data"].first["test_count"]
+          end
+        end
+
+        def test_index_with_module_disabled
+          with(site: site_with_module_disabled) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM users"), as: :json
+
+            assert_response :forbidden
+          end
+        end
+
+        def test_index_with_invalid_query
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM not_existing_table"), as: :json
+
+            assert_response :bad_request
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+            assert_equal 1, response_data["errors"].count
+            assert_match(/UndefinedTable/, response_data["errors"].first["sql"])
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/fixtures/gobierto_admin/group_permissions.yml
+++ b/test/fixtures/gobierto_admin/group_permissions.yml
@@ -83,3 +83,9 @@ madrid_manage_investments:
   namespace: site_module
   resource_type: gobierto_investments
   action_name: manage
+
+madrid_manage_data:
+  admin_group: madrid_group
+  namespace: site_module
+  resource_type: gobierto_data
+  action_name: manage

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -296,6 +296,15 @@ art_gallery_text_code_custom_field_record:
   custom_field: madrid_investments_projects_custom_field_text_code
   payload: <%= { "text-code" => "culture-02" }.to_json %>
 
+## Data datasets
+
+users_dataset_category_custom_field_record:
+  item: users_dataset (GobiertoData::Dataset)
+  custom_field: madrid_data_datasets_custom_field_category
+  payload: <%= {
+     "category" => ActiveRecord::FixtureSet.identify(:culture_term).to_s
+   }.to_json %>
+
 ## Users
 
 peter_custom_field_issue:

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -314,6 +314,20 @@ madrid_investments_projects_custom_field_text_code:
   field_type: <%= GobiertoCommon::CustomField.field_types[:string] %>
   uid: text-code
 
+madrid_data_datasets_custom_field_category:
+  site: madrid
+  class_name: GobiertoData::Dataset
+  position: 1
+  name_translations: <%= { en: "Category", es: "Categoría" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:vocabulary_options] %>
+  uid: category
+  options: <%= {
+    configuration: {
+      vocabulary_type: "single_select"
+    },
+    vocabulary_id: ActiveRecord::FixtureSet.identify(:issues_vocabulary)
+  }.to_json %>
+
 madrid_custom_field_human_resources_table_plugin:
   site: madrid
   class_name: GobiertoPlans::Node

--- a/test/fixtures/gobierto_data/datasets.yml
+++ b/test/fixtures/gobierto_data/datasets.yml
@@ -1,0 +1,7 @@
+users_dataset:
+  site: madrid
+  name_translations: <%= { en: "Users", es: "Usuarios" }.to_json %>
+  table_name: users
+  slug: users-dataset
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -147,6 +147,13 @@ gobierto_citizens_charters_settings_madrid:
   module_name: "GobiertoCitizensCharters"
   settings: <%= { "categories_vocabulary_id": ActiveRecord::FixtureSet.identify(:citizens_services_categories) }.to_json %>
 
+gobierto_cata_settings_madrid:
+  site: madrid
+  module_name: "GobiertoData"
+  settings: <%= {
+    db_config: Rails.configuration.database_configuration["test"]
+  }.to_json %>
+
 gobierto_budgets_settings_organization_wadus:
   site: organization_wadus
   module_name: "GobiertoBudgets"

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -15,7 +15,8 @@ madrid:
       "GobiertoPlans",
       "GobiertoCitizensCharters",
       "GobiertoObservatory",
-      "GobiertoInvestments"
+      "GobiertoInvestments",
+      "GobiertoData"
     ],
     "default_locale" => "en",
     "available_locales" => ["en", "es"],

--- a/test/forms/gobierto_admin/admin_group_form_test.rb
+++ b/test/forms/gobierto_admin/admin_group_form_test.rb
@@ -93,19 +93,20 @@ module GobiertoAdmin
                                                                       gobierto_budget_consultations: [:manage],
                                                                       gobierto_participation: [:manage],
                                                                       gobierto_plans: [:manage],
-                                                                      gobierto_investments: [:manage] }))
+                                                                      gobierto_investments: [:manage],
+                                                                      gobierto_data: [:manage] }))
 
-      assert_equal 4, tony.modules_permissions.size
+      assert_equal 5, tony.modules_permissions.size
 
       assert form.save
 
-      assert_equal 5, tony.modules_permissions.size
+      assert_equal 6, tony.modules_permissions.size
     end
 
     def test_revoke_module_permissions
       form = subject.new(madrid_group_params.merge(modules_actions: { gobierto_people: [:manage] }))
 
-      assert_equal 4, tony.modules_permissions.size
+      assert_equal 5, tony.modules_permissions.size
 
       assert form.save
 

--- a/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
+++ b/test/integration/gobierto_admin/admin_groups/admin_group_update_test.rb
@@ -142,7 +142,7 @@ module GobiertoAdmin
               refute find("#admin_group_people_#{richard.id}", visible: false).checked?
             end
 
-            assert_equal 10, madrid_group.permissions.count
+            assert_equal 11, madrid_group.permissions.count
             assert GobiertoAdmin::Permission::GobiertoPlans.where(admin_group: madrid_group, action_name: "moderate").exists?
             assert madrid_group.permissions.for_people.where(action_name: "manage_all").exists?
           end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoData
+    module Datasets
+      class CreateDatasetTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = new_admin_data_dataset_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_regular_admin
+          @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def test_regular_admin_permissions_not_authorized
+          with(site: site, admin: unauthorized_regular_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal edit_admin_admin_settings_path, current_path
+          end
+        end
+
+        def test_regular_admin_permissions_authorized
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+            assert has_no_content?("You are not authorized to perform this action")
+            assert_equal @path, current_path
+          end
+        end
+
+        def test_create_dataset_errors
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            click_button "Create"
+
+            assert has_alert?("Name can't be blank")
+          end
+        end
+
+        def test_create_dataset
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            fill_in "dataset_name_translations_en", with: "Vocabularies"
+            switch_locale "ES"
+            fill_in "dataset_name_translations_es", with: "Vocabularios"
+            select "vocabularies", from: "dataset_table_name"
+            fill_in "dataset_slug", with: "vocabularies-slug"
+
+            click_button "Create"
+
+            assert has_message?("Dataset created correctly.")
+            assert has_field?("dataset_name_translations_en", with: "Vocabularies")
+            switch_locale "ES"
+            assert has_field?("dataset_name_translations_es", with: "Vocabularios")
+            assert has_field?("dataset_slug", with: "vocabularies-slug")
+            assert has_select?("Table name", selected: "vocabularies")
+          end
+
+          activity = Activity.last
+          new_dataset = ::GobiertoData::Dataset.last
+          assert_equal new_dataset, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_data.dataset.dataset_created", activity.action
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/datasets_index_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/datasets_index_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoData
+    module Datasets
+      class DatasetsIndexTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_data_datasets_path
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_regular_admin
+          @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def datasets
+          @datasets ||= site.datasets
+        end
+
+        def test_regular_admin_permissions_not_authorized
+          with(site: site, admin: unauthorized_regular_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal edit_admin_admin_settings_path, current_path
+          end
+        end
+
+        def test_regular_admin_permissions_authorized
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+            assert has_no_content?("You are not authorized to perform this action")
+            assert_equal @path, current_path
+          end
+        end
+
+        def test_datasets_index
+          with(site: site, admin: admin) do
+            visit @path
+
+            within "table tbody" do
+              assert has_selector?("tr", count: datasets.size)
+
+              datasets.each do |dataset|
+                assert has_selector?("tr#dataset-item-#{ dataset.id }")
+
+                within "tr#dataset-item-#{ dataset.id }" do
+                  assert has_link?(dataset.name)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/delete_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/delete_dataset_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoData
+    module Datasets
+      class DeleteDatasetTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = admin_data_datasets_path
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def dataset
+          @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def test_delete_dataset
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+
+            within "#dataset-item-#{dataset.id}" do
+              find("a[data-method='delete']").click
+            end
+
+            assert has_message?("Dataset deleted correctly.")
+
+            refute site.datasets.exists?(id: dataset.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoData
+    module Datasets
+      class UpdateDatasetTest < ActionDispatch::IntegrationTest
+        def setup
+          super
+          @path = edit_admin_data_dataset_path(dataset)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:nick)
+        end
+
+        def unauthorized_regular_admin
+          @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+        end
+
+        def authorized_regular_admin
+          @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def dataset
+          @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def test_regular_admin_permissions_not_authorized
+          with(site: site, admin: unauthorized_regular_admin) do
+            visit @path
+            assert has_content?("You are not authorized to perform this action")
+            assert_equal edit_admin_admin_settings_path, current_path
+          end
+        end
+
+        def test_regular_admin_permissions_authorized
+          with(site: site, admin: authorized_regular_admin) do
+            visit @path
+            assert has_no_content?("You are not authorized to perform this action")
+            assert_equal @path, current_path
+          end
+        end
+
+        def test_update_dataset
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            fill_in "dataset_name_translations_en", with: "Vocabulary updated"
+            switch_locale "ES"
+            fill_in "dataset_name_translations_es", with: "Vocabulario actualizado"
+            select "terms", from: "dataset_table_name"
+            fill_in "dataset_slug", with: "vocabularies-updated-slug"
+
+            click_button "Update"
+
+            assert has_message?("Dataset updated correctly.")
+            assert has_field? "dataset_name_translations_en", with: "Vocabulary updated"
+            switch_locale "ES"
+            assert has_field?("dataset_name_translations_es", with: "Vocabulario actualizado")
+            assert has_field?("dataset_slug", with: "vocabularies-updated-slug")
+            assert has_select?("Table name", selected: "terms")
+          end
+
+          activity = Activity.last
+          assert_equal dataset, activity.subject
+          assert_equal admin, activity.author
+          assert_equal site.id, activity.site_id
+          assert_equal "gobierto_data.dataset.dataset_updated", activity.action
+        end
+
+        def test_update_dataset_error
+          with_javascript do
+            with_signed_in_admin(admin) do
+              with_current_site(site) do
+                visit @path
+
+                fill_in "dataset_name_translations_en", with: ""
+                switch_locale "ES"
+                fill_in "dataset_name_translations_es", with: ""
+
+                click_button "Update"
+
+                assert has_alert?("can't be blank")
+              end
+            end
+          end
+        end
+
+        def test_update_custom_field_updates_dataset
+          with(site: site, admin: admin) do
+            visit @path
+
+            assert_changes "dataset.reload.updated_at" do
+              select "Economy", from: "dataset_custom_records_category_value"
+              click_button "Update"
+              assert has_message?("Dataset updated correctly.")
+              assert has_select?("Category", selected: "Economy")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -33,8 +33,8 @@ module GobiertoData
       result = Connection.execute_query(site, "SELECT COUNT(*) FROM not_existing_table")
       hash_result = JSON.parse(result.to_json)
 
-      assert hash_result.has_key?("error")
-      assert_match(/UndefinedTable/, hash_result["error"])
+      assert hash_result.has_key?("errors")
+      assert_match(/UndefinedTable/, hash_result["errors"].first["sql"])
     end
 
     def test_execute_query_with_module_disabled

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class ConnectionTest < ActiveSupport::TestCase
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def site_with_module_disabled
+      @site_with_module_disabled ||= sites(:santander)
+    end
+
+    def test_execute_query_with_module_enabled
+      result = Connection.execute_query(site, "SELECT COUNT(*) AS test_count FROM users")
+      hash_result = JSON.parse(result.to_json)
+
+      assert_equal [{ "test_count" => 7 }], hash_result
+    end
+
+    def test_execute_query_with_wrong_configuration
+      module_settings = site.gobierto_data_settings
+      module_settings.db_config = { foo: :bar }
+      module_settings.save
+
+      assert_raise ActiveRecord::AdapterNotSpecified do
+        Connection.execute_query(site, "SELECT COUNT(*) AS test_count FROM users")
+      end
+    end
+
+    def test_execute_query_with_error_in_query
+      result = Connection.execute_query(site, "SELECT COUNT(*) FROM not_existing_table")
+      hash_result = JSON.parse(result.to_json)
+
+      assert hash_result.has_key?("error")
+      assert_match(/UndefinedTable/, hash_result["error"])
+    end
+
+    def test_execute_query_with_module_disabled
+      result = Connection.execute_query(site_with_module_disabled, "SELECT COUNT(*) FROM users")
+      hash_result = JSON.parse(result.to_json)
+
+      assert_equal [], hash_result
+    end
+  end
+end


### PR DESCRIPTION
Closes PopulateTools/issues#811


## :v: What does this PR do?

* Adds `GobiertoData::Dataset` model
* Adds administration of model from backoffice
* Adds a method in Dataset model to wrap connection to table with a rails model
* Adds admin site activities for creation and update of datasets
* Adds a lateral menu entry for GobiertoData linked with datasets index
* Adds custom fields to datasets
* Adds admins group permission class for GobiertoData module
* Improves the API using appropriate HTTP response codes and error messages 
* Adds integration tests for datasets management in backoffice for admins (index, creation, deletion and update)
* Changes translations of dataset term in ES and CA

This PR is built on top of #2664, so it includes the changes described on it.

## :mag: How should this be manually tested?

Visit backoffice of a site with `GobiertoData` enabled and an admin with permissions on the module and create/edit datasets.

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![811-after](https://user-images.githubusercontent.com/446459/69328518-a9445980-0c4f-11ea-990a-8a5b3946c6e4.gif)


## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [x] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [x] new module/submodule settings?
- [ ] significant changes in some feature?
