### PR TITLE
Rollbar style null & d3 destructuration

### DIFF
--- a/app/javascript/lib/visualizations/modules/age_distribution.js
+++ b/app/javascript/lib/visualizations/modules/age_distribution.js
@@ -224,7 +224,7 @@ export class VisAgeDistribution {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/age_distribution.js
+++ b/app/javascript/lib/visualizations/modules/age_distribution.js
@@ -1,4 +1,12 @@
-import * as d3 from 'd3'
+import { select, selectAll } from 'd3-selection'
+import { scaleBand, scaleLinear } from 'd3-scale'
+import { axisBottom, axisRight } from 'd3-axis'
+import { json } from 'd3-request'
+import { max, sum } from 'd3-array'
+import { interpolateHcl } from 'd3-interpolate'
+
+const d3 = { select, selectAll, scaleBand, scaleLinear, axisBottom, axisRight, json, max, sum, interpolateHcl }
+
 import { accounting } from 'lib/shared'
 
 export class VisAgeDistribution {
@@ -216,7 +224,7 @@ export class VisAgeDistribution {
   }
 
   _width() {
-    return parseInt(d3.select(this.container).style('width'));
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/age_report.js
+++ b/app/javascript/lib/visualizations/modules/age_report.js
@@ -178,7 +178,7 @@ export class VisAgeReport {
   }
 
   _width() {
-    return parseInt(d3.select(this.container).style('width'));
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/age_report.js
+++ b/app/javascript/lib/visualizations/modules/age_report.js
@@ -1,4 +1,13 @@
-import * as d3 from 'd3'
+import { select, selectAll } from 'd3-selection'
+import { scaleBand, scaleLinear } from 'd3-scale'
+import { axisBottom, axisRight } from 'd3-axis'
+import { csv } from 'd3-request'
+import { nest } from 'd3-collection'
+import { max } from 'd3-array'
+import { format } from 'd3-format'
+
+const d3 = { select, selectAll, scaleBand, scaleLinear, axisBottom, axisRight, csv, nest, max, format }
+
 import { accounting } from 'lib/shared'
 
 export class VisAgeReport {
@@ -178,7 +187,7 @@ export class VisAgeReport {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/bubble_legend.js
+++ b/app/javascript/lib/visualizations/modules/bubble_legend.js
@@ -1,4 +1,8 @@
-import * as d3 from 'd3'
+import { select, selectAll } from 'd3-selection'
+import { scaleOrdinal } from 'd3-scale'
+import { range } from 'd3-array'
+
+const d3 = { select, selectAll, scaleOrdinal, range }
 
 export class VisBubbleLegend {
   constructor(divId) {
@@ -14,7 +18,7 @@ export class VisBubbleLegend {
       .domain(colors.reverse())
       .range(d3.range(0, 100, 100 / colors.length));
 
-    var margin = {top: 15, right: 5, bottom: 15, left: 5},
+    var margin = { top: 15, right: 5, bottom: 15, left: 5 },
       width = parseInt(d3.select(this.container).style('width')) - margin.left - margin.right,
       height = this.isMobile ? 320 : 520 - margin.top - margin.bottom;
 

--- a/app/javascript/lib/visualizations/modules/card.js
+++ b/app/javascript/lib/visualizations/modules/card.js
@@ -1,4 +1,8 @@
-import * as d3 from 'd3'
+import { select } from 'd3-selection'
+import { timeFormatDefaultLocale } from 'd3-time-format'
+
+const d3 = { timeFormatDefaultLocale, select }
+
 import { d3locale, accounting } from 'lib/shared'
 
 export class Card {

--- a/app/javascript/lib/visualizations/modules/card_bars.js
+++ b/app/javascript/lib/visualizations/modules/card_bars.js
@@ -1,4 +1,10 @@
-import * as d3 from 'd3'
+import { select } from 'd3-selection'
+import { scaleLinear } from 'd3-scale'
+import { max } from 'd3-array'
+import { timeFormat, timeParse } from 'd3-time-format'
+
+const d3 = { select, scaleLinear, timeFormat, timeParse, max }
+
 import { Card } from './card.js'
 
 export class BarsCard extends Card {
@@ -15,7 +21,7 @@ export class BarsCard extends Card {
 
     this.div.selectAll('.tw-sharer')
       .attr('target', '_blank')
-      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' +  encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(data[0].figure))  + '&url=' + window.location.href + '&via=gobierto&source=webclient');
+      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' + encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(data[0].figure)) + '&url=' + window.location.href + '&via=gobierto&source=webclient');
 
     this.div.selectAll('.fb-sharer')
       .attr('target', '_blank')

--- a/app/javascript/lib/visualizations/modules/card_comparison.js
+++ b/app/javascript/lib/visualizations/modules/card_comparison.js
@@ -1,4 +1,7 @@
-import * as d3 from 'd3'
+import { timeFormat, timeParse } from 'd3-time-format'
+
+const d3 = { timeFormat, timeParse }
+
 import { Card } from './card.js'
 import { accounting } from 'lib/shared'
 
@@ -17,7 +20,7 @@ export class ComparisonCard extends Card {
 
     this.div.selectAll('.tw-sharer')
       .attr('target', '_blank')
-      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' +  encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(this.firstDataType, value_1))  + '&url=' + window.location.href + '&via=gobierto&source=webclient');
+      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' + encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(this.firstDataType, value_1)) + '&url=' + window.location.href + '&via=gobierto&source=webclient');
 
     this.div.selectAll('.fb-sharer')
       .attr('target', '_blank')

--- a/app/javascript/lib/visualizations/modules/card_simple.js
+++ b/app/javascript/lib/visualizations/modules/card_simple.js
@@ -1,4 +1,7 @@
-import * as d3 from 'd3'
+import { timeFormat, timeParse } from 'd3-time-format'
+
+const d3 = { timeFormat, timeParse }
+
 import { Card } from './card.js'
 import { Sparkline } from './sparkline.js'
 import { accounting } from 'lib/shared'
@@ -22,7 +25,7 @@ export class SimpleCard extends Card {
 
     this.div.selectAll('.tw-sharer')
       .attr('target', '_blank')
-      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' +  encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(value))  + '&url=' + window.location.href + '&via=gobierto&source=webclient');
+      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' + encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(value)) + '&url=' + window.location.href + '&via=gobierto&source=webclient');
 
     this.div.selectAll('.fb-sharer')
       .attr('target', '_blank')

--- a/app/javascript/lib/visualizations/modules/card_sparkline_table.js
+++ b/app/javascript/lib/visualizations/modules/card_sparkline_table.js
@@ -1,4 +1,7 @@
-import * as d3 from 'd3'
+import { timeFormat, timeParse } from 'd3-time-format'
+
+const d3 = { timeFormat, timeParse }
+
 import { Card } from './card.js'
 import { accounting } from 'lib/shared'
 
@@ -16,7 +19,7 @@ export class SparklineTableCard extends Card {
 
     this.div.selectAll('.tw-sharer')
       .attr('target', '_blank')
-      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' +  encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(value[0].value))  + '&url=' + window.location.href + '&via=gobierto&source=webclient');
+      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' + encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(value[0].value)) + '&url=' + window.location.href + '&via=gobierto&source=webclient');
 
     this.div.selectAll('.fb-sharer')
       .attr('target', '_blank')
@@ -47,7 +50,7 @@ export class SparklineTableCard extends Card {
       .text(formatDate(parsedDate));
 
     var rows = value.map(function(d) {
-      return '<td>' + I18n.t('gobierto_common.visualizations.cards.' + cardName + '.' + this._normalize(d.key), {place: window.populateData.municipalityName, province: window.populateData.provinceName }) + '</td> \
+      return '<td>' + I18n.t('gobierto_common.visualizations.cards.' + cardName + '.' + this._normalize(d.key), { place: window.populateData.municipalityName, province: window.populateData.provinceName }) + '</td> \
         <td class="sparktable sparkline-' + this._normalize(d.key) + '"></td> \
         <td>' + accounting.formatNumber(d.diff, 1) + '%</td> \
         <td>' + this._printData(d.value) + '</td>'

--- a/app/javascript/lib/visualizations/modules/card_table.js
+++ b/app/javascript/lib/visualizations/modules/card_table.js
@@ -1,4 +1,7 @@
-import * as d3 from 'd3'
+import { timeFormat, timeParse } from 'd3-time-format'
+
+const d3 = { timeFormat, timeParse }
+
 import { Card } from './card.js'
 import { accounting } from 'lib/shared'
 
@@ -17,7 +20,7 @@ export class TableCard extends Card {
 
     this.div.selectAll('.tw-sharer')
       .attr('target', '_blank')
-      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' +  encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(nest[0].value.valueOne))  + '&url=' + window.location.href + '&via=gobierto&source=webclient');
+      .attr('href', 'https://twitter.com/intent/tweet?text=' + I18n.t('gobierto_common.visualizations.where') + encodeURI(window.populateData.municipalityName) + ': ' + encodeURI(I18n.t('gobierto_common.visualizations.cards.' + cardName + '.title')).toLowerCase() + I18n.t('gobierto_common.visualizations.time') + encodeURI(formatDate(parsedDate).toLowerCase()) + ', ' + encodeURI(this._printData(nest[0].value.valueOne)) + '&url=' + window.location.href + '&via=gobierto&source=webclient');
 
     this.div.selectAll('.fb-sharer')
       .attr('target', '_blank')

--- a/app/javascript/lib/visualizations/modules/consultation_indicators.js
+++ b/app/javascript/lib/visualizations/modules/consultation_indicators.js
@@ -1,4 +1,12 @@
-import * as d3 from 'd3'
+import { csv } from 'd3-request'
+import { nest, keys } from 'd3-collection'
+import { select } from 'd3-selection'
+import { format } from 'd3-format'
+import { sum, mean } from 'd3-array'
+import { scaleQuantile } from 'd3-scale'
+
+const d3 = { csv, nest, select, format, sum, mean, scaleQuantile, keys }
+
 import { accounting } from 'lib/shared'
 
 export class VisIndicators {
@@ -158,7 +166,7 @@ export class VisIndicators {
 
     var columns = [
       { head: I18n.t('gobierto_common.visualizations.questions'), headCl: 'title', cl: 'title', html(d) { return d.key; } },
-      { head: I18n.t('gobierto_common.visualizations.reduce'), headCl: 'center', cl(d) { return customClass(extractValue(d.values, '-5')) }, html(d) { return returnValue(extractValue(d.values, '-5'))  } },
+      { head: I18n.t('gobierto_common.visualizations.reduce'), headCl: 'center', cl(d) { return customClass(extractValue(d.values, '-5')) }, html(d) { return returnValue(extractValue(d.values, '-5')) } },
       { head: I18n.t('gobierto_common.visualizations.keep'), headCl: 'center', cl(d) { return customClass(extractValue(d.values, '0')) }, html(d) { return returnValue(extractValue(d.values, '0')) } },
       { head: I18n.t('gobierto_common.visualizations.increase'), headCl: 'center', cl(d) { return customClass(extractValue(d.values, '5')) }, html(d) { return returnValue(extractValue(d.values, '5')) } },
     ];

--- a/app/javascript/lib/visualizations/modules/d3-distance-limited-voronoi.js
+++ b/app/javascript/lib/visualizations/modules/d3-distance-limited-voronoi.js
@@ -1,4 +1,7 @@
-import * as d3 from 'd3'
+import { voronoi } from 'd3-voronoi'
+import { path } from 'd3-path'
+
+const d3 = { voronoi, path }
 
 export function distanceLimitedVoronoi() {
   /////// Internals ///////

--- a/app/javascript/lib/visualizations/modules/evo_line.js
+++ b/app/javascript/lib/visualizations/modules/evo_line.js
@@ -171,7 +171,7 @@ export class VisEvoLine {
   }
 
   _width() {
-    return parseInt(d3.select(this.container).style('width'));
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _resize() {

--- a/app/javascript/lib/visualizations/modules/evo_line.js
+++ b/app/javascript/lib/visualizations/modules/evo_line.js
@@ -1,4 +1,12 @@
-import * as d3 from 'd3'
+import { select } from 'd3-selection'
+import { scaleLinear } from 'd3-scale'
+import { axisBottom, axisRight } from 'd3-axis'
+import { json } from 'd3-request'
+import { extent, max } from 'd3-array'
+import { line } from 'd3-shape'
+import { format } from 'd3-format'
+
+const d3 = { select, scaleLinear, axisBottom, axisRight, json, extent, line, max, format }
 
 export class VisEvoLine {
   constructor(divId, series, current_year) {
@@ -171,7 +179,7 @@ export class VisEvoLine {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _resize() {

--- a/app/javascript/lib/visualizations/modules/population_pyramid.js
+++ b/app/javascript/lib/visualizations/modules/population_pyramid.js
@@ -1,8 +1,13 @@
-import * as d3 from 'd3'
+import { scaleLinear, scaleBand } from 'd3-scale'
+import { axisBottom, axisRight } from 'd3-axis'
+import { select, selectAll } from 'd3-selection'
+import { json, csv } from 'd3-request'
+import { queue } from 'd3-queue'
+import { max, min } from 'd3-array'
 import { transition } from 'd3-transition'
 import { URLParams } from 'lib/shared'
 
-d3.selection.prototype.transition = transition;
+const d3 = { scaleLinear, scaleBand, axisBottom, axisRight, select, selectAll, json, csv, queue, max, min, transition }
 
 export class VisPopulationPyramid {
   constructor(divId, city_id, current_year, filter) {
@@ -196,6 +201,7 @@ export class VisPopulationPyramid {
         }
 
         this.data = aux
+
         this.update(this.data)
       }.bind(this))
   }
@@ -232,18 +238,18 @@ export class VisPopulationPyramid {
 
   _updateAxes () {
     this.pyramid
-      .transition().duration(500)
       .select(".x.axis.males")
+      .transition().duration(500)
       .call(this._xAxisMale.bind(this))
 
     this.pyramid
-      .transition().duration(500)
       .select(".x.axis.females")
+      .transition().duration(500)
       .call(this._xAxisFemale.bind(this))
 
     this.pyramid
-      .transition().duration(500)
       .select(".y.axis")
+      .transition().duration(500)
       .call(this._yAxis.bind(this))
   }
 
@@ -271,7 +277,6 @@ export class VisPopulationPyramid {
       .on("mouseout", this._mouseout.bind(this))
       .transition()
       .duration(500)
-      .selectAll("g.bars g.males rect")
       .attr("width", d => (this.width.pyramid / 2) - this.xScaleMale(d._value))
       .attr("x", d => this.xScaleMale(d._value)) // Real value
 
@@ -282,7 +287,6 @@ export class VisPopulationPyramid {
       .attr("y2", d => this.yScale(d.age) + this.yScale.bandwidth() - 1)
       .transition()
       .duration(500)
-      .selectAll("g.bars g.males line")
       .attr("x1", d => this.xScaleMale(d._value))
 
     let ff = female.enter().append("g")
@@ -295,7 +299,6 @@ export class VisPopulationPyramid {
       .on("mouseout", this._mouseout.bind(this))
       .transition()
       .duration(500)
-      .selectAll("g.bars g.females rect")
       .attr("width", d => this.xScaleFemale(d._value))
 
     ff.append("line")
@@ -305,33 +308,28 @@ export class VisPopulationPyramid {
       .attr("y2", d => this.yScale(d.age) + this.yScale.bandwidth() - 1)
       .transition()
       .duration(500)
-      .selectAll("g.bars g.females line")
       .attr("x2", d => this.width.pyramid / 2 + this.xScaleFemale(d._value))
 
     // updates
     male.select("rect")
       .transition()
       .duration(500)
-      .selectAll("g.bars g.males rect")
       .attr("width", d => (this.width.pyramid / 2) - this.xScaleMale(d._value))
       .attr("x", d => this.xScaleMale(d._value)) // Real value
 
     male.select("line")
       .transition()
       .duration(500)
-      .selectAll("g.bars g.males line")
       .attr("x1", d => this.xScaleMale(d._value))
 
     female.select("rect")
       .transition()
       .duration(500)
-      .selectAll("g.bars g.females rect")
       .attr("width", d => this.xScaleFemale(d._value))
 
     female.select("line")
       .transition()
       .duration(500)
-      .selectAll("g.bars g.females line")
       .attr("x2", d => this.width.pyramid / 2 + this.xScaleFemale(d._value))
   }
 
@@ -353,7 +351,6 @@ export class VisPopulationPyramid {
       .attr("height", d => this.yScale(d.range[0]) - this.yScale(d.range[1]))
       .transition()
       .duration(1000)
-      .selectAll("g.range rect")
       .attr("width", d => chartWidth - this.xScaleAgeRanges(d.value))
       .attr("x", d => this.xScaleAgeRanges(d.value)) // Real value
 
@@ -374,7 +371,6 @@ export class VisPopulationPyramid {
     g.select("rect")
       .transition()
       .duration(1000)
-      .selectAll("g.range rect")
       .attr("width", d => chartWidth - this.xScaleAgeRanges(d.value))
       .attr("x", d => this.xScaleAgeRanges(d.value)) // Real value
 
@@ -419,7 +415,6 @@ export class VisPopulationPyramid {
       .transition()
       .delay(1000)
       .duration(1000)
-      .selectAll("g.r-fake rect.inner")
       .attr("height", d => yFakeScale(d.fake))
       .attr("y", 0)
 
@@ -432,7 +427,6 @@ export class VisPopulationPyramid {
       .transition()
       .delay(1000)
       .duration(1000)
-      .selectAll("g.r-fake text")
       .attr("opacity", 1)
 
     // updates
@@ -441,14 +435,12 @@ export class VisPopulationPyramid {
       .transition()
       .delay(1000)
       .duration(1000)
-      .selectAll("g.r-fake")
       .attr("transform", d => `translate(0, ${this.yScale(d.range[0]) - this.yScale(d.range[1]) - yFakeScale(d.fake)})`)
 
     g.select("g.r-fake rect")
       .transition()
       .delay(1000)
       .duration(1000)
-      .selectAll("g.r-fake rect")
       .attr("width", d => chartWidth - this.xScaleAgeRanges(d.value))
       .attr("x", d => this.xScaleAgeRanges(d.value)) // Real value
       .attr("height", d => yFakeScale(d.fake))
@@ -472,7 +464,6 @@ export class VisPopulationPyramid {
     marks
       .transition()
       .duration(1000)
-      .selectAll("g.mark")
       .attr("transform", d => `translate(0, ${this.yScale(d.value)})`)
 
     marks.append("line")
@@ -489,7 +480,6 @@ export class VisPopulationPyramid {
     g
       .transition()
       .duration(500)
-      .selectAll("g.mark")
       .attr("transform", d =>`translate(0, ${this.yScale(d.value)})`)
 
     g.select("text")

--- a/app/javascript/lib/visualizations/modules/rent_distribution.js
+++ b/app/javascript/lib/visualizations/modules/rent_distribution.js
@@ -298,7 +298,7 @@ export class VisRentDistribution {
   }
 
   _width() {
-    return parseInt(d3.select(this.container).style('width'));
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/rent_distribution.js
+++ b/app/javascript/lib/visualizations/modules/rent_distribution.js
@@ -1,8 +1,15 @@
-import * as __d3 from 'd3'
+import { format, formatDefaultLocale } from 'd3-format'
+import { scaleLog, scaleLinear, scaleSequential, interpolatePlasma } from 'd3-scale'
+import { axisBottom, axisRight } from 'd3-axis'
+import { select, selectAll, mouse } from 'd3-selection'
+import { json } from 'd3-request'
+import { queue } from 'd3-queue'
+import { extent } from 'd3-array'
 import { distanceLimitedVoronoi } from './d3-distance-limited-voronoi.js'
-import { d3locale, accounting } from 'lib/shared'
 
-const d3 = { ...__d3, distanceLimitedVoronoi }
+const d3 = { format, formatDefaultLocale, scaleLog, scaleLinear, scaleSequential, axisBottom, axisRight, select, json, interpolatePlasma, distanceLimitedVoronoi, extent, queue, selectAll, mouse }
+
+import { d3locale, accounting } from 'lib/shared'
 
 export class VisRentDistribution {
   constructor(divId, city_id, province_id, current_year) {
@@ -298,7 +305,7 @@ export class VisRentDistribution {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/sparkline.js
+++ b/app/javascript/lib/visualizations/modules/sparkline.js
@@ -106,7 +106,7 @@ export class Sparkline {
   }
 
   _width() {
-    return parseInt(d3.select(this.container).style('width')) || +(d3.select(this.container).node() || document.createElement("div")).getBoundingClientRect().width
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/sparkline.js
+++ b/app/javascript/lib/visualizations/modules/sparkline.js
@@ -1,4 +1,11 @@
-import * as d3 from 'd3'
+import { timeParse } from 'd3-time-format'
+import { scaleTime, scaleLinear, scaleOrdinal } from 'd3-scale'
+import { select } from 'd3-selection'
+import { extent } from 'd3-array'
+import { line } from 'd3-shape'
+import { axisTop } from 'd3-axis'
+
+const d3 = { timeParse, scaleTime, scaleLinear, scaleOrdinal, select, extent, line, axisTop }
 
 export class Sparkline {
   constructor(context, data, options = {}) {
@@ -106,7 +113,7 @@ export class Sparkline {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/treemap.js
+++ b/app/javascript/lib/visualizations/modules/treemap.js
@@ -1,4 +1,10 @@
-import * as d3 from 'd3'
+import { scaleOrdinal } from 'd3-scale'
+import { select } from 'd3-selection'
+import { json } from 'd3-request'
+import { treemap, hierarchy } from 'd3-hierarchy'
+
+const d3 = { scaleOrdinal, select, json, treemap, hierarchy }
+
 import { accounting } from 'lib/shared'
 
 export class VisTreemap {

--- a/app/javascript/lib/visualizations/modules/unemployment_age.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_age.js
@@ -219,7 +219,7 @@ export class VisUnemploymentAge {
   }
 
   _width() {
-    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/unemployment_age.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_age.js
@@ -219,7 +219,7 @@ export class VisUnemploymentAge {
   }
 
   _width() {
-    return this.container ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/unemployment_age.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_age.js
@@ -219,7 +219,7 @@ export class VisUnemploymentAge {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/unemployment_rate.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_rate.js
@@ -258,7 +258,7 @@ export class VisUnemploymentRate {
   }
 
   _width() {
-    return this.container ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/unemployment_rate.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_rate.js
@@ -258,7 +258,7 @@ export class VisUnemploymentRate {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/unemployment_sex.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_sex.js
@@ -274,7 +274,7 @@ export class VisUnemploymentSex {
   }
 
   _width() {
-    return this.container ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {

--- a/app/javascript/lib/visualizations/modules/unemployment_sex.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_sex.js
@@ -274,7 +274,7 @@ export class VisUnemploymentSex {
   }
 
   _width() {
-    return d3.select(this.container) ? parseInt(d3.select(this.container).style('width')) : 0;
+    return d3.select(this.container).node() ? parseInt(d3.select(this.container).style('width')) : 0;
   }
 
   _height() {


### PR DESCRIPTION
Closes #2662 
Closes https://rollbar.com/Populate/gobierto/items/2776/

## :v: What does this PR do?
- Provide a proper fallback for charts with `d3.select(this.container).style(...)`
- Destructuration of d3 dependencies for all visualizations

## Caveats
Such destructurarion shrinks bundle size. After this, dependencies graph will look like:

![imagen](https://user-images.githubusercontent.com/817526/69138848-b5011600-0abf-11ea-9d7a-d75625e6af21.png)

I would consider to get rid of commons chunks. Or perhaps, reduce the chunks factor (current: 5). That means, the bundle groups into a single file those dependencies repeated all over the app.
The point is if that's worth: how much final clients ACTUALLY use more than 2 or 3 modules? cc/ @ferblape 

With no common chunk, the chart would look like this:
![imagen](https://user-images.githubusercontent.com/817526/69139006-ff829280-0abf-11ea-819c-69743b427dd1.png)

