### PR TITLE
Remove turbolinks event

### DIFF
--- a/app/views/layouts/_javascript_hook.html.erb
+++ b/app/views/layouts/_javascript_hook.html.erb
@@ -1,7 +1,5 @@
 <% if content_for? :javascript_hook %>
   <%= javascript_tag do %>
-    $(document).on('turbolinks:load', function() {
-      <%= yield(:javascript_hook) %>
-    });
+    <%= yield(:javascript_hook) %>
   <% end %>
 <% end%>


### PR DESCRIPTION
## :v: What does this PR do?
remove from javascript_hook turbolinks:load event 