### PR TITLE
Fix elaboration issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 814933d614c7fe05ffac21e838d6cf8d0f9531d6
+  revision: 970d544dba508108a4c84b7991993c35c906613e
   specs:
     gobierto_data (0.1.0)
       actionpack (>= 5.0.0.1)
@@ -78,13 +78,13 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-sdk (2.11.396)
-      aws-sdk-resources (= 2.11.396)
-    aws-sdk-core (2.11.396)
+    aws-sdk (2.11.402)
+      aws-sdk-resources (= 2.11.402)
+    aws-sdk-core (2.11.402)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.396)
-      aws-sdk-core (= 2.11.396)
+    aws-sdk-resources (2.11.402)
+      aws-sdk-core (= 2.11.402)
     aws-ses (0.6.0)
       builder
       mail (> 2.2.5)
@@ -138,15 +138,15 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (6.3.1)
-      elasticsearch-api (= 6.3.1)
-      elasticsearch-transport (= 6.3.1)
-    elasticsearch-api (6.3.1)
+    elasticsearch (6.8.0)
+      elasticsearch-api (= 6.8.0)
+      elasticsearch-transport (= 6.8.0)
+    elasticsearch-api (6.8.0)
       multi_json
     elasticsearch-extensions (0.0.31)
       ansi
       elasticsearch
-    elasticsearch-transport (6.3.1)
+    elasticsearch-transport (6.8.0)
       faraday
       multi_json
     erubi (1.9.0)
@@ -303,7 +303,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     ntlm-http (0.1.1)
-    oj (3.7.11)
+    oj (3.9.2)
     os (1.0.1)
     paper_trail (10.3.1)
       activerecord (>= 4.2)

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -212,13 +212,6 @@ module GobiertoBudgets
                return nil if v1.nil? || v2.nil?
                ((v1.to_f - v2.to_f) / v2.to_f) * 100
       end
-      total_income = 0
-      (1..5).each do |code|
-        total_income += get_income_budget_line(year, code)
-      end
-      return 0 if total_income == 0
-
-
       if diff < 0
         direction = I18n.t("gobierto_budgets.budgets.index.less")
         diff *= -1

--- a/test/models/gobierto_budgets/site_stats_test.rb
+++ b/test/models/gobierto_budgets/site_stats_test.rb
@@ -187,5 +187,13 @@ module GobiertoBudgets
       end
     end
 
+    def test_percentage_difference
+      f1 = total(forecast: TOTAL_BUDGET)
+      f2 = total(executed: TOTAL_BUDGET/2)
+
+      with factories: [f1, f2] do
+        assert_equal "100.00 % more", stats.percentage_difference(variable1: :total_budget, variable2: :total_budget_executed, year: Date.today.year)
+      end
+    end
   end
 end


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

- Fixes a bug in a bad merge in the percentage difference method
- Updates gobierto_data gem to fix debt and population automatic imports

## :mag: How should this be manually tested?

Visit a site with elaboration enabled, you should see again the differences between years.

## :eyes: Screenshots

### After this PR

![Screen Shot 2019-11-21 at 14 12 09](https://user-images.githubusercontent.com/17616/69340975-f3860480-0c68-11ea-8e91-522830dc4f7d.png)
