### PR TITLE
811 gobierto data 2nd iteration

### DIFF
--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -5,6 +5,8 @@ class ApiBaseController < ActionController::API
   include ::GobiertoCommon::ModuleHelper
   include ApplicationConcern
 
+  before_action :disable_cors
+
   def preferred_locale
     @preferred_locale ||= begin
                             locale_param = params[:locale]
@@ -36,6 +38,11 @@ class ApiBaseController < ActionController::API
 
   def raise_module_not_allowed
     send_unauthorized(message: "Module not allowed")
+  end
+
+  def disable_cors
+    response.set_header("Access-Control-Allow-Origin", "*")
+    response.set_header("Access-Control-Request-Method", "*")
   end
 
 end

--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -11,6 +11,7 @@ module GobiertoCommon
     end
 
     def filtered_relation
+      @resource ||= base_relation.try(:model)&.new
       return base_relation unless filter_params.present?
 
       query = GobiertoCommon::CustomFieldsQuery.new(relation: base_relation)

--- a/app/controllers/gobierto_admin/gobierto_data/configuration/settings_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/configuration/settings_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoData
+    module Configuration
+      class SettingsController < GobiertoAdmin::GobiertoData::BaseController
+        def edit
+          @settings_form = SettingsForm.new(site_id: current_site.id)
+        end
+
+        def update
+          @settings_form = SettingsForm.new(settings_params.merge(site_id: current_site.id))
+
+          if @settings_form.save
+            redirect_to edit_admin_data_configuration_settings_path, notice: t(".success")
+          else
+            redirect_to edit_admin_data_configuration_settings_path, alert: t(".error", validation_errors: @settings_form.errors.full_messages.to_sentence)
+          end
+        end
+
+        private
+
+        def settings_params
+          params.require(:gobierto_data_settings).permit(:db_config)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -56,6 +56,14 @@ module GobiertoData
           )
         end
 
+        def available_locales_hash
+          @available_locales_hash ||= current_site.configuration.available_locales.inject({}) do |hash, locale|
+            hash.update(
+              locale => nil
+            )
+          end
+        end
+
       end
     end
   end

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -34,6 +34,14 @@ module GobiertoData
           end.force_encoding("utf-8")
         end
 
+        def render_csv(content)
+          headers["Content-Disposition"] = "inline"
+          headers["Content-Type"] = "text/plain; charset=utf-8"
+          render(
+            plain: content
+          )
+        end
+
       end
     end
   end

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -34,6 +34,20 @@ module GobiertoData
           end.force_encoding("utf-8")
         end
 
+        def csv_from_relation(relation, options = {})
+          serialized_data_as_json = ActiveModelSerializers::SerializableResource.new(relation, exclude_links: true, string_output: true).as_json
+          new = ActiveModelSerializers::SerializableResource.new(relation.new, exclude_links: true, string_output: true).as_json
+
+          return "" if serialized_data_as_json.blank?
+
+          CSV.generate(**options) do |csv|
+            csv << new.keys
+            serialized_data_as_json.each do |row|
+              csv << new.merge(row).values
+            end
+          end.force_encoding("utf-8")
+        end
+
         def render_csv(content)
           headers["Content-Disposition"] = "inline"
           headers["Content-Type"] = "text/plain; charset=utf-8"

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -36,7 +36,7 @@ module GobiertoData
 
         def csv_from_relation(relation, options = {})
           serialized_data_as_json = ActiveModelSerializers::SerializableResource.new(relation, exclude_links: true, string_output: true).as_json
-          new = ActiveModelSerializers::SerializableResource.new(relation.new, exclude_links: true, string_output: true).as_json
+          new = ActiveModelSerializers::SerializableResource.new(relation.model.new, exclude_links: true, string_output: true, site: current_site).as_json
 
           return "" if serialized_data_as_json.blank?
 

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -4,8 +4,35 @@ module GobiertoData
   module Api
     module V1
       class BaseController < ApiBaseController
+        include ActionController::MimeResponds
 
         before_action { module_enabled!(current_site, "GobiertoData", false) }
+
+        private
+
+        def csv_options_params
+          separator_tr = {
+            "semicolon" => ";",
+            "colon" => ":",
+            "comma" => ","
+          }
+          {}.tap do |options|
+            if (separator = params[:csv_separator]).present?
+              options[:col_sep] = separator_tr.fetch(separator, separator)
+            end
+          end
+        end
+
+        def csv_from_query_result(result, options = {})
+          return if result.blank?
+
+          CSV.generate(**options) do |csv|
+            csv << result.fields
+            result.each_row do |row|
+              csv << row
+            end
+          end.force_encoding("utf-8")
+        end
 
       end
     end

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -35,8 +35,19 @@ module GobiertoData
         end
 
         def csv_from_relation(relation, options = {})
-          serialized_data_as_json = ActiveModelSerializers::SerializableResource.new(relation, exclude_links: true, string_output: true).as_json
-          new = ActiveModelSerializers::SerializableResource.new(relation.model.new, exclude_links: true, string_output: true, site: current_site).as_json
+          serialized_data_as_json = ActiveModelSerializers::SerializableResource.new(
+            relation,
+            exclude_links: true,
+            exclude_relationships: true,
+            string_output: true
+          ).as_json
+          new = ActiveModelSerializers::SerializableResource.new(
+            relation.model.new,
+            exclude_links: true,
+            exclude_relationships: true,
+            string_output: true,
+            site: current_site
+          ).as_json
 
           return "" if serialized_data_as_json.blank?
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -14,7 +14,7 @@ module GobiertoData
           relation = filtered_relation
           respond_to do |format|
             format.json do
-              render json: relation, links: { self: gobierto_data_api_v1_datasets_path }, adapter: :json_api
+              render json: relation, links: links(:index), adapter: :json_api
             end
 
             format.csv do
@@ -78,11 +78,19 @@ module GobiertoData
         end
 
         def links(self_key = nil)
+          id = @item&.id
           {
-            data: gobierto_data_api_v1_dataset_path(params[:slug]),
-            metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
-            queries: gobierto_data_api_v1_dataset_queries_path(params[:slug])
+            index: gobierto_data_api_v1_datasets_path
           }.tap do |hash|
+            if id.present?
+              hash.merge!(
+                data: gobierto_data_api_v1_dataset_path(params[:slug]),
+                metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
+                queries: gobierto_data_api_v1_queries_path(dataset_id: @item.id),
+                visualizations: gobierto_data_api_v1_visualizations_path(dataset_id: @item.id)
+              )
+            end
+
             hash[:self] = hash.delete(self_key) if self_key.present?
           end
         end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -89,8 +89,8 @@ module GobiertoData
               hash.merge!(
                 data: gobierto_data_api_v1_dataset_path(params[:slug]),
                 metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
-                queries: gobierto_data_api_v1_queries_path(dataset_id: @item.id),
-                visualizations: gobierto_data_api_v1_visualizations_path(dataset_id: @item.id)
+                queries: gobierto_data_api_v1_queries_path(filter: { dataset_id: @item.id }),
+                visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: @item.id })
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class DatasetsController < BaseController
+
+        include ::GobiertoCommon::CustomFieldsApi
+
+        # GET /api/v1/data/datasets
+        # GET /api/v1/data/datasets.json
+        # GET /api/v1/data/datasets.csv
+        def index
+          respond_to do |format|
+            format.json do
+              render json: base_relation, links: { self: gobierto_data_api_v1_datasets_path }, adapter: :json_api
+            end
+
+            format.csv do
+              render_csv(csv_from_relation(base_relation, csv_options_params))
+            end
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug
+        # GET /api/v1/data/datasets/dataset-slug.json
+        # GET /api/v1/data/datasets/dataset-slug.csv
+        def show
+          find_item
+          relation = @item.rails_model.all
+          query_result = execute_query relation
+          respond_to do |format|
+            format.json do
+              render(
+                json:
+                {
+                  data: query_result.delete(:result),
+                  meta: query_result,
+                  links:
+                  {
+                    self: gobierto_data_api_v1_dataset_path(params[:slug], format: :json),
+                    metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug])
+                  }
+                },
+                adapter: :json_api
+              )
+            end
+
+            format.csv do
+              render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+            end
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug/metadata
+        # GET /api/v1/data/datasets/dataset-slug/metadata.json
+        def dataset_meta
+          find_item
+
+          render(
+            json: @item,
+            links:
+            {
+              self: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
+              data: gobierto_data_api_v1_dataset_path(params[:slug], format: :json)
+            },
+            serializer: ::GobiertoData::DatasetMetaSerializer,
+            exclude_links: true,
+            adapter: :json_api
+          )
+        end
+
+        private
+
+        def base_relation
+          current_site.datasets
+        end
+
+        def find_item
+          @item = base_relation.find_by!(slug: params[:slug])
+        end
+
+        def execute_query(relation)
+          GobiertoData::Connection.execute_query(current_site, relation.to_sql)
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -37,11 +37,7 @@ module GobiertoData
                 {
                   data: query_result.delete(:result),
                   meta: query_result,
-                  links:
-                  {
-                    self: gobierto_data_api_v1_dataset_path(params[:slug], format: :json),
-                    metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug])
-                  }
+                  links: links(:data)
                 },
                 adapter: :json_api
               )
@@ -60,7 +56,10 @@ module GobiertoData
 
           render(
             json: @item,
-            serializer: ::GobiertoData::DatasetMetaSerializer
+            serializer: ::GobiertoData::DatasetMetaSerializer,
+            exclude_links: true,
+            links: links(:metadata),
+            adapter: :json_api
           )
         end
 
@@ -76,6 +75,16 @@ module GobiertoData
 
         def execute_query(relation)
           GobiertoData::Connection.execute_query(current_site, relation.to_sql)
+        end
+
+        def links(self_key = nil)
+          {
+            data: gobierto_data_api_v1_dataset_path(params[:slug]),
+            metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
+            queries: gobierto_data_api_v1_dataset_queries_path(params[:slug])
+          }.tap do |hash|
+            hash[:self] = hash.delete(self_key) if self_key.present?
+          end
         end
 
       end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -80,7 +80,10 @@ module GobiertoData
         def links(self_key = nil)
           id = @item&.id
           {
-            index: gobierto_data_api_v1_datasets_path
+            index: gobierto_data_api_v1_datasets_path,
+            datasets_meta: meta_gobierto_data_api_v1_datasets_path,
+            queries: gobierto_data_api_v1_queries_path,
+            visualizations: gobierto_data_api_v1_visualizations_path
           }.tap do |hash|
             if id.present?
               hash.merge!(

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -59,14 +59,7 @@ module GobiertoData
 
           render(
             json: @item,
-            links:
-            {
-              self: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
-              data: gobierto_data_api_v1_dataset_path(params[:slug], format: :json)
-            },
-            serializer: ::GobiertoData::DatasetMetaSerializer,
-            exclude_links: true,
-            adapter: :json_api
+            serializer: ::GobiertoData::DatasetMetaSerializer
           )
         end
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -11,13 +11,14 @@ module GobiertoData
         # GET /api/v1/data/datasets.json
         # GET /api/v1/data/datasets.csv
         def index
+          relation = filtered_relation
           respond_to do |format|
             format.json do
-              render json: base_relation, links: { self: gobierto_data_api_v1_datasets_path }, adapter: :json_api
+              render json: relation, links: { self: gobierto_data_api_v1_datasets_path }, adapter: :json_api
             end
 
             format.csv do
-              render_csv(csv_from_relation(base_relation, csv_options_params))
+              render_csv(csv_from_relation(relation, csv_options_params))
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -89,8 +89,8 @@ module GobiertoData
               hash.merge!(
                 data: gobierto_data_api_v1_dataset_path(params[:slug]),
                 metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
-                queries: gobierto_data_api_v1_queries_path(filter: { dataset_id: @item.id }),
-                visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: @item.id })
+                queries: gobierto_data_api_v1_queries_path(filter: { dataset_id: id }),
+                visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: id })
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -5,9 +5,9 @@ module GobiertoData
     module V1
       class QueriesController < BaseController
 
-        # GET /api/v1/data/dataset/dataset-slug/q
-        # GET /api/v1/data/dataset/dataset-slug/q.json
-        # GET /api/v1/data/dataset/dataset-slug/q.csv
+        # GET /api/v1/data/queries
+        # GET /api/v1/data/queries.json
+        # GET /api/v1/data/queries.csv
         def index
           respond_to do |format|
             format.json do
@@ -20,9 +20,9 @@ module GobiertoData
           end
         end
 
-        # GET /api/v1/data/dataset/dataset-slug/q/1
-        # GET /api/v1/data/dataset/dataset-slug/q/1.json
-        # GET /api/v1/data/dataset/dataset-slug/q/1.csv
+        # GET /api/v1/data/queries/1
+        # GET /api/v1/data/queries/1.json
+        # GET /api/v1/data/queries/1.csv
         def show
           find_item
           query_result = @item.result
@@ -45,8 +45,8 @@ module GobiertoData
           end
         end
 
-        # GET /api/v1/data/dataset/dataset-slug/q/1/meta
-        # GET /api/v1/data/dataset/dataset-slug/q/1/meta.json
+        # GET /api/v1/data/queries/1/meta
+        # GET /api/v1/data/queries/1/meta.json
         def meta
           find_item
 
@@ -58,8 +58,8 @@ module GobiertoData
           )
         end
 
-        # GET /api/v1/data/dataset/dataset-slug/q/new
-        # GET /api/v1/data/dataset/dataset-slug/q/new.json
+        # GET /api/v1/data/queries/new
+        # GET /api/v1/data/queries/new.json
         def new
           @item = base_relation.new(name_translations: available_locales_hash)
 
@@ -72,8 +72,8 @@ module GobiertoData
           )
         end
 
-        # POST /api/v1/data/dataset/dataset-slug/q
-        # POST /api/v1/data/dataset/dataset-slug/q.json
+        # POST /api/v1/data/queries
+        # POST /api/v1/data/queries.json
         def create
           @query_form = QueryForm.new(query_params.merge(site_id: current_site.id))
 
@@ -92,8 +92,8 @@ module GobiertoData
           end
         end
 
-        # PUT /api/v1/data/dataset/dataset-slug/q/1
-        # PUT /api/v1/data/dataset/dataset-slug/q/1.json
+        # PUT /api/v1/data/queries/1
+        # PUT /api/v1/data/queries/1.json
         def update
           find_item
           @query_form = QueryForm.new(query_params.except(*ignored_attributes_on_update).merge(site_id: current_site.id, id: @item.id))
@@ -111,8 +111,8 @@ module GobiertoData
           end
         end
 
-        # DELETE /api/v1/data/dataset/dataset-slug/q/1
-        # DELETE /api/v1/data/dataset/dataset-slug/q/1.json
+        # DELETE /api/v1/data/queries/1
+        # DELETE /api/v1/data/queries/1.json
         def destroy
           find_item
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -80,7 +80,7 @@ module GobiertoData
           if @query_form.save
             @item = @query_form.query
             render(
-              json: @query_form.query,
+              json: @item,
               status: :created,
               exclude_links: true,
               with_translations: true,

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -136,7 +136,7 @@ module GobiertoData
         end
 
         def query_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :dataset_id, :name_translations, :privacy_status, :sql])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :dataset_id, :name_translations, :name, :privacy_status, :sql])
         end
 
         def filter_params

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class QueriesController < BaseController
+
+        include ::GobiertoCommon::CustomFieldsApi
+
+        # GET /api/v1/data/dataset/dataset-slug/q
+        # GET /api/v1/data/dataset/dataset-slug/q.json
+        # GET /api/v1/data/dataset/dataset-slug/q.csv
+        def index
+          relation = filtered_relation
+          respond_to do |format|
+            format.json do
+              render json: relation, links: links(:index), adapter: :json_api
+            end
+
+            format.csv do
+              render_csv(csv_from_relation(relation, csv_options_params))
+            end
+          end
+        end
+
+        # GET /api/v1/data/dataset/dataset-slug/q/1
+        # GET /api/v1/data/dataset/dataset-slug/q/1.json
+        # GET /api/v1/data/dataset/dataset-slug/q/1.csv
+        def show
+          find_item
+          query_result = @item.result
+          respond_to do |format|
+            format.json do
+              render(
+                json:
+                {
+                  data: query_result.delete(:result),
+                  meta: query_result,
+                  links: links(:data)
+                },
+                adapter: :json_api
+              )
+            end
+
+            format.csv do
+              render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+            end
+          end
+        end
+
+        # GET /api/v1/data/dataset/dataset-slug/q/1/meta
+        # GET /api/v1/data/dataset/dataset-slug/q/1/meta.json
+        def meta
+          find_item
+
+          render(
+            json: @item,
+            exclude_links: true,
+            links: links(:metadata),
+            adapter: :json_api
+          )
+        end
+
+        # GET /api/v1/data/dataset/dataset-slug/q/new
+        # GET /api/v1/data/dataset/dataset-slug/q/new.json
+        def new
+          @item = base_relation.new(name_translations: available_locales_hash)
+
+          render(
+            json: @item,
+            exclude_links: true,
+            with_translations: true,
+            links: links(:new),
+            adapter: :json_api
+          )
+        end
+
+        # POST /api/v1/data/dataset/dataset-slug/q
+        # POST /api/v1/data/dataset/dataset-slug/q.json
+        def create
+          find_dataset
+          @query_form = QueryForm.new(query_params.merge(site_id: current_site.id, dataset_id: @dataset.id))
+
+          if @query_form.save
+            render(
+              json: @query_form.query,
+              status: :created,
+              exclude_links: true,
+              with_translations: true,
+              links: links(:metadata, id: @query_form.query.id),
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@query_form, adapter: :json_api)
+          end
+        end
+
+        # PUT /api/v1/data/dataset/dataset-slug/q/1
+        # PUT /api/v1/data/dataset/dataset-slug/q/1.json
+        def update
+          find_item
+          @query_form = QueryForm.new(query_params.merge(site_id: current_site.id, dataset_id: @dataset.id, id: @item.id))
+
+          if @query_form.save
+            render(
+              json: @query_form.query,
+              exclude_links: true,
+              with_translations: true,
+              links: links,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@query_form, adapter: :json_api)
+          end
+        end
+
+        # DELETE /api/v1/data/dataset/dataset-slug/q/1
+        # DELETE /api/v1/data/dataset/dataset-slug/q/1.json
+        def destroy
+          find_item
+
+          @item.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def base_relation
+          find_dataset
+          @dataset.queries.open
+        end
+
+        def find_dataset
+          @dataset = current_site.datasets.find_by!(slug: params[:dataset_slug])
+        end
+
+        def query_params
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :name_translations, :privacy_status, :sql])
+        end
+
+        def find_item
+          @item = base_relation.unscope(where: :privacy_status).find(params[:id])
+        end
+
+        def links(self_key = nil, opts = {})
+          id = opts[:id] || params[:id]
+          {
+            index: gobierto_data_api_v1_dataset_queries_path(params[:dataset_slug]),
+            new: new_gobierto_data_api_v1_dataset_query_path(params[:dataset_slug])
+          }.tap do |hash|
+            if id.present?
+              hash.merge!(
+                data: gobierto_data_api_v1_dataset_query_path(params[:dataset_slug], id),
+                metadata: meta_gobierto_data_api_v1_dataset_query_path(params[:dataset_slug], id)
+              )
+            end
+
+            hash[:self] = hash.delete(self_key) if self_key.present?
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -11,11 +11,11 @@ module GobiertoData
         def index
           respond_to do |format|
             format.json do
-              render json: base_relation, links: links(:index), adapter: :json_api
+              render json: filtered_relation, links: links(:index), adapter: :json_api
             end
 
             format.csv do
-              render_csv(csv_from_relation(base_relation, csv_options_params))
+              render_csv(csv_from_relation(filtered_relation, csv_options_params))
             end
           end
         end
@@ -140,7 +140,11 @@ module GobiertoData
         end
 
         def filter_params
-          params.permit(:dataset_id)
+          params.fetch(:filter, {}).permit(:user_id, :dataset_id)
+        end
+
+        def filtered_relation
+          base_relation.where(filter_params)
         end
 
         def find_item
@@ -150,7 +154,7 @@ module GobiertoData
         def links(self_key = nil)
           id = @item&.id
           {
-            index: gobierto_data_api_v1_queries_path(filter_params),
+            index: gobierto_data_api_v1_queries_path(filter: filter_params),
             new: new_gobierto_data_api_v1_query_path,
             visualizations: gobierto_data_api_v1_visualizations_path
           }.tap do |hash|
@@ -158,7 +162,7 @@ module GobiertoData
               hash.merge!(
                 data: gobierto_data_api_v1_query_path(id),
                 metadata: meta_gobierto_data_api_v1_query_path(id),
-                visualizations: gobierto_data_api_v1_visualizations_path(query_id: id)
+                visualizations: gobierto_data_api_v1_visualizations_path(filter: { query_id: id })
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -151,7 +151,8 @@ module GobiertoData
           id = @item&.id
           {
             index: gobierto_data_api_v1_queries_path(filter_params),
-            new: new_gobierto_data_api_v1_query_path
+            new: new_gobierto_data_api_v1_query_path,
+            visualizations: gobierto_data_api_v1_visualizations_path
           }.tap do |hash|
             if id.present?
               hash.merge!(

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -152,7 +152,8 @@ module GobiertoData
             if id.present?
               hash.merge!(
                 data: gobierto_data_api_v1_dataset_query_path(params[:dataset_slug], id),
-                metadata: meta_gobierto_data_api_v1_dataset_query_path(params[:dataset_slug], id)
+                metadata: meta_gobierto_data_api_v1_dataset_query_path(params[:dataset_slug], id),
+                visualizations: gobierto_data_api_v1_dataset_query_visualizations_path(params[:dataset_slug], id)
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -5,20 +5,17 @@ module GobiertoData
     module V1
       class QueriesController < BaseController
 
-        include ::GobiertoCommon::CustomFieldsApi
-
         # GET /api/v1/data/dataset/dataset-slug/q
         # GET /api/v1/data/dataset/dataset-slug/q.json
         # GET /api/v1/data/dataset/dataset-slug/q.csv
         def index
-          relation = filtered_relation
           respond_to do |format|
             format.json do
-              render json: relation, links: links(:index), adapter: :json_api
+              render json: base_relation, links: links(:index), adapter: :json_api
             end
 
             format.csv do
-              render_csv(csv_from_relation(relation, csv_options_params))
+              render_csv(csv_from_relation(base_relation, csv_options_params))
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -6,13 +6,26 @@ module GobiertoData
       class QueryController < BaseController
 
         # GET /api/v1/data?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/data.json?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/data.csv?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          query_result = execute_query(params[:sql] || "")
+          query_result = execute_query(params[:sql] || {})
 
           if query_result.is_a?(Hash) && query_result.has_key?(:errors)
             render json: query_result, status: :bad_request, adapter: :json_api
           else
-            render json: { data: query_result.delete(:result), meta: query_result }, adapter: :json_api
+            respond_to do |format|
+              format.json do
+                render json: { data: query_result.delete(:result), meta: query_result }, adapter: :json_api
+              end
+
+              format.csv do
+                render(
+                  csv: csv_from_query_result(query_result.fetch(:result, ""), csv_options_params),
+                  filename: "query_result"
+                )
+              end
+            end
           end
         end
 

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -20,11 +20,7 @@ module GobiertoData
               end
 
               format.csv do
-                headers["Content-Disposition"] = "inline"
-                headers["Content-Type"] = "text/plain; charset=utf-8"
-                render(
-                  plain: csv_from_query_result(query_result.fetch(:result, ""), csv_options_params)
-                )
+                render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
               end
             end
           end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -20,9 +20,10 @@ module GobiertoData
               end
 
               format.csv do
+                headers["Content-Disposition"] = "inline"
+                headers["Content-Type"] = "text/plain; charset=utf-8"
                 render(
-                  csv: csv_from_query_result(query_result.fetch(:result, ""), csv_options_params),
-                  filename: "query_result"
+                  plain: csv_from_query_result(query_result.fetch(:result, ""), csv_options_params)
                 )
               end
             end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -12,7 +12,7 @@ module GobiertoData
           if query_result.is_a?(Hash) && query_result.has_key?(:errors)
             render json: query_result, status: :bad_request, adapter: :json_api
           else
-            render json: { data: query_result }, adapter: :json_api
+            render json: { data: query_result.delete(:result), meta: query_result }, adapter: :json_api
           end
         end
 

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -117,7 +117,7 @@ module GobiertoData
         end
 
         def visualization_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :query_id, :name_translations, :privacy_status, :spec])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :query_id, :name_translations, :name, :privacy_status, :spec])
         end
 
         def filter_params

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -53,12 +53,13 @@ module GobiertoData
           @visualization_form = VisualizationForm.new(visualization_params.merge(site_id: current_site.id))
 
           if @visualization_form.save
+            @item = @visualization_form.id
             render(
               json: @visualization_form.visualization,
               status: :created,
               exclude_links: true,
               with_translations: true,
-              links: links(:show, id: @visualization_form.visualization.id),
+              links: links(:show),
               adapter: :json_api
             )
           else
@@ -119,19 +120,23 @@ module GobiertoData
           ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :query_id, :name_translations, :privacy_status, :spec])
         end
 
+        def filter_params
+          params.permit(:dataset_id, :query_id)
+        end
+
         def find_item
           @item = base_relation.unscope(where: :privacy_status).find(params[:id])
         end
 
-        def links(self_key = nil, opts = {})
-          id = opts[:id] || params[:id]
+        def links(self_key = nil)
+          id = @item&.id
           {
-            index: gobierto_data_api_v1_dataset_query_visualizations_path(params[:dataset_slug], params[:query_id]),
-            new: new_gobierto_data_api_v1_dataset_query_visualization_path(params[:dataset_slug], params[:query_id])
+            index: gobierto_data_api_v1_visualizations_path(filter_params),
+            new: new_gobierto_data_api_v1_visualization_path
           }.tap do |hash|
             if id.present?
               hash.merge!(
-                show: gobierto_data_api_v1_dataset_query_visualization_path(params[:dataset_slug], params[:query_id], id)
+                show: gobierto_data_api_v1_visualization_path(id)
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -36,7 +36,7 @@ module GobiertoData
         # GET /api/v1/data/visualizations/new
         # GET /api/v1/data/visualizations/new.json
         def new
-          @item = base_relation.new(name_translations: available_locales_hash)
+          @item = base_relation.model.new(name_translations: available_locales_hash)
 
           render(
             json: @item,

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -121,7 +121,11 @@ module GobiertoData
         end
 
         def filter_params
-          params.fetch(:filter, {}).permit(:user_id, :dataset_id, :query_id)
+          params.fetch(:filter, {}).permit(:user_id, :dataset_id, :query_id).tap do |f_params|
+            if (dataset_id = f_params.delete(:dataset_id))
+              f_params[Query.table_name] = { dataset_id: dataset_id }
+            end
+          end
         end
 
         def filtered_relation

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -53,9 +53,9 @@ module GobiertoData
           @visualization_form = VisualizationForm.new(visualization_params.merge(site_id: current_site.id))
 
           if @visualization_form.save
-            @item = @visualization_form.id
+            @item = @visualization_form.visualization
             render(
-              json: @visualization_form.visualization,
+              json: @item,
               status: :created,
               exclude_links: true,
               with_translations: true,

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -11,11 +11,11 @@ module GobiertoData
         def index
           respond_to do |format|
             format.json do
-              render json: base_relation, links: links(:index), adapter: :json_api
+              render json: filtered_relation, links: links(:index), adapter: :json_api
             end
 
             format.csv do
-              render_csv(csv_from_relation(base_relation, csv_options_params))
+              render_csv(csv_from_relation(filtered_relation, csv_options_params))
             end
           end
         end
@@ -121,7 +121,11 @@ module GobiertoData
         end
 
         def filter_params
-          params.permit(:dataset_id, :query_id)
+          params.fetch(:filter, {}).permit(:user_id, :dataset_id, :query_id)
+        end
+
+        def filtered_relation
+          base_relation.where(filter_params)
         end
 
         def find_item
@@ -131,7 +135,7 @@ module GobiertoData
         def links(self_key = nil)
           id = @item&.id
           {
-            index: gobierto_data_api_v1_visualizations_path(filter_params),
+            index: gobierto_data_api_v1_visualizations_path(filter: filter_params),
             new: new_gobierto_data_api_v1_visualization_path
           }.tap do |hash|
             if id.present?

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -5,9 +5,9 @@ module GobiertoData
     module V1
       class VisualizationsController < BaseController
 
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v.json
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v.csv
+        # GET /api/v1/data/visualizations
+        # GET /api/v1/data/visualizations.json
+        # GET /api/v1/data/visualizations.csv
         def index
           respond_to do |format|
             format.json do
@@ -20,8 +20,8 @@ module GobiertoData
           end
         end
 
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v/1
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v/1.json
+        # GET /api/v1/data/visualizations/1
+        # GET /api/v1/data/visualizations/1.json
         def show
           find_item
 
@@ -33,8 +33,8 @@ module GobiertoData
           )
         end
 
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v/new
-        # GET /api/v1/data/dataset/dataset-slug/q/1/v/new.json
+        # GET /api/v1/data/visualizations/new
+        # GET /api/v1/data/visualizations/new.json
         def new
           @item = base_relation.new(name_translations: available_locales_hash)
 
@@ -47,8 +47,8 @@ module GobiertoData
           )
         end
 
-        # POST /api/v1/data/dataset/dataset-slug/q/1/v
-        # POST /api/v1/data/dataset/dataset-slug/q/1/v.json
+        # POST /api/v1/data/visualizations
+        # POST /api/v1/data/visualizations.json
         def create
           @visualization_form = VisualizationForm.new(visualization_params.merge(site_id: current_site.id))
 
@@ -67,8 +67,8 @@ module GobiertoData
           end
         end
 
-        # PUT /api/v1/data/dataset/dataset-slug/q/1/v/1
-        # PUT /api/v1/data/dataset/dataset-slug/q/1/v/1.json
+        # PUT /api/v1/data/visualizations/1
+        # PUT /api/v1/data/visualizations/1.json
         def update
           find_item
           @visualization_form = VisualizationForm.new(visualization_params.except(*ignored_attributes_on_update).merge(site_id: current_site.id, id: @item.id))
@@ -86,8 +86,8 @@ module GobiertoData
           end
         end
 
-        # DELETE /api/v1/data/dataset/dataset-slug/q/1/v/1
-        # DELETE /api/v1/data/dataset/dataset-slug/q/1/v/1.json
+        # DELETE /api/v1/data/visualizations/1
+        # DELETE /api/v1/data/visualizations/1.json
         def destroy
           find_item
 

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class VisualizationsController < BaseController
+
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v.json
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v.csv
+        def index
+          respond_to do |format|
+            format.json do
+              render json: base_relation, links: links(:index), adapter: :json_api
+            end
+
+            format.csv do
+              render_csv(csv_from_relation(base_relation, csv_options_params))
+            end
+          end
+        end
+
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v/1
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v/1.json
+        def show
+          find_item
+
+          render(
+            json: @item,
+            exclude_links: true,
+            links: links(:show),
+            adapter: :json_api
+          )
+        end
+
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v/new
+        # GET /api/v1/data/dataset/dataset-slug/q/1/v/new.json
+        def new
+          @item = base_relation.new(name_translations: available_locales_hash)
+
+          render(
+            json: @item,
+            exclude_links: true,
+            with_translations: true,
+            links: links(:new),
+            adapter: :json_api
+          )
+        end
+
+        # POST /api/v1/data/dataset/dataset-slug/q/1/v
+        # POST /api/v1/data/dataset/dataset-slug/q/1/v.json
+        def create
+          find_query
+          @visualization_form = VisualizationForm.new(visualization_params.merge(site_id: current_site.id, query_id: @query.id))
+
+          if @visualization_form.save
+            render(
+              json: @visualization_form.visualization,
+              status: :created,
+              exclude_links: true,
+              with_translations: true,
+              links: links(:show, id: @visualization_form.visualization.id),
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@visualization_form, adapter: :json_api)
+          end
+        end
+
+        # PUT /api/v1/data/dataset/dataset-slug/q/1/v/1
+        # PUT /api/v1/data/dataset/dataset-slug/q/1/v/1.json
+        def update
+          find_item
+          @visualization_form = VisualizationForm.new(visualization_params.merge(site_id: current_site.id, query_id: @query.id, id: @item.id))
+
+          if @visualization_form.save
+            render(
+              json: @visualization_form.visualization,
+              exclude_links: true,
+              with_translations: true,
+              links: links,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@visualization_form, adapter: :json_api)
+          end
+        end
+
+        # DELETE /api/v1/data/dataset/dataset-slug/q/1/v/1
+        # DELETE /api/v1/data/dataset/dataset-slug/q/1/v/1.json
+        def destroy
+          find_item
+
+          @item.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def base_relation
+          find_query
+          @query.visualizations.open
+        end
+
+        def find_dataset
+          @dataset = current_site.datasets.find_by!(slug: params[:dataset_slug])
+        end
+
+        def find_query
+          find_dataset
+          @query = @dataset.queries.find(params[:query_id])
+        end
+
+        def visualization_params
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :name_translations, :privacy_status, :spec])
+        end
+
+        def find_item
+          @item = base_relation.unscope(where: :privacy_status).find(params[:id])
+        end
+
+        def links(self_key = nil, opts = {})
+          id = opts[:id] || params[:id]
+          {
+            index: gobierto_data_api_v1_dataset_query_visualizations_path(params[:dataset_slug], params[:query_id]),
+            new: new_gobierto_data_api_v1_dataset_query_visualization_path(params[:dataset_slug], params[:query_id])
+          }.tap do |hash|
+            if id.present?
+              hash.merge!(
+                show: gobierto_data_api_v1_dataset_query_visualization_path(params[:dataset_slug], params[:query_id], id)
+              )
+            end
+
+            hash[:self] = hash.delete(self_key) if self_key.present?
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -14,7 +14,6 @@ module GobiertoInvestments
         # GET /gobierto_investments/api/v1/projects
         # GET /gobierto_investments/api/v1/projects.json
         def index
-          @resource = GobiertoInvestments::Project.new
           relation = filtered_relation
 
           if stale?(relation)

--- a/app/forms/concerns/gobierto_core/translations_helpers.rb
+++ b/app/forms/concerns/gobierto_core/translations_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module GobiertoCore
+  module TranslationsHelpers
+    extend ActiveSupport::Concern
+
+    def available_locales_blank_translations
+      @available_locales_blank_translations ||= begin
+                                                  if try(:site).present?
+                                                    site.configuration.available_locales.inject({}) do |hash, locale|
+                                                      hash.update(
+                                                        locale => nil
+                                                      )
+                                                    end
+                                                  else
+                                                    { I18n.locale => nil }
+                                                  end
+                                                end.with_indifferent_access
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_data/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/settings_form.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoData
+    class SettingsForm < BaseForm
+
+      attr_writer(
+        :site_id,
+        :db_config
+      )
+
+      delegate :persisted?, to: :gobierto_module_settings
+      validates :site, :db_config, presence: true
+      validate :db_config_format, :db_config_connection
+
+      def save
+        valid? && save_settings
+      end
+
+      def gobierto_module_settings
+        @gobierto_module_settings ||= gobierto_module_settings_class.find_by(site_id: site_id, module_name: module_name) || build_gobierto_module_settings
+      end
+
+      def site_id
+        @site_id ||= gobierto_module_settings.site_id
+      end
+
+      def site
+        @site ||= Site.find site_id
+      end
+
+      def db_config
+        @db_config ||= gobierto_module_settings.db_config.present? ? JSON.pretty_generate(gobierto_module_settings.db_config) : nil
+      end
+
+      private
+
+      def db_config_format
+        return if db_config.blank?
+
+        JSON.parse(db_config)
+      rescue JSON::ParserError
+        errors.add :db_config, :invalid_format
+      end
+
+      def db_config_connection
+        return if errors.added? :db_config, :invalid_format
+
+        ::GobiertoData::Connection.test_connection_config(db_config_format)
+      rescue ActiveRecord::ActiveRecordError => e
+        errors.add(:db_config, :invalid_connection, error_message: e.message)
+      end
+
+      def gobierto_module_settings_class
+        ::GobiertoModuleSettings
+      end
+
+      def module_name
+        self.class.parent.name.demodulize
+      end
+
+      def build_gobierto_module_settings
+        gobierto_module_settings_class.new
+      end
+
+      def save_settings
+        @gobierto_module_settings = gobierto_module_settings.tap do |settings_attributes|
+          settings_attributes.module_name = module_name
+          settings_attributes.site_id = site_id
+          settings_attributes.db_config = db_config_format
+        end
+
+        if @gobierto_module_settings.save
+          true
+        else
+          promote_errors(@gobierto_module_settings.errors)
+          false
+        end
+      end
+
+    end
+  end
+end

--- a/app/forms/gobierto_data/query_form.rb
+++ b/app/forms/gobierto_data/query_form.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class QueryForm < BaseForm
+
+    attr_accessor(
+      :id,
+      :site_id,
+      :dataset_id,
+      :user_id,
+      :name_translations,
+      :sql
+    )
+
+    attr_writer(
+      :privacy_status
+    )
+
+    validates :dataset, :site, :user, :sql, presence: true
+    validates :name_translations, translated_attribute_presence: true
+    validate :sql_validation
+
+    delegate :persisted?, to: :query
+
+    def query
+      @query ||= query_class.find_by(id: id) || build_query
+    end
+
+    def dataset
+      @dataset ||= site.datasets.find_by(id: dataset_id)
+    end
+
+    def user
+      @user ||= site.users.find_by(id: user_id)
+    end
+
+    def privacy_status
+      @privacy_status ||= :open
+    end
+
+    def save
+      save_query if valid?
+    end
+
+    private
+
+    def build_query
+      query_class.new
+    end
+
+    def query_class
+      Query
+    end
+
+    def save_query
+      @query = query.tap do |attributes|
+        attributes.dataset_id = dataset_id
+        attributes.user_id = user_id
+        attributes.name_translations = name_translations
+        attributes.sql = sql
+        attributes.privacy_status = privacy_status
+      end
+
+      return @query if @query.save
+
+      promote_errors(@query.errors)
+
+      false
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id)
+    end
+
+    def sql_validation
+      return if sql.blank?
+
+      query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
+      if query_test.has_key? :errors
+        errors.add(:sql, query_test[:errors].map { |error| error[:sql] }.join("\n"))
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_data/query_form.rb
+++ b/app/forms/gobierto_data/query_form.rb
@@ -27,11 +27,11 @@ module GobiertoData
     end
 
     def dataset
-      @dataset ||= site.datasets.find_by(id: dataset_id)
+      @dataset ||= site.datasets.find_by(id: dataset_id) || query.dataset
     end
 
     def user
-      @user ||= site.users.find_by(id: user_id)
+      @user ||= site.users.find_by(id: user_id) || query.user
     end
 
     def privacy_status
@@ -54,8 +54,8 @@ module GobiertoData
 
     def save_query
       @query = query.tap do |attributes|
-        attributes.dataset_id = dataset_id
-        attributes.user_id = user_id
+        attributes.dataset_id = dataset.id
+        attributes.user_id = user.id
         attributes.name_translations = name_translations
         attributes.sql = sql
         attributes.privacy_status = privacy_status

--- a/app/forms/gobierto_data/query_form.rb
+++ b/app/forms/gobierto_data/query_form.rb
@@ -2,18 +2,20 @@
 
 module GobiertoData
   class QueryForm < BaseForm
+    include ::GobiertoCore::TranslationsHelpers
 
     attr_accessor(
       :id,
       :site_id,
       :dataset_id,
       :user_id,
-      :name_translations,
+      :name,
       :sql
     )
 
     attr_writer(
-      :privacy_status
+      :privacy_status,
+      :name_translations
     )
 
     validates :dataset, :site, :user, :sql, presence: true
@@ -32,6 +34,18 @@ module GobiertoData
 
     def user
       @user ||= site.users.find_by(id: user_id) || query.user
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id)
+    end
+
+    def name_translations
+      @name_translations ||= begin
+                               (query.name_translations || available_locales_blank_translations).tap do |translations|
+                                 translations[I18n.locale] = name if name.present?
+                               end
+                             end
     end
 
     def privacy_status
@@ -66,10 +80,6 @@ module GobiertoData
       promote_errors(@query.errors)
 
       false
-    end
-
-    def site
-      @site ||= Site.find_by(id: site_id)
     end
 
     def sql_validation

--- a/app/forms/gobierto_data/query_form.rb
+++ b/app/forms/gobierto_data/query_form.rb
@@ -29,11 +29,11 @@ module GobiertoData
     end
 
     def dataset
-      @dataset ||= site.datasets.find_by(id: dataset_id) || query.dataset
+      @dataset ||= site.presence && site.datasets.find_by(id: dataset_id) || query.dataset
     end
 
     def user
-      @user ||= site.users.find_by(id: user_id) || query.user
+      @user ||= site.presence && site.users.find_by(id: user_id) || query.user
     end
 
     def site

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -27,11 +27,11 @@ module GobiertoData
     end
 
     def query
-      @query ||= site.queries.find_by(id: query_id)
+      @query ||= site.queries.find_by(id: query_id) || visualization.query
     end
 
     def user
-      @user ||= site.users.find_by(id: user_id)
+      @user ||= site.users.find_by(id: user_id) || visualization.user
     end
 
     def privacy_status
@@ -58,8 +58,8 @@ module GobiertoData
 
     def save_visualization
       @visualization = visualization.tap do |attributes|
-        attributes.query_id = query_id
-        attributes.user_id = user_id
+        attributes.query_id = query.id
+        attributes.user_id = user.id
         attributes.name_translations = name_translations
         attributes.privacy_status = privacy_status
         attributes.spec = spec

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -2,17 +2,19 @@
 
 module GobiertoData
   class VisualizationForm < BaseForm
+    include ::GobiertoCore::TranslationsHelpers
 
     attr_accessor(
       :id,
       :site_id,
       :query_id,
       :user_id,
-      :name_translations
+      :name
     )
 
     attr_writer(
       :privacy_status,
+      :name_translations,
       :spec
     )
 
@@ -32,6 +34,18 @@ module GobiertoData
 
     def user
       @user ||= site.users.find_by(id: user_id) || visualization.user
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id)
+    end
+
+    def name_translations
+      @name_translations ||= begin
+                               (visualization.name_translations || available_locales_blank_translations).tap do |translations|
+                                 translations[I18n.locale] = name if name.present?
+                               end
+                             end
     end
 
     def privacy_status
@@ -70,10 +84,6 @@ module GobiertoData
       promote_errors(@visualization.errors)
 
       false
-    end
-
-    def site
-      @site ||= Site.find_by(id: site_id)
     end
 
     def spec_validation

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -29,11 +29,11 @@ module GobiertoData
     end
 
     def query
-      @query ||= site.queries.find_by(id: query_id) || visualization.query
+      @query ||= site.presence && site.queries.find_by(id: query_id) || visualization.query
     end
 
     def user
-      @user ||= site.users.find_by(id: user_id) || visualization.user
+      @user ||= site.presence && site.users.find_by(id: user_id) || visualization.user
     end
 
     def site

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class VisualizationForm < BaseForm
+
+    attr_accessor(
+      :id,
+      :site_id,
+      :query_id,
+      :user_id,
+      :name_translations
+    )
+
+    attr_writer(
+      :privacy_status,
+      :spec
+    )
+
+    validates :query, :site, :user, :spec, presence: true
+    validates :name_translations, translated_attribute_presence: true
+    validate :spec_validation
+
+    delegate :persisted?, to: :visualization
+
+    def visualization
+      @visualization ||= visualization_class.find_by(id: id) || build_visualization
+    end
+
+    def query
+      @query ||= site.queries.find_by(id: query_id)
+    end
+
+    def user
+      @user ||= site.users.find_by(id: user_id)
+    end
+
+    def privacy_status
+      @privacy_status ||= :open
+    end
+
+    def spec
+      @spec ||= {}
+    end
+
+    def save
+      save_visualization if valid?
+    end
+
+    private
+
+    def build_visualization
+      visualization_class.new
+    end
+
+    def visualization_class
+      Visualization
+    end
+
+    def save_visualization
+      @visualization = visualization.tap do |attributes|
+        attributes.query_id = query_id
+        attributes.user_id = user_id
+        attributes.name_translations = name_translations
+        attributes.privacy_status = privacy_status
+        attributes.spec = spec
+      end
+
+      return @visualization if @visualization.save
+
+      promote_errors(@visualization.errors)
+
+      false
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id)
+    end
+
+    def spec_validation
+      return if spec.blank?
+    end
+  end
+end

--- a/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
+++ b/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
@@ -7,7 +7,7 @@ module GobiertoCommon::CustomFieldValue
     end
 
     def value_string
-      value.map(&:name)
+      value.map(&:name).join(", ")
     end
 
     def filter_value

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -9,7 +9,7 @@ module GobiertoData
     class << self
 
       def execute_query(site, query)
-        with_connection(site, fallback: null_query) do
+        with_connection(db_config(site), fallback: null_query) do
           connection.execute(query) || null_query
         end
       rescue ActiveRecord::StatementInvalid => e
@@ -17,7 +17,7 @@ module GobiertoData
       end
 
       def tables(site)
-        with_connection(site) do
+        with_connection(db_config(site)) do
           connection.tables
         end
       end
@@ -26,11 +26,17 @@ module GobiertoData
         site&.gobierto_data_settings&.db_config
       end
 
+      def test_connection_config(config)
+        with_connection(config) do
+          connection.present?
+        end
+      end
+
       private
 
-      def with_connection(site, fallback: nil)
+      def with_connection(db_conf, fallback: nil)
         base_connection_config = connection_config
-        return fallback unless (db_conf = db_config(site)).present?
+        return fallback if db_conf.nil?
 
         establish_connection(db_conf)
         yield

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -7,6 +7,8 @@ module GobiertoData
     include GobiertoCommon::Sluggable
 
     belongs_to :site
+    has_many :queries, dependent: :destroy
+    has_many :visualizations, through: :queries
 
     translates :name
 

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -32,6 +32,22 @@ module GobiertoData
                        end
     end
 
+    def create_dataset_from_file(file_path, schema_file: nil, export_files: false, csv_separator: ",")
+      schema = schema_file.present? ? JSON.parse(File.read(schema_file)).deep_symbolize_keys : {}
+      statements = GobiertoData::Datasets::CreationStatements.new(
+        dataset: self,
+        source_file: file_path,
+        schema: schema,
+        csv_separator: csv_separator
+      )
+      if export_files
+        base_path = File.join(File.dirname(file_path), File.basename(file_path, ".*"))
+        File.open("#{base_path}_schema.json", "w") { |file| file.write(JSON.pretty_generate(statements.schema)) } if schema_file.blank?
+        File.open("#{base_path}_script.sql", "w") { |file| file.write(statements.sql_code) }
+      end
+      Connection.execute_query(site, statements.sql_code)
+    end
+
     private
 
     def internal_rails_class_name

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -34,7 +34,7 @@ module GobiertoData
                        end
     end
 
-    def create_dataset_from_file(file_path, schema_file: nil, export_files: false, csv_separator: ",")
+    def load_data_from_file(file_path, schema_file: nil, export_files: false, csv_separator: ",")
       schema = schema_file.present? ? JSON.parse(File.read(schema_file)).deep_symbolize_keys : {}
       statements = GobiertoData::Datasets::CreationStatements.new(
         dataset: self,

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  class Query < ApplicationRecord
+    belongs_to :dataset
+    belongs_to :user
+    has_many :visualizations, dependent: :destroy
+
+    translates :name
+
+    validates :dataset, :user, :name, presence: true
+    validate :sql_validation
+    delegate :site, to: :dataset
+
+    def result
+      Connection.execute_query(site, sql)
+    end
+
+    private
+
+    def sql_validation
+      return if sql.blank?
+
+      query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
+      if query_test.has_key? :errors
+        errors.add(:sql, query_test[:errors].map { |error| error[:sql] }.join("\n"))
+      end
+    end
+  end
+end

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -7,26 +7,14 @@ module GobiertoData
     belongs_to :dataset
     belongs_to :user
     has_many :visualizations, dependent: :destroy
+    enum privacy_status: { open: 0, closed: 1 }
 
     translates :name
 
-    validates :dataset, :user, :name, presence: true
-    validate :sql_validation
     delegate :site, to: :dataset
 
     def result
       Connection.execute_query(site, sql)
-    end
-
-    private
-
-    def sql_validation
-      return if sql.blank?
-
-      query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
-      if query_test.has_key? :errors
-        errors.add(:sql, query_test[:errors].map { |error| error[:sql] }.join("\n"))
-      end
     end
   end
 end

--- a/app/models/gobierto_data/visualization.rb
+++ b/app/models/gobierto_data/visualization.rb
@@ -4,14 +4,13 @@ require_dependency "gobierto_data"
 
 module GobiertoData
   class Visualization < ApplicationRecord
-
     belongs_to :query
     belongs_to :user
+    enum privacy_status: { open: 0, closed: 1 }
 
     translates :name
 
     validates :query, :user, :name, presence: true
-    delegate :site, to: :query
-
+    delegate :site, :dataset, to: :query
   end
 end

--- a/app/models/gobierto_data/visualization.rb
+++ b/app/models/gobierto_data/visualization.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  class Visualization < ApplicationRecord
+
+    belongs_to :query
+    belongs_to :user
+
+    translates :name
+
+    validates :query, :user, :name, presence: true
+    delegate :site, to: :query
+
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -89,6 +89,8 @@ class Site < ApplicationRecord
 
   # GobiertoData integration
   has_many :datasets, dependent: :destroy, class_name: "GobiertoData::Dataset"
+  has_many :queries, through: :datasets, class_name: "GobiertoData::Query"
+  has_many :visualizations, through: :queries, class_name: "GobiertoData::Visualization"
 
   serialize :configuration_data
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ApplicationRecord
   has_many :votes, dependent: :destroy, class_name: "GobiertoParticipation::Vote"
   has_many :comment, dependent: :destroy, class_name: "GobiertoParticipation::Comment"
 
+  # GobiertoData
+  has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
+  has_many :visualizations, dependent: :destroy, class_name: "GobiertoData::Visualization"
+
   accepts_nested_attributes_for :custom_records
 
   validates :email, uniqueness: { scope: :site }

--- a/app/queries/gobierto_data/datasets/creation_statements.rb
+++ b/app/queries/gobierto_data/datasets/creation_statements.rb
@@ -12,7 +12,7 @@ module GobiertoData
         @base_table_name = dataset.table_name
         @source_file = source_file
         @csv_separator = csv_separator
-        @schema = schema.present? ? schema.deep_symbolize_keys : inspect_csv_schema(source_file)
+        @schema = schema.present? ? schema.deep_symbolize_keys : inspect_csv_schema(source_file, csv_separator: csv_separator)
         @transform_functions = @schema.inject({}) do |functions, (column, params)|
           functions.update(
             column => SqlFunction::Transformation.new(
@@ -88,8 +88,8 @@ module GobiertoData
         SQL
       end
 
-      def inspect_csv_schema(source_file)
-        data = CSV.parse(File.open(source_file, "r").first(2).join, headers: true)
+      def inspect_csv_schema(source_file, csv_separator:)
+        data = CSV.parse(File.open(source_file, "r").first(2).join, headers: true, col_sep: csv_separator)
         data.headers.inject({}) do |cols, col|
           col_name = col.parameterize.underscore.to_sym
           cols.update(

--- a/app/queries/gobierto_data/datasets/creation_statements.rb
+++ b/app/queries/gobierto_data/datasets/creation_statements.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  module Datasets
+    class CreationStatements
+      attr_reader :schema
+
+      def initialize(dataset:, source_file:, schema:, csv_separator:)
+        @dataset = dataset
+        @base_table_name = dataset.table_name
+        @source_file = source_file
+        @csv_separator = csv_separator
+        @schema = schema.present? ? schema.deep_symbolize_keys : inspect_csv_schema(source_file)
+        @transform_functions = @schema.inject({}) do |functions, (column, params)|
+          functions.update(
+            column => SqlFunction::Transformation.new(
+              function: params[:type],
+              id: column,
+              optional_params: params.fetch(:optional_params, {})
+            )
+          )
+        end
+      end
+
+      def sql_code
+        [
+          create_raw_temp_table,
+          create_transformed_temp_table,
+          create_destination_table,
+          extract_csv_operation,
+          define_transform_functions,
+          transform_operation,
+          load_operation,
+          clear_transform_functions
+        ].join("\n")
+      end
+
+      private
+
+      def create_raw_temp_table
+        "CREATE TEMP TABLE #{@base_table_name}_raw(\n#{schema.map { |column, _| "#{column} TEXT" }.join(",\n")}\n);"
+      end
+
+      def create_transformed_temp_table
+        "CREATE TEMP TABLE #{@base_table_name}_transformed(\n#{schema.map { |column, params| "#{column} #{params[:type]}" }.join(",\n")}\n);"
+      end
+
+      def create_destination_table
+        <<-SQL
+        DROP TABLE IF EXISTS #{@base_table_name};
+        CREATE TABLE #{@base_table_name}(
+          #{schema.map { |column, params| "#{column} #{params[:type]}" }.join(",\n")}
+        );
+        SQL
+      end
+
+      def extract_csv_operation
+        "COPY #{@base_table_name}_raw (#{schema.keys.join(", ")}) FROM '#{@source_file}' DELIMITER '#{@csv_separator}' CSV HEADER NULL '';"
+      end
+
+      def define_transform_functions
+        @transform_functions.values.map(&:function_definition).join("\n")
+      end
+
+      def clear_transform_functions
+        @transform_functions.values.map(&:function_drop).join("\n")
+      end
+
+      def transform_operation
+        <<-SQL
+        INSERT INTO #{@base_table_name}_transformed (
+          #{schema.keys.join(",\n")}
+        )
+        SELECT #{ @transform_functions.map { |column, f| f.function_call(column) }.join(",\n")}
+        from #{@base_table_name}_raw;
+        SQL
+      end
+
+      def load_operation
+        <<-SQL
+        insert into #{@base_table_name}(
+          #{schema.keys.join(",\n")}
+        )
+        SELECT *
+        from #{@base_table_name}_transformed;
+        SQL
+      end
+
+      def inspect_csv_schema(source_file)
+        data = CSV.parse(File.open(source_file, "r").first(2).join, headers: true)
+        data.headers.inject({}) do |cols, col|
+          col_name = col.parameterize.underscore.to_sym
+          cols.update(
+            col_name => { original_name: col, type: "text" }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/queries/gobierto_data/datasets/creation_statements.rb
+++ b/app/queries/gobierto_data/datasets/creation_statements.rb
@@ -44,14 +44,14 @@ module GobiertoData
       end
 
       def create_transformed_temp_table
-        "CREATE TEMP TABLE #{@base_table_name}_transformed(\n#{schema.map { |column, params| "#{column} #{params[:type]}" }.join(",\n")}\n);"
+        "CREATE TEMP TABLE #{@base_table_name}_transformed(\n#{@transform_functions.map { |column, f| "#{column} #{f.output_type}" }.join(",\n")}\n);"
       end
 
       def create_destination_table
         <<-SQL
         DROP TABLE IF EXISTS #{@base_table_name};
         CREATE TABLE #{@base_table_name}(
-          #{schema.map { |column, params| "#{column} #{params[:type]}" }.join(",\n")}
+          #{@transform_functions.map { |column, f| "#{column} #{f.output_type}" }.join(",\n")}
         );
         SQL
       end

--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -19,6 +19,12 @@ module GobiertoData
           sql: "select (nullif(trim($1), '#null_value')::numeric);",
           optional_params: { null_value: "" }
         },
+        numeric_with_custom_decimal_separator: {
+          input_type: "text",
+          output_type: "numeric",
+          sql: "select (replace(nullif(trim($1), '#null_value'), '#decimal_separator', '.')::numeric);",
+          optional_params: { null_value: "", decimal_separator: "," }
+        },
         text: {
           input_type: "text",
           output_type: "text",

--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -10,31 +10,31 @@ module GobiertoData
         integer: {
           input_type: "text",
           output_type: "integer",
-          sql: "select (nullif($1, '#null_value')::integer);",
+          sql: "select (nullif(trim($1), '#null_value')::integer);",
           optional_params: { null_value: "" }
         },
         numeric: {
           input_type: "text",
           output_type: "numeric",
-          sql: "select (nullif($1, '#null_value')::numeric);",
+          sql: "select (nullif(trim($1), '#null_value')::numeric);",
           optional_params: { null_value: "" }
         },
         text: {
           input_type: "text",
           output_type: "text",
-          sql: "select (nullif($1, '#null_value')::text);",
+          sql: "select (nullif(trim($1), '#null_value')::text);",
           optional_params: { null_value: "" }
         },
         date: {
           input_type: "text",
           output_type: "date",
-          sql: "select (to_date(nullif($1, '#null_value'), '#date_format'));",
+          sql: "select (to_date(nullif(trim($1), '#null_value'), '#date_format'));",
           optional_params: { date_format: "DD-MON-YYY", null_value: "" }
         },
         boolean: {
           input_type: "text",
           output_type: "boolean",
-          sql: "select (case\n  when $1 = '#true_value' then true\n  when $1 = '#false_value' then false\n  else NULL\nend)",
+          sql: "select (case\n  when trim($1) = '#true_value' then true\n  when trim($1) = '#false_value' then false\n  else NULL\nend)",
           optional_params: { false_value: "0", true_value: "1" }
         }
       }.freeze

--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module SqlFunction
+    class Transformation
+
+      attr_reader :function_type, :function_name, :function
+
+      SQL_FUNCTIONS = {
+        integer: {
+          input_type: "text",
+          output_type: "integer",
+          sql: "select (nullif($1, '#null_value')::integer);",
+          optional_params: { null_value: "" }
+        },
+        numeric: {
+          input_type: "text",
+          output_type: "numeric",
+          sql: "select (nullif($1, '#null_value')::numeric);",
+          optional_params: { null_value: "" }
+        },
+        text: {
+          input_type: "text",
+          output_type: "text",
+          sql: "select (nullif($1, '#null_value')::text);",
+          optional_params: { null_value: "" }
+        },
+        date: {
+          input_type: "text",
+          output_type: "date",
+          sql: "select (to_date(nullif($1, '#null_value'), '#date_format'));",
+          optional_params: { date_format: "DD-MON-YYY", null_value: "" }
+        },
+        boolean: {
+          input_type: "text",
+          output_type: "boolean",
+          sql: "select (case\n  when $1 = '#true_value' then true\n  when $1 = '#false_value' then false\n  else NULL\nend)",
+          optional_params: { false_value: "0", true_value: "1" }
+        }
+      }.freeze
+
+      def initialize(opts = {})
+        @function_type = opts.fetch(:function, :text).to_sym
+        @id = opts.fetch(:id, "generic")
+        @function_name = "#{function_type}_#{@id}_transformation"
+        @function = SQL_FUNCTIONS[function_type]
+        default_optional_params = @function.fetch(:optional_params, {})
+        @optional_params = default_optional_params.merge(opts.fetch(:optional_params, {}).slice(*default_optional_params.keys))
+      end
+
+      def function_definition
+        return unless function.present?
+
+        <<-SQL
+        CREATE FUNCTION #{function_name}(#{function[:input_type]}) RETURNS #{function[:output_type]} AS $$
+        #{ @optional_params.inject(function[:sql]) { |sql, (param, value)| sql.gsub("##{param}", value) }}
+        $$ LANGUAGE SQL;
+        SQL
+      end
+
+      def function_drop
+        return unless function.present?
+
+        "DROP FUNCTION IF EXISTS #{function_name}(#{function[:input_type]});"
+      end
+
+      def function_call(attribute)
+        "#{function_name}(#{attribute})"
+      end
+
+    end
+  end
+end

--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -48,6 +48,10 @@ module GobiertoData
         @optional_params = default_optional_params.merge(opts.fetch(:optional_params, {}).slice(*default_optional_params.keys))
       end
 
+      def output_type
+        function[:output_type]
+      end
+
       def function_definition
         return unless function.present?
 

--- a/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
+++ b/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
@@ -10,11 +10,11 @@ module GobiertoCommon
 
       if data[:id].present?
         ::GobiertoCommon::CustomFieldRecord.includes(:custom_field).where(custom_field: custom_fields, item: object).sorted.each do |record|
-          data[record.custom_field.uid] = record.value
+          data[record.custom_field.uid] = instance_options[:string_output] ? record.value_string : record.value
         end
       else
         custom_fields.each do |custom_field|
-          data[custom_field.uid] = custom_field.records.new.value
+          data[custom_field.uid] = instance_options[:string_output] ? custom_field.records.new.value_string : custom_field.records.new.value
         end
       end
 

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -2,8 +2,14 @@
 
 module GobiertoData
   class DatasetMetaSerializer < DatasetSerializer
-    attribute :rows_count do
-      object.rails_model.count
+    attribute :data_summary do
+      {
+        number_of_rows: object.rails_model.count
+      }
+    end
+
+    attribute :data_preview do
+      object.rails_model.first(50)
     end
   end
 end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -3,6 +3,7 @@
 module GobiertoData
   class DatasetMetaSerializer < DatasetSerializer
     has_many :queries
+    has_many :visualizations
 
     attribute :data_summary do
       {

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -2,6 +2,8 @@
 
 module GobiertoData
   class DatasetMetaSerializer < DatasetSerializer
+    has_many :queries
+
     attribute :data_summary do
       {
         number_of_rows: object.rails_model.count

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class DatasetMetaSerializer < DatasetSerializer
+    attribute :rows_count do
+      object.rails_model.count
+    end
+  end
+end

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -16,7 +16,7 @@ module GobiertoData
     end
 
     def current_site
-      Site.find(object.site_id)
+      Site.find_by(id: object.site_id) || instance_options[:site]
     end
 
     def exclude_links?

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class DatasetSerializer < ActiveModel::Serializer
+    include Rails.application.routes.url_helpers
+    include ::GobiertoCommon::HasCustomFieldsAttributes
+
+    attributes :id, :name, :slug, :updated_at
+
+    attribute :links, unless: :exclude_links? do
+      slug = object.slug
+      {
+        data: gobierto_data_api_v1_dataset_path(slug),
+        metadata: meta_gobierto_data_api_v1_dataset_path(slug)
+      }
+    end
+
+    def current_site
+      Site.find(object.site_id)
+    end
+
+    def exclude_links?
+      instance_options[:exclude_links]
+    end
+
+  end
+end

--- a/app/serializers/gobierto_data/query_serializer.rb
+++ b/app/serializers/gobierto_data/query_serializer.rb
@@ -3,7 +3,6 @@
 module GobiertoData
   class QuerySerializer < ActiveModel::Serializer
     include Rails.application.routes.url_helpers
-    include ::GobiertoCommon::HasCustomFieldsAttributes
 
     attributes :id
     attribute :name, unless: :with_translations?

--- a/app/serializers/gobierto_data/query_serializer.rb
+++ b/app/serializers/gobierto_data/query_serializer.rb
@@ -13,11 +13,10 @@ module GobiertoData
     has_many :visualizations
 
     attribute :links, unless: :exclude_links? do
-      slug = object.dataset.slug
       id = object.id
       {
-        data: gobierto_data_api_v1_dataset_query_path(slug, id),
-        metadata: meta_gobierto_data_api_v1_dataset_query_path(slug, id)
+        data: gobierto_data_api_v1_query_path(id),
+        metadata: meta_gobierto_data_api_v1_query_path(id)
       }
     end
 

--- a/app/serializers/gobierto_data/query_serializer.rb
+++ b/app/serializers/gobierto_data/query_serializer.rb
@@ -11,6 +11,7 @@ module GobiertoData
     attributes :privacy_status, :sql, :dataset_id, :user_id
     belongs_to :dataset
     belongs_to :user
+    has_many :visualizations
 
     attribute :links, unless: :exclude_links? do
       slug = object.dataset.slug

--- a/app/serializers/gobierto_data/query_serializer.rb
+++ b/app/serializers/gobierto_data/query_serializer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class QuerySerializer < ActiveModel::Serializer
+    include Rails.application.routes.url_helpers
+    include ::GobiertoCommon::HasCustomFieldsAttributes
+
+    attributes :id
+    attribute :name, unless: :with_translations?
+    attribute :name_translations, if: :with_translations?
+    attributes :privacy_status, :sql, :dataset_id, :user_id
+    belongs_to :dataset
+    belongs_to :user
+
+    attribute :links, unless: :exclude_links? do
+      slug = object.dataset.slug
+      id = object.id
+      {
+        data: gobierto_data_api_v1_dataset_query_path(slug, id),
+        metadata: meta_gobierto_data_api_v1_dataset_query_path(slug, id)
+      }
+    end
+
+    def current_site
+      Site.find(object.site.id)
+    end
+
+    def exclude_links?
+      instance_options[:exclude_links]
+    end
+
+    def with_translations?
+      instance_options[:with_translations]
+    end
+  end
+end

--- a/app/serializers/gobierto_data/query_serializer.rb
+++ b/app/serializers/gobierto_data/query_serializer.rb
@@ -8,9 +8,9 @@ module GobiertoData
     attribute :name, unless: :with_translations?
     attribute :name_translations, if: :with_translations?
     attributes :privacy_status, :sql, :dataset_id, :user_id
-    belongs_to :dataset
-    belongs_to :user
-    has_many :visualizations
+    belongs_to :dataset, unless: :exclude_relationships?
+    belongs_to :user, unless: :exclude_relationships?
+    has_many :visualizations, unless: :exclude_relationships?
 
     attribute :links, unless: :exclude_links? do
       id = object.id
@@ -26,6 +26,10 @@ module GobiertoData
 
     def exclude_links?
       instance_options[:exclude_links]
+    end
+
+    def exclude_relationships?
+      instance_options[:exclude_relationships]
     end
 
     def with_translations?

--- a/app/serializers/gobierto_data/visualization_serializer.rb
+++ b/app/serializers/gobierto_data/visualization_serializer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class VisualizationSerializer < ActiveModel::Serializer
+    include Rails.application.routes.url_helpers
+
+    attributes :id
+    attribute :name, unless: :with_translations?
+    attribute :name_translations, if: :with_translations?
+    attributes :privacy_status, :spec, :query_id, :user_id
+    belongs_to :query
+    belongs_to :user
+
+    attribute :links, unless: :exclude_links? do
+      dataset_slug = object.dataset.slug
+      query_id = object.query_id
+      id = object.id
+      {
+        show: gobierto_data_api_v1_dataset_query_visualization_path(dataset_slug: dataset_slug, query_id: query_id, id: id)
+      }
+    end
+
+    def current_site
+      Site.find(object.site.id)
+    end
+
+    def exclude_links?
+      instance_options[:exclude_links]
+    end
+
+    def with_translations?
+      instance_options[:with_translations]
+    end
+  end
+end

--- a/app/serializers/gobierto_data/visualization_serializer.rb
+++ b/app/serializers/gobierto_data/visualization_serializer.rb
@@ -8,8 +8,8 @@ module GobiertoData
     attribute :name, unless: :with_translations?
     attribute :name_translations, if: :with_translations?
     attributes :privacy_status, :spec, :query_id, :user_id
-    belongs_to :query
-    belongs_to :user
+    belongs_to :query, unless: :exclude_relationships?
+    belongs_to :user, unless: :exclude_relationships?
 
     attribute :links, unless: :exclude_links? do
       {
@@ -23,6 +23,10 @@ module GobiertoData
 
     def exclude_links?
       instance_options[:exclude_links]
+    end
+
+    def exclude_relationships?
+      instance_options[:exclude_relationships]
     end
 
     def with_translations?

--- a/app/serializers/gobierto_data/visualization_serializer.rb
+++ b/app/serializers/gobierto_data/visualization_serializer.rb
@@ -12,11 +12,8 @@ module GobiertoData
     belongs_to :user
 
     attribute :links, unless: :exclude_links? do
-      dataset_slug = object.dataset.slug
-      query_id = object.query_id
-      id = object.id
       {
-        show: gobierto_data_api_v1_dataset_query_visualization_path(dataset_slug: dataset_slug, query_id: query_id, id: id)
+        show: gobierto_data_api_v1_visualization_path(object.id)
       }
     end
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :bio
+end

--- a/app/views/gobierto_admin/gobierto_data/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/configuration/settings/edit.html.erb
@@ -1,0 +1,38 @@
+<div class="admin_breadcrumb">
+  <%= link_to t("gobierto_admin.welcome.index.title"), admin_root_path %> »
+  <%= link_to t("gobierto_admin.gobierto_data.datasets.index.title"), admin_data_datasets_path %> »
+  <%= t(".title") %>
+</div>
+
+<h1><%= t(".title") %></h1>
+
+<div class="tabs">
+  <ul>
+    <li class="active">
+      <%= link_to t("gobierto_admin.gobierto_data.configuration.settings.title"), edit_admin_data_configuration_settings_path %>
+    </li>
+  </ul>
+</div>
+
+<%= form_for @settings_form, as: :gobierto_data_settings, url: admin_data_configuration_settings_path,  method: :patch, html: { autocomplete: "off" } do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+      <div class="form_item textarea">
+        <%= label_tag "gobierto_data_settings[db_config]" do %>
+                <%= t("activemodel.attributes.gobierto_admin/gobierto_data/settings_form.db_config") %>
+
+        <%= attribute_indication_tag required: true %>
+      <% end %>
+        <%= f.text_area :db_config, placeholder: JSON.pretty_generate(JSON.parse(t('.db_config_placeholder'))) %>
+      </div>
+    </div>
+
+    <div class="pure-u-1 pure-u-md-2-24"></div>
+
+    <div class="pure-u-1 pure-u-md-1-4 ">
+      <div class="widget_save stick_in_parent">
+        <%= f.submit t(".update"), class: "button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
@@ -6,6 +6,11 @@
 <h1><%= t('.title') %></h1>
 
 <div class="admin_tools right">
+  <%= link_to edit_admin_data_configuration_settings_path do %>
+    <i class="fas fa-cog"></i>
+    <%= t("gobierto_admin.gobierto_data.configuration.settings.edit.title") %>
+  <% end %>
+
   <%= link_to t(".new"), new_admin_data_dataset_path, class: "button" %>
 </div>
 

--- a/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
@@ -2,6 +2,11 @@
 ca:
   gobierto_admin:
     gobierto_data:
+      configuration:
+        settings:
+          update:
+            error: 'Hi ha hagut un error al desar la configuració: %{validation_errors}'
+            success: Configuració guardada correctament
       datasets:
         create:
           success: El conjunt de dades s'ha creat correctament.

--- a/config/locales/gobierto_admin/gobierto_data/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/en.yml
@@ -2,6 +2,11 @@
 en:
   gobierto_admin:
     gobierto_data:
+      configuration:
+        settings:
+          update:
+            error: 'There was a problem when saving configuration: %{validation_errors}'
+            success: Configuration stored successfully
       datasets:
         create:
           success: Dataset created correctly.

--- a/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
@@ -2,6 +2,11 @@
 es:
   gobierto_admin:
     gobierto_data:
+      configuration:
+        settings:
+          update:
+            error: 'Se ha producido un error al actualizar la configuración: %{validation_errors}'
+            success: Configuración guardada correctamente
       datasets:
         create:
           success: El conjunto de datos ha sido creado correctamente.

--- a/config/locales/gobierto_admin/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/ca.yml
@@ -6,9 +6,17 @@ ca:
         name: Nom
         slug: Slug
         table_name: Nom de la taula
+      gobierto_admin/gobierto_data/settings_form:
+        db_config: Configuració de la connexió a la base de dades
     errors:
       models:
         gobierto_admin/gobierto_data/dataset_form:
           attributes:
             table_name:
               invalid_table: 'No es pot accedir a la taula. Missatge d''error: "%{error_message}"'
+        gobierto_admin/gobierto_data/settings_form:
+          attributes:
+            db_config:
+              invalid_connection: 'No es pot connectar amb les dades de configuració.
+                Missatge d''error: "%{error_message}"'
+              invalid_format: La configuració no té un format JSON vàlid

--- a/config/locales/gobierto_admin/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/en.yml
@@ -6,9 +6,17 @@ en:
         name: Name
         slug: Slug
         table_name: Table name
+      gobierto_admin/gobierto_data/settings_form:
+        db_config: Database connection configuration
     errors:
       models:
         gobierto_admin/gobierto_data/dataset_form:
           attributes:
             table_name:
               invalid_table: 'Unable to access the table. Error message: "%{error_message}"'
+        gobierto_admin/gobierto_data/settings_form:
+          attributes:
+            db_config:
+              invalid_connection: 'Unable to connect using configuration data. Error
+                message: "%{error_message}"'
+              invalid_format: The configuration does not have a valid JSON format

--- a/config/locales/gobierto_admin/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/es.yml
@@ -6,9 +6,17 @@ es:
         name: Nombre
         slug: Slug
         table_name: Nombre de la tabla
+      gobierto_admin/gobierto_data/settings_form:
+        db_config: Configuración de la conexión a la base de datos
     errors:
       models:
         gobierto_admin/gobierto_data/dataset_form:
           attributes:
             table_name:
               invalid_table: 'No se puede acceder a la tabla. Mensaje de error: "%{error_message}"'
+        gobierto_admin/gobierto_data/settings_form:
+          attributes:
+            db_config:
+              invalid_connection: 'No se puede conectar con los datos de configuración.
+                Mensaje de error: "%{error_message}"'
+              invalid_format: La configuración no tiene un formato JSON válido

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -2,6 +2,14 @@
 ca:
   gobierto_admin:
     gobierto_data:
+      configuration:
+        settings:
+          edit:
+            db_config_placeholder: '{"pool":5, "adapter":"postgresql", "database":"gobierto_test",
+              "encoding":"unicode", "password":"gobierto", "username":"gobierto"}'
+            title: Configuració
+            update: Actualitzar
+          title: Preferencies
       datasets:
         form:
           placeholders:

--- a/config/locales/gobierto_admin/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/en.yml
@@ -2,6 +2,14 @@
 en:
   gobierto_admin:
     gobierto_data:
+      configuration:
+        settings:
+          edit:
+            db_config_placeholder: '{"pool":5, "adapter":"postgresql", "database":"gobierto_test",
+              "encoding":"unicode", "password":"gobierto", "username":"gobierto"}'
+            title: Configuration
+            update: Update
+          title: Preferences
       datasets:
         form:
           placeholders:

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -2,6 +2,14 @@
 es:
   gobierto_admin:
     gobierto_data:
+      configuration:
+        settings:
+          edit:
+            db_config_placeholder: '{"pool":5, "adapter":"postgresql", "database":"gobierto_test",
+              "encoding":"unicode", "password":"gobierto", "username":"gobierto"}'
+            title: Configuración
+            update: Actualizar
+          title: Preferencias
       datasets:
         form:
           placeholders:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -565,7 +565,7 @@ Rails.application.routes.draw do
         # API
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
-            get "/" => "query#index", as: :root
+            get "/" => "query#index", as: :root, defaults: { :format => "json" }
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -570,6 +570,11 @@ Rails.application.routes.draw do
               collection do
                 get :meta
               end
+              resources :queries, except: [:edit], defaults: { format: "json" }, path: "q" do
+                member do
+                  get :meta
+                end
+              end
               member do
                 get "meta" => "datasets#dataset_meta"
               end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,10 @@ Rails.application.routes.draw do
 
       namespace :gobierto_data, as: :data do
         resources :datasets
+
+        namespace :configuration do
+          resource :settings, only: [:edit, :update], path: :settings
+        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -565,7 +565,7 @@ Rails.application.routes.draw do
         # API
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
-            get "/" => "query#index", as: :root, defaults: { format: "json" }
+            get "data" => "query#index", as: :root, defaults: { format: "json" }
             resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
               collection do
                 get :meta

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -565,7 +565,15 @@ Rails.application.routes.draw do
         # API
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
-            get "/" => "query#index", as: :root, defaults: { :format => "json" }
+            get "/" => "query#index", as: :root, defaults: { format: "json" }
+            resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
+              collection do
+                get :meta
+              end
+              member do
+                get "meta" => "datasets#dataset_meta"
+              end
+            end
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -574,6 +574,7 @@ Rails.application.routes.draw do
                 member do
                   get :meta
                 end
+                resources :visualizations, except: [:edit], defaults: { format: "json" }, path: "v"
               end
               member do
                 get "meta" => "datasets#dataset_meta"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -570,16 +570,16 @@ Rails.application.routes.draw do
               collection do
                 get :meta
               end
-              resources :queries, except: [:edit], defaults: { format: "json" }, path: "q" do
-                member do
-                  get :meta
-                end
-                resources :visualizations, except: [:edit], defaults: { format: "json" }, path: "v"
-              end
               member do
                 get "meta" => "datasets#dataset_meta"
               end
             end
+            resources :queries, except: [:edit], defaults: { format: "json" } do
+              member do
+                get :meta
+              end
+            end
+            resources :visualizations, except: [:edit], defaults: { format: "json" }
           end
         end
       end

--- a/db/migrate/20191212104748_create_gdata_queries.rb
+++ b/db/migrate/20191212104748_create_gdata_queries.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGdataQueries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :gdata_queries do |t|
+      t.references :dataset, index: true
+      t.references :user, index: true
+      t.jsonb :name_translations
+      t.integer :privacy_status, null: false, default: 0
+      t.string :sql
+      t.jsonb :options
+    end
+  end
+end

--- a/db/migrate/20191212104759_create_gdata_visualizations.rb
+++ b/db/migrate/20191212104759_create_gdata_visualizations.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateGdataVisualizations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :gdata_visualizations do |t|
+      t.references :query, index: true
+      t.references :user, index: true
+      t.jsonb :name_translations
+      t.integer :privacy_status, null: false, default: 0
+      t.jsonb :spec
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_152643) do
+ActiveRecord::Schema.define(version: 2019_12_12_104759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -531,6 +531,27 @@ ActiveRecord::Schema.define(version: 2019_11_14_152643) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["site_id"], name: "index_gdata_datasets_on_site_id"
+  end
+
+  create_table "gdata_queries", force: :cascade do |t|
+    t.bigint "dataset_id"
+    t.bigint "user_id"
+    t.jsonb "name_translations"
+    t.integer "privacy_status", default: 0, null: false
+    t.string "sql"
+    t.jsonb "options"
+    t.index ["dataset_id"], name: "index_gdata_queries_on_dataset_id"
+    t.index ["user_id"], name: "index_gdata_queries_on_user_id"
+  end
+
+  create_table "gdata_visualizations", force: :cascade do |t|
+    t.bigint "query_id"
+    t.bigint "user_id"
+    t.jsonb "name_translations"
+    t.integer "privacy_status", default: 0, null: false
+    t.jsonb "spec"
+    t.index ["query_id"], name: "index_gdata_visualizations_on_query_id"
+    t.index ["user_id"], name: "index_gdata_visualizations_on_user_id"
   end
 
   create_table "gi_indicators", force: :cascade do |t|

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class DatasetsControllerTest < GobiertoControllerTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def user
+          @user ||= users(:dennis)
+        end
+
+        def datasets_count
+          @datasets_count ||= site.datasets.count
+        end
+
+        def dataset
+          @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def datasets_category
+          @datasets_category ||= gobierto_common_custom_fields(:madrid_data_datasets_custom_field_category)
+        end
+
+        def other_site_dataset
+          @other_site_dataset ||= gobierto_data_datasets(:santander_dataset)
+        end
+
+        def array_data(dataset)
+          [
+            dataset.id.to_s,
+            dataset.name,
+            dataset.slug,
+            dataset.updated_at.to_s,
+            GobiertoCommon::CustomFieldRecord.find_by(item: dataset, custom_field: datasets_category)&.value_string
+          ]
+        end
+
+        def test_index_with_module_disabled
+          with(site: site_with_module_disabled) do
+            get gobierto_data_api_v1_datasets_path
+
+            assert_response :forbidden
+          end
+        end
+
+        # GET /api/v1/data/datasets.json
+        def test_index_as_json
+          with(site: site) do
+            get gobierto_data_api_v1_datasets_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal datasets_count, response_data["data"].count
+            datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes datasets_names, dataset.name
+            refute_includes datasets_names, other_site_dataset.name
+            assert response_data.has_key? "links"
+            assert_includes response_data["links"].values, gobierto_data_api_v1_datasets_path
+            assert_includes response_data["links"].values, meta_gobierto_data_api_v1_datasets_path
+          end
+        end
+
+        # GET /api/v1/data/datasets.csv
+        def test_index_as_csv
+          with(site: site) do
+            get gobierto_data_api_v1_datasets_path(format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            assert_equal datasets_count + 1, parsed_csv.count
+            assert_equal %w(id name slug updated_at category), parsed_csv.first
+            assert_includes parsed_csv, array_data(dataset)
+            refute_includes parsed_csv, array_data(other_site_dataset)
+          end
+        end
+
+        # GET /api/v1/data/datasets.csv
+        def test_index_csv_format_separator
+          with(site: site) do
+            get gobierto_data_api_v1_datasets_path(csv_separator: "semicolon", format: :csv), as: :csv
+
+            assert_response :success
+
+            parsed_csv_with_semicolon = CSV.parse(response.parsed_body, col_sep: ";")
+
+            get gobierto_data_api_v1_datasets_path(format: :csv), as: :csv
+            default_parsed_csv = CSV.parse(response.parsed_body)
+
+            assert_equal parsed_csv_with_semicolon, default_parsed_csv
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug.json
+        def test_dataset_data
+          with(site: site) do
+            get gobierto_data_api_v1_dataset_path(dataset.slug), as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+            assert response_data.has_key? "data"
+            assert_equal dataset.rails_model.count, response_data["data"].count
+            assert_equal dataset.rails_model.all.map(&:id).sort, response_data["data"].map { |row| row["id"] }.sort
+
+            assert response_data.has_key? "links"
+            assert_includes response_data["links"].values, gobierto_data_api_v1_datasets_path
+            assert_includes response_data["links"].values, meta_gobierto_data_api_v1_datasets_path
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug.csv
+        def test_dataset_data_as_csv
+          with(site: site) do
+            get gobierto_data_api_v1_dataset_path(dataset.slug, format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            assert_equal dataset.rails_model.count + 1, parsed_csv.count
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug/metadata
+        def test_dataset_metadata
+          with(site: site) do
+            get meta_gobierto_data_api_v1_dataset_path(dataset.slug), as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+
+            # data
+            assert response_data.has_key? "data"
+            resource_data = response_data["data"]
+            assert_equal resource_data["id"], dataset.id.to_s
+
+            # attributes
+            %w(name slug updated_at data_summary data_preview).each do |attribute|
+              resource_data["attributes"].has_key? attribute
+            end
+            assert resource_data["attributes"].has_key?(datasets_category.uid)
+
+            # relationships
+            assert resource_data.has_key? "relationships"
+            resource_relationships = resource_data["relationships"]
+            assert resource_relationships.has_key? "queries"
+            assert resource_relationships.has_key? "visualizations"
+
+            # links
+            assert response_data.has_key? "links"
+            assert_includes response_data["links"].values, gobierto_data_api_v1_datasets_path
+            assert_includes response_data["links"].values, meta_gobierto_data_api_v1_datasets_path
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -1,0 +1,429 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class QueriesControllerTest < GobiertoControllerTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def user
+          @user ||= users(:dennis)
+        end
+
+        def query
+          @query ||= gobierto_data_queries(:users_count_query)
+        end
+        alias open_query query
+        alias user_query query
+        alias dataset_query query
+
+        def closed_query
+          @closed_query ||= gobierto_data_queries(:census_verified_users_query)
+        end
+        alias other_user_query closed_query
+
+        def other_dataset_query
+          @other_dataset_query ||= gobierto_data_queries(:events_count_query)
+        end
+
+        def dataset
+          @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def other_dataset
+          @other_dataset ||= gobierto_data_datasets(:events_dataset)
+        end
+
+        def queries_count
+          @queries_count ||= site.queries.count
+        end
+
+        def open_queries_count
+          @open_queries_count ||= site.queries.open.count
+        end
+
+        def attributes_data(query)
+          {
+            id: query.id,
+            name: query.name,
+            name_translations: query.name_translations,
+            privacy_status: query.privacy_status,
+            sql: query.sql,
+            dataset_id: query.dataset_id,
+            user_id: query.user_id
+          }.with_indifferent_access
+        end
+
+        def array_data(query)
+          attributes = attributes_data(query)
+          [
+            attributes[:id].to_s,
+            attributes[:name],
+            attributes[:privacy_status],
+            attributes[:sql],
+            attributes[:dataset_id].to_s,
+            attributes[:user_id].to_s
+          ]
+        end
+
+        def valid_params
+          {
+            data:
+            {
+              type: "gobierto_data-queries",
+              attributes:
+              {
+                name_translations: {
+                  en: "Users with bio",
+                  es: "Usuarios con bio"
+                },
+                privacy_status: "open",
+                sql: "select count(*) from users where bio is not null",
+                dataset_id: dataset.id,
+                user_id: user.id
+              }
+            }
+          }
+        end
+
+        def test_index_with_module_disabled
+          with(site: site_with_module_disabled) do
+            get gobierto_data_api_v1_queries_path
+
+            assert_response :forbidden
+          end
+        end
+
+        # GET /api/v1/data/queries.json
+        def test_index_as_json
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            refute_equal queries_count, response_data["data"].count
+            assert_equal open_queries_count, response_data["data"].count
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes queries_names, open_query.name
+            refute_includes queries_names, closed_query.name
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_queries_path
+            assert_includes links, new_gobierto_data_api_v1_query_path
+            assert_includes links, gobierto_data_api_v1_visualizations_path
+          end
+        end
+
+        # GET /api/v1/data/queries.csv
+        def test_index_as_csv
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            refute_equal queries_count + 1, parsed_csv.count
+            assert_equal open_queries_count + 1, parsed_csv.count
+            assert_equal %w(id name privacy_status sql dataset_id user_id), parsed_csv.first
+            assert_includes parsed_csv, array_data(open_query)
+            refute_includes parsed_csv, array_data(closed_query)
+          end
+        end
+
+        # GET /api/v1/data/queries.csv
+        def test_index_csv_format_separator
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(csv_separator: "semicolon", format: :csv), as: :csv
+
+            assert_response :success
+
+            parsed_csv_with_semicolon = CSV.parse(response.parsed_body, col_sep: ";")
+
+            get gobierto_data_api_v1_queries_path(format: :csv), as: :csv
+            default_parsed_csv = CSV.parse(response.parsed_body)
+
+            assert_equal parsed_csv_with_semicolon, default_parsed_csv
+          end
+        end
+
+        # GET /api/v1/data/queries.json?dataset_id=1
+        def test_index_filtered_by_dataset
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(filter: { dataset_id: dataset.id }), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes queries_names, dataset_query.name
+            refute_includes queries_names, other_dataset_query.name
+            refute_includes queries_names, closed_query.name
+          end
+        end
+
+        # GET /api/v1/data/queries.json?user_id=1
+        def test_index_filtered_by_user
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(filter: { user_id: user.id }), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes queries_names, user_query.name
+            assert_includes queries_names, other_dataset_query.name
+            refute_includes queries_names, closed_query.name
+          end
+        end
+
+        # GET /api/v1/data/queries.json?user_id=1&dataset_id=1
+        def test_index_filtered_by_user_and_dataset
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(filter: { dataset_id: other_dataset.id, user_id: user.id }), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes queries_names, other_dataset_query.name
+            refute_includes queries_names, user_query.name
+            refute_includes queries_names, closed_query.name
+          end
+        end
+
+        # GET /api/v1/data/queries/1.json
+        def test_query_data
+          with(site: site) do
+            get gobierto_data_api_v1_query_path(query), as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+            assert response_data.has_key? "data"
+            assert_equal 1, response_data["data"].count
+            assert_equal [{ "count" => 7 }], response_data["data"]
+
+            assert response_data.has_key? "meta"
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_queries_path
+            assert_includes links, new_gobierto_data_api_v1_query_path
+            assert_includes links, gobierto_data_api_v1_query_path(query)
+            assert_includes links, meta_gobierto_data_api_v1_query_path(query)
+            assert_includes links, gobierto_data_api_v1_visualizations_path(filter: { query_id: query.id })
+          end
+        end
+
+        # GET /api/v1/data/queries/1.csv
+        def test_dataset_data_as_csv
+          with(site: site) do
+            get gobierto_data_api_v1_query_path(query, format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            assert_equal 2, parsed_csv.count
+            assert_equal %w(count), parsed_csv.first
+            assert_equal %w(7), parsed_csv.last
+          end
+        end
+
+        # GET /api/v1/data/queries/1/meta
+        def test_query_metadata
+          with(site: site) do
+            get meta_gobierto_data_api_v1_query_path(query), as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+
+            # data
+            assert response_data.has_key? "data"
+            resource_data = response_data["data"]
+            assert_equal resource_data["id"], query.id.to_s
+
+            # attributes
+            attributes = attributes_data(query)
+            %w(name privacy_status sql dataset_id user_id).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal attributes[attribute], resource_data["attributes"][attribute]
+            end
+
+            # relationships
+            assert resource_data.has_key? "relationships"
+            resource_relationships = resource_data["relationships"]
+            assert resource_relationships.has_key? "user"
+            assert resource_relationships.has_key? "dataset"
+            assert resource_relationships.has_key? "visualizations"
+
+            # links
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_queries_path
+            assert_includes links, new_gobierto_data_api_v1_query_path
+            assert_includes links, gobierto_data_api_v1_query_path(query)
+            assert_includes links, meta_gobierto_data_api_v1_query_path(query)
+            assert_includes links, gobierto_data_api_v1_visualizations_path(filter: { query_id: query.id })
+          end
+        end
+
+        # GET /api/v1/data/queries/new
+        def test_new
+          with(site: site) do
+            get new_gobierto_data_api_v1_query_path, as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+
+            # data
+            assert response_data.has_key? "data"
+            resource_data = response_data["data"]
+
+            # attributes
+            %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+            end
+
+            # links
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_queries_path
+            assert_includes links, new_gobierto_data_api_v1_query_path
+          end
+        end
+
+        # POST /api/v1/data/queries
+        def test_create
+          with(site: site) do
+            assert_difference "GobiertoData::Query.count", 1 do
+              post gobierto_data_api_v1_queries_path, params: valid_params, as: :json
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_query = Query.last
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal resource_data["id"], new_query.id.to_s
+
+              # attributes
+              attributes = attributes_data(new_query)
+              %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              # relationships
+              assert resource_data.has_key? "relationships"
+
+              # links
+              assert response_data.has_key? "links"
+              links = response_data["links"].values
+              assert_includes links, gobierto_data_api_v1_queries_path
+              assert_includes links, new_gobierto_data_api_v1_query_path
+              assert_includes links, gobierto_data_api_v1_query_path(new_query)
+              assert_includes links, meta_gobierto_data_api_v1_query_path(new_query)
+              assert_includes links, gobierto_data_api_v1_visualizations_path(filter: { query_id: new_query.id })
+            end
+          end
+        end
+
+        # POST /api/v1/data/queries
+        def test_create_invalid_params
+          with(site: site) do
+            post gobierto_data_api_v1_queries_path, params: {}, as: :json
+
+            assert_response :unprocessable_entity
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              put gobierto_data_api_v1_query_path(query), params: valid_params, as: :json
+
+              assert_response :success
+              response_data = response.parsed_body
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal resource_data["id"], query.id.to_s
+
+              # attributes
+              attributes = valid_params[:data][:attributes].with_indifferent_access
+              %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              # relationships
+              assert resource_data.has_key? "relationships"
+
+              # links
+              assert response_data.has_key? "links"
+              links = response_data["links"].values
+              assert_includes links, gobierto_data_api_v1_queries_path
+              assert_includes links, new_gobierto_data_api_v1_query_path
+              assert_includes links, gobierto_data_api_v1_query_path(query)
+              assert_includes links, meta_gobierto_data_api_v1_query_path(query)
+              assert_includes links, gobierto_data_api_v1_visualizations_path(filter: { query_id: query.id })
+            end
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update_invalid_params
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: {}, as: :json
+
+            assert_response :unprocessable_entity
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
+        def test_delete
+          id = query.id
+          assert_difference "GobiertoData::Query.count", -1 do
+            with(site: site) do
+              delete gobierto_data_api_v1_query_path(id), as: :json
+
+              assert_response :no_content
+
+              assert_nil Query.find_by(id: id)
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_data/api/v1/query_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/query_controller_test.rb
@@ -15,6 +15,14 @@ module GobiertoData
           @site_with_module_disabled ||= sites(:santander)
         end
 
+        def user
+          @user ||= users(:dennis)
+        end
+
+        def users_count
+          @users_count ||= User.count
+        end
+
         def test_index
           with(site: site) do
             get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM users"), as: :json
@@ -25,7 +33,39 @@ module GobiertoData
 
             assert response_data.has_key? "data"
             assert_equal 1, response_data["data"].count
-            assert_equal 7, response_data["data"].first["test_count"]
+            assert_equal users_count, response_data["data"].first["test_count"]
+          end
+        end
+
+        def test_index_csv_format
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT id, name FROM users", format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            assert_match(/\Aid,name\n/, response_data)
+            assert_equal users_count + 1, parsed_csv.count
+            assert_equal %w(id name), parsed_csv.first
+            assert_includes parsed_csv, [user.id.to_s, user.name]
+          end
+        end
+
+        def test_index_csv_format_separator
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT id, name FROM users", csv_separator: "semicolon", format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data, col_sep: ";")
+
+            assert_match(/\Aid\;name\n/, response_data)
+            assert_equal users_count + 1, parsed_csv.count
+            assert_equal %w(id name), parsed_csv.first
+            assert_includes parsed_csv, [user.id.to_s, user.name]
           end
         end
 

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -1,0 +1,407 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class VisualizationsControllerTest < GobiertoControllerTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def user
+          @user ||= users(:dennis)
+        end
+
+        def visualization
+          @visualization ||= gobierto_data_visualizations(:users_count_visualization)
+        end
+        alias open_visualization visualization
+        alias user_visualization visualization
+        alias query_visualization visualization
+        alias dataset_visualization visualization
+
+        def closed_visualization
+          @closed_visualization ||= gobierto_data_visualizations(:events_count_closed_visualization)
+        end
+
+        def other_dataset_visualization
+          @other_dataset_visualization ||= gobierto_data_visualizations(:events_count_open_visualization)
+        end
+
+        def other_query_visualization
+          @other_query_visualization ||= gobierto_data_visualizations(:census_verified_users_visualization)
+        end
+        alias other_user_visualization other_query_visualization
+
+        def query
+          @query ||= gobierto_data_queries(:users_count_query)
+        end
+
+        def other_query
+          @other_query ||= gobierto_data_queries(:census_verified_user_query)
+        end
+
+        def other_dataset_query
+          @other_dataset_query ||= gobierto_data_queries(:events_count_query)
+        end
+
+        def dataset
+          @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def other_dataset
+          @other_dataset ||= gobierto_data_datasets(:events_dataset)
+        end
+
+        def visualizations_count
+          @visualizations_count ||= site.visualizations.count
+        end
+
+        def open_visualizations_count
+          @open_visualizations_count ||= site.visualizations.open.count
+        end
+
+        def attributes_data(visualization)
+          {
+            id: visualization.id,
+            name: visualization.name,
+            name_translations: visualization.name_translations,
+            privacy_status: visualization.privacy_status,
+            spec: visualization.spec,
+            query_id: visualization.query_id,
+            user_id: visualization.user_id
+          }.with_indifferent_access
+        end
+
+        def array_data(visualization)
+          attributes = attributes_data(visualization)
+          [
+            attributes[:id].to_s,
+            attributes[:name],
+            attributes[:privacy_status],
+            attributes[:spec].to_s,
+            attributes[:query_id].to_s,
+            attributes[:user_id].to_s
+          ]
+        end
+
+        def valid_params
+          {
+            data:
+            {
+              type: "gobierto_data-visualizations",
+              attributes:
+              {
+                name_translations: {
+                  en: "New visualization",
+                  es: "Nueva visualización"
+                },
+                privacy_status: "open",
+                spec: {
+                  "x" => 1,
+                  "y" => 2,
+                  "z" => 3
+                },
+                query_id: query.id,
+                user_id: user.id
+              }
+            }
+          }
+        end
+
+        def test_index_with_module_disabled
+          with(site: site_with_module_disabled) do
+            get gobierto_data_api_v1_visualizations_path
+
+            assert_response :forbidden
+          end
+        end
+
+        # GET /api/v1/data/visualizations.json
+        def test_index_as_json
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            refute_equal visualizations_count, response_data["data"].count
+            assert_equal open_visualizations_count, response_data["data"].count
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, open_visualization.name
+            refute_includes visualizations_names, closed_visualization.name
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_visualizations_path
+            assert_includes links, new_gobierto_data_api_v1_visualization_path
+          end
+        end
+
+        # GET /api/v1/data/visualizations.csv
+        def test_index_as_csv
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(format: :csv), as: :csv
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            refute_equal visualizations_count + 1, parsed_csv.count
+            assert_equal open_visualizations_count + 1, parsed_csv.count
+            assert_equal %w(id name privacy_status spec query_id user_id), parsed_csv.first
+            assert_includes parsed_csv, array_data(open_visualization)
+            refute_includes parsed_csv, array_data(closed_visualization)
+          end
+        end
+
+        # GET /api/v1/data/visualizations.csv
+        def test_index_csv_format_separator
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(csv_separator: "semicolon", format: :csv), as: :csv
+
+            assert_response :success
+
+            parsed_csv_with_semicolon = CSV.parse(response.parsed_body, col_sep: ";")
+
+            get gobierto_data_api_v1_visualizations_path(format: :csv), as: :csv
+            default_parsed_csv = CSV.parse(response.parsed_body)
+
+            assert_equal parsed_csv_with_semicolon, default_parsed_csv
+          end
+        end
+
+        # GET /api/v1/data/queries.json?dataset_id=1
+        def test_index_filtered_by_dataset
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(filter: { dataset_id: dataset.id }), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, dataset_visualization.name
+            assert_includes visualizations_names, other_query_visualization.name
+            refute_includes visualizations_names, other_dataset_visualization.name
+            refute_includes visualizations_names, closed_visualization.name
+          end
+        end
+
+        # GET /api/v1/data/queries.json?query_id=1
+        def test_index_filtered_by_query
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(filter: { query_id: query.id }), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, query_visualization.name
+            refute_includes visualizations_names, other_query_visualization.name
+            refute_includes visualizations_names, other_dataset_visualization.name
+            refute_includes visualizations_names, closed_visualization.name
+          end
+        end
+
+        # GET /api/v1/data/queries.json?user_id=1
+        def test_index_filtered_by_user
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(filter: { user_id: user.id }), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, user_visualization.name
+            assert_includes visualizations_names, other_dataset_visualization.name
+            refute_includes visualizations_names, other_user_visualization.name
+            refute_includes visualizations_names, closed_visualization.name
+          end
+        end
+
+        # GET /api/v1/data/visualizations/1.json
+        def test_show
+          with(site: site) do
+            get gobierto_data_api_v1_visualization_path(visualization), as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+
+            # data
+            assert response_data.has_key? "data"
+            resource_data = response_data["data"]
+            assert_equal resource_data["id"], visualization.id.to_s
+
+            # attributes
+            attributes = attributes_data(visualization)
+            %w(name privacy_status spec query_id user_id).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal attributes[attribute], resource_data["attributes"][attribute]
+            end
+
+            # relationships
+            assert resource_data.has_key? "relationships"
+            resource_relationships = resource_data["relationships"]
+            assert resource_relationships.has_key? "user"
+            assert resource_relationships.has_key? "query"
+
+            # links
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_visualizations_path
+            assert_includes links, new_gobierto_data_api_v1_visualization_path
+            assert_includes links, gobierto_data_api_v1_visualization_path(visualization)
+          end
+        end
+
+        # GET /api/v1/data/visualizations/new
+        def test_new
+          with(site: site) do
+            get new_gobierto_data_api_v1_visualization_path, as: :json
+
+            assert_response :success
+            response_data = response.parsed_body
+
+            # data
+            assert response_data.has_key? "data"
+            resource_data = response_data["data"]
+
+            # attributes
+            %w(name_translations privacy_status spec query_id user_id).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+            end
+
+            # links
+            assert response_data.has_key? "links"
+            links = response_data["links"].values
+            assert_includes links, gobierto_data_api_v1_visualizations_path
+            assert_includes links, new_gobierto_data_api_v1_visualization_path
+          end
+        end
+
+        # POST /api/v1/data/visualizations
+        def test_create
+          with(site: site) do
+            assert_difference "GobiertoData::Visualization.count", 1 do
+              post gobierto_data_api_v1_visualizations_path, params: valid_params, as: :json
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_visualization = Visualization.last
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal resource_data["id"], new_visualization.id.to_s
+
+              # attributes
+              attributes = attributes_data(new_visualization)
+              %w(name_translations privacy_status spec query_id user_id).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              # relationships
+              assert resource_data.has_key? "relationships"
+
+              # links
+              assert response_data.has_key? "links"
+              links = response_data["links"].values
+              assert_includes links, gobierto_data_api_v1_visualizations_path
+              assert_includes links, new_gobierto_data_api_v1_visualization_path
+              assert_includes links, gobierto_data_api_v1_visualization_path(new_visualization)
+            end
+          end
+        end
+
+        # POST /api/v1/data/visualizations
+        def test_create_invalid_params
+          with(site: site) do
+            post gobierto_data_api_v1_visualizations_path, params: {}, as: :json
+
+            assert_response :unprocessable_entity
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update
+          with(site: site) do
+            assert_no_difference "GobiertoData::Visualization.count" do
+              put gobierto_data_api_v1_visualization_path(visualization), params: valid_params, as: :json
+
+              assert_response :success
+              response_data = response.parsed_body
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal resource_data["id"], visualization.id.to_s
+
+              # attributes
+              attributes = valid_params[:data][:attributes].with_indifferent_access
+              %w(name_translations privacy_status spec query_id user_id).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              # relationships
+              assert resource_data.has_key? "relationships"
+
+              # links
+              assert response_data.has_key? "links"
+              links = response_data["links"].values
+              assert_includes links, gobierto_data_api_v1_visualizations_path
+              assert_includes links, new_gobierto_data_api_v1_visualization_path
+              assert_includes links, gobierto_data_api_v1_visualization_path(visualization)
+            end
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update_invalid_params
+          with(site: site) do
+            put gobierto_data_api_v1_visualization_path(visualization), params: {}, as: :json
+
+            assert_response :unprocessable_entity
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
+        def test_delete
+          id = visualization.id
+          assert_difference "GobiertoData::Visualization.count", -1 do
+            with(site: site) do
+              delete gobierto_data_api_v1_visualization_path(id), as: :json
+
+              assert_response :no_content
+
+              assert_nil Visualization.find_by(id: id)
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/fixtures/gobierto_data/datasets.yml
+++ b/test/fixtures/gobierto_data/datasets.yml
@@ -5,3 +5,11 @@ users_dataset:
   slug: users-dataset
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+
+events_dataset:
+  site: madrid
+  name_translations: <%= { en: "Events", es: "Eventos" }.to_json %>
+  table_name: gc_events
+  slug: events-dataset
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/fixtures/gobierto_data/datasets.yml
+++ b/test/fixtures/gobierto_data/datasets.yml
@@ -13,3 +13,11 @@ events_dataset:
   slug: events-dataset
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+
+santander_dataset:
+  site: santander
+  name_translations: <%= { en: "Santander dataset", es: "Dataset de Santander" }.to_json %>
+  table_name: activities
+  slug: santander-dataset
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/fixtures/gobierto_data/queries.yml
+++ b/test/fixtures/gobierto_data/queries.yml
@@ -1,0 +1,20 @@
+users_count_query:
+  dataset: users_dataset
+  user: dennis
+  name_translations: <%= { en: "Users count", es: "Cuenta de usuarios" }.to_json %>
+  privacy_status: <%= GobiertoData::Query.privacy_statuses["open"] %>
+  sql: "select count(*) from users"
+
+census_verified_users_query:
+  dataset: users_dataset
+  user: peter
+  name_translations: <%= { en: "Verified users", es: "Usuarios verificados" }.to_json %>
+  privacy_status: <%= GobiertoData::Query.privacy_statuses["closed"] %>
+  sql: "select id, email, name from users where census_verified"
+
+events_count_query:
+  dataset: events_dataset
+  user: dennis
+  name_translations: <%= { en: "Published events", es: "Eventos publicados" }.to_json %>
+  privacy_status: <%= GobiertoData::Query.privacy_statuses["open"] %>
+  sql: "select * from events where state = <%= GobiertoCalendars::Event.states["published"] %>"

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -1,0 +1,55 @@
+users_count_visualization:
+  query: users_count_query
+  user: dennis
+  name_translations: <%= { en: "Users count visualization", es: "Visualización de cuenta de usuarios" }.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
+  spec: <%= {
+    "$schema" => "https://vega.github.io/schema/vega/v5.json",
+    "description" => "A specification outline example.",
+    "width" => 500,
+    "height" => 200,
+    "padding" => 5,
+    "autosize" => "pad",
+    "signals" => [],
+    "data" => [],
+    "scales" => [],
+    "projections" => [],
+    "axes" => [],
+    "legends" => [],
+    "marks" => []
+  }.to_json %>
+
+census_verified_users_visualization:
+  query: census_verified_users_query
+  user: peter
+  name_translations: <%= { en: "Verified users", es: "Usuarios verificados" }.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
+  spec: <%= {
+    "$schema" => "https://vega.github.io/schema/vega/v5.json",
+    "description" => "A specification outline example.",
+    "width" => 500,
+    "height" => 200,
+    "padding" => 5,
+    "autosize" => "pad",
+    "signals" => [],
+    "data" => [],
+    "scales" => [],
+    "projections" => [],
+    "axes" => [],
+    "legends" => [],
+    "marks" => []
+  }.to_json %>
+
+events_count_open_visualization:
+  query: events_count_query
+  user: dennis
+  name_translations: <%= { en: "Events count visualization open", es: "Visualización de cuenta de eventos abierta" }.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
+  spec: "{}"
+
+events_count_closed_visualization:
+  query: events_count_query
+  user: dennis
+  name_translations: <%= { en: "Events count visualization closed", es: "Visualización de cuenta de eventos cerrada" }.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["closed"] %>
+  spec: "{}"

--- a/test/forms/gobierto_data/query_form_test.rb
+++ b/test/forms/gobierto_data/query_form_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class QueryFormTest < ActiveSupport::TestCase
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def user
+      @user ||= users(:janet)
+    end
+
+    def subject
+      @subject ||= QueryForm
+    end
+
+    def dataset
+      @dataset ||= gobierto_data_datasets(:events_dataset)
+    end
+
+    def query
+      @query ||= gobierto_data_queries(:users_count_query)
+    end
+
+    def valid_attributes
+      @valid_attributes ||= {
+        site_id: site.id,
+        dataset_id: dataset.id,
+        user_id: user.id,
+        name_translations: { es: "Nueva query", en: "New query" },
+        name: "New query",
+        privacy_status: "open",
+        sql: "select count(*) from users where census_verified"
+      }
+    end
+
+    def test_create_new_with_valid_attributes
+      form = subject.new(valid_attributes)
+
+      assert form.valid?
+
+      assert_difference "GobiertoData::Query.count", 1 do
+        assert form.save
+      end
+
+      item = form.query
+
+      assert item.persisted?
+      assert "New query", item.name
+      assert "Nueva query", item.name_es
+      assert item.open?
+      assert user, item.user
+      assert dataset, item.dataset
+    end
+
+    def test_update_with_valid_attributes
+      form = subject.new(valid_attributes.merge(id: query.id))
+
+      assert form.valid?
+
+      assert_no_difference "GobiertoData::Query.count" do
+        assert form.save
+      end
+
+      item = form.query
+
+      assert item.persisted?
+      assert query.id, item.id
+      assert "New query", item.name
+      assert "Nueva query", item.name_es
+      assert item.open?
+      assert user, item.user
+      assert dataset, item.dataset
+    end
+
+    def test_validate_sql
+      form = subject.new(valid_attributes.merge(sql: "select * from not_existing_table"))
+
+      refute form.valid?
+      assert form.errors[:sql].present?
+      assert_match(/PG::UndefinedTable: ERROR:  relation \"not_existing_table\" does not exist/, form.errors[:sql].join("\n"))
+    end
+
+    def test_name_is_ignored_if_name_translations_present
+      form = subject.new(valid_attributes.merge(name: "WADUS"))
+
+      assert form.save
+      assert form.query.name_translations.values.exclude? "WADUS"
+    end
+
+    def test_name_is_converted_to_translation
+      form = subject.new(valid_attributes.except(:name_translations).merge(name: "WADUS"))
+
+      assert form.save
+      assert_equal "WADUS", form.query.name_en
+    end
+
+    def test_privacy_status_open_by_default
+      form = subject.new(valid_attributes.except(:name_translations).merge(name: "WADUS"))
+
+      assert form.save
+      assert form.query.open?
+    end
+
+    def test_invalid_missing_attributes
+      form = subject.new(valid_attributes.except(:site_id, :dataset_id, :user_id, :sql, :name, :name_translations))
+
+      refute form.valid?
+      %w(site dataset user sql name_translations).each do |attribute|
+        assert form.errors[attribute].include? "can't be blank"
+      end
+    end
+  end
+end

--- a/test/forms/gobierto_data/visualization_form_test.rb
+++ b/test/forms/gobierto_data/visualization_form_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class VisualizationFormTest < ActiveSupport::TestCase
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def user
+      @user ||= users(:janet)
+    end
+
+    def subject
+      @subject ||= VisualizationForm
+    end
+
+    def query
+      @query ||= gobierto_data_queries(:events_count_query)
+    end
+
+    def visualization
+      @visualization ||= gobierto_data_visualizations(:users_count_visualization)
+    end
+
+    def valid_attributes
+      @valid_attributes ||= {
+        site_id: site.id,
+        query_id: query.id,
+        user_id: user.id,
+        name_translations: { es: "Nueva visualización", en: "New visualization" },
+        name: "New visualization",
+        privacy_status: "open",
+        spec: { a: 1, b: 2 }
+      }
+    end
+
+    def test_create_new_with_valid_attributes
+      form = subject.new(valid_attributes)
+
+      assert form.valid?
+
+      assert_difference "GobiertoData::Visualization.count", 1 do
+        assert form.save
+      end
+
+      item = form.visualization
+
+      assert item.persisted?
+      assert "New visualization", item.name
+      assert "Nueva visualización", item.name_es
+      assert item.open?
+      assert user, item.user
+      assert query, item.query
+    end
+
+    def test_update_with_valid_attributes
+      form = subject.new(valid_attributes.merge(id: visualization.id))
+
+      assert form.valid?
+
+      assert_no_difference "GobiertoData::Visualization.count" do
+        assert form.save
+      end
+
+      item = form.visualization
+
+      assert item.persisted?
+      assert visualization.id, item.id
+      assert "New visualization", item.name
+      assert "Nueva visualización", item.name_es
+      assert item.open?
+      assert user, item.user
+      assert query, item.query
+    end
+
+    def test_name_is_ignored_if_name_translations_present
+      form = subject.new(valid_attributes.merge(name: "WADUS"))
+
+      assert form.save
+      assert form.visualization.name_translations.values.exclude? "WADUS"
+    end
+
+    def test_name_is_converted_to_translation
+      form = subject.new(valid_attributes.except(:name_translations).merge(name: "WADUS"))
+
+      assert form.save
+      assert_equal "WADUS", form.visualization.name_en
+    end
+
+    def test_privacy_status_open_by_default
+      form = subject.new(valid_attributes.except(:name_translations).merge(name: "WADUS"))
+
+      assert form.save
+      assert form.visualization.open?
+    end
+
+    def test_invalid_missing_attributes
+      form = subject.new(valid_attributes.except(:site_id, :query_id, :user_id, :spec, :name, :name_translations))
+
+      refute form.valid?
+      %w(site query user spec name_translations).each do |attribute|
+        assert form.errors[attribute].include? "can't be blank"
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_data/configuration/settings/update_settings_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/configuration/settings/update_settings_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoData
+    module Configuration
+      module Settings
+        class UpdateSettgingsTest < ActionDispatch::IntegrationTest
+
+          def setup
+            super
+            @path = edit_admin_data_configuration_settings_path
+          end
+
+          def admin
+            @admin ||= gobierto_admin_admins(:nick)
+          end
+
+          def unauthorized_regular_admin
+            @unauthorized_regular_admin ||= gobierto_admin_admins(:steve)
+          end
+
+          def authorized_regular_admin
+            @authorized_regular_admin ||= gobierto_admin_admins(:tony)
+          end
+
+          def valid_connection_params
+            @valid_connection_params ||= site.gobierto_data_settings.db_config.to_json
+          end
+
+          def invalid_connection_params
+            @invalid_connection_params ||= { foo: :bar }.to_json
+          end
+
+          def site
+            @site ||= sites(:madrid)
+          end
+
+          def test_regular_admin_permissions_not_authorized
+            with(site: site, admin: unauthorized_regular_admin) do
+              visit @path
+              assert has_content?("You are not authorized to perform this action")
+              assert_equal edit_admin_admin_settings_path, current_path
+            end
+          end
+
+          def test_regular_admin_permissions_authorized
+            with(site: site, admin: authorized_regular_admin) do
+              visit @path
+              assert has_no_content?("You are not authorized to perform this action")
+              assert_equal @path, current_path
+            end
+          end
+
+          def test_update_db_config_invalid_json
+            with(site: site, admin: admin) do
+              visit @path
+
+              fill_in "gobierto_data_settings_db_config", with: "wadus wadus"
+
+              click_button "Update"
+
+              assert has_alert?("The configuration does not have a valid JSON format")
+            end
+          end
+
+          def test_update_db_config_invalid_connection_params
+            with(site: site, admin: admin) do
+              visit @path
+
+              fill_in "gobierto_data_settings_db_config", with: invalid_connection_params
+
+              click_button "Update"
+
+              assert has_alert?("Unable to connect using configuration data")
+            end
+          end
+
+          def test_update_db_config_valid_connection_params
+            site.gobierto_data_settings.destroy
+
+            with(site: site, admin: admin) do
+              visit @path
+
+              assert has_field? "gobierto_data_settings_db_config", with: ""
+
+              fill_in "gobierto_data_settings_db_config", with: valid_connection_params
+
+              click_button "Update"
+
+              assert has_message?("Configuration stored successfully")
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/test/models/gobierto_common/custom_field_value/vocabulary_options_test.rb
+++ b/test/models/gobierto_common/custom_field_value/vocabulary_options_test.rb
@@ -40,15 +40,15 @@ module GobiertoCommon::CustomFieldValue
     end
 
     def test_vocabulary_single_select_value_string
-      assert_equal [mammal_term.name], single_select_record.value_string
+      assert_equal mammal_term.name, single_select_record.value_string
     end
 
     def test_vocabulary_multiple_select_value_string
-      assert_equal [mammal_term.name, dog_term.name], multiple_select_record.value_string
+      assert_equal "#{mammal_term.name}, #{dog_term.name}", multiple_select_record.value_string
     end
 
     def test_vocabulary_tags_value_string
-      assert_equal [mammal_term.name, dog_term.name], multiple_tags_select_record.value_string
+      assert_equal "#{mammal_term.name}, #{dog_term.name}", multiple_tags_select_record.value_string
     end
 
     def test_vocabulary_single_select_filter_value
@@ -66,56 +66,56 @@ module GobiertoCommon::CustomFieldValue
     def test_vocabulary_single_select_value_assign_with_vocabulary_term
       single_select_record.value = vocabulary_term
 
-      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.name, single_select_record.value_string
       assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_other_vocabulary_term
       single_select_record.value = other_vocabulary_term
 
-      assert_equal [], single_select_record.value_string
+      assert_equal "", single_select_record.value_string
       refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_term_integer_id
       single_select_record.value = vocabulary_term.id
 
-      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.name, single_select_record.value_string
       assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_other_vocabulary_integer_id
       single_select_record.value = other_vocabulary_term.id
 
-      assert_equal [], single_select_record.value_string
+      assert_equal "", single_select_record.value_string
       refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_term_string_id
       single_select_record.value = vocabulary_term.id.to_s
 
-      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.name, single_select_record.value_string
       assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_other_vocabulary_string_id
       single_select_record.value = other_vocabulary_term.id.to_s
 
-      assert_equal [], single_select_record.value_string
+      assert_equal "", single_select_record.value_string
       refute_equal other_vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_array_of_integer_ids
       single_select_record.value = [vocabulary_term.id, mammal_term.id]
 
-      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.name, single_select_record.value_string
       assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 
     def test_vocabulary_single_select_value_assign_with_array_of_string_ids
       single_select_record.value = [vocabulary_term.id.to_s, mammal_term.id.to_s]
 
-      assert_equal [vocabulary_term.name], single_select_record.value_string
+      assert_equal vocabulary_term.name, single_select_record.value_string
       assert_equal vocabulary_term.id.to_s, single_select_record.filter_value
     end
 

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -12,6 +12,14 @@ module GobiertoData
       @site_with_module_disabled ||= sites(:santander)
     end
 
+    def valid_connection_config
+      @valid_connection_config ||= site.gobierto_data_settings.db_config
+    end
+
+    def invalid_connection_config
+      @invalid_connection_config ||= { foo: :bar }
+    end
+
     def test_execute_query_with_module_enabled
       result = Connection.execute_query(site, "SELECT COUNT(*) AS test_count FROM users")
       hash_result = JSON.parse(result.to_json)
@@ -21,7 +29,7 @@ module GobiertoData
 
     def test_execute_query_with_wrong_configuration
       module_settings = site.gobierto_data_settings
-      module_settings.db_config = { foo: :bar }
+      module_settings.db_config = invalid_connection_config
       module_settings.save
 
       assert_raise ActiveRecord::AdapterNotSpecified do
@@ -42,6 +50,14 @@ module GobiertoData
       hash_result = JSON.parse(result.to_json)
 
       assert_equal [], hash_result
+    end
+
+    def test_test_connection_config_with_valid_config
+      assert Connection.test_connection_config(valid_connection_config)
+    end
+
+    def test_test_connection_config_with_invalid_config
+      assert_raises(Exception) { Connection.test_connection_config(invalid_connection_config) }
     end
   end
 end

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -24,7 +24,10 @@ module GobiertoData
       result = Connection.execute_query(site, "SELECT COUNT(*) AS test_count FROM users")
       hash_result = JSON.parse(result.to_json)
 
-      assert_equal [{ "test_count" => 7 }], hash_result
+      assert hash_result.has_key?("result")
+      assert hash_result.has_key?("rows")
+      assert hash_result.has_key?("duration")
+      assert_equal [{ "test_count" => 7 }], hash_result["result"]
     end
 
     def test_execute_query_with_wrong_configuration

--- a/test/models/gobierto_data/dataset_test.rb
+++ b/test/models/gobierto_data/dataset_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class DatasetTest < ActiveSupport::TestCase
+    def subject
+      @subject ||= gobierto_data_datasets(:users_dataset)
+    end
+
+    def test_valid
+      assert subject.valid?
+    end
+  end
+end

--- a/test/models/gobierto_data/query_test.rb
+++ b/test/models/gobierto_data/query_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class QueryTest < ActiveSupport::TestCase
+    def subject
+      @subject ||= gobierto_data_queries(:users_count_query)
+    end
+
+    def test_valid
+      assert subject.valid?
+    end
+  end
+end

--- a/test/models/gobierto_data/visualization_test.rb
+++ b/test/models/gobierto_data/visualization_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class VisualizationTest < ActiveSupport::TestCase
+    def subject
+      @subject ||= gobierto_data_visualizations(:users_count_visualization)
+    end
+
+    def test_valid
+      assert subject.valid?
+    end
+  end
+end


### PR DESCRIPTION
Closes #N


## :v: What does this PR do?

Second iteration of gobierto data module:
- Updates `GobiertoData::Dataset` model including a `create_dataset_from_file` methods which allows to load data into dataset table from a csv file with the option to use a schema file (documentation pending)
- Adds `GobiertoData::Query` and `Gobierto::Data::Visualization` models, forms, API controller, etc.
- Adds fixtures and tests for datasets, queries and visualizations models, forms and API controllers

## :mag: How should this be manually tested?

Follow the documentation in: https://github.com/PopulateTools/issues/wiki/Gobierto-Data

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [x] new module/submodule settings? Documentation is required for module connection setting and `create_dataset_from_file` Dataset model method usage
- [ ] significant changes in some feature?
