### PR TITLE
Add admin API endpoint for vocabulary terms creation

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    module Api
+      class TermsController < ::GobiertoAdmin::Api::BaseController
+        include ::GobiertoCommon::SecuredWithToken
+
+        skip_before_action :authenticate_admin!, :set_admin_with_token
+        before_action :set_admin_by_session_or_token
+
+        def create
+          load_vocabulary
+
+          term = @vocabulary.terms.find_or_create_by(term_params)
+
+          render json: term, serializer: ::GobiertoAdmin::GobiertoCommon::TermSerializer
+        end
+
+        private
+
+        def load_vocabulary
+          @vocabulary = current_site.vocabularies.find(params[:vocabulary_id])
+        end
+
+        def term_params
+          params.require(:term).permit(name_translations: {})
+        end
+
+        def set_admin_by_session_or_token
+          set_admin_with_token unless (@current_admin = find_current_admin).present?
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
@@ -8,6 +8,7 @@ module GobiertoAdmin
 
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token
+        before_action :check_permissions!
 
         def create
           load_vocabulary
@@ -31,6 +32,9 @@ module GobiertoAdmin
           set_admin_with_token unless (@current_admin = find_current_admin).present?
         end
 
+        def check_permissions!
+          render(json: { message: "Module not allowed" }, status: :unauthorized) unless current_admin.can_edit_vocabularies?
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,7 +174,9 @@ Rails.application.routes.draw do
         end
 
         namespace :api do
-          resources :vocabularies, only: [:show]
+          resources :vocabularies, only: [:show] do
+            resources :terms, only: [:create]
+          end
         end
       end
 

--- a/test/controllers/gobierto_admin/gobierto_common/api/terms_controller_test.rb
+++ b/test/controllers/gobierto_admin/gobierto_common/api/terms_controller_test.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module Api
+    class TermsControllerTest < GobiertoControllerTest
+
+      attr_reader :default_secret, :token_service
+
+      def setup
+        super
+
+        @default_secret = "S3cr3t"
+        @token_service = with_stubbed_jwt_default_secret(default_secret) do
+          GobiertoCommon::TokenService.new
+        end
+      end
+
+      def path
+        @path ||= admin_common_api_vocabulary_terms_path(vocabulary)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def site_witout_terms_authorizations
+        @site_witout_terms_authorizations ||= sites(:santander)
+      end
+
+      def vocabulary
+        @vocabulary ||= gobierto_common_vocabularies(:madrid_political_groups_vocabulary)
+      end
+
+      def existing_term
+        @existing_term ||= gobierto_common_terms(:dc_term)
+      end
+
+      def existing_term_from_other_vocabulary
+        @existing_term_from_other_vocabulary ||= gobierto_common_terms(:culture_term)
+      end
+
+      def manager_admin
+        gobierto_admin_admins(:nick)
+      end
+
+      def authorized_regular_admin
+        gobierto_admin_admins(:tony)
+      end
+
+      def unauthorized_regular_admin
+        gobierto_admin_admins(:steve)
+      end
+
+      def auth_token(admin)
+        token_service.encode(sub: "login", api_token: admin.api_token)
+      end
+
+      def new_term_data
+        @new_term_data ||= {
+          "term": {
+            "name_translations": {
+              "es": "Bruguera",
+              "en": "Bruguera & Co."
+            }
+          }
+        }.with_indifferent_access
+      end
+
+      def existing_term_data
+        @existing_term_data ||= {
+          "term": {
+            "name_translations": {
+              "es": "DC",
+              "en": "DC"
+            }
+          }
+        }.with_indifferent_access
+      end
+
+      # Create
+      #
+      # POST /admin/api/vocabularies/1/terms
+      # POST /admin/api/vocabularies/1/terms.json
+      def test_create_without_token
+        with(site: site) do
+          post path, as: :json
+
+          assert_response :unauthorized
+          assert_equal({ "message" => "Unauthorized" }, response.parsed_body)
+        end
+      end
+
+      def test_create_invalid_token
+        with(site: site) do
+          with_stubbed_jwt_default_secret(default_secret) do
+            auth_header = "Bearer WADUS"
+
+            post(
+              path,
+              headers: { "Authorization" => auth_header },
+              params: new_term_data,
+              as: :json
+            )
+            assert_response :unauthorized
+            assert_equal({ "message" => "Unauthorized" }, response.parsed_body)
+          end
+        end
+      end
+
+      def test_create_with_nil_api_token
+        with(site: site) do
+          with_stubbed_jwt_default_secret(default_secret) do
+            auth_header = "Bearer #{token_service.encode(sub: "login", api_token: nil)}"
+            post(
+              path,
+              headers: { "Authorization" => auth_header },
+              params: new_term_data,
+              as: :json
+            )
+            assert_response :unauthorized
+            assert_equal({ "message" => "Unauthorized" }, response.parsed_body)
+          end
+        end
+      end
+
+      def test_create_invalid_default_secret
+        with(site: site) do
+          with_stubbed_jwt_default_secret(default_secret) do
+            @token_service = GobiertoCommon::TokenService.new(secret: "Wadus!")
+            auth_header = "Bearer #{ auth_token(authorized_regular_admin) }"
+
+            post(
+              path,
+              headers: { "Authorization" => auth_header },
+              params: new_term_data,
+              as: :json
+            )
+            assert_response :unauthorized
+            assert_equal({ "message" => "Unauthorized" }, response.parsed_body)
+          end
+        end
+      end
+
+      def test_create_regular_admin_unauthorized
+        with(site: site) do
+          with_stubbed_jwt_default_secret(default_secret) do
+            auth_header = "Bearer #{ auth_token(unauthorized_regular_admin) }"
+
+            post(
+              path,
+              headers: { "Authorization" => auth_header },
+              params: new_term_data,
+              as: :json
+            )
+            assert_response :unauthorized
+            assert_equal({ "message" => "Module not allowed" }, response.parsed_body)
+          end
+        end
+      end
+
+      def test_create_regular_admin_authorized
+        with(site: site) do
+          with_stubbed_jwt_default_secret(default_secret) do
+            auth_header = "Bearer #{ auth_token(authorized_regular_admin) }"
+
+            assert_difference "GobiertoCommon::Term.count", 1 do
+              post(
+                path,
+                headers: { "Authorization" => auth_header },
+                params: new_term_data,
+                as: :json
+              )
+            end
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            assert_equal(
+              response_data["name_translations"],
+              new_term_data["term"]["name_translations"]
+            )
+            assert response_data["id"].present?
+          end
+        end
+      end
+
+      def test_create_regular_admin_authorized_with_existing_term
+        with(site: site) do
+          with_stubbed_jwt_default_secret(default_secret) do
+            auth_header = "Bearer #{ auth_token(authorized_regular_admin) }"
+
+            assert_difference "GobiertoCommon::Term.count", 0 do
+              post(
+                path,
+                headers: { "Authorization" => auth_header },
+                params: existing_term_data,
+                as: :json
+              )
+            end
+
+            assert_response :success
+
+            response_data = response.parsed_body
+            assert_equal(
+              response_data["name_translations"],
+              existing_term.name_translations
+            )
+            assert_equal existing_term.id, response_data["id"].to_i
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

Adds an API admin endpoint to add terms to a vocabulary. The requests must include a valid token of an admin with permissions.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Added page for API endpoint