### PR TITLE
Fix tests related with custom fields used by plugins

### DIFF
--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -192,7 +192,7 @@ madrid_custom_field_progress_plugin:
   options: <%= {
     configuration: {
       plugin_type: "progress",
-      plugin_configuration: { custom_field_uids: ["human-resources"] }
+      plugin_configuration: { custom_field_uids: ["human_resources_table"] }
     }
   }.to_json %>
 

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_indicators_attachment_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_indicators_attachment_test.rb
@@ -32,7 +32,7 @@ module GobiertoPlans
     end
 
     def test_plugin_data
-      assert_equal "Indicators", plugin_data[:title_translations][:en]
+      assert_equal "Indicator (table)", plugin_data[:title_translations]["en"]
       assert_equal 2, plugin_data[:data].size
       assert_equal expected_indicator_attributes, plugin_data[:data].first
     end

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_indicators_attachment_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/decorators/gobierto_plans/category_term_decorator_indicators_attachment_test.rb
@@ -17,7 +17,7 @@ module GobiertoPlans
 
     def expected_indicator_attributes
       {
-        id: 162407219,
+        id: 162_407_219,
         name_translations: {
           "en" => "Raw savings",
           "es" => "Ahorro bruto"

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/models/gobierto_common/custom_field_functions/human_resource_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/models/gobierto_common/custom_field_functions/human_resource_test.rb
@@ -15,12 +15,12 @@ module GobiertoCommon::CustomFieldFunctions
       @item.update_attribute(:ends_at, 2.days.from_now)
       @item.update_attribute(:ends_at, 3.days.from_now)
 
-      @human_resource_record = gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+      @human_resource_record = gobierto_common_custom_field_records(:political_agendas_human_resources_table_custom_field_record)
       @human_resource_record.paper_trail.save_with_version
       @human_resource_record.update(
         payload:
         {
-          human_resources: [
+          human_resources_table: [
             {
               human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
               cost: 30_000,
@@ -46,7 +46,7 @@ module GobiertoCommon::CustomFieldFunctions
       @human_resource_record.update(
         payload:
         {
-          human_resources: [
+          human_resources_table: [
             {
               human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
               cost: 35_000,

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -46,7 +46,7 @@ module GobiertoPlans
     end
 
     def human_resources_record
-      @human_resources_record ||= gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+      @human_resources_record ||= gobierto_common_custom_field_records(:political_agendas_human_resources_table_custom_field_record)
     end
 
     def publish_last_version_on_all_projects!
@@ -147,7 +147,7 @@ module GobiertoPlans
       human_resources_record.update(
         payload:
         {
-          human_resources: [
+          human_resources_table: [
             {
               human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
               cost: 35_000,

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/test/integration/progress_plugin_test.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/test/integration/progress_plugin_test.rb
@@ -25,17 +25,17 @@ class ProgressPluginTest < ActionDispatch::IntegrationTest
   end
 
   def source_custom_field_of_progress_calculations
-    gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+    gobierto_common_custom_field_records(:political_agendas_human_resources_table_custom_field_record)
   end
 
   def clear_source_payload
-    source_custom_field_of_progress_calculations.update_attributes!(payload: { human_resources: [] })
+    source_custom_field_of_progress_calculations.update_attributes!(payload: { human_resources_table: [] })
   end
 
   def set_source_payload
     source_custom_field_of_progress_calculations.update_attributes!(
       payload: {
-        human_resources: [
+        human_resources_table: [
           {
             human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
             cost: 35_000,

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/test/models/gobierto_common/custom_field_functions/progress_test.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/test/models/gobierto_common/custom_field_functions/progress_test.rb
@@ -16,12 +16,12 @@ module GobiertoCommon::CustomFieldFunctions
       @item.update_attribute(:ends_at, 3.days.from_now)
 
       @progress_record = gobierto_common_custom_field_records(:political_agendas_progress_custom_field_record)
-      @source_calculations_record = gobierto_common_custom_field_records(:political_agendas_human_resources_custom_field_record)
+      @source_calculations_record = gobierto_common_custom_field_records(:political_agendas_human_resources_table_custom_field_record)
       @source_calculations_record.paper_trail.save_with_version
       @source_calculations_record.update(
         payload:
         {
-          human_resources: [
+          human_resources_table: [
             {
               human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
               cost: 35_000,
@@ -47,7 +47,7 @@ module GobiertoCommon::CustomFieldFunctions
       @source_calculations_record.update(
         payload:
         {
-          human_resources: [
+          human_resources_table: [
             {
               human_resource: ActiveRecord::FixtureSet.identify(:human_resources_supervisor),
               cost: 35_000,

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/test/models/gobierto_common/custom_field_functions/progress_test.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/test/models/gobierto_common/custom_field_functions/progress_test.rb
@@ -85,13 +85,13 @@ module GobiertoCommon::CustomFieldFunctions
     end
 
     def test_progress_refered_to_not_existing_custom_field
-      progress_custom_field.update_attribute(:options, {"configuration"=>{"plugin_type"=>"progress", "plugin_configuration"=>{"custom_field_uids"=>["wadus"]}}})
+      progress_custom_field.update_attribute(:options, "configuration" => { "plugin_type" => "progress", "plugin_configuration" => { "custom_field_uids" => %w(wadus) } })
 
       assert_nil progress_record.functions.progress
     end
 
     def test_progress_refered_to_custom_field_not_providing_progress_function
-      progress_custom_field.update_attribute(:options, {"configuration"=>{"plugin_type"=>"progress", "plugin_configuration"=>{"custom_field_uids"=>["goals"]}}})
+      progress_custom_field.update_attribute(:options, "configuration" => { "plugin_type" => "progress", "plugin_configuration" => { "custom_field_uids" => %w(goals) } })
 
       assert_nil progress_record.functions.progress
     end

--- a/vendor/gobierto_engines/custom-fields-table-plugin/app/models/gobierto_common/custom_field_functions/table.rb
+++ b/vendor/gobierto_engines/custom-fields-table-plugin/app/models/gobierto_common/custom_field_functions/table.rb
@@ -3,11 +3,66 @@
 module GobiertoCommon::CustomFieldFunctions
   class Table < Base
 
-    def initialize(record, options = {})
-      @version = options.delete(:version)
+    def progress(options = {})
+      date = options[:date] || Date.current
 
-      super
+      result = progress_percentages(date).instance_eval do
+        return nil if blank?
+
+        sum / size.to_f
+      end
+
+      result.nan? ? nil : result
     end
 
+    def executed_cost(options = {})
+      percentages = progress_percentages(options[:date] || Date.current)
+
+      percentages.each_with_index.inject(0) do |total, (percentage, index)|
+        total + percentage * data[index].cost
+      end
+    end
+
+    def planned_cost(_options = {})
+      data.map(&:cost).compact.sum
+    end
+
+    private
+
+    def data
+      @data ||= begin
+                  resources = value.is_a?(Array) ? value : value.dig(custom_field.uid) || []
+
+                  resources.map do |resource|
+                    OpenStruct.new(
+                      start_date: parse_date(resource["start_date"]),
+                      end_date: parse_date(resource["end_date"]),
+                      cost: resource["cost"].to_f
+                    )
+                  end
+                end
+    end
+
+    def progress_percentages(date)
+      data.map do |resource|
+        if resource.start_date && date < resource.start_date
+          0.0
+        elsif resource.end_date && date > resource.end_date
+          1.0
+        else
+          next unless resource.start_date.present? && resource.end_date.present?
+
+          (date - resource.start_date).to_f / (resource.end_date - resource.start_date)
+        end
+      end.compact
+    end
+
+    def parse_date(date, fallback = nil)
+      return unless date
+
+      Date.parse(date)
+    rescue ArgumentError
+      fallback
+    end
   end
 end


### PR DESCRIPTION
##  :v: What does this PR do?

* Fixes names of fixtures used on some tests, replacing `political_agendas_human_resources_custom_field_record` with `political_agendas_human_resources_table_custom_field_record`
* Replaces `human_resources` with `human_resources_table` uid used in attributes of some tests
* Adds methods to calculate progress and cost used by human resources plugin to table plugin, since they are quite generic, expecting the presence of columns with id `start_date`, `end_date` and `cost`
* Fixes some rubocop offenses

There are some tests that continue to fail but don't seem to be related with custom fields for plugins. These errors will be fixed in other issue

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
