### PR TITLE
848 gobierto data xlsx format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
 
 # API
 gem "jwt"
+gem "rubyXL"
 
 group :development, :test do
   gem "byebug", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,9 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    rubyXL (3.4.10)
+      nokogiri (>= 1.4.4)
+      rubyzip (>= 1.3.0)
     ruby_px (0.5.0)
       activesupport (>= 4.2.5)
     rubyntlm (0.6.2)
@@ -548,6 +551,7 @@ DEPENDENCIES
   responders
   rollbar
   rubocop
+  rubyXL
   ruby_px
   sass (~> 3.4)
   sassc

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -10,6 +10,7 @@ module GobiertoData
         # GET /api/v1/data/datasets
         # GET /api/v1/data/datasets.json
         # GET /api/v1/data/datasets.csv
+        # GET /api/v1/data/datasets.xlsx
         def index
           relation = filtered_relation
           respond_to do |format|
@@ -20,12 +21,17 @@ module GobiertoData
             format.csv do
               render_csv(csv_from_relation(relation, csv_options_params))
             end
+
+            format.xlsx do
+              send_data xlsx_from_relation(relation, name: controller_name.titleize).read, filename: "#{controller_name.underscore}.xlsx"
+            end
           end
         end
 
         # GET /api/v1/data/datasets/dataset-slug
         # GET /api/v1/data/datasets/dataset-slug.json
         # GET /api/v1/data/datasets/dataset-slug.csv
+        # GET /api/v1/data/datasets/dataset-slug.xlsx
         def show
           find_item
           relation = @item.rails_model.all
@@ -45,6 +51,10 @@ module GobiertoData
 
             format.csv do
               render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+            end
+
+            format.xlsx do
+              send_data xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, filename: "#{@item.slug}.xlsx"
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -8,6 +8,7 @@ module GobiertoData
         # GET /api/v1/data/queries
         # GET /api/v1/data/queries.json
         # GET /api/v1/data/queries.csv
+        # GET /api/v1/data/queries.xlsx
         def index
           respond_to do |format|
             format.json do
@@ -17,12 +18,17 @@ module GobiertoData
             format.csv do
               render_csv(csv_from_relation(filtered_relation, csv_options_params))
             end
+
+            format.xlsx do
+              send_data xlsx_from_relation(filtered_relation, name: controller_name.titleize).read, filename: "#{controller_name.underscore}.xlsx"
+            end
           end
         end
 
         # GET /api/v1/data/queries/1
         # GET /api/v1/data/queries/1.json
         # GET /api/v1/data/queries/1.csv
+        # GET /api/v1/data/queries/1.xlsx
         def show
           find_item
           query_result = @item.result
@@ -41,6 +47,10 @@ module GobiertoData
 
             format.csv do
               render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+            end
+
+            format.xlsx do
+              send_data xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, filename: "#{@item.id}.xlsx"
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -8,6 +8,7 @@ module GobiertoData
         # GET /api/v1/data?sql=SELECT%20%2A%20FROM%20table_name
         # GET /api/v1/data.json?sql=SELECT%20%2A%20FROM%20table_name
         # GET /api/v1/data.csv?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/data.xlsx?sql=SELECT%20%2A%20FROM%20table_name
         def index
           query_result = execute_query(params[:sql] || {})
 
@@ -21,6 +22,10 @@ module GobiertoData
 
               format.csv do
                 render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+              end
+
+              format.xlsx do
+                send_data xlsx_from_query_result(query_result.fetch(:result, "")).read, filename: "data.xlsx"
               end
             end
           end

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -8,6 +8,7 @@ module GobiertoData
         # GET /api/v1/data/visualizations
         # GET /api/v1/data/visualizations.json
         # GET /api/v1/data/visualizations.csv
+        # GET /api/v1/data/visualizations.xlsx
         def index
           respond_to do |format|
             format.json do
@@ -16,6 +17,10 @@ module GobiertoData
 
             format.csv do
               render_csv(csv_from_relation(filtered_relation, csv_options_params))
+            end
+
+            format.xlsx do
+              send_data xlsx_from_relation(filtered_relation, name: controller_name.titleize).read, filename: "#{controller_name.underscore}.xlsx"
             end
           end
         end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "application/xlsx", :xlsx

--- a/test/controllers/gobierto_data/api/v1/query_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/query_controller_test.rb
@@ -69,6 +69,25 @@ module GobiertoData
           end
         end
 
+        def test_index_xlsx_format
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT id, name FROM users", format: :xlsx), as: :xlsx
+
+            assert_response :success
+
+            parsed_xlsx = RubyXL::Parser.parse_buffer response.parsed_body
+
+            assert_equal 1, parsed_xlsx.worksheets.count
+            sheet = parsed_xlsx.worksheets.first
+            assert_nil sheet[users_count + 1]
+            assert_equal %w(id name), sheet[0].cells.map(&:value)
+            values = (1..users_count).map do |row_number|
+              sheet[row_number].cells.map(&:value)
+            end
+            assert_includes values, [user.id, user.name]
+          end
+        end
+
         def test_index_with_module_disabled
           with(site: site_with_module_disabled) do
             get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM users"), as: :json

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -180,6 +180,27 @@ module GobiertoData
           end
         end
 
+        # GET /api/v1/data/visualizations.xlsx
+        def test_index_xlsx_format
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(format: :xlsx), as: :xlsx
+
+            assert_response :success
+
+            parsed_xlsx = RubyXL::Parser.parse_buffer response.parsed_body
+
+            assert_equal 1, parsed_xlsx.worksheets.count
+            sheet = parsed_xlsx.worksheets.first
+            assert_nil sheet[open_visualizations_count + 1]
+            assert_equal %w(id name privacy_status spec query_id user_id), sheet[0].cells.map(&:value)
+            values = (1..open_visualizations_count).map do |row_number|
+              sheet[row_number].cells.map { |cell| cell.value.to_s }
+            end
+            assert_includes values, array_data(open_visualization)
+            refute_includes values, array_data(closed_visualization)
+          end
+        end
+
         # GET /api/v1/data/queries.json?dataset_id=1
         def test_index_filtered_by_dataset
           with(site: site) do


### PR DESCRIPTION
Closes PopulateTools/issues#848

## :v: What does this PR do?

* Adds support to API to return data in xlsx format for:
  * `data/data`: queries using sql
  * `data/datasets` index of datasets
  * `data/datasets/DATASET-SLUG` content of dataset
  * `data/queries` index of queries
  * `data/queries/QUERY-ID` result of query
  * `data/visualizations` index of visualizations
* Adds some tests for the API response

## :mag: How should this be manually tested?
Send requests using [documentation](https://github.com/PopulateTools/issues/wiki/Gobierto-Data) for endpoints able to return xlsx

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
