### PR TITLE
Add columns attribute to datasets meta

### DIFF
--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -11,6 +11,10 @@ module GobiertoData
       }
     end
 
+    attribute :columns do
+      object.rails_model.column_names
+    end
+
     attribute :data_preview do
       object.rails_model.first(50)
     end

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -188,7 +188,7 @@ module GobiertoData
             assert_equal resource_data["id"], dataset.id.to_s
 
             # attributes
-            %w(name slug updated_at data_summary data_preview).each do |attribute|
+            %w(name slug updated_at data_summary columns data_preview).each do |attribute|
               resource_data["attributes"].has_key? attribute
             end
             assert resource_data["attributes"].has_key?(datasets_category.uid)


### PR DESCRIPTION
## :v: What does this PR do?

Adds the list of columns of the table of a dataset to dataset meta endpoint

## :mag: How should this be manually tested?

Visit meta of a dataset. The columns should be in data[attributes][columns]

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
