### PR TITLE
Fix production queue adapter

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,8 +58,7 @@ Rails.application.configure do
   end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "gobierto_#{Rails.env}"
+  config.active_job.queue_adapter = :sidekiq
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -57,9 +57,6 @@ Rails.application.configure do
   end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "rails_template_#{Rails.env}"
-
   config.active_job.queue_adapter = :sidekiq
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
Should fix https://github.com/PopulateTools/populate-ansible/issues/95 (ensure check is working before closing the issue).

At systems levels everything is configured OK, I made a quick test changing the adapter in the server and restarting and jobs were correctly processed by sidekiq:

![Captura de pantalla 2020-01-13 a las 10 26 13](https://user-images.githubusercontent.com/9287468/72244927-99157e80-35ef-11ea-8aa5-72f9f65bcb92.png)

And the queues started showing the jobs:

![image](https://user-images.githubusercontent.com/9287468/72244985-b8aca700-35ef-11ea-99eb-f041e79789fb.png)

