### PR TITLE
2750 users auth token

### DIFF
--- a/app/controllers/concerns/gobierto_common/secured_with_admin_token.rb
+++ b/app/controllers/concerns/gobierto_common/secured_with_admin_token.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GobiertoCommon
-  module SecuredWithToken
+  module SecuredWithAdminToken
     extend ActiveSupport::Concern
 
     included do

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -3,12 +3,6 @@
 module User::ApiAuthenticationHelper
   extend ActiveSupport::Concern
 
-  included do
-    if respond_to?(:helper_method)
-      helper_method :current_user, :user_authenticated?
-    end
-  end
-
   private
 
   def current_user

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -28,6 +28,6 @@ module User::ApiAuthenticationHelper
   end
 
   def token
-    @token = request.headers["token"] || params["token"]
+    @token = request.headers["Authorization"] || params["token"]
   end
 end

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module User::ApiAuthenticationHelper
+  extend ActiveSupport::Concern
+
+  included do
+    if respond_to?(:helper_method)
+      helper_method :current_user, :user_authenticated?
+    end
+  end
+
+  private
+
+  def current_user
+    @current_user ||= find_current_user
+  end
+
+  def user_authenticated?
+    current_user.present?
+  end
+
+  def authenticate_user!
+    raise_unauthorized unless user_authenticated?
+  end
+
+  def find_current_user
+    return unless token.present?
+
+    current_site.users.confirmed.joins(:api_tokens).find_by(user_api_tokens: { token: token })
+  end
+
+  def raise_unauthorized
+    render(json: { message: "Unauthorized" }, status: :unauthorized, adapter: :json_api) && return
+  end
+
+  def token
+    @token = request.headers["token"] || params["token"]
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   module GobiertoAttachments
     module Api
       class AttachmentsController < ::GobiertoAdmin::Api::BaseController
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token
 

--- a/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   module GobiertoCommon
     module Api
       class TermsController < ::GobiertoAdmin::Api::BaseController
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
 
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token

--- a/app/controllers/gobierto_admin/gobierto_common/api/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/vocabularies_controller.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   module GobiertoCommon
     module Api
       class VocabulariesController < ::GobiertoAdmin::Api::BaseController
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
 
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -5,6 +5,7 @@ module GobiertoData
     module V1
       class BaseController < ApiBaseController
         include ActionController::MimeResponds
+        include ::User::ApiAuthenticationHelper
 
         before_action { module_enabled!(current_site, "GobiertoData", false) }
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -5,6 +5,9 @@ module GobiertoData
     module V1
       class QueriesController < BaseController
 
+        before_action :authenticate_user!, except: [:index, :show, :meta, :new]
+        before_action :allow_author!, only: [:update, :destroy]
+
         # GET /api/v1/data/queries
         # GET /api/v1/data/queries.json
         # GET /api/v1/data/queries.csv
@@ -71,7 +74,7 @@ module GobiertoData
         # GET /api/v1/data/queries/new
         # GET /api/v1/data/queries/new.json
         def new
-          @item = base_relation.new(name_translations: available_locales_hash)
+          @item = base_relation.new(name_translations: available_locales_hash, user: current_user)
 
           render(
             json: @item,
@@ -85,7 +88,7 @@ module GobiertoData
         # POST /api/v1/data/queries
         # POST /api/v1/data/queries.json
         def create
-          @query_form = QueryForm.new(query_params.merge(site_id: current_site.id))
+          @query_form = QueryForm.new(query_params.merge(site_id: current_site.id, user_id: current_user.id))
 
           if @query_form.save
             @item = @query_form.query
@@ -105,7 +108,6 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         # PUT /api/v1/data/queries/1.json
         def update
-          find_item
           @query_form = QueryForm.new(query_params.except(*ignored_attributes_on_update).merge(site_id: current_site.id, id: @item.id))
 
           if @query_form.save
@@ -124,8 +126,6 @@ module GobiertoData
         # DELETE /api/v1/data/queries/1
         # DELETE /api/v1/data/queries/1.json
         def destroy
-          find_item
-
           @item.destroy
 
           head :no_content
@@ -146,7 +146,7 @@ module GobiertoData
         end
 
         def query_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :dataset_id, :name_translations, :name, :privacy_status, :sql])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:dataset_id, :name_translations, :name, :privacy_status, :sql])
         end
 
         def filter_params
@@ -182,6 +182,11 @@ module GobiertoData
 
         def ignored_attributes_on_update
           [:dataset_id, :user_id]
+        end
+
+        def allow_author!
+          find_item
+          render(json: { message: "Unauthorized" }, status: :unauthorized, adapter: :json_api) && return if @item.user != current_user
         end
 
       end

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -6,7 +6,7 @@ module GobiertoInvestments
       class ProjectsController < ApiBaseController
 
         include ::GobiertoCommon::CustomFieldsApi
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
 
         skip_before_action :set_admin_with_token, only: [:index, :show, :new, :meta]
         before_action :module_allowed, except: [:index, :show, :new, :meta]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,11 +14,14 @@ class User < ApplicationRecord
   has_many :id_number_verifications, class_name: "User::Verification::IdNumber"
   has_many :subscriptions, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :api_tokens, dependent: :destroy
   has_many :custom_records, dependent: :destroy, class_name: "GobiertoCommon::CustomUserFieldRecord"
   has_many :contributions, dependent: :destroy, class_name: "GobiertoParticipation::Contribution"
   has_many :flags, dependent: :destroy, class_name: "GobiertoParticipation::Flag"
   has_many :votes, dependent: :destroy, class_name: "GobiertoParticipation::Vote"
   has_many :comment, dependent: :destroy, class_name: "GobiertoParticipation::Comment"
+
+  after_create :primary_api_token!
 
   # GobiertoData
   has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
@@ -60,6 +63,14 @@ class User < ApplicationRecord
     if value.present?
       super(value.downcase)
     end
+  end
+
+  def primary_api_token!
+    primary_api_token || api_tokens.primary.create
+  end
+
+  def primary_api_token
+    api_tokens.primary.take
   end
 
 end

--- a/app/models/user/api_token.rb
+++ b/app/models/user/api_token.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class User::ApiToken < ApplicationRecord
+  belongs_to :user
+  has_secure_token
+  validates :user, presence: true
+  validates :name, presence: true, unless: :primary?
+  validates :name, uniqueness: { scope: :user }
+  validates :user, uniqueness: { scope: :primary }, if: :primary?
+
+  delegate :site, to: :user
+
+  scope :primary, -> { where(primary: true) }
+end

--- a/db/migrate/20200110121522_create_user_api_tokens.rb
+++ b/db/migrate/20200110121522_create_user_api_tokens.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateUserApiTokens < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_api_tokens do |t|
+      t.references :user
+      t.string :name
+      t.string :token
+      t.boolean :primary, default: false
+
+      t.timestamps
+    end
+
+    User.all.each(&:primary_api_token!)
+  end
+end

--- a/db/migrate/20200113173645_add_unique_constraint_to_user_api_tokens.rb
+++ b/db/migrate/20200113173645_add_unique_constraint_to_user_api_tokens.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToUserApiTokens < ActiveRecord::Migration[5.2]
+  def change
+    add_index :user_api_tokens, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_10_121522) do
+ActiveRecord::Schema.define(version: 2020_01_13_173645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -1024,6 +1024,7 @@ ActiveRecord::Schema.define(version: 2020_01_10_121522) do
     t.boolean "primary", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_user_api_tokens_on_token", unique: true
     t.index ["user_id"], name: "index_user_api_tokens_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_12_104759) do
+ActiveRecord::Schema.define(version: 2020_01_10_121522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -1015,6 +1015,16 @@ ActiveRecord::Schema.define(version: 2019_12_12_104759) do
     t.integer "site_id"
     t.index ["key"], name: "index_translations_on_key"
     t.index ["locale"], name: "index_translations_on_locale"
+  end
+
+  create_table "user_api_tokens", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name"
+    t.string "token"
+    t.boolean "primary", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_api_tokens_on_user_id"
   end
 
   create_table "user_notifications", id: :serial, force: :cascade do |t|

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -376,7 +376,7 @@ module GobiertoData
         def test_create_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              post gobierto_data_api_v1_queries_path, headers: { token: "wadus" }, params: valid_params
+              post gobierto_data_api_v1_queries_path, headers: { Authorization: "wadus" }, params: valid_params
 
               assert_response :unauthorized
             end
@@ -387,7 +387,7 @@ module GobiertoData
         def test_create
           with(site: site) do
             assert_difference "GobiertoData::Query.count", 1 do
-              post gobierto_data_api_v1_queries_path, params: valid_params, headers: { token: user_token.token }, as: :json
+              post gobierto_data_api_v1_queries_path, params: valid_params, headers: { Authorization: user_token.token }, as: :json
 
               assert_response :created
               response_data = response.parsed_body
@@ -427,7 +427,7 @@ module GobiertoData
         # POST /api/v1/data/queries
         def test_create_invalid_params
           with(site: site) do
-            post gobierto_data_api_v1_queries_path, params: {}, headers: { token: user_token.token }, as: :json
+            post gobierto_data_api_v1_queries_path, params: {}, headers: { Authorization: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -448,7 +448,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_with_invalid_token
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: "wadus" }, as: :json
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { Authorization: "wadus" }, as: :json
 
             assert_response :unauthorized
           end
@@ -457,7 +457,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_with_other_user_token
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: other_user_token.token }, as: :json
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { Authorization: other_user_token.token }, as: :json
 
             assert_response :unauthorized
           end
@@ -467,7 +467,7 @@ module GobiertoData
         def test_update
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: user_token.token }, as: :json
+              put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { Authorization: user_token.token }, as: :json
 
               assert_response :success
               response_data = response.parsed_body
@@ -503,7 +503,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_invalid_params
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: {}, headers: { token: user_token.token }, as: :json
+            put gobierto_data_api_v1_query_path(query), params: {}, headers: { Authorization: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -527,7 +527,7 @@ module GobiertoData
         def test_delete_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              delete gobierto_data_api_v1_query_path(query), headers: { token: "wadus" }, as: :json
+              delete gobierto_data_api_v1_query_path(query), headers: { Authorization: "wadus" }, as: :json
 
               assert_response :unauthorized
             end
@@ -538,7 +538,7 @@ module GobiertoData
         def test_delete_with_other_user_token
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              delete gobierto_data_api_v1_query_path(query), headers: { token: other_user_token.token }, as: :json
+              delete gobierto_data_api_v1_query_path(query), headers: { Authorization: other_user_token.token }, as: :json
 
               assert_response :unauthorized
             end
@@ -550,7 +550,7 @@ module GobiertoData
           id = query.id
           assert_difference "GobiertoData::Query.count", -1 do
             with(site: site) do
-              delete gobierto_data_api_v1_query_path(id), headers: { token: user_token.token }, as: :json
+              delete gobierto_data_api_v1_query_path(id), headers: { Authorization: user_token.token }, as: :json
 
               assert_response :no_content
 

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -19,6 +19,18 @@ module GobiertoData
           @user ||= users(:dennis)
         end
 
+        def user_token
+          @user_token ||= user_api_tokens(:dennis_primary_api_token)
+        end
+
+        def other_user
+          @other_user ||= users(:peter)
+        end
+
+        def other_user_token
+          @other_user_token ||= user_api_tokens(:peter_primary_api_token)
+        end
+
         def query
           @query ||= gobierto_data_queries(:users_count_query)
         end
@@ -88,8 +100,7 @@ module GobiertoData
                 },
                 privacy_status: "open",
                 sql: "select count(*) from users where bio is not null",
-                dataset_id: dataset.id,
-                user_id: user.id
+                dataset_id: dataset.id
               }
             }
           }
@@ -351,15 +362,40 @@ module GobiertoData
         end
 
         # POST /api/v1/data/queries
+        def test_create_without_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              post gobierto_data_api_v1_queries_path, params: valid_params
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # POST /api/v1/data/queries
+        def test_create_with_invalid_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              post gobierto_data_api_v1_queries_path, headers: { token: "wadus" }, params: valid_params
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # POST /api/v1/data/queries
         def test_create
           with(site: site) do
             assert_difference "GobiertoData::Query.count", 1 do
-              post gobierto_data_api_v1_queries_path, params: valid_params, as: :json
+              post gobierto_data_api_v1_queries_path, params: valid_params, headers: { token: user_token.token }, as: :json
 
               assert_response :created
               response_data = response.parsed_body
 
               new_query = Query.last
+
+              assert_equal user, new_query.user
+
               # data
               assert response_data.has_key? "data"
               resource_data = response_data["data"]
@@ -367,10 +403,11 @@ module GobiertoData
 
               # attributes
               attributes = attributes_data(new_query)
-              %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+              %w(name_translations privacy_status sql dataset_id).each do |attribute|
                 assert resource_data["attributes"].has_key? attribute
                 assert_equal attributes[attribute], resource_data["attributes"][attribute]
               end
+              assert_equal user.id, resource_data["attributes"]["user_id"]
 
               # relationships
               assert resource_data.has_key? "relationships"
@@ -390,7 +427,7 @@ module GobiertoData
         # POST /api/v1/data/queries
         def test_create_invalid_params
           with(site: site) do
-            post gobierto_data_api_v1_queries_path, params: {}, as: :json
+            post gobierto_data_api_v1_queries_path, params: {}, headers: { token: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -400,10 +437,37 @@ module GobiertoData
         end
 
         # PUT /api/v1/data/queries/1
+        def test_update_without_token
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: valid_params, as: :json
+
+            assert_response :unauthorized
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update_with_invalid_token
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: "wadus" }, as: :json
+
+            assert_response :unauthorized
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update_with_other_user_token
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: other_user_token.token }, as: :json
+
+            assert_response :unauthorized
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
         def test_update
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              put gobierto_data_api_v1_query_path(query), params: valid_params, as: :json
+              put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: user_token.token }, as: :json
 
               assert_response :success
               response_data = response.parsed_body
@@ -415,10 +479,11 @@ module GobiertoData
 
               # attributes
               attributes = valid_params[:data][:attributes].with_indifferent_access
-              %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+              %w(name_translations privacy_status sql dataset_id).each do |attribute|
                 assert resource_data["attributes"].has_key? attribute
                 assert_equal attributes[attribute], resource_data["attributes"][attribute]
               end
+              assert_equal user.id, resource_data["attributes"]["user_id"]
 
               # relationships
               assert resource_data.has_key? "relationships"
@@ -438,7 +503,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_invalid_params
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: {}, as: :json
+            put gobierto_data_api_v1_query_path(query), params: {}, headers: { token: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -448,11 +513,44 @@ module GobiertoData
         end
 
         # DELETE /api/v1/data/queries/1
+        def test_delete_without_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              delete gobierto_data_api_v1_query_path(query), as: :json
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
+        def test_delete_with_invalid_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              delete gobierto_data_api_v1_query_path(query), headers: { token: "wadus" }, as: :json
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
+        def test_delete_with_other_user_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              delete gobierto_data_api_v1_query_path(query), headers: { token: other_user_token.token }, as: :json
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
         def test_delete
           id = query.id
           assert_difference "GobiertoData::Query.count", -1 do
             with(site: site) do
-              delete gobierto_data_api_v1_query_path(id), as: :json
+              delete gobierto_data_api_v1_query_path(id), headers: { token: user_token.token }, as: :json
 
               assert_response :no_content
 

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -341,7 +341,7 @@ module GobiertoData
         def test_create_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              post gobierto_data_api_v1_visualizations_path, headers: { token: "wadus" }, params: valid_params
+              post gobierto_data_api_v1_visualizations_path, headers: { Authorization: "wadus" }, params: valid_params
 
               assert_response :unauthorized
             end
@@ -352,7 +352,7 @@ module GobiertoData
         def test_create
           with(site: site) do
             assert_difference "GobiertoData::Visualization.count", 1 do
-              post gobierto_data_api_v1_visualizations_path, headers: { token: user_token.token }, params: valid_params, as: :json
+              post gobierto_data_api_v1_visualizations_path, headers: { Authorization: user_token.token }, params: valid_params, as: :json
 
               assert_response :created
               response_data = response.parsed_body
@@ -390,7 +390,7 @@ module GobiertoData
         # POST /api/v1/data/visualizations
         def test_create_invalid_params
           with(site: site) do
-            post gobierto_data_api_v1_visualizations_path, headers: { token: user_token.token }, params: {}, as: :json
+            post gobierto_data_api_v1_visualizations_path, headers: { Authorization: user_token.token }, params: {}, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -411,7 +411,7 @@ module GobiertoData
         # PUT /api/v1/data/visualizations/1
         def test_update_with_invalid_token
           with(site: site) do
-            put gobierto_data_api_v1_visualization_path(visualization), headers: { token: "wadus" }, params: valid_params, as: :json
+            put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: "wadus" }, params: valid_params, as: :json
 
             assert_response :unauthorized
           end
@@ -420,7 +420,7 @@ module GobiertoData
         # PUT /api/v1/data/visualizations/1
         def test_update_with_other_user_token
           with(site: site) do
-            put gobierto_data_api_v1_visualization_path(visualization), headers: { token: other_user_token.token }, params: valid_params, as: :json
+            put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: other_user_token.token }, params: valid_params, as: :json
 
             assert_response :unauthorized
           end
@@ -430,7 +430,7 @@ module GobiertoData
         def test_update
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              put gobierto_data_api_v1_visualization_path(visualization), headers: { token: user_token.token }, params: valid_params, as: :json
+              put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: user_token.token }, params: valid_params, as: :json
 
               assert_response :success
               response_data = response.parsed_body
@@ -464,7 +464,7 @@ module GobiertoData
         # PUT /api/v1/data/visualizations/1
         def test_update_invalid_params
           with(site: site) do
-            put gobierto_data_api_v1_visualization_path(visualization), headers: { token: user_token.token }, params: {}, as: :json
+            put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: user_token.token }, params: {}, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -488,7 +488,7 @@ module GobiertoData
         def test_delete_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              delete gobierto_data_api_v1_visualization_path(visualization), headers: { token: "wadus" }, as: :json
+              delete gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: "wadus" }, as: :json
 
               assert_response :unauthorized
             end
@@ -499,7 +499,7 @@ module GobiertoData
         def test_delete_with_other_user_token
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              delete gobierto_data_api_v1_visualization_path(visualization), headers: { token: other_user_token.token }, as: :json
+              delete gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: other_user_token.token }, as: :json
 
               assert_response :unauthorized
             end
@@ -511,7 +511,7 @@ module GobiertoData
           id = visualization.id
           assert_difference "GobiertoData::Visualization.count", -1 do
             with(site: site) do
-              delete gobierto_data_api_v1_visualization_path(id), headers: { token: user_token.token }, as: :json
+              delete gobierto_data_api_v1_visualization_path(id), headers: { Authorization: user_token.token }, as: :json
 
               assert_response :no_content
 

--- a/test/fixtures/user/api_tokens.yml
+++ b/test/fixtures/user/api_tokens.yml
@@ -1,0 +1,34 @@
+dennis_primary_api_token:
+  user: dennis
+  primary: true
+  token: dennis_primary_api_token
+
+reed_primary_api_token:
+  user: reed
+  primary: true
+  token: reed_primary_api_token
+
+susan_primary_api_token:
+  user: susan
+  primary: true
+  token: susan_primary_api_token
+
+peter_primary_api_token:
+  user: peter
+  primary: true
+  token: peter_primary_api_token
+
+charles_primary_api_token:
+  user: charles
+  primary: true
+  token: charles_primary_api_token
+
+janet_primary_api_token:
+  user: janet
+  primary: true
+  token: janet_primary_api_token
+
+martin_primary_api_token:
+  user: martin
+  primary: true
+  token: martin_primary_api_token

--- a/test/models/user/api_token_test.rb
+++ b/test/models/user/api_token_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class User::ApiTokenTest < ActiveSupport::TestCase
+  def user_primary_api_token
+    @user_primary_api_token ||= user_api_tokens(:dennis_primary_api_token)
+  end
+
+  def test_valid
+    assert user_primary_api_token.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -47,6 +47,10 @@ class UserTest < ActiveSupport::TestCase
     @santander_user ||= users(:susan)
   end
 
+  def user_primary_api_token
+    @user_primary_api_token ||= user_api_tokens(:dennis_primary_api_token)
+  end
+
   def test_by_user_site_scope
     subject = User.by_site(madrid_site)
 
@@ -82,4 +86,29 @@ class UserTest < ActiveSupport::TestCase
     Timecop.freeze(birthdate.change(year: 2005, month: 3, day: 1)) { assert_equal 1, user.age }
   end
 
+  def test_primary_api_token_on_creation
+    new_user = User.create(
+      email: "wadus@example.org",
+      site: user.site
+    )
+    assert new_user.primary_api_token.present?
+  end
+
+  def test_primary_api_token
+    assert_equal user_primary_api_token, user.primary_api_token
+
+    user.primary_api_token.destroy
+    assert_nil user.primary_api_token
+  end
+
+  def test_primary_api_token!
+    assert_equal user_primary_api_token, user.primary_api_token!
+
+    user.primary_api_token.destroy
+
+    assert_difference "User::ApiToken.count", 1 do
+      refute_nil user.primary_api_token!
+      assert user.api_tokens.primary.exists?
+    end
+  end
 end


### PR DESCRIPTION
Closes #2750


## :v: What does this PR do?

* Adds a `User::ApiToken` model allowing users to have at least one token
* When a user is created a primary token is created automatically
* Adds a concern to be used in API controllers allowing to set current_user from requests looking for a token both in headers and query params.
* Protects CUD actions of queries and visualizations controllers with token authentication:
  * Authenticated users can create resources owned by them (`user_id` is assigned with current_user)
  * Authenticated users can update/delete only resources owned by them.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Added a page of authentication to readme.io and created an edit suggestion to gobierto data API documentation covering changes in queries and visualizations controllers.
