### PR TITLE
847 gdata favs with auth

### DIFF
--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -32,6 +32,11 @@ class ApiBaseController < ActionController::API
     render(json: { message: message }, status: :unauthorized, adapter: :json_api) && return
   end
 
+  def send_not_found(options = {})
+    message = options.delete(:message) || "Not found"
+    render(json: { message: message }, status: :not_found, adapter: :json_api) && return
+  end
+
   def raise_module_not_enabled(_redirect)
     head :forbidden
   end

--- a/app/controllers/concerns/gobierto_common/secured_with_admin_token.rb
+++ b/app/controllers/concerns/gobierto_common/secured_with_admin_token.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GobiertoCommon
-  module SecuredWithToken
+  module SecuredWithAdminToken
     extend ActiveSupport::Concern
 
     included do

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -3,12 +3,6 @@
 module User::ApiAuthenticationHelper
   extend ActiveSupport::Concern
 
-  included do
-    if respond_to?(:helper_method)
-      helper_method :current_user, :user_authenticated?
-    end
-  end
-
   private
 
   def current_user

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -28,6 +28,6 @@ module User::ApiAuthenticationHelper
   end
 
   def token
-    @token = request.headers["token"] || params["token"]
+    @token = request.headers["Authorization"] || params["token"]
   end
 end

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module User::ApiAuthenticationHelper
+  extend ActiveSupport::Concern
+
+  included do
+    if respond_to?(:helper_method)
+      helper_method :current_user, :user_authenticated?
+    end
+  end
+
+  private
+
+  def current_user
+    @current_user ||= find_current_user
+  end
+
+  def user_authenticated?
+    current_user.present?
+  end
+
+  def authenticate_user!
+    raise_unauthorized unless user_authenticated?
+  end
+
+  def find_current_user
+    return unless token.present?
+
+    current_site.users.confirmed.joins(:api_tokens).find_by(user_api_tokens: { token: token })
+  end
+
+  def raise_unauthorized
+    render(json: { message: "Unauthorized" }, status: :unauthorized, adapter: :json_api) && return
+  end
+
+  def token
+    @token = request.headers["token"] || params["token"]
+  end
+end

--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   module GobiertoAttachments
     module Api
       class AttachmentsController < ::GobiertoAdmin::Api::BaseController
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token
 

--- a/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/terms_controller.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   module GobiertoCommon
     module Api
       class TermsController < ::GobiertoAdmin::Api::BaseController
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
 
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token

--- a/app/controllers/gobierto_admin/gobierto_common/api/vocabularies_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/api/vocabularies_controller.rb
@@ -4,7 +4,7 @@ module GobiertoAdmin
   module GobiertoCommon
     module Api
       class VocabulariesController < ::GobiertoAdmin::Api::BaseController
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
 
         skip_before_action :authenticate_admin!, :set_admin_with_token
         before_action :set_admin_by_session_or_token

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -5,6 +5,7 @@ module GobiertoData
     module V1
       class BaseController < ApiBaseController
         include ActionController::MimeResponds
+        include ::User::ApiAuthenticationHelper
 
         before_action { module_enabled!(current_site, "GobiertoData", false) }
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -101,9 +101,7 @@ module GobiertoData
                 metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
                 queries: gobierto_data_api_v1_queries_path(filter: { dataset_id: id }),
                 visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: id }),
-                favorites: gobierto_data_api_v1_dataset_favorites_path(@item.slug),
-                user_favorited_queries: user_favorited_queries_gobierto_data_api_v1_dataset_favorites_path(@item.slug),
-                user_favorited_visualizations: user_favorited_visualizations_gobierto_data_api_v1_dataset_favorites_path(@item.slug)
+                favorites: gobierto_data_api_v1_dataset_favorites_path(@item.slug)
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -100,7 +100,10 @@ module GobiertoData
                 data: gobierto_data_api_v1_dataset_path(params[:slug]),
                 metadata: meta_gobierto_data_api_v1_dataset_path(params[:slug]),
                 queries: gobierto_data_api_v1_queries_path(filter: { dataset_id: id }),
-                visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: id })
+                visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: id }),
+                favorites: gobierto_data_api_v1_dataset_favorites_path(@item.slug),
+                user_favorited_queries: user_favorited_queries_gobierto_data_api_v1_dataset_favorites_path(@item.slug),
+                user_favorited_visualizations: user_favorited_visualizations_gobierto_data_api_v1_dataset_favorites_path(@item.slug)
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -5,7 +5,7 @@ module GobiertoData
     module V1
       class FavoritesController < BaseController
 
-        before_action :authenticate_user!, except: [:index, :user_favorited_queries, :user_favorited_visualizations, :new]
+        before_action :authenticate_user!, except: [:index, :new]
         before_action :allow_author!, only: [:destroy]
 
         # GET /api/v1/data/resource_type/resource_id/favorites
@@ -25,40 +25,6 @@ module GobiertoData
                     meta["#{res_type}_favorited"] = @user.data_favorites.exists?(favorited: @favorited.send(res_type)) if @favorited.respond_to?(res_type)
                   end
                 end
-              )
-            end
-          end
-        end
-
-        # GET /api/v1/data/resource_type/resource_id/user_favorited_queries?user_id=1
-        # GET /api/v1/data/resource_type/resource_id/user_favorited_queries.json?user_id=1
-        def user_favorited_queries
-          find_favorited
-          find_user
-          respond_to do |format|
-            format.json do
-              render(
-                json: GobiertoData::Query.favorited_by_user(@user, parent: @favorited),
-                exclude_relationships: true,
-                links: links(:user_favorited_queries),
-                adapter: :json_api
-              )
-            end
-          end
-        end
-
-        # GET /api/v1/data/resource_type/resource_id/user_favorited_visualizations?user_id=1
-        # GET /api/v1/data/resource_type/resource_id/user_favorited_visualizations.json?user_id=1
-        def user_favorited_visualizations
-          find_favorited
-          find_user
-          respond_to do |format|
-            format.json do
-              render(
-                json: GobiertoData::Visualization.favorited_by_user(@user, parent: @favorited),
-                exclude_relationships: true,
-                links: links(:user_favorited_visualizations),
-                adapter: :json_api
               )
             end
           end
@@ -161,12 +127,6 @@ module GobiertoData
             index: send("gobierto_data_api_v1_#{resource_type}_favorites_path", filter: filter_params),
             new: send("new_gobierto_data_api_v1_#{resource_type}_favorite_path", filter: filter_params)
           }.tap do |hash|
-            if resource_type == :dataset
-              hash[:user_favorited_queries] = send("user_favorited_queries_gobierto_data_api_v1_#{resource_type}_favorites_path", user_id: params[:user_id])
-            end
-            if [:dataset, :query].include? resource_type
-              hash[:user_favorited_visualizations] = send("user_favorited_visualizations_gobierto_data_api_v1_#{resource_type}_favorites_path", user_id: params[:user_id])
-            end
             hash[:self] = hash.delete(self_key) if self_key.present?
           end
         end

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -117,7 +117,7 @@ module GobiertoData
         end
 
         def find_user
-          @user = User.find_by(id: params[:user_id]) || current_user
+          @user = current_site.users.find_by(id: filter_params&.dig(:user_id)) || current_user
         end
 
         def links(self_key = nil)

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -21,7 +21,7 @@ module GobiertoData
                 meta: {
                   self_favorited: user_favorites.exists?(favorited: @favorited)
                 }.tap do |meta|
-                  [:query, :visualization].each do |res_type|
+                  [:dataset, :query].each do |res_type|
                     meta["#{res_type}_favorited"] = @user.data_favorites.exists?(favorited: @favorited.send(res_type)) if @favorited.respond_to?(res_type)
                   end
                 end

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class FavoritesController < BaseController
+
+        # GET /api/v1/data/resource_type/resource_id/favorites
+        # GET /api/v1/data/resource_type/resource_id/favorites.json
+        def index
+          respond_to do |format|
+            format.json do
+              render json: filtered_relation.recent, links: links(:index), adapter: :json_api
+            end
+          end
+        end
+
+        # GET /api/v1/data/resource_type/resource_id/favorites/new
+        # GET /api/v1/data/resource_type/resource_id/favorites/new.json
+        def new
+          @item = filtered_relation.new
+
+          render(
+            json: @item,
+            exclude_links: true,
+            links: links(:new),
+            adapter: :json_api
+          )
+        end
+
+        # POST /api/v1/data/resource_type/resource_id/favorites
+        # POST /api/v1/data/resource_type/resource_id/favorites.json
+        def create
+          find_favorited
+          @favorite_form = FavoriteForm.new(favorite_params.merge(site_id: current_site.id, favorited: @favorited))
+
+          if @favorite_form.save
+            @item = @favorite_form.favorite
+            render(
+              json: @item,
+              status: :created,
+              exclude_links: true,
+              links: links,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@favorite_form, adapter: :json_api)
+          end
+        end
+
+        # DELETE /api/v1/data/resource_type/resource_id/favorites/1
+        # DELETE /api/v1/data/resource_type/resource_id/favorites/1.json
+        def destroy
+          find_item
+
+          @item.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def base_relation
+          if find_favorited.present?
+            @favorited.favorites
+          else
+            GobiertoData::Favorite.none
+          end
+        end
+
+        def find_favorited
+          @favorited = case resource_type
+                       when :dataset
+                         current_site.datasets.find_by(slug: params[:dataset_slug])
+                       when :query
+                         current_site.queries.find_by(id: params[:query_id])
+                       when :visualization
+                         current_site.visualizations.find_by(id: params[:visualization_id])
+                       end
+        end
+
+        def resource_type
+          @resource_type ||= if params.has_key? :dataset_slug
+                               :dataset
+                             elsif params.has_key? :query_id
+                               :query
+                             elsif params.has_key? :visualization_id
+                               :visualization
+                             end
+        end
+
+        def favorite_params
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id])
+        end
+
+        def filter_params
+          return unless params[:filter].present?
+
+          params.fetch(:filter, {}).permit(:user_id)
+        end
+
+        def filtered_relation
+          base_relation.where(filter_params)
+        end
+
+        def find_item
+          @item = filtered_relation.find(params[:id])
+        end
+
+        def links(self_key = nil)
+          return unless resource_type.present?
+
+          {
+            index: send("gobierto_data_api_v1_#{resource_type}_favorites_path", filter: filter_params),
+            new: send("new_gobierto_data_api_v1_#{resource_type}_favorite_path", filter: filter_params)
+          }.tap do |hash|
+            hash[:self] = hash.delete(self_key) if self_key.present?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -5,12 +5,27 @@ module GobiertoData
     module V1
       class FavoritesController < BaseController
 
+        before_action :authenticate_user!, except: [:index, :user_favorited_queries, :user_favorited_visualizations, :new]
+        before_action :allow_author!, only: [:destroy]
+
         # GET /api/v1/data/resource_type/resource_id/favorites
         # GET /api/v1/data/resource_type/resource_id/favorites.json
         def index
           respond_to do |format|
             format.json do
-              render json: filtered_relation.recent, links: links(:index), adapter: :json_api
+              render(
+                json: user_favorites,
+                exclude_relationships: true,
+                links: links(:index),
+                adapter: :json_api,
+                meta: {
+                  self_favorited: user_favorites.exists?(favorited: @favorited)
+                }.tap do |meta|
+                  [:query, :visualization].each do |res_type|
+                    meta["#{res_type}_favorited"] = @user.data_favorites.exists?(favorited: @favorited.send(res_type)) if @favorited.respond_to?(res_type)
+                  end
+                end
+              )
             end
           end
         end
@@ -66,7 +81,7 @@ module GobiertoData
         # POST /api/v1/data/resource_type/resource_id/favorites.json
         def create
           find_favorited
-          @favorite_form = FavoriteForm.new(favorite_params.merge(site_id: current_site.id, favorited: @favorited))
+          @favorite_form = FavoriteForm.new(site_id: current_site.id, favorited: @favorited, user_id: current_user.id)
 
           if @favorite_form.save
             @item = @favorite_form.favorite
@@ -85,15 +100,9 @@ module GobiertoData
         # DELETE /api/v1/data/resource_type/resource_id/favorites/1
         # DELETE /api/v1/data/resource_type/resource_id/favorites/1.json
         def destroy
-          find_item
+          @item.destroy
 
-          if @item.present?
-            @item.destroy
-
-            head :no_content
-          else
-            send_not_found
-          end
+          head :no_content
         end
 
         private
@@ -127,10 +136,6 @@ module GobiertoData
                              end
         end
 
-        def favorite_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id])
-        end
-
         def filter_params
           return unless params[:filter].present?
 
@@ -142,11 +147,11 @@ module GobiertoData
         end
 
         def find_item
-          @item = filtered_relation.find_by(id: params[:id])
+          @item = filtered_relation.find_by(user_id: current_user.id)
         end
 
         def find_user
-          @user = User.find_by(id: params[:user_id])
+          @user = User.find_by(id: params[:user_id]) || current_user
         end
 
         def links(self_key = nil)
@@ -164,6 +169,45 @@ module GobiertoData
             end
             hash[:self] = hash.delete(self_key) if self_key.present?
           end
+        end
+
+        def allow_author!
+          render(json: { message: "Unauthorized" }, status: :unauthorized, adapter: :json_api) && return unless find_item
+        end
+
+        def user_favorites
+          @user_favorites ||= begin
+                                find_favorited
+                                find_user
+                                return GobiertoData::Favorite.none unless @user.present?
+
+                                user_favs = @user.data_favorites
+                                case resource_type
+
+                                when :dataset
+                                  user_favs.where(
+                                    favorited: @favorited.visualizations
+                                  ).or(
+                                    user_favs.where(
+                                      favorited: @favorited.queries
+                                    ).or(
+                                      user_favs.where(
+                                        favorited: @favorited
+                                      )
+                                    )
+                                  ).order(favorited_type: :asc).recent
+                                when :query
+                                  user_favs.where(
+                                    favorited: @favorited.visualizations
+                                  ).or(
+                                    user_favs.where(
+                                      favorited: @favorited
+                                    )
+                                  ).order(favorited_type: :asc).recent
+                                else
+                                  user_favs.where(favorited: @favorited)
+                                end
+                              end
         end
       end
     end

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -5,7 +5,7 @@ module GobiertoData
     module V1
       class FavoritesController < BaseController
 
-        before_action :authenticate_user!, except: [:index, :new]
+        before_action :authenticate_user!, except: [:index]
         before_action :allow_author!, only: [:destroy]
 
         # GET /api/v1/data/resource_type/resource_id/favorites
@@ -28,19 +28,6 @@ module GobiertoData
               )
             end
           end
-        end
-
-        # GET /api/v1/data/resource_type/resource_id/favorites/new
-        # GET /api/v1/data/resource_type/resource_id/favorites/new.json
-        def new
-          @item = filtered_relation.new
-
-          render(
-            json: @item,
-            exclude_links: true,
-            links: links(:new),
-            adapter: :json_api
-          )
         end
 
         # POST /api/v1/data/resource_type/resource_id/favorites
@@ -124,8 +111,7 @@ module GobiertoData
           return unless resource_type.present?
 
           {
-            index: send("gobierto_data_api_v1_#{resource_type}_favorites_path", filter: filter_params),
-            new: send("new_gobierto_data_api_v1_#{resource_type}_favorite_path", filter: filter_params)
+            index: send("gobierto_data_api_v1_#{resource_type}_favorites_path", filter: filter_params)
           }.tap do |hash|
             hash[:self] = hash.delete(self_key) if self_key.present?
           end

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -87,9 +87,13 @@ module GobiertoData
         def destroy
           find_item
 
-          @item.destroy
+          if @item.present?
+            @item.destroy
 
-          head :no_content
+            head :no_content
+          else
+            send_not_found
+          end
         end
 
         private
@@ -138,7 +142,7 @@ module GobiertoData
         end
 
         def find_item
-          @item = filtered_relation.find(params[:id])
+          @item = filtered_relation.find_by(id: params[:id])
         end
 
         def find_user

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -172,7 +172,9 @@ module GobiertoData
               hash.merge!(
                 data: gobierto_data_api_v1_query_path(id),
                 metadata: meta_gobierto_data_api_v1_query_path(id),
-                visualizations: gobierto_data_api_v1_visualizations_path(filter: { query_id: id })
+                visualizations: gobierto_data_api_v1_visualizations_path(filter: { query_id: id }),
+                favorites: gobierto_data_api_v1_query_favorites_path(@item),
+                user_favorited_visualizations: user_favorited_visualizations_gobierto_data_api_v1_query_favorites_path(@item)
               )
             end
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -5,6 +5,9 @@ module GobiertoData
     module V1
       class QueriesController < BaseController
 
+        before_action :authenticate_user!, except: [:index, :show, :meta, :new]
+        before_action :allow_author!, only: [:update, :destroy]
+
         # GET /api/v1/data/queries
         # GET /api/v1/data/queries.json
         # GET /api/v1/data/queries.csv
@@ -71,7 +74,7 @@ module GobiertoData
         # GET /api/v1/data/queries/new
         # GET /api/v1/data/queries/new.json
         def new
-          @item = base_relation.new(name_translations: available_locales_hash)
+          @item = base_relation.new(name_translations: available_locales_hash, user: current_user)
 
           render(
             json: @item,
@@ -85,7 +88,7 @@ module GobiertoData
         # POST /api/v1/data/queries
         # POST /api/v1/data/queries.json
         def create
-          @query_form = QueryForm.new(query_params.merge(site_id: current_site.id))
+          @query_form = QueryForm.new(query_params.merge(site_id: current_site.id, user_id: current_user.id))
 
           if @query_form.save
             @item = @query_form.query
@@ -105,7 +108,6 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         # PUT /api/v1/data/queries/1.json
         def update
-          find_item
           @query_form = QueryForm.new(query_params.except(*ignored_attributes_on_update).merge(site_id: current_site.id, id: @item.id))
 
           if @query_form.save
@@ -124,8 +126,6 @@ module GobiertoData
         # DELETE /api/v1/data/queries/1
         # DELETE /api/v1/data/queries/1.json
         def destroy
-          find_item
-
           @item.destroy
 
           head :no_content
@@ -146,7 +146,7 @@ module GobiertoData
         end
 
         def query_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:user_id, :dataset_id, :name_translations, :name, :privacy_status, :sql])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:dataset_id, :name_translations, :name, :privacy_status, :sql])
         end
 
         def filter_params
@@ -182,6 +182,11 @@ module GobiertoData
 
         def ignored_attributes_on_update
           [:dataset_id, :user_id]
+        end
+
+        def allow_author!
+          find_item
+          render(json: { message: "Unauthorized" }, status: :unauthorized, adapter: :json_api) && return if @item.user != current_user
         end
 
       end

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -173,8 +173,7 @@ module GobiertoData
                 data: gobierto_data_api_v1_query_path(id),
                 metadata: meta_gobierto_data_api_v1_query_path(id),
                 visualizations: gobierto_data_api_v1_visualizations_path(filter: { query_id: id }),
-                favorites: gobierto_data_api_v1_query_favorites_path(@item),
-                user_favorited_visualizations: user_favorited_visualizations_gobierto_data_api_v1_query_favorites_path(@item)
+                favorites: gobierto_data_api_v1_query_favorites_path(@item)
               )
             end
 

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -6,7 +6,7 @@ module GobiertoInvestments
       class ProjectsController < ApiBaseController
 
         include ::GobiertoCommon::CustomFieldsApi
-        include ::GobiertoCommon::SecuredWithToken
+        include ::GobiertoCommon::SecuredWithAdminToken
 
         skip_before_action :set_admin_with_token, only: [:index, :show, :new, :meta]
         before_action :module_allowed, except: [:index, :show, :new, :meta]

--- a/app/forms/gobierto_data/favorite_form.rb
+++ b/app/forms/gobierto_data/favorite_form.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class FavoriteForm < BaseForm
+    include ::GobiertoCore::TranslationsHelpers
+
+    attr_accessor(
+      :site_id,
+      :favorited,
+      :user_id
+    )
+
+    validates :site, :user, :favorited, presence: true
+
+    delegate :persisted?, to: :favorite
+
+    def favorite
+      @favorite ||= build_favorite
+    end
+
+    def user
+      @user ||= site.presence && site.users.find_by(id: user_id)
+    end
+
+    def site
+      @site ||= Site.find_by(id: site_id)
+    end
+
+    def save
+      save_favorite if valid?
+    end
+
+    private
+
+    def build_favorite
+      favorite_class.new
+    end
+
+    def favorite_class
+      Favorite
+    end
+
+    def save_favorite
+      @favorite = favorite.tap do |attributes|
+        attributes.user_id = user.id
+        attributes.favorited = favorited
+      end
+
+      return @favorite if @favorite.save
+
+      promote_errors(@favorite.errors)
+
+      false
+    end
+  end
+end

--- a/app/models/concerns/gobierto_data/favoriteable.rb
+++ b/app/models/concerns/gobierto_data/favoriteable.rb
@@ -11,5 +11,18 @@ module GobiertoData
         favorites.exists?(user_id: user.id)
       end
     end
+
+    class_methods do
+      def favorited_by_user(user, parent: nil)
+        return none unless user.present?
+
+        parent ||= user.site
+        association_name = parent.class.reflect_on_all_associations(:has_many).find { |association| association.options[:class_name] == name }&.name
+
+        return none unless association_name.present?
+
+        parent.send(association_name).joins(:favorites).where(GobiertoData::Favorite.table_name => { user_id: user&.id })
+      end
+    end
   end
 end

--- a/app/models/concerns/gobierto_data/favoriteable.rb
+++ b/app/models/concerns/gobierto_data/favoriteable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Favoriteable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :favorites, as: :favorited, dependent: :destroy
+
+      def favorited_by_user?(user)
+        favorites.exists?(user_id: user.id)
+      end
+    end
+  end
+end

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -8,8 +8,8 @@ module GobiertoData
     include GobiertoData::Favoriteable
 
     belongs_to :site
-    has_many :queries, dependent: :destroy
-    has_many :visualizations, through: :queries
+    has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
+    has_many :visualizations, through: :queries, class_name: "GobiertoData::Visualization"
 
     translates :name
 

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -5,6 +5,7 @@ require_dependency "gobierto_data"
 module GobiertoData
   class Dataset < ApplicationRecord
     include GobiertoCommon::Sluggable
+    include GobiertoData::Favoriteable
 
     belongs_to :site
     has_many :queries, dependent: :destroy

--- a/app/models/gobierto_data/favorite.rb
+++ b/app/models/gobierto_data/favorite.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_dependency "gobierto_data"
+
+module GobiertoData
+  class Favorite < ApplicationRecord
+    belongs_to :user
+    belongs_to :favorited, polymorphic: true
+
+    validates :user_id, uniqueness: { scope: [:favorited_type, :favorited_id] }
+
+    delegate :site, to: :user
+
+    scope :recent, -> { order(created_at: :desc) }
+  end
+end

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -8,7 +8,7 @@ module GobiertoData
 
     belongs_to :dataset
     belongs_to :user
-    has_many :visualizations, dependent: :destroy
+    has_many :visualizations, dependent: :destroy, class_name: "GobiertoData::Visualization"
     enum privacy_status: { open: 0, closed: 1 }
 
     translates :name

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -4,6 +4,8 @@ require_dependency "gobierto_data"
 
 module GobiertoData
   class Query < ApplicationRecord
+    include GobiertoData::Favoriteable
+
     belongs_to :dataset
     belongs_to :user
     has_many :visualizations, dependent: :destroy

--- a/app/models/gobierto_data/visualization.rb
+++ b/app/models/gobierto_data/visualization.rb
@@ -4,6 +4,8 @@ require_dependency "gobierto_data"
 
 module GobiertoData
   class Visualization < ApplicationRecord
+    include GobiertoData::Favoriteable
+
     belongs_to :query
     belongs_to :user
     enum privacy_status: { open: 0, closed: 1 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
   # GobiertoData
   has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
   has_many :visualizations, dependent: :destroy, class_name: "GobiertoData::Visualization"
+  has_many :data_favorites, dependent: :destroy, class_name: "GobiertoData::Favorite"
 
   accepts_nested_attributes_for :custom_records
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,11 +14,14 @@ class User < ApplicationRecord
   has_many :id_number_verifications, class_name: "User::Verification::IdNumber"
   has_many :subscriptions, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :api_tokens, dependent: :destroy
   has_many :custom_records, dependent: :destroy, class_name: "GobiertoCommon::CustomUserFieldRecord"
   has_many :contributions, dependent: :destroy, class_name: "GobiertoParticipation::Contribution"
   has_many :flags, dependent: :destroy, class_name: "GobiertoParticipation::Flag"
   has_many :votes, dependent: :destroy, class_name: "GobiertoParticipation::Vote"
   has_many :comment, dependent: :destroy, class_name: "GobiertoParticipation::Comment"
+
+  after_create :primary_api_token!
 
   # GobiertoData
   has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
@@ -60,6 +63,14 @@ class User < ApplicationRecord
     if value.present?
       super(value.downcase)
     end
+  end
+
+  def primary_api_token!
+    primary_api_token || api_tokens.primary.create
+  end
+
+  def primary_api_token
+    api_tokens.primary.take
   end
 
 end

--- a/app/models/user/api_token.rb
+++ b/app/models/user/api_token.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class User::ApiToken < ApplicationRecord
+  belongs_to :user
+  has_secure_token
+  validates :user, presence: true
+  validates :name, presence: true, unless: :primary?
+  validates :name, uniqueness: { scope: :user }
+  validates :user, uniqueness: { scope: :primary }, if: :primary?
+
+  delegate :site, to: :user
+
+  scope :primary, -> { where(primary: true) }
+end

--- a/app/serializers/gobierto_data/favorite_serializer.rb
+++ b/app/serializers/gobierto_data/favorite_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class FavoriteSerializer < ActiveModel::Serializer
+    attributes :id, :user_id, :favorited_type, :favorited_id
+    belongs_to :user, unless: :exclude_relationships?
+    belongs_to :favorited, polymorphic: true, unless: :exclude_relationships?
+
+    def current_site
+      Site.find(object.site.id)
+    end
+
+    def exclude_relationships?
+      instance_options[:exclude_relationships]
+    end
+  end
+end

--- a/app/serializers/gobierto_data/favorite_serializer.rb
+++ b/app/serializers/gobierto_data/favorite_serializer.rb
@@ -2,7 +2,7 @@
 
 module GobiertoData
   class FavoriteSerializer < ActiveModel::Serializer
-    attributes :id, :user_id, :favorited_type, :favorited_id
+    attributes :id, :user_id, :favorited_type, :favorited_id, :favorited, :created_at
     belongs_to :user, unless: :exclude_relationships?
     belongs_to :favorited, polymorphic: true, unless: :exclude_relationships?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -570,12 +570,7 @@ Rails.application.routes.draw do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
             resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
               resource :favorite, only: [:new, :create, :destroy]
-              resources :favorites, only: [:index] do
-                collection do
-                  get :user_favorited_queries
-                  get :user_favorited_visualizations
-                end
-              end
+              resources :favorites, only: [:index]
               collection do
                 get :meta
               end
@@ -585,11 +580,7 @@ Rails.application.routes.draw do
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do
               resource :favorite, only: [:new, :create, :destroy]
-              resources :favorites, only: [:index] do
-                collection do
-                  get :user_favorited_visualizations
-                end
-              end
+              resources :favorites, only: [:index]
               member do
                 get :meta
               end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,7 +569,8 @@ Rails.application.routes.draw do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
             resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
-              resources :favorites, only: [:index, :new, :create, :destroy] do
+              resource :favorite, only: [:new, :create, :destroy]
+              resources :favorites, only: [:index] do
                 collection do
                   get :user_favorited_queries
                   get :user_favorited_visualizations
@@ -583,7 +584,8 @@ Rails.application.routes.draw do
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do
-              resources :favorites, only: [:index, :new, :create, :destroy] do
+              resource :favorite, only: [:new, :create, :destroy]
+              resources :favorites, only: [:index] do
                 collection do
                   get :user_favorited_visualizations
                 end
@@ -593,7 +595,8 @@ Rails.application.routes.draw do
               end
             end
             resources :visualizations, except: [:edit], defaults: { format: "json" } do
-              resources :favorites, only: [:index, :new, :create, :destroy]
+              resource :favorite, only: [:new, :create, :destroy]
+              resources :favorites, only: [:index]
             end
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,6 +569,7 @@ Rails.application.routes.draw do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
             resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
+              resources :favorites, only: [:index, :new, :create, :destroy]
               collection do
                 get :meta
               end
@@ -577,11 +578,14 @@ Rails.application.routes.draw do
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do
+              resources :favorites, only: [:index, :new, :create, :destroy]
               member do
                 get :meta
               end
             end
-            resources :visualizations, except: [:edit], defaults: { format: "json" }
+            resources :visualizations, except: [:edit], defaults: { format: "json" } do
+              resources :favorites, only: [:index, :new, :create, :destroy]
+            end
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,7 +569,12 @@ Rails.application.routes.draw do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
             resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
-              resources :favorites, only: [:index, :new, :create, :destroy]
+              resources :favorites, only: [:index, :new, :create, :destroy] do
+                collection do
+                  get :user_favorited_queries
+                  get :user_favorited_visualizations
+                end
+              end
               collection do
                 get :meta
               end
@@ -578,7 +583,11 @@ Rails.application.routes.draw do
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do
-              resources :favorites, only: [:index, :new, :create, :destroy]
+              resources :favorites, only: [:index, :new, :create, :destroy] do
+                collection do
+                  get :user_favorited_visualizations
+                end
+              end
               member do
                 get :meta
               end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,7 +569,7 @@ Rails.application.routes.draw do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
             resources :datasets, only: [:index, :show], param: :slug, defaults: { format: "json" } do
-              resource :favorite, only: [:new, :create, :destroy]
+              resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]
               collection do
                 get :meta
@@ -579,14 +579,14 @@ Rails.application.routes.draw do
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do
-              resource :favorite, only: [:new, :create, :destroy]
+              resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]
               member do
                 get :meta
               end
             end
             resources :visualizations, except: [:edit], defaults: { format: "json" } do
-              resource :favorite, only: [:new, :create, :destroy]
+              resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]
             end
           end

--- a/db/migrate/20200103121539_create_gdata_favorites.rb
+++ b/db/migrate/20200103121539_create_gdata_favorites.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateGdataFavorites < ActiveRecord::Migration[5.2]
+  def change
+    create_table :gdata_favorites do |t|
+      t.references :user
+      t.references :favorited, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200110121522_create_user_api_tokens.rb
+++ b/db/migrate/20200110121522_create_user_api_tokens.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateUserApiTokens < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_api_tokens do |t|
+      t.references :user
+      t.string :name
+      t.string :token
+      t.boolean :primary, default: false
+
+      t.timestamps
+    end
+
+    User.all.each(&:primary_api_token!)
+  end
+end

--- a/db/migrate/20200113173645_add_unique_constraint_to_user_api_tokens.rb
+++ b/db/migrate/20200113173645_add_unique_constraint_to_user_api_tokens.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToUserApiTokens < ActiveRecord::Migration[5.2]
+  def change
+    add_index :user_api_tokens, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_10_121522) do
+ActiveRecord::Schema.define(version: 2020_01_13_173645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -1024,6 +1024,7 @@ ActiveRecord::Schema.define(version: 2020_01_10_121522) do
     t.boolean "primary", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_user_api_tokens_on_token", unique: true
     t.index ["user_id"], name: "index_user_api_tokens_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_12_104759) do
+ActiveRecord::Schema.define(version: 2020_01_10_121522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -1015,6 +1015,16 @@ ActiveRecord::Schema.define(version: 2019_12_12_104759) do
     t.integer "site_id"
     t.index ["key"], name: "index_translations_on_key"
     t.index ["locale"], name: "index_translations_on_locale"
+  end
+
+  create_table "user_api_tokens", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name"
+    t.string "token"
+    t.boolean "primary", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_api_tokens_on_user_id"
   end
 
   create_table "user_notifications", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -533,6 +533,16 @@ ActiveRecord::Schema.define(version: 2020_01_13_173645) do
     t.index ["site_id"], name: "index_gdata_datasets_on_site_id"
   end
 
+  create_table "gdata_favorites", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "favorited_type"
+    t.bigint "favorited_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["favorited_type", "favorited_id"], name: "index_gdata_favorites_on_favorited_type_and_favorited_id"
+    t.index ["user_id"], name: "index_gdata_favorites_on_user_id"
+  end
+
   create_table "gdata_queries", force: :cascade do |t|
     t.bigint "dataset_id"
     t.bigint "user_id"

--- a/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
@@ -166,6 +166,7 @@ module GobiertoData
 
             assert response_data.has_key? "meta"
             assert response_data["meta"]["self_favorited"]
+            assert response_data["meta"].has_key? "dataset_favorited"
             refute response_data["meta"]["dataset_favorited"]
           end
         end
@@ -192,7 +193,9 @@ module GobiertoData
 
             assert response_data.has_key? "meta"
             assert response_data["meta"]["self_favorited"]
+            assert response_data["meta"].has_key? "query_favorited"
             refute response_data["meta"]["query_favorited"]
+            assert response_data["meta"].has_key? "dataset_favorited"
             refute response_data["meta"]["dataset_favorited"]
           end
         end

--- a/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
@@ -197,53 +197,6 @@ module GobiertoData
           end
         end
 
-        # GET /api/v1/data/datasets/slug/favorites/user_favorited_queries?user_id=1
-        def test_user_favorited_queries_on_dataset
-          with(site: site) do
-            get user_favorited_queries_gobierto_data_api_v1_dataset_favorites_path(dataset.slug, user_id: user.id)
-
-            assert_response :success
-
-            response_data = response.parsed_body
-
-            favorited_ids = response_data["data"].map { |element| element["id"].to_i }
-
-            assert_includes favorited_ids, query.id
-            refute_includes favorited_ids, other_user_query_favorite.favorited.id
-            refute_includes favorited_ids, other_dataset_query_favorite.favorited.id
-          end
-        end
-
-        def test_user_favorited_visualizations_on_dataset
-          with(site: site) do
-            get user_favorited_visualizations_gobierto_data_api_v1_dataset_favorites_path(dataset.slug, user_id: user.id)
-
-            assert_response :success
-
-            response_data = response.parsed_body
-
-            favorited_ids = response_data["data"].map { |element| element["id"].to_i }
-
-            assert_includes favorited_ids, visualization.id
-            assert_includes favorited_ids, other_visualization.id
-          end
-        end
-
-        def test_user_favorited_visualizations_on_query
-          with(site: site) do
-            get user_favorited_visualizations_gobierto_data_api_v1_query_favorites_path(query, user_id: user.id)
-
-            assert_response :success
-
-            response_data = response.parsed_body
-
-            favorited_ids = response_data["data"].map { |element| element["id"].to_i }
-
-            assert_includes favorited_ids, visualization.id
-            refute_includes favorited_ids, other_visualization.id
-          end
-        end
-
         def test_create_dataset_favorite_without_token
           with(site: site) do
             assert_no_difference "GobiertoData::Favorite.count", 1 do

--- a/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
@@ -119,9 +119,9 @@ module GobiertoData
         end
 
         # GET /api/v1/data/datasets/slug/favorites.json
-        def test_dataset_index_with_user_id
+        def test_dataset_index_filtered_by_user_id
           with(site: site) do
-            get gobierto_data_api_v1_dataset_favorites_path(dataset.slug, user_id: user.id), headers: { Authorization: other_user_token.token }, as: :json
+            get gobierto_data_api_v1_dataset_favorites_path(dataset.slug, filter: { user_id: user.id }), headers: { Authorization: other_user_token.token }, as: :json
 
             assert_response :success
 

--- a/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/favorites_controller_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class FavoritessControllerTest < GobiertoControllerTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def user
+          @user ||= users(:dennis)
+        end
+
+        def other_user
+          @other_user ||= users(:peter)
+        end
+
+        def dataset_favorite
+          @dataset_favorite ||= gobierto_data_favorites(:dennis_users_dataset_favorite)
+        end
+
+        def other_user_query_favorite
+          @other_user_query_favorite ||= gobierto_data_favorites(:reed_census_verified_users_query_favorite)
+        end
+
+        def other_dataset_query_favorite
+          @other_dataset_query_favorite ||= gobierto_data_favorites(:dennis_events_count_query_favorite)
+        end
+
+        def dataset
+          @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def other_dataset
+          @other_dataset ||= gobierto_data_datasets(:events_dataset)
+        end
+
+        def query
+          @query ||= gobierto_data_queries(:users_count_query)
+        end
+
+        def visualization
+          @visualization ||= gobierto_data_visualizations(:users_count_visualization)
+        end
+
+        def other_visualization
+          @other_visualization ||= gobierto_data_visualizations(:census_verified_users_visualization)
+        end
+
+        def valid_params(user)
+          {
+            data:
+            {
+              attributes:
+              {
+                user_id: user.id
+              }
+            }
+          }
+        end
+
+        def test_dataset_index_with_module_disabled
+          with(site: site_with_module_disabled) do
+            get gobierto_data_api_v1_dataset_favorites_path(dataset.slug)
+
+            assert_response :forbidden
+          end
+        end
+
+        # GET /api/v1/data/datasets/slug/favorites.json
+        def test_dataset_index_as_json
+          with(site: site) do
+            get gobierto_data_api_v1_dataset_favorites_path(dataset.slug), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            response_data["data"].each do |item|
+              assert_equal "GobiertoData::Dataset", item["attributes"]["favorited_type"]
+              assert_equal dataset.id, item["attributes"]["favorited_id"]
+            end
+
+            favorite_user_ids = response_data["data"].map { |item| item["attributes"]["user_id"] }
+            favorited_dataset_ids = response_data["data"].map { |item| item["attributes"]["favorited_id"] }.uniq
+
+            assert_equal 1, favorited_dataset_ids.count
+            assert_equal dataset_favorite.favorited_id, favorited_dataset_ids.first
+
+            assert_includes favorite_user_ids, user.id
+            assert_includes favorite_user_ids, other_user.id
+          end
+        end
+
+        # GET /api/v1/data/datasets/slug/favorites/user_favorited_queries?user_id=1
+        def test_user_favorited_queries_on_dataset
+          with(site: site) do
+            get user_favorited_queries_gobierto_data_api_v1_dataset_favorites_path(dataset.slug, user_id: user.id)
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            favorited_ids = response_data["data"].map { |element| element["id"].to_i }
+
+            assert_includes favorited_ids, query.id
+            refute_includes favorited_ids, other_user_query_favorite.favorited.id
+            refute_includes favorited_ids, other_dataset_query_favorite.favorited.id
+          end
+        end
+
+        def test_user_favorited_visualizations_on_dataset
+          with(site: site) do
+            get user_favorited_visualizations_gobierto_data_api_v1_dataset_favorites_path(dataset.slug, user_id: user.id)
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            favorited_ids = response_data["data"].map { |element| element["id"].to_i }
+
+            assert_includes favorited_ids, visualization.id
+            assert_includes favorited_ids, other_visualization.id
+          end
+        end
+
+        def test_user_favorited_visualizations_on_query
+          with(site: site) do
+            get user_favorited_visualizations_gobierto_data_api_v1_query_favorites_path(query, user_id: user.id)
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            favorited_ids = response_data["data"].map { |element| element["id"].to_i }
+
+            assert_includes favorited_ids, visualization.id
+            refute_includes favorited_ids, other_visualization.id
+          end
+        end
+
+        def test_create_dataset_favorite
+          with(site: site) do
+            assert_difference "GobiertoData::Favorite.count", 1 do
+              post gobierto_data_api_v1_dataset_favorites_path(other_dataset.slug, valid_params(other_user))
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_favorite = Favorite.last
+
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+
+              assert_equal resource_data["id"], new_favorite.id.to_s
+              assert_equal resource_data["attributes"]["user_id"], other_user.id
+              assert_equal resource_data["attributes"]["favorited_id"], other_dataset.id
+              assert_equal resource_data["attributes"]["favorited_type"], "GobiertoData::Dataset"
+            end
+          end
+        end
+
+        def test_create_dataset_favorite_already_favorited
+          with(site: site) do
+            post gobierto_data_api_v1_dataset_favorites_path(dataset.slug, valid_params(user))
+
+            assert_response :unprocessable_entity
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+          end
+        end
+
+        def test_delete
+          id = dataset_favorite.id
+
+          assert_difference "GobiertoData::Favorite.count", -1 do
+            with(site: site) do
+              delete gobierto_data_api_v1_dataset_favorite_path(dataset.slug, id)
+
+              assert_response :no_content
+
+              assert_nil Favorite.find_by(id: id)
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -376,7 +376,7 @@ module GobiertoData
         def test_create_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              post gobierto_data_api_v1_queries_path, headers: { token: "wadus" }, params: valid_params
+              post gobierto_data_api_v1_queries_path, headers: { Authorization: "wadus" }, params: valid_params
 
               assert_response :unauthorized
             end
@@ -387,7 +387,7 @@ module GobiertoData
         def test_create
           with(site: site) do
             assert_difference "GobiertoData::Query.count", 1 do
-              post gobierto_data_api_v1_queries_path, params: valid_params, headers: { token: user_token.token }, as: :json
+              post gobierto_data_api_v1_queries_path, params: valid_params, headers: { Authorization: user_token.token }, as: :json
 
               assert_response :created
               response_data = response.parsed_body
@@ -427,7 +427,7 @@ module GobiertoData
         # POST /api/v1/data/queries
         def test_create_invalid_params
           with(site: site) do
-            post gobierto_data_api_v1_queries_path, params: {}, headers: { token: user_token.token }, as: :json
+            post gobierto_data_api_v1_queries_path, params: {}, headers: { Authorization: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -448,7 +448,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_with_invalid_token
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: "wadus" }, as: :json
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { Authorization: "wadus" }, as: :json
 
             assert_response :unauthorized
           end
@@ -457,7 +457,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_with_other_user_token
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: other_user_token.token }, as: :json
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { Authorization: other_user_token.token }, as: :json
 
             assert_response :unauthorized
           end
@@ -467,7 +467,7 @@ module GobiertoData
         def test_update
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: user_token.token }, as: :json
+              put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { Authorization: user_token.token }, as: :json
 
               assert_response :success
               response_data = response.parsed_body
@@ -503,7 +503,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_invalid_params
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: {}, headers: { token: user_token.token }, as: :json
+            put gobierto_data_api_v1_query_path(query), params: {}, headers: { Authorization: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -527,7 +527,7 @@ module GobiertoData
         def test_delete_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              delete gobierto_data_api_v1_query_path(query), headers: { token: "wadus" }, as: :json
+              delete gobierto_data_api_v1_query_path(query), headers: { Authorization: "wadus" }, as: :json
 
               assert_response :unauthorized
             end
@@ -538,7 +538,7 @@ module GobiertoData
         def test_delete_with_other_user_token
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              delete gobierto_data_api_v1_query_path(query), headers: { token: other_user_token.token }, as: :json
+              delete gobierto_data_api_v1_query_path(query), headers: { Authorization: other_user_token.token }, as: :json
 
               assert_response :unauthorized
             end
@@ -550,7 +550,7 @@ module GobiertoData
           id = query.id
           assert_difference "GobiertoData::Query.count", -1 do
             with(site: site) do
-              delete gobierto_data_api_v1_query_path(id), headers: { token: user_token.token }, as: :json
+              delete gobierto_data_api_v1_query_path(id), headers: { Authorization: user_token.token }, as: :json
 
               assert_response :no_content
 

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -19,6 +19,18 @@ module GobiertoData
           @user ||= users(:dennis)
         end
 
+        def user_token
+          @user_token ||= user_api_tokens(:dennis_primary_api_token)
+        end
+
+        def other_user
+          @other_user ||= users(:peter)
+        end
+
+        def other_user_token
+          @other_user_token ||= user_api_tokens(:peter_primary_api_token)
+        end
+
         def query
           @query ||= gobierto_data_queries(:users_count_query)
         end
@@ -88,8 +100,7 @@ module GobiertoData
                 },
                 privacy_status: "open",
                 sql: "select count(*) from users where bio is not null",
-                dataset_id: dataset.id,
-                user_id: user.id
+                dataset_id: dataset.id
               }
             }
           }
@@ -351,15 +362,40 @@ module GobiertoData
         end
 
         # POST /api/v1/data/queries
+        def test_create_without_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              post gobierto_data_api_v1_queries_path, params: valid_params
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # POST /api/v1/data/queries
+        def test_create_with_invalid_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              post gobierto_data_api_v1_queries_path, headers: { token: "wadus" }, params: valid_params
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # POST /api/v1/data/queries
         def test_create
           with(site: site) do
             assert_difference "GobiertoData::Query.count", 1 do
-              post gobierto_data_api_v1_queries_path, params: valid_params, as: :json
+              post gobierto_data_api_v1_queries_path, params: valid_params, headers: { token: user_token.token }, as: :json
 
               assert_response :created
               response_data = response.parsed_body
 
               new_query = Query.last
+
+              assert_equal user, new_query.user
+
               # data
               assert response_data.has_key? "data"
               resource_data = response_data["data"]
@@ -367,10 +403,11 @@ module GobiertoData
 
               # attributes
               attributes = attributes_data(new_query)
-              %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+              %w(name_translations privacy_status sql dataset_id).each do |attribute|
                 assert resource_data["attributes"].has_key? attribute
                 assert_equal attributes[attribute], resource_data["attributes"][attribute]
               end
+              assert_equal user.id, resource_data["attributes"]["user_id"]
 
               # relationships
               assert resource_data.has_key? "relationships"
@@ -390,7 +427,7 @@ module GobiertoData
         # POST /api/v1/data/queries
         def test_create_invalid_params
           with(site: site) do
-            post gobierto_data_api_v1_queries_path, params: {}, as: :json
+            post gobierto_data_api_v1_queries_path, params: {}, headers: { token: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -400,10 +437,37 @@ module GobiertoData
         end
 
         # PUT /api/v1/data/queries/1
+        def test_update_without_token
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: valid_params, as: :json
+
+            assert_response :unauthorized
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update_with_invalid_token
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: "wadus" }, as: :json
+
+            assert_response :unauthorized
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
+        def test_update_with_other_user_token
+          with(site: site) do
+            put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: other_user_token.token }, as: :json
+
+            assert_response :unauthorized
+          end
+        end
+
+        # PUT /api/v1/data/queries/1
         def test_update
           with(site: site) do
             assert_no_difference "GobiertoData::Query.count" do
-              put gobierto_data_api_v1_query_path(query), params: valid_params, as: :json
+              put gobierto_data_api_v1_query_path(query), params: valid_params, headers: { token: user_token.token }, as: :json
 
               assert_response :success
               response_data = response.parsed_body
@@ -415,10 +479,11 @@ module GobiertoData
 
               # attributes
               attributes = valid_params[:data][:attributes].with_indifferent_access
-              %w(name_translations privacy_status sql dataset_id user_id).each do |attribute|
+              %w(name_translations privacy_status sql dataset_id).each do |attribute|
                 assert resource_data["attributes"].has_key? attribute
                 assert_equal attributes[attribute], resource_data["attributes"][attribute]
               end
+              assert_equal user.id, resource_data["attributes"]["user_id"]
 
               # relationships
               assert resource_data.has_key? "relationships"
@@ -438,7 +503,7 @@ module GobiertoData
         # PUT /api/v1/data/queries/1
         def test_update_invalid_params
           with(site: site) do
-            put gobierto_data_api_v1_query_path(query), params: {}, as: :json
+            put gobierto_data_api_v1_query_path(query), params: {}, headers: { token: user_token.token }, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -448,11 +513,44 @@ module GobiertoData
         end
 
         # DELETE /api/v1/data/queries/1
+        def test_delete_without_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              delete gobierto_data_api_v1_query_path(query), as: :json
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
+        def test_delete_with_invalid_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              delete gobierto_data_api_v1_query_path(query), headers: { token: "wadus" }, as: :json
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
+        def test_delete_with_other_user_token
+          with(site: site) do
+            assert_no_difference "GobiertoData::Query.count" do
+              delete gobierto_data_api_v1_query_path(query), headers: { token: other_user_token.token }, as: :json
+
+              assert_response :unauthorized
+            end
+          end
+        end
+
+        # DELETE /api/v1/data/queries/1
         def test_delete
           id = query.id
           assert_difference "GobiertoData::Query.count", -1 do
             with(site: site) do
-              delete gobierto_data_api_v1_query_path(id), as: :json
+              delete gobierto_data_api_v1_query_path(id), headers: { token: user_token.token }, as: :json
 
               assert_response :no_content
 

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -341,7 +341,7 @@ module GobiertoData
         def test_create_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              post gobierto_data_api_v1_visualizations_path, headers: { token: "wadus" }, params: valid_params
+              post gobierto_data_api_v1_visualizations_path, headers: { Authorization: "wadus" }, params: valid_params
 
               assert_response :unauthorized
             end
@@ -352,7 +352,7 @@ module GobiertoData
         def test_create
           with(site: site) do
             assert_difference "GobiertoData::Visualization.count", 1 do
-              post gobierto_data_api_v1_visualizations_path, headers: { token: user_token.token }, params: valid_params, as: :json
+              post gobierto_data_api_v1_visualizations_path, headers: { Authorization: user_token.token }, params: valid_params, as: :json
 
               assert_response :created
               response_data = response.parsed_body
@@ -390,7 +390,7 @@ module GobiertoData
         # POST /api/v1/data/visualizations
         def test_create_invalid_params
           with(site: site) do
-            post gobierto_data_api_v1_visualizations_path, headers: { token: user_token.token }, params: {}, as: :json
+            post gobierto_data_api_v1_visualizations_path, headers: { Authorization: user_token.token }, params: {}, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -411,7 +411,7 @@ module GobiertoData
         # PUT /api/v1/data/visualizations/1
         def test_update_with_invalid_token
           with(site: site) do
-            put gobierto_data_api_v1_visualization_path(visualization), headers: { token: "wadus" }, params: valid_params, as: :json
+            put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: "wadus" }, params: valid_params, as: :json
 
             assert_response :unauthorized
           end
@@ -420,7 +420,7 @@ module GobiertoData
         # PUT /api/v1/data/visualizations/1
         def test_update_with_other_user_token
           with(site: site) do
-            put gobierto_data_api_v1_visualization_path(visualization), headers: { token: other_user_token.token }, params: valid_params, as: :json
+            put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: other_user_token.token }, params: valid_params, as: :json
 
             assert_response :unauthorized
           end
@@ -430,7 +430,7 @@ module GobiertoData
         def test_update
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              put gobierto_data_api_v1_visualization_path(visualization), headers: { token: user_token.token }, params: valid_params, as: :json
+              put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: user_token.token }, params: valid_params, as: :json
 
               assert_response :success
               response_data = response.parsed_body
@@ -464,7 +464,7 @@ module GobiertoData
         # PUT /api/v1/data/visualizations/1
         def test_update_invalid_params
           with(site: site) do
-            put gobierto_data_api_v1_visualization_path(visualization), headers: { token: user_token.token }, params: {}, as: :json
+            put gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: user_token.token }, params: {}, as: :json
 
             assert_response :unprocessable_entity
             response_data = response.parsed_body
@@ -488,7 +488,7 @@ module GobiertoData
         def test_delete_with_invalid_token
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              delete gobierto_data_api_v1_visualization_path(visualization), headers: { token: "wadus" }, as: :json
+              delete gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: "wadus" }, as: :json
 
               assert_response :unauthorized
             end
@@ -499,7 +499,7 @@ module GobiertoData
         def test_delete_with_other_user_token
           with(site: site) do
             assert_no_difference "GobiertoData::Visualization.count" do
-              delete gobierto_data_api_v1_visualization_path(visualization), headers: { token: other_user_token.token }, as: :json
+              delete gobierto_data_api_v1_visualization_path(visualization), headers: { Authorization: other_user_token.token }, as: :json
 
               assert_response :unauthorized
             end
@@ -511,7 +511,7 @@ module GobiertoData
           id = visualization.id
           assert_difference "GobiertoData::Visualization.count", -1 do
             with(site: site) do
-              delete gobierto_data_api_v1_visualization_path(id), headers: { token: user_token.token }, as: :json
+              delete gobierto_data_api_v1_visualization_path(id), headers: { Authorization: user_token.token }, as: :json
 
               assert_response :no_content
 

--- a/test/fixtures/gobierto_data/favorites.yml
+++ b/test/fixtures/gobierto_data/favorites.yml
@@ -1,0 +1,47 @@
+dennis_users_dataset_favorite:
+  user: dennis
+  favorited: users_dataset (GobiertoData::Dataset)
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+dennis_events_dataset_favorite:
+  user: dennis
+  favorited: events_dataset (GobiertoData::Dataset)
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+dennis_users_count_query_favorite:
+  user: dennis
+  favorited: users_count_query (GobiertoData::Query)
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+dennis_events_count_query_favorite:
+  user: dennis
+  favorited: events_count_query (GobiertoData::Query)
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+dennis_users_count_visualization_favorite:
+  user: dennis
+  favorited: users_count_visualization (GobiertoData::Visualization)
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+dennis_census_verified_users_visualization_favorite:
+  user: dennis
+  favorited: census_verified_users_visualization (GobiertoData::Visualization)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+
+peter_dataset_favorite:
+  user: peter
+  favorited: users_dataset (GobiertoData::Dataset)
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+
+reed_census_verified_users_query_favorite:
+  user: reed
+  favorited: census_verified_users_query (GobiertoData::Query)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>

--- a/test/fixtures/gobierto_data/favorites.yml
+++ b/test/fixtures/gobierto_data/favorites.yml
@@ -45,3 +45,15 @@ reed_census_verified_users_query_favorite:
   favorited: census_verified_users_query (GobiertoData::Query)
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+
+janet_census_verified_users_query_favorite:
+  user: janet
+  favorited: census_verified_users_query (GobiertoData::Query)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+
+janet_events_count_closed_visualization:
+  user: janet
+  favorited: events_count_closed_visualization (GobiertoData::Visualization)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>

--- a/test/fixtures/user/api_tokens.yml
+++ b/test/fixtures/user/api_tokens.yml
@@ -1,0 +1,34 @@
+dennis_primary_api_token:
+  user: dennis
+  primary: true
+  token: dennis_primary_api_token
+
+reed_primary_api_token:
+  user: reed
+  primary: true
+  token: reed_primary_api_token
+
+susan_primary_api_token:
+  user: susan
+  primary: true
+  token: susan_primary_api_token
+
+peter_primary_api_token:
+  user: peter
+  primary: true
+  token: peter_primary_api_token
+
+charles_primary_api_token:
+  user: charles
+  primary: true
+  token: charles_primary_api_token
+
+janet_primary_api_token:
+  user: janet
+  primary: true
+  token: janet_primary_api_token
+
+martin_primary_api_token:
+  user: martin
+  primary: true
+  token: martin_primary_api_token

--- a/test/models/gobierto_data/favorite_test.rb
+++ b/test/models/gobierto_data/favorite_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class FavoriteTest < ActiveSupport::TestCase
+    def subject
+      @subject ||= gobierto_data_favorites(:dennis_users_dataset_favorite)
+    end
+
+    def test_valid
+      assert subject.valid?
+    end
+  end
+end

--- a/test/models/user/api_token_test.rb
+++ b/test/models/user/api_token_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class User::ApiTokenTest < ActiveSupport::TestCase
+  def user_primary_api_token
+    @user_primary_api_token ||= user_api_tokens(:dennis_primary_api_token)
+  end
+
+  def test_valid
+    assert user_primary_api_token.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -47,6 +47,10 @@ class UserTest < ActiveSupport::TestCase
     @santander_user ||= users(:susan)
   end
 
+  def user_primary_api_token
+    @user_primary_api_token ||= user_api_tokens(:dennis_primary_api_token)
+  end
+
   def test_by_user_site_scope
     subject = User.by_site(madrid_site)
 
@@ -82,4 +86,29 @@ class UserTest < ActiveSupport::TestCase
     Timecop.freeze(birthdate.change(year: 2005, month: 3, day: 1)) { assert_equal 1, user.age }
   end
 
+  def test_primary_api_token_on_creation
+    new_user = User.create(
+      email: "wadus@example.org",
+      site: user.site
+    )
+    assert new_user.primary_api_token.present?
+  end
+
+  def test_primary_api_token
+    assert_equal user_primary_api_token, user.primary_api_token
+
+    user.primary_api_token.destroy
+    assert_nil user.primary_api_token
+  end
+
+  def test_primary_api_token!
+    assert_equal user_primary_api_token, user.primary_api_token!
+
+    user.primary_api_token.destroy
+
+    assert_difference "User::ApiToken.count", 1 do
+      refute_nil user.primary_api_token!
+      assert user.api_tokens.primary.exists?
+    end
+  end
 end


### PR DESCRIPTION
Closes PopulateTools/issues#847

## :v: What does this PR do?

Adds favorites functionality to datasets, queries and visualizations in gobierto data.

This PR comes for a rebase of PR #2741 related branch which includes authentication with tokens functionality (given by #2756) and should be considered instead of the other one.

## :mag: How should this be manually tested?

The endpoints are documented in readme.io with more detail.

### List favorites of a user for a resource and subresources

`GET` **/api/v1/data/datasets/DATASET-SLUG/favorites{.json}**
`GET` **/api/v1/data/queries/QUERY-ID/favorites{.json}**
`GET` **/api/v1/data/visualization/VISUALIZATION-ID/favorites{.json}**

A user can favorite multiple resource types, as datasets, queries and visualizations. This endpoint returns the list of favorites of a resource and depending resources (queries and visualizations for datasets, visualizations for queries) of a user. The user can be obtained by API authentication mechanism or a `filter[user_id]` query parameter.

### Create new favorite

`POST` **/api/v1/data/datasets/DATASET-SLUG/favorite{.json}**
`POST` **/api/v1/data/queries/QUERY-ID/favorite{.json}**
`POST` **/api/v1/data/visualization/VISUALIZATION-ID/favorite{.json}**

### Delete a favorite

`DELETE` **/api/v1/data/datasets/DATASET-SLUG/favorite{.json}**
`DELETE` **/api/v1/data/queries/QUERY-ID/favorite{.json}**
`DELETE` **/api/v1/data/visualization/VISUALIZATION-ID/favorite{.json}**


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- WIP Documentation in readme.io