### PR TITLE
2696 gobierto data module settings

### DIFF
--- a/app/controllers/concerns/gobierto_common/module_helper.rb
+++ b/app/controllers/concerns/gobierto_common/module_helper.rb
@@ -8,6 +8,10 @@ module GobiertoCommon
       raise_module_not_enabled(redirect) unless site.configuration.modules.include?(module_namespace.to_s)
     end
 
+    def module_frontend_enabled!(site, module_namespace, redirect = true)
+      raise_module_not_enabled(redirect) unless site.configuration.modules_with_frontend_enabled.include?(module_namespace.to_s)
+    end
+
     def module_allowed!(current_admin, module_namespace)
       raise_module_not_allowed unless current_admin.module_allowed?(module_namespace, current_site)
     end

--- a/app/controllers/gobierto_admin/gobierto_data/configuration/settings_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/configuration/settings_controller.rb
@@ -21,7 +21,7 @@ module GobiertoAdmin
         private
 
         def settings_params
-          params.require(:gobierto_data_settings).permit(:db_config)
+          params.require(:gobierto_data_settings).permit(:db_config, :frontend_enabled)
         end
       end
     end

--- a/app/controllers/gobierto_data/application_controller.rb
+++ b/app/controllers/gobierto_data/application_controller.rb
@@ -4,4 +4,6 @@ class GobiertoData::ApplicationController < ApplicationController
   include User::SessionHelper
 
   layout "gobierto_data/layouts/application"
+
+  before_action { module_frontend_enabled!(current_site, "GobiertoData") }
 end

--- a/app/forms/gobierto_admin/gobierto_data/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/settings_form.rb
@@ -43,7 +43,7 @@ module GobiertoAdmin
       def db_config_format
         return if db_config.blank?
 
-        JSON.parse(db_config)
+        JSON.parse(db_config).with_indifferent_access
       rescue JSON::ParserError
         errors.add :db_config, :invalid_format
       end
@@ -51,7 +51,10 @@ module GobiertoAdmin
       def db_config_connection
         return if errors.added? :db_config, :invalid_format
 
-        ::GobiertoData::Connection.test_connection_config(db_config_format)
+        config = db_config_format
+
+        ::GobiertoData::Connection.test_connection_config(config, :read_db_config)
+        ::GobiertoData::Connection.test_connection_config(config, :write_db_config) if config&.has_key?(:write_db_config)
       rescue ActiveRecord::ActiveRecordError => e
         errors.add(:db_config, :invalid_connection, error_message: e.message)
       end
@@ -72,7 +75,7 @@ module GobiertoAdmin
         @gobierto_module_settings = gobierto_module_settings.tap do |settings_attributes|
           settings_attributes.module_name = module_name
           settings_attributes.site_id = site_id
-          settings_attributes.db_config = db_config_format
+          settings_attributes.db_config = db_config_clean
           settings_attributes.frontend_disabled = frontend_enabled != "1"
         end
 
@@ -82,6 +85,13 @@ module GobiertoAdmin
           promote_errors(@gobierto_module_settings.errors)
           false
         end
+      end
+
+      def db_config_clean
+        config = db_config_format
+        return config if config.blank?
+
+        config.has_key?(:read_db_config) ? config.slice(:read_db_config, :write_db_config) : { read_db_config: config }
       end
 
     end

--- a/app/forms/gobierto_admin/gobierto_data/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/settings_form.rb
@@ -6,7 +6,8 @@ module GobiertoAdmin
 
       attr_writer(
         :site_id,
-        :db_config
+        :db_config,
+        :frontend_enabled
       )
 
       delegate :persisted?, to: :gobierto_module_settings
@@ -31,6 +32,10 @@ module GobiertoAdmin
 
       def db_config
         @db_config ||= gobierto_module_settings.db_config.present? ? JSON.pretty_generate(gobierto_module_settings.db_config) : nil
+      end
+
+      def frontend_enabled
+        @frontend_enabled ||= !gobierto_module_settings.frontend_disabled
       end
 
       private
@@ -68,6 +73,7 @@ module GobiertoAdmin
           settings_attributes.module_name = module_name
           settings_attributes.site_id = site_id
           settings_attributes.db_config = db_config_format
+          settings_attributes.frontend_disabled = frontend_enabled != "1"
         end
 
         if @gobierto_module_settings.save

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -8,9 +8,10 @@ module GobiertoData
 
     class << self
 
-      def execute_query(site, query, include_stats: true)
-        with_connection(db_config(site), fallback: null_query) do
+      def execute_query(site, query, include_stats: true, write: false)
+        connection_key = write ? :write_db_config : :read_db_config
 
+        with_connection(db_config(site), fallback: null_query, connection_key: connection_key) do
           event = nil
           if include_stats
             ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -44,7 +44,7 @@ module GobiertoData
       end
 
       def test_connection_config(config, connection_key = :read_db_config)
-        with_connection(config, connection_key: connection_key) do
+        with_connection(config&.with_indifferent_access, connection_key: connection_key) do
           connection.present?
         end
       end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -40,21 +40,22 @@ module GobiertoData
       end
 
       def db_config(site)
-        site&.gobierto_data_settings&.db_config
+        site&.gobierto_data_settings&.db_config&.with_indifferent_access
       end
 
-      def test_connection_config(config)
-        with_connection(config) do
+      def test_connection_config(config, connection_key = :read_db_config)
+        with_connection(config, connection_key: connection_key) do
           connection.present?
         end
       end
 
       private
 
-      def with_connection(db_conf, fallback: nil)
+      def with_connection(db_conf, fallback: nil, connection_key: :read_db_config)
         base_connection_config = connection_config
         return fallback if db_conf.nil?
 
+        db_conf = db_conf[connection_key] if db_conf.has_key?(connection_key)
         establish_connection(db_conf)
         yield
       ensure

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -49,7 +49,7 @@ module GobiertoData
         File.open("#{base_path}_schema.json", "w") { |file| file.write(JSON.pretty_generate(statements.schema)) } if schema_file.blank?
         File.open("#{base_path}_script.sql", "w") { |file| file.write(statements.sql_code) }
       end
-      Connection.execute_query(site, statements.sql_code)
+      Connection.execute_query(site, statements.sql_code, write: true)
     end
 
     private

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -26,9 +26,11 @@ module GobiertoData
                          db_config = Connection.db_config(site)
                          return if db_config.blank?
 
+                         db_config = db_config.fetch(:read_db_config, db_config)
+
                          Class.new(Connection).tap do |connection_model|
                            Connection.const_set(internal_rails_class_name, connection_model)
-                           connection_model.establish_connection(connection_model.db_config(site))
+                           connection_model.establish_connection(db_config)
                            connection_model.table_name = table_name
                          end
                        end

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -43,6 +43,12 @@ class SiteConfiguration
     @modules.select { |site_module| SITE_MODULES.include?(site_module) }
   end
 
+  def modules_with_frontend_enabled
+    modules.reject do |site_module|
+      GobiertoModuleSettings.find_by(site_id: site_id, module_name: site_module)&.frontend_disabled
+    end
+  end
+
   def available_module?(site_module)
     modules.include?(site_module)
   end

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -90,7 +90,7 @@ class SiteConfiguration
   end
 
   def modules_with_notifications
-    modules & MODULES_WITH_NOTIFICATONS
+    modules_with_frontend_enabled & MODULES_WITH_NOTIFICATONS
   end
 
   def default_modules

--- a/app/views/gobierto_admin/gobierto_data/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/configuration/settings/edit.html.erb
@@ -17,14 +17,33 @@
 <%= form_for @settings_form, as: :gobierto_data_settings, url: admin_data_configuration_settings_path,  method: :patch, html: { autocomplete: "off" } do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">
-      <div class="form_item textarea">
-        <%= label_tag "gobierto_data_settings[db_config]" do %>
-                <%= t("activemodel.attributes.gobierto_admin/gobierto_data/settings_form.db_config") %>
 
-        <%= attribute_indication_tag required: true %>
-      <% end %>
-        <%= f.text_area :db_config, placeholder: JSON.pretty_generate(JSON.parse(t('.db_config_placeholder'))) %>
+      <div class="form_block">
+        <div class="form_item textarea">
+          <%= label_tag "gobierto_data_settings[db_config]" do %>
+            <%= t("activemodel.attributes.gobierto_admin/gobierto_data/settings_form.db_config") %>
+
+            <%= attribute_indication_tag required: true %>
+          <% end %>
+          <%= f.text_area :db_config, placeholder: JSON.pretty_generate(JSON.parse(t('.db_config_placeholder'))) %>
+        </div>
       </div>
+
+      <div class="form_block">
+        <h2><%= t(".frontend") %></h2>
+        <div class="form_item site-module-check-boxes">
+          <div class="options compact">
+            <div class="option">
+              <%= f.check_box :frontend_enabled %>
+              <%= f.label :frontend_enabled do %>
+                <span></span>
+                <%= t(".frontend_enabled")  %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/app/views/gobierto_exports/exports/index.html.erb
+++ b/app/views/gobierto_exports/exports/index.html.erb
@@ -7,7 +7,7 @@
 
   </header>
 
-  <% current_site.configuration.modules.each do |site_module| %>
+  <% current_site.configuration.modules_with_frontend_enabled.each do |site_module| %>
     <%= render_if_exists "#{site_module.underscore}/exports/index" %>
   <% end %>
 

--- a/app/views/gobierto_exports/layouts/_menu_subsections.html.erb
+++ b/app/views/gobierto_exports/layouts/_menu_subsections.html.erb
@@ -1,7 +1,7 @@
 <menu class="sub_sections">
   <div class="pure-menu pure-menu-horizontal pure-menu-scrollable">
     <ul>
-      <% current_site.configuration.modules.each do |site_module| %>
+      <% current_site.configuration.modules_with_frontend_enabled.each do |site_module| %>
         <li><%= render_if_exists "#{site_module.underscore}/exports/nav_item" %></li>
       <% end %>
     </ul>

--- a/app/views/layouts/_hamburger_mobile.html.erb
+++ b/app/views/layouts/_hamburger_mobile.html.erb
@@ -36,7 +36,7 @@
     <% end %>
   <% else %>
     <!-- Modules loop -->
-    <% current_site.configuration.modules.each do |site_module| %>
+    <% current_site.configuration.modules_with_frontend_enabled.each do |site_module| %>
       <div class="navigation-wrap">
         <div class="navigation-item column">
           <%= render_if_exists "#{site_module.underscore}/layouts/navigation.main", { show_active: false } %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -4,7 +4,7 @@
       <% if global_navigation_section? %>
         <%= render "layouts/global_navigation", { show_active: true } %>
       <% else %>
-        <% current_site.configuration.modules.each do |site_module| %>
+        <% current_site.configuration.modules_with_frontend_enabled.each do |site_module| %>
           <%= render_if_exists "#{site_module.underscore}/layouts/navigation.main", { show_active: true } %>
         <% end %>
       <% end %>

--- a/config/locales/gobierto_admin/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/ca.yml
@@ -8,6 +8,7 @@ ca:
         table_name: Nom de la taula
       gobierto_admin/gobierto_data/settings_form:
         db_config: Configuració de la connexió a la base de dades
+        frontend_enabled: Front-end visible
     errors:
       models:
         gobierto_admin/gobierto_data/dataset_form:

--- a/config/locales/gobierto_admin/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/en.yml
@@ -8,6 +8,7 @@ en:
         table_name: Table name
       gobierto_admin/gobierto_data/settings_form:
         db_config: Database connection configuration
+        frontend_enabled: Front-end visible
     errors:
       models:
         gobierto_admin/gobierto_data/dataset_form:

--- a/config/locales/gobierto_admin/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/es.yml
@@ -8,6 +8,7 @@ es:
         table_name: Nombre de la tabla
       gobierto_admin/gobierto_data/settings_form:
         db_config: Configuración de la conexión a la base de datos
+        frontend_enabled: Interfaz pública visible
     errors:
       models:
         gobierto_admin/gobierto_data/dataset_form:

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -7,6 +7,8 @@ ca:
           edit:
             db_config_placeholder: '{"pool":5, "adapter":"postgresql", "database":"gobierto_test",
               "encoding":"unicode", "password":"gobierto", "username":"gobierto"}'
+            frontend: Front-end
+            frontend_enabled: Visible
             title: Configuració
             update: Actualitzar
           title: Preferencies

--- a/config/locales/gobierto_admin/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/en.yml
@@ -7,6 +7,8 @@ en:
           edit:
             db_config_placeholder: '{"pool":5, "adapter":"postgresql", "database":"gobierto_test",
               "encoding":"unicode", "password":"gobierto", "username":"gobierto"}'
+            frontend: Front-end
+            frontend_enabled: Visible
             title: Configuration
             update: Update
           title: Preferences

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -7,6 +7,8 @@ es:
           edit:
             db_config_placeholder: '{"pool":5, "adapter":"postgresql", "database":"gobierto_test",
               "encoding":"unicode", "password":"gobierto", "username":"gobierto"}'
+            frontend: Interfaz pública
+            frontend_enabled: Visible
             title: Configuración
             update: Actualizar
           title: Preferencias

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -151,7 +151,10 @@ gobierto_data_settings_madrid:
   site: madrid
   module_name: "GobiertoData"
   settings: <%= {
-    db_config: Rails.configuration.database_configuration["test"]
+    db_config: {
+      read_db_config: Rails.configuration.database_configuration["test"],
+      write_db_config: Rails.configuration.database_configuration["test"]
+    }
   }.to_json %>
 
 gobierto_budgets_settings_organization_wadus:

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -147,7 +147,7 @@ gobierto_citizens_charters_settings_madrid:
   module_name: "GobiertoCitizensCharters"
   settings: <%= { "categories_vocabulary_id": ActiveRecord::FixtureSet.identify(:citizens_services_categories) }.to_json %>
 
-gobierto_cata_settings_madrid:
+gobierto_data_settings_madrid:
   site: madrid
   module_name: "GobiertoData"
   settings: <%= {

--- a/test/integration/gobierto_data/home_page_test.rb
+++ b/test/integration/gobierto_data/home_page_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class HomePageTest < ActionDispatch::IntegrationTest
+    def setup
+      super
+      @path = gobierto_data_root_path
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def dataset
+      @dataset ||= gobierto_data_datasets(:users_dataset)
+    end
+
+    def test_home_page
+      with_current_site(site) do
+        visit @path
+
+        within("div.container", match: :first) do
+          assert has_content? "Data"
+          assert has_content? dataset.name
+        end
+
+        assert_equal @path, current_path
+      end
+    end
+
+    def test_home_page_with_frontend_disabled
+      site.gobierto_data_settings.frontend_disabled = true
+      site.gobierto_data_settings.save
+
+      with_current_site(site) do
+        visit @path
+
+        within("div.container", match: :first) do
+          assert has_no_content? "Data"
+          assert has_no_content? dataset.name
+        end
+
+        refute_equal @path, current_path
+      end
+    end
+  end
+end

--- a/test/integration/site_navigation_test.rb
+++ b/test/integration/site_navigation_test.rb
@@ -12,6 +12,10 @@ class SiteNavigationTest < ActionDispatch::IntegrationTest
     @site ||= sites(:santander)
   end
 
+  def site_with_data_module
+    @site_with_data_module ||= sites(:madrid)
+  end
+
   def test_navigation
     with_current_site(site) do
       visit @path
@@ -20,6 +24,25 @@ class SiteNavigationTest < ActionDispatch::IntegrationTest
         assert has_link?("Budgets")
         assert has_link?("Officials and Agendas")
         assert has_link?("CMS")
+      end
+    end
+  end
+
+  def test_navigation_with_data_module_frontend_enabled
+    with_current_site(site_with_data_module) do
+      visit @path
+
+      within "nav.main-nav" do
+        assert has_link?("Data")
+      end
+
+      site_with_data_module.gobierto_data_settings.frontend_disabled = true
+      site_with_data_module.gobierto_data_settings.save
+
+      visit @path
+
+      within "nav.main-nav" do
+        assert has_no_link?("Data")
       end
     end
   end


### PR DESCRIPTION
Closes #2696

## :v: What does this PR do?

* Adds a module setting to Gobierto Data allowing to hide its frontend part. When disabled:
  * Links to module in all main navigation menus are hidden.
  * Frontend routes of module are disabled and the user is redirected to root when trying to access them.
  * If user notifications were defined for the module, it won't be available in the notification user settings.
* Splits JSON configuration of database in two, using different keys:
  * `read_db_config`: Connection configuration to be used by datasets and queries to get data
  * `write_db_config`: Connection configuration to load data into datasets tables. The datasets method `load_data_from_file` makes use of this connection
* If the database configuration field is filled only with a connection configuration and no key is provided, the settings form interpret the configuration as `read_db_config`

## :mag: How should this be manually tested?

As admin visit settings form of Gobierto Data module.
* Enable/disable front-end visible option
* Change configuration of module connection setting connections under `read_db_config` and `write_db_config`.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Yes, documentation added in readme.io for module