### PR TITLE
Anonymize personal data in invoices

### DIFF
--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -619,7 +619,10 @@ window.GobiertoBudgets.InvoicesController = (function() {
           autosearch: true,
           align: "center",
           css: "break",
-          width: 30
+          width: 30,
+          itemTemplate: function(value) {
+            return value.substring(0, 16)
+          }
         },
         {
           name: "provider_name",

--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -620,9 +620,7 @@ window.GobiertoBudgets.InvoicesController = (function() {
           align: "center",
           css: "break",
           width: 30,
-          itemTemplate: function(value) {
-            return value.substring(0, 16)
-          }
+          itemTemplate: value => value.substring(0, 16)
         },
         {
           name: "provider_name",


### PR DESCRIPTION
Parts of this fix:

- [This commit](https://github.com/PopulateTools/gobierto_data/commit/b25ee9649d954b9b9fa8b9a34a9948a2f7a17c45) in `gobierto_data`, which obfuscates all provider ids that match a DNI or NIE.
- This PR in Gobierto which truncates provider_id length to don't break the table. 

**Screenshots**

https://mataro.gobify.net/presupuestos/proveedores-facturas

![Captura de pantalla 2020-01-17 a las 9 35 16](https://user-images.githubusercontent.com/9287468/72597509-3b927200-390e-11ea-9519-0d965a8d877f.png)

After this we need to:

- [ ] Notify the client E**
- [ ] Notify client G**
- [ ] If approved, deploy to production gobierto and gobierto-etl-utils and run all providers ETLs again
