### PR TITLE
Fix department people query

### DIFF
--- a/app/decorators/gobierto_people/department_decorator.rb
+++ b/app/decorators/gobierto_people/department_decorator.rb
@@ -31,7 +31,8 @@ module GobiertoPeople
 
     def people
       @people ||= QueryWithEvents.new(
-        source: object.people.active.with_event_attendances(site),
+        source: object.people(from_date: filter_start_date, to_date: filter_end_date)
+                      .active.with_event_attendances(site),
         start_date: filter_start_date,
         end_date: filter_end_date
       )

--- a/app/models/gobierto_people/department.rb
+++ b/app/models/gobierto_people/department.rb
@@ -8,6 +8,7 @@ module GobiertoPeople
     include GobiertoCommon::Metadatable
     include GobiertoCommon::UrlBuildable
     include GobiertoCommon::Sluggable
+    include ActiveRecord::Sanitization::ClassMethods
 
     belongs_to :site
     has_many :events, class_name: "GobiertoCalendars::Event"
@@ -41,8 +42,11 @@ module GobiertoPeople
       [name]
     end
 
-    def people
-      self.class.filter_department_people(site.people, id).distinct
+    def people(params = {})
+      self.class.filter_department_people(
+        params.slice(:from_date, :to_date)
+              .merge(people_relation: site.people, department_id: id)
+      ).distinct
     end
 
     def short_name
@@ -50,13 +54,53 @@ module GobiertoPeople
       I18n.locale == :ca ? result.gsub("i d'", "i ") : result
     end
 
-    def self.filter_department_people(people_relation, department_id)
-      people_relation.left_outer_joins(attending_person_events: :event)
-                     .where("gc_events.department_id = :id OR
-gp_people.id IN (select distinct(person_id) FROM gp_trips WHERE gp_trips.department_id = :id) OR
-gp_people.id IN (select distinct(person_id) FROM gp_invitations WHERE gp_invitations.department_id = :id) OR
-gp_people.id IN (select distinct(person_id) FROM gp_gifts WHERE gp_gifts.department_id = :id)", id: department_id)
+    def self.filter_department_people(params = {})
+      params[:people_relation].left_outer_joins(attending_person_events: :event)
+                              .where(%{
+        #{department_people_linked_throught_events_sql(params)} OR
+        gp_people.id IN (#{department_people_linked_through_trips_sql(params)}) OR
+        gp_people.id IN (#{department_people_linked_through_invitations_sql(params)}) OR
+        gp_people.id IN (#{department_people_linked_through_gifts_sql(params)})
+      })
     end
 
+    ## private
+
+    def self.department_people_linked_throught_events_sql(params = {})
+      sql = sanitize_sql(["(gc_events.department_id = ?", params[:department_id]])
+      sql += sanitize_sql([" AND gc_events.starts_at >= ?", params[:from_date]]) if params[:from_date]
+      sql += sanitize_sql([" AND gc_events.ends_at < ?", params[:to_date]]) if params[:to_date]
+      "#{sql})"
+    end
+
+    def self.department_people_linked_through_trips_sql(params = {})
+      people = GobiertoPeople::Trip.select("DISTINCT(person_id)")
+                                   .where(department_id: params[:department_id])
+                                   .reorder("")
+      people = people.where("start_date >= ?", params[:from_date]) if params[:from_date]
+      people = people.where("end_date < ?", params[:to_date]) if params[:to_date]
+      people.to_sql
+    end
+    private_class_method :department_people_linked_through_trips_sql
+
+    def self.department_people_linked_through_invitations_sql(params = {})
+      people = GobiertoPeople::Invitation.select("DISTINCT(person_id)")
+                                                     .where(department_id: params[:department_id])
+                                                     .reorder("")
+      people = people.where("start_date >= ?", params[:from_date]) if params[:from_date]
+      people = people.where("end_date < ?", params[:to_date]) if params[:to_date]
+      people.to_sql
+    end
+    private_class_method :department_people_linked_through_invitations_sql
+
+    def self.department_people_linked_through_gifts_sql(params = {})
+      people = GobiertoPeople::Gift.select("DISTINCT(person_id)")
+                                         .where(department_id: params[:department_id])
+                                         .reorder("")
+      people = people.where("date >= ?", params[:from_date]) if params[:from_date]
+      people = people.where("date < ?", params[:to_date]) if params[:to_date]
+      people.to_sql
+    end
+    private_class_method :department_people_linked_through_gifts_sql
   end
 end

--- a/app/models/gobierto_people/department.rb
+++ b/app/models/gobierto_people/department.rb
@@ -85,8 +85,8 @@ module GobiertoPeople
 
     def self.department_people_linked_through_invitations_sql(params = {})
       people = GobiertoPeople::Invitation.select("DISTINCT(person_id)")
-                                                     .where(department_id: params[:department_id])
-                                                     .reorder("")
+                                         .where(department_id: params[:department_id])
+                                         .reorder("")
       people = people.where("start_date >= ?", params[:from_date]) if params[:from_date]
       people = people.where("end_date < ?", params[:to_date]) if params[:to_date]
       people.to_sql
@@ -95,8 +95,8 @@ module GobiertoPeople
 
     def self.department_people_linked_through_gifts_sql(params = {})
       people = GobiertoPeople::Gift.select("DISTINCT(person_id)")
-                                         .where(department_id: params[:department_id])
-                                         .reorder("")
+                                   .where(department_id: params[:department_id])
+                                   .reorder("")
       people = people.where("date >= ?", params[:from_date]) if params[:from_date]
       people = people.where("date < ?", params[:to_date]) if params[:to_date]
       people.to_sql

--- a/app/queries/gobierto_people/people_query.rb
+++ b/app/queries/gobierto_people/people_query.rb
@@ -7,7 +7,10 @@ module GobiertoPeople
 
     def append_query_conditions(conditions)
       if conditions[:department_id]
-        @relation = Department.filter_department_people(relation, conditions[:department_id])
+        @relation = Department.filter_department_people(
+          conditions.slice(:department_id, :from_date, :to_date)
+                    .merge(people_relation: relation)
+        )
       end
 
       if conditions[:interest_group_id]

--- a/test/factories/gobierto_people/factory.rb
+++ b/test/factories/gobierto_people/factory.rb
@@ -4,6 +4,19 @@ require "active_record/fixtures"
 
 module GobiertoPeople
   class Factory
+    def self.person(params = {})
+      name = params[:name] || "Bob"
+
+      GobiertoPeople::Person.create!(
+        site: params[:site] || default_site,
+        name: name,
+        visibility_level: GobiertoPeople::Person.visibility_levels["active"],
+        category: GobiertoPeople::Person.categories["politician"],
+        party: GobiertoPeople::Person.parties["government"],
+        position: rand(1..1_000),
+        email: "#{name.downcase}@example.org"
+      )
+    end
 
     def self.trip(params = {})
       default_destinations = {
@@ -22,6 +35,26 @@ module GobiertoPeople
       )
     end
 
+    def self.invitation(params = {})
+      GobiertoPeople::Invitation.create!(
+        person: params[:person] || default_person,
+        organizer: "Important Association",
+        title: "Important Invitation",
+        department: params[:department] || default_department,
+        start_date: params[:start_date] || 1.month.ago,
+        end_date: params[:end_date] || 1.month.ago + 1.day
+      )
+    end
+
+    def self.gift(params = {})
+      GobiertoPeople::Gift.create!(
+        person: params[:person] || default_person,
+        name: "Concert Ticket",
+        department: params[:department] || default_department,
+        date: params[:date] || 2.days.ago
+      )
+    end
+
     def self.department(params = {})
       name = params[:name] || "Department name"
 
@@ -33,7 +66,7 @@ module GobiertoPeople
     end
 
     def self.default_site
-      @default_site ||= GobiertoPeople::Person.find(fixture(:madrid))
+      @default_site ||= Site.find(fixture(:madrid))
     end
     private_class_method :default_site
 
@@ -43,7 +76,7 @@ module GobiertoPeople
     private_class_method :default_person
 
     def self.default_department
-      @default_department ||= GobiertoPeople::Person.find(fixture(:culture_department))
+      @default_department ||= GobiertoPeople::Department.find(fixture(:culture_department))
     end
     private_class_method :default_department
 

--- a/test/models/gobierto_people/department_test.rb
+++ b/test/models/gobierto_people/department_test.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/event_helpers"
+require "factories/gobierto_people/factory"
 
 module GobiertoPeople
   class DepartmentTest < ActiveSupport::TestCase
 
+    include EventHelpers
+
     def department
       @department ||= gobierto_people_departments(:culture_department)
+    end
+
+    def clear_fixtures
+      GobiertoPeople::Person.delete_all
+      GobiertoPeople::Trip.delete_all
+      GobiertoPeople::Gift.delete_all
+      GobiertoPeople::Invitation.delete_all
     end
 
     def test_short_name
@@ -25,6 +36,58 @@ module GobiertoPeople
         department.update_attributes!(name: full_name)
         assert_equal expected_result[full_name], department.short_name
       end
+    end
+
+    def test_filter_department_people_linked_through_events
+      clear_fixtures
+
+      old_department_member = GobiertoPeople::Factory.person
+      department_member = GobiertoPeople::Factory.person(name: "Alice")
+
+      create_event(person: old_department_member, department: department, starts_at: :past)
+      create_event(person: department_member, department: department, starts_at: :future)
+
+      assert_equal [old_department_member], department.people(to_date: Time.current)
+      assert_equal [department_member], department.people(from_date: Time.current)
+    end
+
+    def test_department_people_linked_through_trips
+      clear_fixtures
+
+      old_department_member = GobiertoPeople::Factory.person
+      department_member = GobiertoPeople::Factory.person(name: "Alice")
+
+      GobiertoPeople::Factory.trip(person: old_department_member, start_date: 1.year.ago, end_date: 1.year.ago + 1.day)
+      GobiertoPeople::Factory.trip(person: department_member, start_date: 1.day.from_now, end_date: 2.days.from_now)
+
+      assert_equal [old_department_member], department.people(to_date: Time.current)
+      assert_equal [department_member], department.people(from_date: Time.current)
+    end
+
+    def test_department_people_linked_through_invitations
+      clear_fixtures
+
+      old_department_member = GobiertoPeople::Factory.person
+      department_member = GobiertoPeople::Factory.person(name: "Alice")
+
+      GobiertoPeople::Factory.invitation(person: old_department_member, start_date: 1.year.ago, end_date: 1.year.ago + 1.day)
+      GobiertoPeople::Factory.invitation(person: department_member, start_date: 1.day.from_now, end_date: 2.days.from_now)
+
+      assert_equal [old_department_member], department.people(to_date: Time.current)
+      assert_equal [department_member], department.people(from_date: Time.current)
+    end
+
+    def test_department_people_linked_through_gifts
+      clear_fixtures
+
+      old_department_member = GobiertoPeople::Factory.person
+      department_member = GobiertoPeople::Factory.person(name: "Alice")
+
+      GobiertoPeople::Factory.gift(person: old_department_member, date: 1.year.ago)
+      GobiertoPeople::Factory.gift(person: department_member, date: 1.day.from_now)
+
+      assert_equal [old_department_member], department.people(to_date: Time.current)
+      assert_equal [department_member], department.people(from_date: Time.current)
     end
 
   end


### PR DESCRIPTION
## :v: What does this PR do?

Fixes the query we use to retrieve people for a department. We were joining with the gifts, invitations and trips tables but we were not filtering by date on those tables.

This caused that if a person was linked to a department via a gift, invitation or trip, he/she would always be shown in the UI no matter the date filters.

## :eyes: Screenshots

### Before this PR

![image](https://user-images.githubusercontent.com/9287468/72819793-2b5ff700-3c6e-11ea-981d-ba91e2e5b897.png)

### After this PR

![image](https://user-images.githubusercontent.com/9287468/72819924-6104e000-3c6e-11ea-940c-7df89549cdc9.png)

### Departments that have changed

- https://direcciopublica.transparencia.gencat.cat/departamentos/departament-d-ensenyament vs https://gencat.gobify.net/departamentos/departament-d-ensenyament
- https://direcciopublica.transparencia.gencat.cat/departamentos/departament-d-interior vs https://gencat.gobify.net/departamentos/departament-d-interior
- https://direcciopublica.transparencia.gencat.cat/departamentos/departament-de-la-presidencia vs https://gencat.gobify.net/departamentos/departament-de-la-presidencia

I've manually compared a couple of people checking gifts, events, invitations and trips and it looks OK to me.
