### PR TITLE
Update datasets columns attribute in meta to include data types

### DIFF
--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -12,7 +12,11 @@ module GobiertoData
     end
 
     attribute :columns do
-      object.rails_model.column_names
+      object.rails_model.columns.inject({}) do |columns, column|
+        columns.update(
+          column.name => column.type
+        )
+      end
     end
 
     attribute :data_preview do


### PR DESCRIPTION
Closes #2769


## :v: What does this PR do?

* Replaces the columns attribute array of column names with an object with column names as keys and data types as values

## :mag: How should this be manually tested?

Visit meta endpoint of a dataset

## :eyes: Screenshots

### Before this PR

<img width="302" alt="Screen Shot 2020-01-23 at 11 28 58" src="https://user-images.githubusercontent.com/446459/72976864-b0185580-3dd3-11ea-9df5-45b7f1b81d38.png">

### After this PR

<img width="322" alt="Screen Shot 2020-01-23 at 11 27 37" src="https://user-images.githubusercontent.com/446459/72976914-b60e3680-3dd3-11ea-886f-e8bf0aa497b3.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

API documentation updated
