### PR TITLE
Add signed in users token to footer

### DIFF
--- a/app/views/layouts/_gobierto_footer.html.erb
+++ b/app/views/layouts/_gobierto_footer.html.erb
@@ -34,6 +34,11 @@
   window.populateDataYear = {
     currentYear: <%= @selected_year || Date.current.year %>
   };
+  <% if current_module == "gobierto_data" %>
+    window.gobiertoData = {
+      token: "<%= current_user&.primary_api_token&.token %>"
+    };
+  <% end %>
 </script>
 
 <!-- page controller initialization -->

--- a/app/views/layouts/_gobierto_footer.html.erb
+++ b/app/views/layouts/_gobierto_footer.html.erb
@@ -34,11 +34,9 @@
   window.populateDataYear = {
     currentYear: <%= @selected_year || Date.current.year %>
   };
-  <% if current_module == "gobierto_data" %>
-    window.gobiertoData = {
-      token: "<%= current_user&.primary_api_token&.token %>"
-    };
-  <% end %>
+  window.gobiertoAPI = {
+    token: "<%= current_user&.primary_api_token&.token %>"
+  };
 </script>
 
 <!-- page controller initialization -->


### PR DESCRIPTION
Related to #2775


## :v: What does this PR do?

Adds signed in user gobierto data API token to footer. This allows the front application to send authenticated requests to API

## :mag: How should this be manually tested?

Visit front of gobierto data and check source 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
