### PR TITLE
2768 downloads links

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -20,6 +20,10 @@ module GobiertoData
       [name]
     end
 
+    def available_formats
+      [:json, :csv, :xlsx]
+    end
+
     def rails_model
       @rails_model ||= begin
                          return Connection.const_get(internal_rails_class_name) if Connection.const_defined?(internal_rails_class_name)

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -2,6 +2,8 @@
 
 module GobiertoData
   class DatasetMetaSerializer < DatasetSerializer
+    include Rails.application.routes.url_helpers
+
     has_many :queries
     has_many :visualizations
 
@@ -15,6 +17,14 @@ module GobiertoData
       object.rails_model.columns.inject({}) do |columns, column|
         columns.update(
           column.name => column.type
+        )
+      end
+    end
+
+    attribute :formats do
+      object.available_formats.inject({}) do |formats, format|
+        formats.update(
+          format => gobierto_data_api_v1_dataset_path(object.slug, format: format)
         )
       end
     end

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -189,7 +189,7 @@ module GobiertoData
             assert_equal resource_data["id"], dataset.id.to_s
 
             # attributes
-            %w(name slug updated_at data_summary columns data_preview).each do |attribute|
+            %w(name slug updated_at data_summary columns formats data_preview).each do |attribute|
               resource_data["attributes"].has_key? attribute
             end
             assert resource_data["attributes"].has_key?(datasets_category.uid)


### PR DESCRIPTION
Closes #2768


## :v: What does this PR do?

* Adds an `available_formats` attribute to datasets which returns a list of available formats to get the content of a dataset. For the moment is fixed to be [:json, :csv, :xlsx]. In the future may vary from one dataset to another.
* Includes in the meta endpoint of a dataset the list of available formats and the paths to get the data for each one. 

## :mag: How should this be manually tested?

Visit meta of a dataset via API

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

<img width="386" alt="Screen Shot 2020-01-23 at 18 04 12" src="https://user-images.githubusercontent.com/446459/73006860-a4488580-3e0b-11ea-9f01-c872cd2833c0.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation updated
