### PR TITLE
2795 private resources lists

### DIFF
--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -154,7 +154,11 @@ module GobiertoData
         end
 
         def filtered_relation
-          base_relation.where(filter_params)
+          if user_authenticated? && filter_params[:user_id].present? && current_user.id == filter_params[:user_id].to_i
+            base_relation.unscope(where: :privacy_status).where(filter_params)
+          else
+            base_relation.where(filter_params)
+          end
         end
 
         def find_item

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -134,7 +134,11 @@ module GobiertoData
         end
 
         def filtered_relation
-          base_relation.where(filter_params)
+          if user_authenticated? && filter_params[:user_id].present? && current_user.id == filter_params[:user_id].to_i
+            base_relation.unscope(where: :privacy_status).where(filter_params)
+          else
+            base_relation.where(filter_params)
+          end
         end
 
         def find_item

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -226,6 +226,37 @@ module GobiertoData
           end
         end
 
+        # GET /api/v1/data/queries.json?user_id=1
+        def test_index_filtered_by_user_with_different_user_token
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(filter: { user_id: other_user.id }), headers: { Authorization: user_token.token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_empty(response_data["data"])
+          end
+        end
+
+        # GET /api/v1/data/queries.json?user_id=1
+        def test_index_filtered_by_user_with_same_user_token
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(filter: { user_id: other_user.id }), headers: { Authorization: other_user_token.token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes queries_names, closed_query.name
+            refute_includes queries_names, user_query.name
+            refute_includes queries_names, other_dataset_query.name
+          end
+        end
+
         # GET /api/v1/data/queries.json?user_id=1&dataset_id=1
         def test_index_filtered_by_user_and_dataset
           with(site: site) do

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -266,6 +266,40 @@ module GobiertoData
           end
         end
 
+        # GET /api/v1/data/visualizations.json?user_id=1
+        def test_index_filtered_by_user_with_different_user_token
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(filter: { user_id: user.id }), headers: { Authorization: other_user_token.token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, user_visualization.name
+            refute_includes visualizations_names, closed_visualization.name
+            assert_includes visualizations_names, other_dataset_visualization.name
+          end
+        end
+
+        # GET /api/v1/data/visualizations.json?user_id=1
+        def test_index_filtered_by_user_with_same_user_token
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(filter: { user_id: user.id }), headers: { Authorization: user_token.token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, user_visualization.name
+            assert_includes visualizations_names, closed_visualization.name
+            assert_includes visualizations_names, other_dataset_visualization.name
+          end
+        end
+
         # GET /api/v1/data/visualizations/1.json
         def test_show
           with(site: site) do


### PR DESCRIPTION
Closes #2795


## :v: What does this PR do?

* Allows users authenticated with token to send requests to API and get owned closed queries and visualizations.

## :mag: How should this be manually tested?

Send a request to `/api/v1/data/queries?filter[user_id]=USER-ID` with the token of the same user of `USER-ID`. The closed queries should be listed. Same for visualizations.

## :shipit: Does this PR changes any configuration file?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation updated