### PR TITLE
Include current_user_id in sobiertoAPI footer data

### DIFF
--- a/app/views/layouts/_gobierto_footer.html.erb
+++ b/app/views/layouts/_gobierto_footer.html.erb
@@ -35,6 +35,7 @@
     currentYear: <%= @selected_year || Date.current.year %>
   };
   window.gobiertoAPI = {
+    current_user_id: "<%= current_user&.id %>",
     token: "<%= current_user&.primary_api_token&.token %>"
   };
 </script>


### PR DESCRIPTION
Closes #2798


## :v: What does this PR do?

* Includes a `current_user_id` attrribute next to GobiertoAPI `token`. When a user is not logged in this field is an empty string.

## :mag: How should this be manually tested?

Log in and inspect the html

## :eyes: Screenshots

### After this PR

<img width="242" alt="Screen Shot 2020-01-24 at 15 08 43" src="https://user-images.githubusercontent.com/446459/73075124-83d80400-3ebb-11ea-8ed7-6373f383ad30.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
