### PR TITLE
2768 downloads links

### DIFF
--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -106,6 +106,29 @@ module GobiertoData
           )
         end
 
+        def send_download(content, format, base_filename)
+          case format
+          when :json
+            send_data(
+              ActiveModelSerializers::SerializableResource.new(
+                content
+              ).to_json,
+              filename: "#{base_filename}.json"
+            )
+          when :csv
+            headers["Content-Disposition"] = "attachment"
+            render(
+              csv: content,
+              filename: base_filename
+            )
+          when :xlsx
+            send_data(
+              content,
+              filename: "#{base_filename}.xlsx"
+            )
+          end
+        end
+
         def render_csv(content)
           headers["Content-Disposition"] = "inline"
           headers["Content-Type"] = "text/plain; charset=utf-8"

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -62,6 +62,29 @@ module GobiertoData
           end
         end
 
+        # GET /api/v1/data/datasets/dataset-slug/download.json
+        # GET /api/v1/data/datasets/dataset-slug/download.csv
+        # GET /api/v1/data/datasets/dataset-slug/download.xlsx
+        def download
+          find_item
+          relation = @item.rails_model.all
+          query_result = execute_query relation
+          basename = @item.slug
+          respond_to do |format|
+            format.json do
+              send_download(query_result.fetch(:result, ""), :json, basename)
+            end
+
+            format.csv do
+              send_download(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params), :csv, basename)
+            end
+
+            format.xlsx do
+              send_download(xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, :xlsx, basename)
+            end
+          end
+        end
+
         # GET /api/v1/data/datasets/dataset-slug/metadata
         # GET /api/v1/data/datasets/dataset-slug/metadata.json
         def dataset_meta

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -5,7 +5,7 @@ module GobiertoData
     module V1
       class QueriesController < BaseController
 
-        before_action :authenticate_user!, except: [:index, :show, :meta, :new]
+        before_action :authenticate_user!, except: [:index, :show, :meta, :new, :download]
         before_action :allow_author!, only: [:update, :destroy]
 
         # GET /api/v1/data/queries
@@ -58,6 +58,28 @@ module GobiertoData
           end
         end
 
+        # GET /api/v1/data/queries/1/download.json
+        # GET /api/v1/data/queries/1/download.csv
+        # GET /api/v1/data/queries/1/download.xlsx
+        def download
+          find_item
+          query_result = @item.result
+          basename = @item.file_basename
+          respond_to do |format|
+            format.json do
+              send_download(query_result.fetch(:result, ""), :json, basename)
+            end
+
+            format.csv do
+              send_download(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params), :csv, basename)
+            end
+
+            format.xlsx do
+              send_download(xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, :xlsx, basename)
+            end
+          end
+        end
+
         # GET /api/v1/data/queries/1/meta
         # GET /api/v1/data/queries/1/meta.json
         def meta
@@ -65,6 +87,7 @@ module GobiertoData
 
           render(
             json: @item,
+            serializer: ::GobiertoData::QueryMetaSerializer,
             exclude_links: true,
             links: links(:metadata),
             adapter: :json_api

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -18,5 +18,9 @@ module GobiertoData
     def result
       Connection.execute_query(site, sql)
     end
+
+    def file_basename
+      [dataset.slug, name].join("-").tr("_", " ").parameterize
+    end
   end
 end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -24,7 +24,7 @@ module GobiertoData
     attribute :formats do
       object.available_formats.inject({}) do |formats, format|
         formats.update(
-          format => gobierto_data_api_v1_dataset_path(object.slug, format: format)
+          format => download_gobierto_data_api_v1_dataset_path(object.slug, format: format)
         )
       end
     end

--- a/app/serializers/gobierto_data/query_meta_serializer.rb
+++ b/app/serializers/gobierto_data/query_meta_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class QueryMetaSerializer < QuerySerializer
+    attribute :formats do
+      id = object.id
+      object.dataset.available_formats.inject({}) do |formats, format|
+        formats.update(
+          format => download_gobierto_data_api_v1_query_path(id, format: format)
+        )
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -576,6 +576,7 @@ Rails.application.routes.draw do
               end
               member do
                 get "meta" => "datasets#dataset_meta"
+                get :download, format: true
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do
@@ -583,6 +584,7 @@ Rails.application.routes.draw do
               resources :favorites, only: [:index]
               member do
                 get :meta
+                get :download, format: true
               end
             end
             resources :visualizations, except: [:edit], defaults: { format: "json" } do

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -317,6 +317,7 @@ module GobiertoData
               assert resource_data["attributes"].has_key? attribute
               assert_equal attributes[attribute], resource_data["attributes"][attribute]
             end
+            assert resource_data["attributes"].has_key? "formats"
 
             # relationships
             assert resource_data.has_key? "relationships"
@@ -333,6 +334,52 @@ module GobiertoData
             assert_includes links, gobierto_data_api_v1_query_path(query)
             assert_includes links, meta_gobierto_data_api_v1_query_path(query)
             assert_includes links, gobierto_data_api_v1_visualizations_path(filter: { query_id: query.id })
+          end
+        end
+
+        # GET /api/v1/data/queries/1/download.json
+        def test_query_download_as_json
+          with(site: site) do
+            get download_gobierto_data_api_v1_query_path(query, format: :json), as: :json
+
+            assert_response :success
+            assert_match(/attachment; filename="?#{query.file_basename}.json"?/, response.headers["content-disposition"])
+            response_data = response.parsed_body
+            assert_equal 1, response_data.count
+            assert_equal [{ "count" => 7 }], response_data
+          end
+        end
+
+        # GET /api/v1/data/queries/1/download.csv
+        def test_query_download_as_csv
+          with(site: site) do
+            get download_gobierto_data_api_v1_query_path(query, format: :csv), as: :csv
+
+            assert_response :success
+            assert_match(/attachment; filename="?#{query.file_basename}.csv"?/, response.headers["content-disposition"])
+            response_data = response.parsed_body
+            parsed_csv = CSV.parse(response_data)
+
+            assert_equal 2, parsed_csv.count
+            assert_equal %w(count), parsed_csv.first
+            assert_equal %w(7), parsed_csv.last
+          end
+        end
+
+        # GET /api/v1/data/queries/1/download.xlsx
+        def test_query_download_as_xlsx
+          with(site: site) do
+            get download_gobierto_data_api_v1_query_path(query, format: :xlsx), as: :xlsx
+
+            assert_response :success
+            assert_match(/attachment; filename="?#{query.file_basename}.xlsx"?/, response.headers["content-disposition"])
+            parsed_xlsx = RubyXL::Parser.parse_buffer response.parsed_body
+
+            assert_equal 1, parsed_xlsx.worksheets.count
+            sheet = parsed_xlsx.worksheets.first
+            assert_nil sheet[2]
+            assert_equal %w(count), sheet[0].cells.map(&:value)
+            assert_equal [7], sheet[1].cells.map(&:value)
           end
         end
 


### PR DESCRIPTION
Closes #2768
Closes PopulateTools/issues#928


## :v: What does this PR do?

* Adds download actions to datasets and queries:
  * The response has an `attachment` content-disposition header with filename according to #2768
  * Meta endpoints of datasets and queries include a `formats` attribute with the corresponding paths to the download action

## :eyes: Screenshots

### Before this PR

<img width="391" alt="Screen Shot 2020-01-28 at 11 11 13" src="https://user-images.githubusercontent.com/446459/73254553-ef251d00-41be-11ea-9968-d8a2f7ba4d0c.png">

### After this PR

<img width="475" alt="Screen Shot 2020-01-28 at 11 08 23" src="https://user-images.githubusercontent.com/446459/73254527-de74a700-41be-11ea-8c54-d40069b85465.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation update suggested