### PR TITLE
Add timestamp and timestamptz sql transformation functions

### DIFF
--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -37,6 +37,18 @@ module GobiertoData
           sql: "select (to_date(nullif(trim($1), '#null_value'), '#date_format'));",
           optional_params: { date_format: "DD-MON-YYY", null_value: "" }
         },
+        timestamp: {
+          input_type: "text",
+          output_type: "timestamp",
+          sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format')::timestamp without time zone);",
+          optional_params: { date_format: "DD-MON-YYY", null_value: "" }
+        },
+        timestamptz: {
+          input_type: "text",
+          output_type: "timestamptz",
+          sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format'));",
+          optional_params: { date_format: "DD-MON-YYY", null_value: "" }
+        },
         boolean: {
           input_type: "text",
           output_type: "boolean",


### PR DESCRIPTION
Closes #2805


## :v: What does this PR do?

* Adds 2 new sql transformation functions to use in schema loading data from csv:
  * `timestamp`: Timestamp without timezone
  * `timestamptz`: Timestamp with timezone. The timezone is taken from timezone configured in database. For the moment it's not possible to specify a timezone.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation updated 
