### PR TITLE
Enable gobierto data as root page

### DIFF
--- a/app/models/gobierto_data.rb
+++ b/app/models/gobierto_data.rb
@@ -8,4 +8,8 @@ module GobiertoData
   def self.classes_with_custom_fields
     [GobiertoData::Dataset]
   end
+
+  def self.root_path(current_site)
+    Rails.application.routes.url_helpers.gobierto_data_root_path
+  end
 end

--- a/config/application.yml
+++ b/config/application.yml
@@ -63,6 +63,9 @@ default: &default
     -
       name: Gobierto Investments
       namespace: GobiertoInvestments
+    -
+      name: Gobierto Data
+      namespace: GobiertoData
   dns_config:
     cname_record_target: site.gobierto.test
     a_record_target: 222.111.222.11


### PR DESCRIPTION
## :v: What does this PR do?

This PR allows Gobierto data module to be the homepage of a site.

## :mag: How should this be manually tested?

Check in staging the data demo site.
