### PR TITLE
Cannot read property 'getFullYear' of undefined

### DIFF
--- a/app/javascript/lib/visualizations/modules/lineas_tabla.js
+++ b/app/javascript/lib/visualizations/modules/lineas_tabla.js
@@ -672,7 +672,8 @@ export class VisLineasJ {
       }
     });
 
-    return chosenYear;
+    // set default date if it's undefined
+    return chosenYear || new Date();
   }
 
   _mouseover() {


### PR DESCRIPTION
Closes #2816

## :v: What does this PR do?
If there's no `chosenYear` throws an error