### PR TITLE
Datasets load validations

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -208,11 +208,17 @@ module GobiertoData
                 :data_path,
                 :local_data,
                 :csv_separator,
-                :schema,
                 :append
               ]
+            ).merge(
+              schema: schema_json_param
             )
           end
+        end
+
+        def schema_json_param
+          schema_param = params.dig(:data, :attributes, :schema)
+          schema_param.is_a?(::ActionController::Parameters) ? schema_param.to_unsafe_h : {}
         end
       end
     end

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -97,7 +97,7 @@ module GobiertoData
         data_file.tempfile.rewind
         data_file.tempfile
       else
-        local_data ? File.open(data_path, "r") : URI.open(data_path)
+        local_data ? File.open(data_path, "r") : URI.open(data_path, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
       end
     end
 

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -14,6 +14,14 @@ module GobiertoData
     translates :name
 
     validates :site, :name, :slug, :table_name, presence: true
+    validates(
+      :table_name,
+      format: {
+        with: /\A[a-zA-Z_][a-zA-Z0-9_]+\z/,
+        message: I18n.t("errors.messages.invalid_table_name")
+      },
+      length: { maximum: 50 }
+    )
     validates :slug, uniqueness: { scope: :site_id }
 
     def attributes_for_slug

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -128,6 +128,8 @@ ca:
       invalid: no és vàlid
       invalid_consultation_response: No s'ha desat la consulta. Per favor, revisa
         els valors i prova de nou.
+      invalid_table_name: Ha de començar per una lletra o un guió baix; la resta només
+        pot contenir lletres, dígits o guions baixos
       less_than: ha de ser menor que %{count}
       less_than_or_equal_to: ha de ser menor o igual a %{count}
       not_a_number: no és un número

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -128,6 +128,8 @@ en:
       invalid: is invalid
       invalid_consultation_response: Consultation couldn't be saved. Please, review
         the responses and try again
+      invalid_table_name: Must start with a letter or an underscore; the rest can
+        only contain letters, digits or underscores
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
       not_a_number: is not a number

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -128,6 +128,8 @@ es:
       invalid: no es válido
       invalid_consultation_response: No se ha podido guardar la consulta. Por favor,
         revisa los valores e inténtalo de nuevo.
+      invalid_table_name: Debe comenzar con una letra o un guión bajo; el resto solo
+        puede contener letras, dígitos o guiones bajos
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}
       not_a_number: no es un número


### PR DESCRIPTION
Related to PopulateTools/issues#932
Closes PopulateTools/issues#933

## :v: What does this PR do?

* Adds some validations to datasets `table_name` attribute to prevent errors in database transaction
* Avoids SSL checks for data sources using HTTPS protocol
* Fixes errors when schema in JSON body include uppercase letters
* Improves detection of columns defined by user schema

## :mag: How should this be manually tested?

Use the requests of the issues (For PopulateTools/issues#932 correct the encoding of the file and use UTF-8)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Hmm, not really
