### PR TITLE
2695 datasets draft

### DIFF
--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -7,6 +7,8 @@ class ApiBaseController < ActionController::API
 
   before_action :disable_cors
 
+  rescue_from ActiveRecord::RecordNotFound, with: -> { send_not_found }
+
   def preferred_locale
     @preferred_locale ||= begin
                             locale_param = params[:locale]

--- a/app/controllers/gobierto_admin/gobierto_data/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/base_controller.rb
@@ -3,8 +3,16 @@
 module GobiertoAdmin
   module GobiertoData
     class BaseController < GobiertoAdmin::BaseController
+      helper_method :frontend_enabled?
+
       before_action { module_enabled!(current_site, "GobiertoData") }
       before_action { module_allowed!(current_admin, "GobiertoData") }
+
+      protected
+
+      def frontend_enabled?
+        @frontend_enabled ||= current_site.configuration.modules_with_frontend_enabled.include?("GobiertoData")
+      end
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -5,6 +5,8 @@ module GobiertoAdmin
     class DatasetsController < GobiertoAdmin::GobiertoData::BaseController
       include CustomFieldsHelper
 
+      helper_method :preview_url
+
       def index
         @datasets = current_site.datasets.order(id: :desc)
       end
@@ -85,6 +87,10 @@ module GobiertoAdmin
         current_site.datasets.find(params[:id])
       end
 
+      def preview_url(dataset, options = {})
+        options[:preview_token] = current_admin.preview_token unless dataset.active?
+        gobierto_data_datasets_url(dataset.slug, options)
+      end
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -72,6 +72,7 @@ module GobiertoAdmin
         params.require(:dataset).permit(
           :table_name,
           :slug,
+          :visibility_level,
           name_translations: [*I18n.available_locales]
         )
       end

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -6,6 +6,7 @@ module GobiertoData
       class BaseController < ApiBaseController
         include ActionController::MimeResponds
         include ::User::ApiAuthenticationHelper
+        include ::PreviewTokenHelper
 
         before_action { module_enabled!(current_site, "GobiertoData", false) }
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -149,7 +149,7 @@ module GobiertoData
         private
 
         def base_relation
-          current_site.datasets
+          current_site.datasets.send(valid_preview_token? ? :itself : :active)
         end
 
         def find_item

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -157,7 +157,7 @@ module GobiertoData
         end
 
         def execute_query(relation)
-          GobiertoData::Connection.execute_query(current_site, relation.to_sql)
+          GobiertoData::Connection.execute_query(current_site, relation.to_sql, include_draft: valid_preview_token?)
         end
 
         def links(self_key = nil)

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -195,6 +195,7 @@ module GobiertoData
               :schema,
               :schema_file,
               :append,
+              :visibility_level,
               name_translations: [*I18n.available_locales]
             )
           else
@@ -208,7 +209,9 @@ module GobiertoData
                 :data_path,
                 :local_data,
                 :csv_separator,
-                :append
+                :schema,
+                :append,
+                :visibility_level
               ]
             ).merge(
               schema: schema_json_param

--- a/app/controllers/gobierto_data/api/v1/favorites_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/favorites_controller.rb
@@ -71,11 +71,11 @@ module GobiertoData
         def find_favorited
           @favorited = case resource_type
                        when :dataset
-                         current_site.datasets.find_by(slug: params[:dataset_slug])
+                         current_site.datasets.send(valid_preview_token? ? :itself : :active).find_by(slug: params[:dataset_slug])
                        when :query
-                         current_site.queries.find_by(id: params[:query_id])
+                         current_site.queries.send(valid_preview_token? ? :itself : :active).find_by(id: params[:query_id])
                        when :visualization
-                         current_site.visualizations.find_by(id: params[:visualization_id])
+                         current_site.visualizations.send(valid_preview_token? ? :itself : :active).find_by(id: params[:visualization_id])
                        end
         end
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -34,7 +34,7 @@ module GobiertoData
         # GET /api/v1/data/queries/1.xlsx
         def show
           find_item
-          query_result = @item.result
+          query_result = @item.result(include_draft: valid_preview_token?)
           respond_to do |format|
             format.json do
               render(
@@ -63,7 +63,7 @@ module GobiertoData
         # GET /api/v1/data/queries/1/download.xlsx
         def download
           find_item
-          query_result = @item.result
+          query_result = @item.result(include_draft: valid_preview_token?)
           basename = @item.file_basename
           respond_to do |format|
             format.json do

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -160,12 +160,12 @@ module GobiertoData
           if find_dataset.present?
             @dataset.queries.open
           else
-            current_site.queries.open
+            current_site.queries.send(valid_preview_token? ? :itself : :active).open
           end
         end
 
         def find_dataset
-          @dataset = current_site.datasets.find_by(id: params[:dataset_id])
+          @dataset = current_site.datasets.send(valid_preview_token? ? :itself : :active).find_by(id: params[:dataset_id])
         end
 
         def query_params

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -34,7 +34,7 @@ module GobiertoData
         private
 
         def execute_query(sql)
-          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql))
+          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql), include_draft: valid_preview_token?)
         end
 
       end

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -109,16 +109,16 @@ module GobiertoData
           elsif find_query.present?
             @query.visualizations.open
           else
-            current_site.visualizations.open
+            current_site.visualizations.send(valid_preview_token? ? :itself : :active).open
           end
         end
 
         def find_query
-          @query = current_site.queries.find_by(id: params[:query_id])
+          @query = current_site.queries.send(valid_preview_token? ? :itself : :active).find_by(id: params[:query_id])
         end
 
         def find_dataset
-          @dataset = current_site.datasets.find_by(id: params[:dataset_id])
+          @dataset = current_site.datasets.send(valid_preview_token? ? :itself : :active).find_by(id: params[:dataset_id])
         end
 
         def visualization_params

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -14,6 +14,9 @@ module GobiertoAdmin
         :admin_id,
         :ip
       )
+      attr_writer(
+        :visibility_level
+      )
 
       validates :site_id, presence: true
       validate :table_reachable
@@ -25,6 +28,10 @@ module GobiertoAdmin
       notify_changed :name_translations, :table_name, :slug, as: :attribute
       use_publisher Publishers::AdminGobiertoDataActivity
       use_trackable_subject :dataset
+
+      def visibility_level
+        @visibility_level ||= "draft"
+      end
 
       def save
         save_dataset if valid?
@@ -40,6 +47,10 @@ module GobiertoAdmin
 
       def available_table_names
         ::GobiertoData::Connection.tables(site)
+      end
+
+      def available_visibility_levels
+        dataset_class.visibility_levels
       end
 
       private
@@ -58,6 +69,7 @@ module GobiertoAdmin
           attributes.name_translations = name_translations
           attributes.table_name = table_name
           attributes.slug = slug.blank? ? nil : slug
+          attributes.visibility_level = visibility_level
         end
 
         if @dataset.valid?

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -46,7 +46,7 @@ module GobiertoAdmin
       end
 
       def available_table_names
-        ::GobiertoData::Connection.tables(site, include_draft: true)
+        ::GobiertoData::Connection.tables(site, include_draft: true).sort
       end
 
       def available_visibility_levels

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -18,7 +18,7 @@ module GobiertoAdmin
         :visibility_level
       )
 
-      validates :site_id, presence: true
+      validates :site_id, :visibility_level, presence: true
       validate :table_reachable
 
       delegate :persisted?, to: :dataset

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -46,7 +46,7 @@ module GobiertoAdmin
       end
 
       def available_table_names
-        ::GobiertoData::Connection.tables(site)
+        ::GobiertoData::Connection.tables(site, include_draft: true)
       end
 
       def available_visibility_levels
@@ -86,9 +86,9 @@ module GobiertoAdmin
       end
 
       def table_reachable
-        query_result = ::GobiertoData::Connection.execute_query(site, Arel.sql("SELECT COUNT(*) FROM #{table_name} LIMIT 1"))
+        query_result = ::GobiertoData::Connection.execute_query(site, Arel.sql("SELECT COUNT(*) FROM #{table_name} LIMIT 1"), include_draft: true)
 
-        errors.add(:table_name, :invalid_table, error_message: query_result[:error]) if query_result.is_a?(Hash) && query_result.has_key?(:error)
+        errors.add(:table_name, :invalid_table, error_message: query_result[:error]) if query_result.is_a?(Hash) && query_result.has_key?(:errors)
       end
     end
   end

--- a/app/forms/gobierto_admin/gobierto_data/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/settings_form.rb
@@ -54,6 +54,7 @@ module GobiertoAdmin
         config = db_config_format
 
         ::GobiertoData::Connection.test_connection_config(config, :read_db_config)
+        ::GobiertoData::Connection.test_connection_config(config, :read_draft_db_config) if config&.has_key?(:read_draft_db_config)
         ::GobiertoData::Connection.test_connection_config(config, :write_db_config) if config&.has_key?(:write_db_config)
       rescue ActiveRecord::ActiveRecordError => e
         errors.add(:db_config, :invalid_connection, error_message: e.message)
@@ -91,7 +92,7 @@ module GobiertoAdmin
         config = db_config_format
         return config if config.blank?
 
-        config.has_key?(:read_db_config) ? config.slice(:read_db_config, :write_db_config) : { read_db_config: config }
+        config.has_key?(:read_db_config) ? config.slice(:read_db_config, :read_draft_db_config, :write_db_config) : { read_db_config: config }
       end
 
     end

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -8,7 +8,8 @@ module GobiertoData
     attr_accessor(
       :site_id,
       :data_path,
-      :data_file
+      :data_file,
+      :visibility_level
     )
 
     attr_writer(
@@ -115,6 +116,7 @@ module GobiertoData
         attributes.table_name = table_name
         attributes.name_translations = name_translations
         attributes.slug = slug
+        attributes.visibility_level = visibility_level
       end
 
       if @resource.save && load_data

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -8,8 +8,7 @@ module GobiertoData
     attr_accessor(
       :site_id,
       :data_path,
-      :data_file,
-      :visibility_level
+      :data_file
     )
 
     attr_writer(
@@ -22,11 +21,13 @@ module GobiertoData
       :name,
       :slug,
       :append,
-      :local_data
+      :local_data,
+      :visibility_level
     )
 
-    validates :table_name, :name, presence: true
+    validates :table_name, :name, :visibility_level, presence: true
     validates :name_translations, translated_attribute_presence: true
+    validates :visibility_level, inclusion: { in: Dataset.visibility_levels.keys }
 
     delegate :persisted?, :data_updated_at, to: :resource
 
@@ -65,6 +66,10 @@ module GobiertoData
 
     def name
       name_translations.with_indifferent_access[I18n.locale]
+    end
+
+    def visibility_level
+      @visibility_level ||= "draft"
     end
 
     def save

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -8,10 +8,11 @@ module GobiertoData
 
     class << self
 
-      def execute_query(site, query, include_stats: true, write: false)
-        connection_key = write ? :write_db_config : :read_db_config
+      def execute_query(site, query, include_stats: true, write: false, include_draft: false)
+        with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(write, include_draft)) do
+          connection.execute("CREATE SCHEMA IF NOT EXISTS draft") if write
+          connection.execute("SET search_path TO draft, public") if write || include_draft
 
-        with_connection(db_config(site), fallback: null_query, connection_key: connection_key) do
           event = nil
           if include_stats
             ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
@@ -34,10 +35,12 @@ module GobiertoData
         failed_query(e.message)
       end
 
-      def execute_write_query_from_file_using_stdin(site, query, file_path: nil)
+      def execute_write_query_from_file_using_stdin(site, query, file_path: nil, include_draft: false)
         return unless file_path.present?
 
         with_connection(db_config(site), fallback: null_query, connection_key: :write_db_config) do
+          connection.execute("CREATE SCHEMA IF NOT EXISTS draft") if include_draft
+
           raw_connection = connection.raw_connection
 
           execution = raw_connection.copy_data(query) do
@@ -78,6 +81,12 @@ module GobiertoData
         yield
       ensure
         establish_connection(base_connection_config)
+      end
+
+      def connection_key_from_options(write, include_draft)
+        access_mode_key = write ? "write_" : "read_"
+        draft_key = include_draft && !write ? "draft_" : ""
+        :"#{access_mode_key}#{draft_key}db_config"
       end
 
       def null_query

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -54,8 +54,9 @@ module GobiertoData
         failed_query(e.message)
       end
 
-      def tables(site)
-        with_connection(db_config(site)) do
+      def tables(site, include_draft: false)
+        with_connection(db_config(site), connection_key: connection_key_from_options(false, include_draft)) do
+          connection.execute("SET search_path TO draft, public") if include_draft
           connection.tables
         end
       end

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -24,7 +24,7 @@ module GobiertoData
       },
       length: { maximum: 50 }
     )
-    validates :slug, uniqueness: { scope: :site_id }
+    validates :slug, :table_name, uniqueness: { scope: :site_id }
 
     before_save :set_schema, if: :will_save_change_to_visibility_level?
 

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -13,6 +13,8 @@ module GobiertoData
 
     translates :name
 
+    enum visibility_level: { draft: 0, active: 1 }
+
     validates :site, :name, :slug, :table_name, presence: true
     validates(
       :table_name,

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -43,10 +43,12 @@ module GobiertoData
                          db_config = Connection.db_config(site)
                          return if db_config.blank?
 
-                         db_config = db_config.fetch(:read_db_config, db_config)
+                         db_config = db_config.values_at(:read_draft_db_config, :read_db_config).compact.first || db_config
 
                          Class.new(Connection).tap do |connection_model|
                            Connection.const_set(internal_rails_class_name, connection_model)
+                           connection_model.connection.execute("SET search_path TO draft, public")
+
                            connection_model.establish_connection(db_config)
                            connection_model.table_name = table_name
                          end

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -13,7 +13,9 @@ module GobiertoData
 
     translates :name
 
-    delegate :site, to: :dataset
+    scope :active, -> { joins(:dataset).where(GobiertoData::Dataset.table_name => { visibility_level: GobiertoData::Dataset.visibility_levels[:active] }) }
+
+    delegate :site, :visibility_level, to: :dataset
 
     def result
       Connection.execute_query(site, sql)

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -17,8 +17,8 @@ module GobiertoData
 
     delegate :site, :visibility_level, to: :dataset
 
-    def result
-      Connection.execute_query(site, sql)
+    def result(include_draft: false)
+      Connection.execute_query(site, sql, include_draft: include_draft)
     end
 
     def file_basename

--- a/app/models/gobierto_data/visualization.rb
+++ b/app/models/gobierto_data/visualization.rb
@@ -8,11 +8,14 @@ module GobiertoData
 
     belongs_to :query
     belongs_to :user
+    has_one :dataset, through: :query
     enum privacy_status: { open: 0, closed: 1 }
 
     translates :name
 
+    scope :active, -> { joins(:dataset).where(GobiertoData::Dataset.table_name => { visibility_level: GobiertoData::Dataset.visibility_levels[:active] }) }
+
     validates :query, :user, :name, presence: true
-    delegate :site, :dataset, to: :query
+    delegate :site, :dataset, :visibility_level, to: :query
   end
 end

--- a/app/serializers/gobierto_data/dataset_form_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_form_serializer.rb
@@ -5,7 +5,20 @@ module GobiertoData
     include Rails.application.routes.url_helpers
     include ::GobiertoCommon::HasCustomFieldsAttributes
 
-    attributes :id, :name, :name_translations, :table_name, :data_updated_at, :slug, :data_path, :local_data, :csv_separator, :schema, :append
+    attributes(
+      :id,
+      :name,
+      :name_translations,
+      :table_name,
+      :data_updated_at,
+      :slug,
+      :data_path,
+      :local_data,
+      :csv_separator,
+      :schema,
+      :append,
+      :visibility_level
+    )
 
     def current_site
       Site.find_by(id: object.site_id) || instance_options[:site]

--- a/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
@@ -47,19 +47,7 @@
 
     <div class="pure-u-1 pure-u-md-2-24"></div>
 
-    <div class="pure-u-1 pure-u-md-1-4 ">
-
-      <div class="stick_in_parent">
-
-        <div class="widget_save ">
-
-          <%= f.submit class: "button" %>
-
-        </div>
-
-      </div>
-
-    </div>
+    <%= render partial: 'gobierto_admin/shared/save_widget', locals: { f: f, levels: @dataset_form.available_visibility_levels } %>
 
   </div>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
@@ -20,6 +20,7 @@
       <th class="icon_col"></th>
       <th><%= t(".header.name") %></th>
       <th><%= t(".header.table_name") %></th>
+      <th><%= t(".header.status") %></th>
       <th class="icon_col"></th>
     </tr>
   </thead>
@@ -36,6 +37,14 @@
       </td>
       <td>
         <%= dataset.table_name %>
+      </td>
+      <td class="visibility_level">
+        <% if dataset.draft? %>
+          <i class="fas fa-lock"></i>
+        <% else %>
+          <i class="fas fa-check"></i>
+        <% end %>
+        <%= t("gobierto_admin.shared.save_widget.visibility_level.#{dataset.visibility_level}") %>
       </td>
       <td>
         <%= link_to admin_data_dataset_path(dataset.id),

--- a/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/index.html.erb
@@ -21,6 +21,9 @@
       <th><%= t(".header.name") %></th>
       <th><%= t(".header.table_name") %></th>
       <th><%= t(".header.status") %></th>
+      <% if frontend_enabled? %>
+        <th></th>
+      <% end %>
       <th class="icon_col"></th>
     </tr>
   </thead>
@@ -46,6 +49,14 @@
         <% end %>
         <%= t("gobierto_admin.shared.save_widget.visibility_level.#{dataset.visibility_level}") %>
       </td>
+      <% if frontend_enabled? %>
+        <td>
+          <%= link_to preview_url(dataset, host: current_site.domain), target: "_blank", class: "view_item" do %>
+            <i class="fas fa-eye"></i>
+            <%= t(".view_dataset") %>
+          <% end %>
+        </td>
+      <% end %>
       <td>
         <%= link_to admin_data_dataset_path(dataset.id),
                     title: t("gobierto_admin.shared.archive.element"),

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -24,5 +24,6 @@ ca:
             table_name: Nom de la taula
           new: Nou
           title: Conjunts de dades
+          view_dataset: Veure conjunt de dades
         new:
           title: Nou conjunt de dades

--- a/config/locales/gobierto_admin/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/ca.yml
@@ -20,6 +20,7 @@ ca:
         index:
           header:
             name: Nom
+            status: Estat
             table_name: Nom de la taula
           new: Nou
           title: Conjunts de dades

--- a/config/locales/gobierto_admin/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/en.yml
@@ -20,6 +20,7 @@ en:
         index:
           header:
             name: Name
+            status: Status
             table_name: Table name
           new: New
           title: Datasets

--- a/config/locales/gobierto_admin/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/en.yml
@@ -24,5 +24,6 @@ en:
             table_name: Table name
           new: New
           title: Datasets
+          view_dataset: See dataset
         new:
           title: New dataset

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -20,6 +20,7 @@ es:
         index:
           header:
             name: Nombre
+            status: Estado
             table_name: Nombre de la tabla
           new: Nuevo
           title: Conjuntos de datos

--- a/config/locales/gobierto_admin/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/views/es.yml
@@ -24,5 +24,6 @@ es:
             table_name: Nombre de la tabla
           new: Nuevo
           title: Conjuntos de datos
+          view_dataset: Ver conjunto de datos
         new:
           title: Nuevo conjunto de datos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -562,7 +562,7 @@ Rails.application.routes.draw do
     namespace :gobierto_data, path: "/" do
       constraints GobiertoSiteConstraint.new do
         get "/datos" => "welcome#index", as: :root
-        get "/datos/:id" => "welcome#index"
+        get "/datos/:id" => "welcome#index", as: :datasets
 
         # API
         namespace :api, path: "/" do

--- a/db/migrate/20200129160520_add_visibility_level_to_gdata_datasets.rb
+++ b/db/migrate/20200129160520_add_visibility_level_to_gdata_datasets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibilityLevelToGdataDatasets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :gdata_datasets, :visibility_level, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20200129160520_add_visibility_level_to_gdata_datasets.rb
+++ b/db/migrate/20200129160520_add_visibility_level_to_gdata_datasets.rb
@@ -3,5 +3,7 @@
 class AddVisibilityLevelToGdataDatasets < ActiveRecord::Migration[5.2]
   def change
     add_column :gdata_datasets, :visibility_level, :integer, null: false, default: 0
+
+    GobiertoData::Dataset.update_all(visibility_level: 1)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_102016) do
+ActiveRecord::Schema.define(version: 2020_01_29_160520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -531,6 +531,7 @@ ActiveRecord::Schema.define(version: 2020_01_17_102016) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "data_updated_at"
+    t.integer "visibility_level", default: 0, null: false
     t.index ["site_id"], name: "index_gdata_datasets_on_site_id"
   end
 

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -19,8 +19,8 @@ module GobiertoData
           @user ||= users(:dennis)
         end
 
-        def datasets_count
-          @datasets_count ||= site.datasets.count
+        def active_datasets_count
+          @active_datasets_count ||= site.datasets.active.count
         end
 
         def dataset
@@ -64,7 +64,7 @@ module GobiertoData
             response_data = response.parsed_body
 
             assert response_data.has_key? "data"
-            assert_equal datasets_count, response_data["data"].count
+            assert_equal active_datasets_count, response_data["data"].count
             datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
             assert_includes datasets_names, dataset.name
             refute_includes datasets_names, other_site_dataset.name
@@ -84,7 +84,7 @@ module GobiertoData
             response_data = response.parsed_body
             parsed_csv = CSV.parse(response_data).map { |row| row.map(&:to_s) }
 
-            assert_equal datasets_count + 1, parsed_csv.count
+            assert_equal active_datasets_count + 1, parsed_csv.count
             assert_equal %w(id name slug table_name data_updated_at category), parsed_csv.first
             assert_includes parsed_csv, array_data(dataset)
             refute_includes parsed_csv, array_data(other_site_dataset)
@@ -118,9 +118,9 @@ module GobiertoData
 
             assert_equal 1, parsed_xlsx.worksheets.count
             sheet = parsed_xlsx.worksheets.first
-            assert_nil sheet[datasets_count + 1]
+            assert_nil sheet[active_datasets_count + 1]
             assert_equal %w(id name slug table_name data_updated_at category), sheet[0].cells.map(&:value)
-            values = (1..datasets_count).map do |row_number|
+            values = (1..active_datasets_count).map do |row_number|
               sheet[row_number].cells.map { |cell| cell.value.to_s }
             end
             assert_includes values, array_data(dataset)

--- a/test/controllers/gobierto_data/api/v1/drafts_controllers_test.rb
+++ b/test/controllers/gobierto_data/api/v1/drafts_controllers_test.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class DraftsControllersTest < GobiertoControllerTest
+        self.use_transactional_tests = false
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def user
+          @user ||= users(:dennis)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def active_dataset
+          @active_dataset ||= gobierto_data_datasets(:events_dataset)
+        end
+
+        def draft_dataset
+          @draft_dataset ||= gobierto_data_datasets(:draft_dataset)
+        end
+
+        def draft_query
+          @draft_query ||= gobierto_data_queries(:draft_dataset_query)
+        end
+
+        def draft_visualization
+          @draft_visualization ||= gobierto_data_visualizations(:draft_dataset_visualization)
+        end
+
+        def array_data(dataset)
+          [
+            dataset.id.to_s,
+            dataset.name,
+            dataset.slug,
+            dataset.table_name,
+            dataset.data_updated_at.to_s,
+            GobiertoCommon::CustomFieldRecord.find_by(item: dataset, custom_field: datasets_category)&.value_string
+          ]
+        end
+
+        def test_query_draft_dataset_table_without_preview_token
+          active_dataset.update_attribute(:visibility_level, "draft")
+
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM gc_events"), as: :json
+
+            assert_response :bad_request
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "errors"
+            assert_match(/PG::UndefinedTable/, response_data["errors"].first["sql"])
+          end
+          active_dataset.update_attribute(:visibility_level, "active")
+        end
+
+        def test_query_draft_dataset_table_with_valid_preview_token
+          events_count = GobiertoCalendars::Event.count
+          active_dataset.update_attribute(:visibility_level, "draft")
+
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT COUNT(*) AS test_count FROM gc_events", preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal 1, response_data["data"].count
+            assert_equal events_count, response_data["data"].first["test_count"]
+          end
+          active_dataset.update_attribute(:visibility_level, "active")
+        end
+
+        # GET /api/v1/data/datasets.json
+        def test_datasets_index_without_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_datasets_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            refute_includes datasets_names, draft_dataset.name
+          end
+        end
+
+        # GET /api/v1/data/datasets.json
+        def test_datasets_index_with_valid_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_datasets_path(preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes datasets_names, draft_dataset.name
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug.json
+        def test_draft_dataset_data_without_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_dataset_path(draft_dataset.slug), as: :json
+
+            assert_response :not_found
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug.json
+        def test_draft_dataset_data_with_valid_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_dataset_path(draft_dataset.slug, preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+          end
+        end
+
+        # GET /api/v1/data/datasets/dataset-slug/metadata
+        def test_dataset_metadata_with_valid_preview_token
+          with(site: site) do
+            get meta_gobierto_data_api_v1_dataset_path(draft_dataset.slug, preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+          end
+        end
+
+        def test_queries_index_without_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            refute_includes queries_names, draft_query.name
+          end
+        end
+
+        def test_queries_index_with_valid_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_queries_path(preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes queries_names, draft_query.name
+          end
+        end
+
+        def test_draft_query_show_without_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_query_path(draft_query), as: :json
+
+            assert_response :not_found
+          end
+        end
+
+        def test_draft_query_show_with_valid_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_query_path(draft_query, preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+          end
+        end
+
+        def test_visualizations_index_without_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            refute_includes visualizations_names, draft_visualization.name
+          end
+        end
+
+        def test_visualizations_index_with_valid_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_visualizations_path(preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
+            assert_includes visualizations_names, draft_visualization.name
+          end
+        end
+
+        def test_draft_visualization_show_without_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_visualization_path(draft_visualization), as: :json
+
+            assert_response :not_found
+          end
+        end
+
+        def test_draft_visualization_show_with_valid_preview_token
+          with(site: site) do
+            get gobierto_data_api_v1_visualization_path(draft_visualization, preview_token: admin.preview_token), as: :json
+
+            assert_response :success
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/queries_controller_test.rb
@@ -55,12 +55,12 @@ module GobiertoData
           @other_dataset ||= gobierto_data_datasets(:events_dataset)
         end
 
-        def queries_count
-          @queries_count ||= site.queries.count
+        def active_queries_count
+          @active_queries_count ||= site.queries.active.count
         end
 
-        def open_queries_count
-          @open_queries_count ||= site.queries.open.count
+        def open_active_queries_count
+          @open_active_queries_count ||= site.queries.active.open.count
         end
 
         def attributes_data(query)
@@ -124,8 +124,8 @@ module GobiertoData
             response_data = response.parsed_body
 
             assert response_data.has_key? "data"
-            refute_equal queries_count, response_data["data"].count
-            assert_equal open_queries_count, response_data["data"].count
+            refute_equal active_queries_count, response_data["data"].count
+            assert_equal open_active_queries_count, response_data["data"].count
             queries_names = response_data["data"].map { |item| item.dig("attributes", "name") }
             assert_includes queries_names, open_query.name
             refute_includes queries_names, closed_query.name
@@ -147,8 +147,8 @@ module GobiertoData
             response_data = response.parsed_body
             parsed_csv = CSV.parse(response_data)
 
-            refute_equal queries_count + 1, parsed_csv.count
-            assert_equal open_queries_count + 1, parsed_csv.count
+            refute_equal active_queries_count + 1, parsed_csv.count
+            assert_equal open_active_queries_count + 1, parsed_csv.count
             assert_equal %w(id name privacy_status sql dataset_id user_id), parsed_csv.first
             assert_includes parsed_csv, array_data(open_query)
             refute_includes parsed_csv, array_data(closed_query)
@@ -182,9 +182,9 @@ module GobiertoData
 
             assert_equal 1, parsed_xlsx.worksheets.count
             sheet = parsed_xlsx.worksheets.first
-            assert_nil sheet[open_queries_count + 1]
+            assert_nil sheet[open_active_queries_count + 1]
             assert_equal %w(id name privacy_status sql dataset_id user_id), sheet[0].cells.map(&:value)
-            values = (1..open_queries_count).map do |row_number|
+            values = (1..open_active_queries_count).map do |row_number|
               sheet[row_number].cells.map { |cell| cell.value.to_s }
             end
             assert_includes values, array_data(open_query)

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -72,12 +72,12 @@ module GobiertoData
           @other_dataset ||= gobierto_data_datasets(:events_dataset)
         end
 
-        def visualizations_count
-          @visualizations_count ||= site.visualizations.count
+        def active_visualizations_count
+          @active_visualizations_count ||= site.visualizations.active.count
         end
 
-        def open_visualizations_count
-          @open_visualizations_count ||= site.visualizations.open.count
+        def open_active_visualizations_count
+          @open_active_visualizations_count ||= site.visualizations.active.open.count
         end
 
         def attributes_data(visualization)
@@ -145,8 +145,8 @@ module GobiertoData
             response_data = response.parsed_body
 
             assert response_data.has_key? "data"
-            refute_equal visualizations_count, response_data["data"].count
-            assert_equal open_visualizations_count, response_data["data"].count
+            refute_equal active_visualizations_count, response_data["data"].count
+            assert_equal open_active_visualizations_count, response_data["data"].count
             visualizations_names = response_data["data"].map { |item| item.dig("attributes", "name") }
             assert_includes visualizations_names, open_visualization.name
             refute_includes visualizations_names, closed_visualization.name
@@ -167,8 +167,8 @@ module GobiertoData
             response_data = response.parsed_body
             parsed_csv = CSV.parse(response_data)
 
-            refute_equal visualizations_count + 1, parsed_csv.count
-            assert_equal open_visualizations_count + 1, parsed_csv.count
+            refute_equal active_visualizations_count + 1, parsed_csv.count
+            assert_equal open_active_visualizations_count + 1, parsed_csv.count
             assert_equal %w(id name privacy_status spec query_id user_id), parsed_csv.first
             assert_includes parsed_csv, array_data(open_visualization)
             refute_includes parsed_csv, array_data(closed_visualization)
@@ -202,9 +202,9 @@ module GobiertoData
 
             assert_equal 1, parsed_xlsx.worksheets.count
             sheet = parsed_xlsx.worksheets.first
-            assert_nil sheet[open_visualizations_count + 1]
+            assert_nil sheet[open_active_visualizations_count + 1]
             assert_equal %w(id name privacy_status spec query_id user_id), sheet[0].cells.map(&:value)
-            values = (1..open_visualizations_count).map do |row_number|
+            values = (1..open_active_visualizations_count).map do |row_number|
               sheet[row_number].cells.map { |cell| cell.value.to_s }
             end
             assert_includes values, array_data(open_visualization)

--- a/test/fixtures/gobierto_data/datasets.yml
+++ b/test/fixtures/gobierto_data/datasets.yml
@@ -5,6 +5,7 @@ users_dataset:
   slug: users-dataset
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
 
 events_dataset:
   site: madrid
@@ -13,6 +14,16 @@ events_dataset:
   slug: events-dataset
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
+
+draft_dataset:
+  site: madrid
+  name_translations: <%= { en: "Interest Groups", es: "Grupos de Interés" }.to_json %>
+  table_name: gp_interest_groups
+  slug: interest-groups-dataset
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+  visibility_level: <%= GobiertoData::Dataset.visibility_levels["draft"] %>
 
 santander_dataset:
   site: santander
@@ -21,3 +32,4 @@ santander_dataset:
   slug: santander-dataset
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+  visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>

--- a/test/fixtures/gobierto_data/favorites.yml
+++ b/test/fixtures/gobierto_data/favorites.yml
@@ -57,3 +57,21 @@ janet_events_count_closed_visualization:
   favorited: events_count_closed_visualization (GobiertoData::Visualization)
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+
+draft_dataset_favorite:
+  user: dennis
+  favorited: draft_dataset (GobiertoData::Dataset)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+
+draft_query_favorite:
+  user: dennis
+  favorited: draft_dataset_query (GobiertoData::Query)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+
+draft_visualization_favorite:
+  user: dennis
+  favorited: draft_dataset_visualization (GobiertoData::Visualization)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>

--- a/test/fixtures/gobierto_data/queries.yml
+++ b/test/fixtures/gobierto_data/queries.yml
@@ -18,3 +18,10 @@ events_count_query:
   name_translations: <%= { en: "Published events", es: "Eventos publicados" }.to_json %>
   privacy_status: <%= GobiertoData::Query.privacy_statuses["open"] %>
   sql: "select * from events where state = <%= GobiertoCalendars::Event.states["published"] %>"
+
+draft_dataset_query:
+  dataset: draft_dataset
+  user: dennis
+  name_translations: <%= { en: "Interest Groups by domain", es: "Grupos de interés por dominio" }.to_json %>
+  privacy_status: <%= GobiertoData::Query.privacy_statuses["open"] %>
+  sql: "select sites.domain, count(*) from gp_interest_groups join sites on gp_interest_groups.site_id = sites.id group by sites.domain"

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -53,3 +53,10 @@ events_count_closed_visualization:
   name_translations: <%= { en: "Events count visualization closed", es: "Visualización de cuenta de eventos cerrada" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["closed"] %>
   spec: "{}"
+
+draft_dataset_visualization:
+  query: draft_dataset_query
+  user: dennis
+  name_translations: <%= { en: "Interest Groups by domain visualization", es: "Visualización de grupos de interés por dominio" }.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["closed"] %>
+  spec: "{}"

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -58,5 +58,5 @@ draft_dataset_visualization:
   query: draft_dataset_query
   user: dennis
   name_translations: <%= { en: "Interest Groups by domain visualization", es: "Visualización de grupos de interés por dominio" }.to_json %>
-  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["closed"] %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
   spec: "{}"

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -153,6 +153,7 @@ gobierto_data_settings_madrid:
   settings: <%= {
     db_config: {
       read_db_config: Rails.configuration.database_configuration["test"],
+      read_draft_db_config: Rails.configuration.database_configuration["test"],
       write_db_config: Rails.configuration.database_configuration["test"]
     }
   }.to_json %>

--- a/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
@@ -6,6 +6,8 @@ module GobiertoAdmin
   module GobiertoData
     module Datasets
       class CreateDatasetTest < ActionDispatch::IntegrationTest
+        self.use_transactional_tests = false
+
         def setup
           super
           @path = new_admin_data_dataset_path

--- a/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
@@ -63,6 +63,10 @@ module GobiertoAdmin
             select "vocabularies", from: "dataset_table_name"
             fill_in "dataset_slug", with: "vocabularies-slug"
 
+            within ".widget_save" do
+              find("label", text: "Published").click
+            end
+
             click_button "Create"
 
             assert has_message?("Dataset created correctly.")

--- a/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
@@ -9,6 +9,7 @@ module GobiertoAdmin
         def setup
           super
           @path = edit_admin_data_dataset_path(dataset)
+          @draft_path = edit_admin_data_dataset_path(draft_dataset)
         end
 
         def admin
@@ -29,6 +30,10 @@ module GobiertoAdmin
 
         def dataset
           @dataset ||= gobierto_data_datasets(:users_dataset)
+        end
+
+        def draft_dataset
+          @draft_dataset ||= gobierto_data_datasets(:draft_dataset)
         end
 
         def test_regular_admin_permissions_not_authorized
@@ -102,6 +107,17 @@ module GobiertoAdmin
               assert has_message?("Dataset updated correctly.")
               assert has_select?("Category", selected: "Economy")
             end
+          end
+        end
+
+        def publish_dataset
+          with(site: site, admin: admin, js: true) do
+            within ".widget_save" do
+              find("label", text: "Published").click
+            end
+            click_button "Update"
+
+            assert has_message?("Dataset updated correctly.")
           end
         end
       end


### PR DESCRIPTION
Closes #2695


## :v: What does this PR do?

Adds visibility level (draft/active) to datasets and dependant resources:
* Adds visibility_level to datasets model. Draft by default.
* Allows admins to set visibility_level from backoffice and API.
* Filters in API responses the draft datasets and dependant queries and visualizations.
* Disables endpoints to favorites lists and actions for draft resources.
* Adds a callback to move tables of datasets between a public and draft schema depending on the visisbility_level.
* Adds a module database configuration with a connection with a user with read permissions and access to draft schema.
* Allows admins to get draft datasets and send queries to tables in draft schema if they are using a valid preview_token in the API request params.
* Changes backoffice dataset_form and controller to check draft connection and list tables both in public and draft schemas.
* Adds tests using draft schema.
* Adds links to datasets in front (if enabled) adding preview_token if the dataset has draft status.
* Adds a validation to avoid datasets sharing the same table.

## :shipit: Does this PR changes any configuration file?

Yes, Ansible must create draft schema an user in datasets and add permissions to existing tables

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Suggestions sent
