### PR TITLE
940 show users they are using a saved query

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
@@ -63,10 +63,6 @@ export default {
   created(){
     this.$root.$on('sendYourCode', this.runYourQuery)
     this.tableName = this.$route.params.tableName
-  },
-  mounted() {
-    this.$root.$on('postRecentQuery', this.saveNewRecentQuery)
-    this.$root.$on('activateModalRecent', this.saveRecentQuery)
     if (localStorage.getItem('recentQueries')) {
       try {
         this.recentQueries = JSON.parse(localStorage.getItem('recentQueries'));
@@ -74,6 +70,10 @@ export default {
         localStorage.removeItem('recentQueries');
       }
     }
+    this.$root.$on('activateModalRecent', this.loadRecentQuery)
+  },
+  mounted() {
+    this.$root.$on('postRecentQuery', this.saveNewRecentQuery)
     this.getSlug()
   },
   methods: {

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
@@ -95,6 +95,9 @@ export default {
         this.saveRecentQuery();
       }
     },
+    loadRecentQuery() {
+      this.$root.$emit('storeQuery', this.recentQueries)
+    },
     saveRecentQuery() {
       const parsed = JSON.stringify(this.recentQueries);
       localStorage.setItem('recentQueries', parsed);

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -259,9 +259,12 @@ export default {
       this.runQuery()
     },
     queryParams(queryParams) {
+      this.saveQueryState = true;
+      this.showBtnCancel = true;
+      this.showBtnSave = true;
       this.disabledRecents = false;
       this.disabledSave = false;
-      this.disabledRunQuery = false;
+      this.$root.$emit('saveQueryState', true);
 
       this.labelQueryName = queryParams[0]
       this.privacyStatus = queryParams[1]

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -65,7 +65,7 @@
           v-model="labelQueryName"
           type="text"
           class="gobierto-data-sql-editor-container-save-text"
-          @keyup="labelQueryName = $event.target.value; onSave()"
+          @keyup="onSave($event.target.value)"
         >
         <input
           v-if="showLabelPrivate"
@@ -253,8 +253,9 @@ export default {
     this.token = getToken()
   },
   methods: {
-    onSave() {
+    onSave(queryName) {
       this.disabledSave = false
+      this.labelQueryName = queryName
     },
     runYourQuery(code) {
       this.queryEditor = code

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -65,7 +65,7 @@
           v-model="labelQueryName"
           type="text"
           class="gobierto-data-sql-editor-container-save-text"
-          @keyup="nameQuery = $event.target.value; onSave()"
+          @keyup="labelQueryName = $event.target.value; onSave()"
         >
         <input
           v-if="showLabelPrivate"
@@ -218,7 +218,6 @@ export default {
       labelQueryName: '',
       labelEdit: '',
       labelModifiedQuery: '',
-      nameQuery: '',
       codeQuery: '',
       endPoint: '',
       privacyStatus: '',
@@ -304,7 +303,7 @@ export default {
     },
     saveQueryName() {
       this.showSaveQueries = true
-      if (this.saveQueryState === true && this.nameQuery.length > 0) {
+      if (this.saveQueryState === true && this.labelQueryName.length > 0) {
         this.showBtnCancel = false;
         this.showBtnEdit = true;
         this.showBtnSave = false;
@@ -338,7 +337,7 @@ export default {
       this.disableInputName = false;
     },
     cancelQuery() {
-      if (this.nameQuery.length > 0) {
+      if (this.labelQueryName.length > 0) {
         this.showBtnCancel = false;
         this.showBtnEdit = true;
         this.showBtnSave = false;
@@ -427,7 +426,7 @@ export default {
           "data": {
               "type": "gobierto_data-queries",
               "attributes": {
-                  "name": this.nameQuery,
+                  "name": this.labelQueryName,
                   "privacy_status": this.privacyStatus,
                   "sql": this.codeQuery,
                   "dataset_id": this.datasetId

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -73,7 +73,7 @@
           :checked="privateQuery"
           type="checkbox"
           class="gobierto-data-sql-editor-container-save-checkbox"
-          @input="privateQuery = $event.target.checked"
+          @input="privateQueryValue($event.target.checked)"
         >
         <label
           v-if="showLabelPrivate"
@@ -417,6 +417,10 @@ export default {
           'Authorization': `${this.token}`
         }
       });
+    },
+    privateQueryValue(valuePrivate) {
+      this.disabledSave = false
+      this.privateQuery = valuePrivate
     },
     postQuery() {
       this.urlPath = location.origin

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -62,10 +62,10 @@
         <input
           ref="inputText"
           :class="disableInputName ? 'disable-input-text' : ' '"
-          :placeholder="labelQueryName"
+          v-model="labelQueryName"
           type="text"
           class="gobierto-data-sql-editor-container-save-text"
-          @keyup="nameQuery = $event.target.value"
+          @keyup="nameQuery = $event.target.value; onSave()"
         >
         <input
           v-if="showLabelPrivate"
@@ -254,16 +254,23 @@ export default {
     this.token = getToken()
   },
   methods: {
+    onSave() {
+      this.disabledSave = false
+    },
     runYourQuery(code) {
       this.queryEditor = code
       this.runQuery()
     },
     queryParams(queryParams) {
       this.saveQueryState = true;
-      this.showBtnCancel = true;
-      this.showBtnSave = true;
+      this.showBtnCancel = false;
+      this.showBtnSave = false;
       this.disabledRecents = false;
-      this.disabledSave = false;
+      this.disabledSave = true;
+      this.showBtnEdit = true;
+      this.removeLabelBtn = true;
+      this.showLabelPrivate = false;
+      this.disableInputName = true;
       this.$root.$emit('saveQueryState', true);
 
       this.labelQueryName = queryParams[0]


### PR DESCRIPTION
Closes #N
https://github.com/PopulateTools/issues/issues/940

## :v: What does this PR do?
When user load query, we show name query, privacy status and edit button

## :eyes: Screenshots

### Before this PR
![before-load-query 2020-01-30 11_26_45](https://user-images.githubusercontent.com/2649175/73441532-6f7c8700-4353-11ea-86e3-dbf80915384e.gif)
### After this PR
![saved-query 2020-01-30 11_25_08](https://user-images.githubusercontent.com/2649175/73441382-35ab8080-4353-11ea-90b0-91d803dab0b1.gif)

