### PR TITLE
enable recent queries | make modal more bigger

### DIFF
--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -433,8 +433,8 @@
     background-color: #fff;
     z-index: 10;
     top: 135%;
-    width: max-content;
-    min-width: 50rem;
+    width: 50rem;
+    max-width: 50rem;
 
     &.active {
       display: block;

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -433,10 +433,10 @@
     background-color: #fff;
     z-index: 10;
     top: 135%;
-    width: 40vw;
+    width: 50vw;
     max-height: 600px;
-    height: 25vw;
-
+    height: 35vw;
+    max-width: 750px;
     &.active {
       display: block;
     }

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -1,8 +1,9 @@
-.gobierto-data {
+:root {
+  --transition: .1s ease-in;
+  --shadow: 0 2px 20px rgba(0, 0, 0, .3);
+}
 
-  :root {
-    --transition: .1s ease-in;
-  }
+.gobierto-data {
 
   @include min-screen(768) {
     @include gutters(66px)
@@ -15,7 +16,6 @@
 
   &-home-nav--tab {
     list-style: none;
-
     display: inline-block;
     color: var(--color-base);
     text-transform: uppercase;
@@ -348,7 +348,7 @@
 
   &-btn-download-data-modal,
   &-sql-editor-recent-queries {
-    box-shadow: 0 2px 20px rgba(0, 0, 0, .3);
+    box-shadow: var(--shadow);
     border: 1px solid var(--color-base);
     border-radius: 3px;
     padding: .5rem 0;
@@ -744,6 +744,7 @@
   }
 
   &-sql-editor-your-queries-container {
+    box-shadow: var(--shadow);
     position: absolute;
     top: 45px;
     left: 0;

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -419,7 +419,7 @@
   }
 
   &-btn-download-data-modal-container {
-    overflow: scroll;
+    overflow-y: scroll;
     height: 100%;
   }
 

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -728,6 +728,9 @@
   }
 
   &-sql-editor-your-queries-container {
+    @include min-screen(768) {
+      width: 50vw;
+    }
     box-shadow: var(--shadow);
     position: absolute;
     top: 45px;
@@ -735,7 +738,7 @@
     background: white;
     padding: 0;
     z-index: 10;
-    width: 50vw;
+    width: 70vw;
 
     .gobierto-data-summary-queries-panel {
       border-color: var(--color-base);

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -356,7 +356,7 @@
     width: 30rem;
     display: none;
     top: 100%;
-    height: 160px;
+    height: 210px;
     background-color: #fff;
 
     &.modal-left {
@@ -433,8 +433,7 @@
     background-color: #fff;
     z-index: 10;
     top: 135%;
-    width: 50rem;
-    max-width: 50rem;
+    width: 50vw;
 
     &.active {
       display: block;
@@ -699,7 +698,6 @@
     padding: .5rem;
     font-size: 14px;
     font-weight: normal;
-    color: #000;
     display: block;
     width: 100%;
     border-radius: 0;
@@ -707,6 +705,7 @@
     text-transform: none !important;
     box-sizing: border-box;
     position: relative;
+    color: #666;
 
     &:hover {
       background-color: rgba(var(--color-base-string), .1);
@@ -714,21 +713,6 @@
       &::before {
         display: inline-block;
       }
-    }
-
-    &::before {
-      padding: .5rem;
-      content: attr(data-id);
-      background-color: var(--color-base);
-      width: max-content;
-      display: none;
-      color: #fff;
-      position: absolute;
-      left: 0;
-      top: 0;
-      z-index: 10;
-      width: 100%;
-
     }
   }
 

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -433,7 +433,9 @@
     background-color: #fff;
     z-index: 10;
     top: 135%;
-    width: 50vw;
+    width: 40vw;
+    max-height: 600px;
+    height: 25vw;
 
     &.active {
       display: block;
@@ -706,6 +708,7 @@
     box-sizing: border-box;
     position: relative;
     color: #666;
+    font-family: monospace;
 
     &:hover {
       background-color: rgba(var(--color-base-string), .1);

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -433,9 +433,19 @@
     background-color: #fff;
     z-index: 10;
     top: 135%;
+    width: max-content;
+    min-width: 50rem;
 
     &.active {
       display: block;
+    }
+
+    &.arrow-top.modal-left {
+
+      &::after,
+      &::before {
+        left: 2%;
+      }
     }
 
   }

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
@@ -63,10 +63,6 @@ export default {
   created(){
     this.$root.$on('sendYourCode', this.runYourQuery)
     this.tableName = this.$route.params.tableName
-  },
-  mounted() {
-    this.$root.$on('postRecentQuery', this.saveNewRecentQuery)
-    this.$root.$on('activateModalRecent', this.saveRecentQuery)
     if (localStorage.getItem('recentQueries')) {
       try {
         this.recentQueries = JSON.parse(localStorage.getItem('recentQueries'));
@@ -74,6 +70,10 @@ export default {
         localStorage.removeItem('recentQueries');
       }
     }
+    this.$root.$on('activateModalRecent', this.loadRecentQuery)
+  },
+  mounted() {
+    this.$root.$on('postRecentQuery', this.saveNewRecentQuery)
     this.getSlug()
   },
   methods: {
@@ -98,6 +98,9 @@ export default {
     saveRecentQuery() {
       const parsed = JSON.stringify(this.recentQueries);
       localStorage.setItem('recentQueries', parsed);
+      this.$root.$emit('storeQuery', this.recentQueries)
+    },
+    loadRecentQuery() {
       this.$root.$emit('storeQuery', this.recentQueries)
     },
     getSlug() {

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditor.vue
@@ -89,9 +89,6 @@ export default {
         this.saveRecentQuery();
       }
     },
-    loadRecentQuery() {
-      this.$root.$emit('storeQuery', this.recentQueries)
-    },
     saveRecentQuery() {
       const parsed = JSON.stringify(this.recentQueries);
       localStorage.setItem('recentQueries', parsed);

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorCode.vue
@@ -96,6 +96,7 @@ export default {
     this.$root.$on('apiError', this.showError)
     this.$root.$on('showMessages', this.handleShowMessages)
     this.$root.$on('sendQueryCode', this.queryCode)
+    this.$root.$emit('activateModalRecent')
 
     this.tableName = this.$route.params.tableName
 

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -190,7 +190,7 @@ export default {
   data() {
     return {
       showStoreQueries: [],
-      disabledRecents: true,
+      disabledRecents: false,
       disabledQueries: false,
       disabledSave: true,
       disabledRunQuery: true,

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -25,7 +25,7 @@
           <transition
             name="fade"
             mode="out-in"
-            >
+          >
             <RecentQueries
               v-show="isActive"
               :class="[
@@ -34,7 +34,7 @@
               ]"
             />
           </transition>
-      </keep-alive>
+        </keep-alive>
       </div>
       <div class="gobierto-data-sql-editor-your-queries">
         <Button

--- a/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SQLEditorHeader.vue
@@ -21,13 +21,20 @@
           background="#fff"
           @click.native="recentQueries()"
         />
-        <RecentQueries
-          v-if="showStoreQueries"
-          :class="[
-            directionLeft ? 'modal-left': 'modal-right',
-            isActive ? 'active' : ''
-          ]"
-        />
+        <keep-alive>
+          <transition
+            name="fade"
+            mode="out-in"
+            >
+            <RecentQueries
+              v-show="isActive"
+              :class="[
+                directionLeft ? 'modal-left': 'modal-right',
+                isActive ? 'active' : ''
+              ]"
+            />
+          </transition>
+      </keep-alive>
       </div>
       <div class="gobierto-data-sql-editor-your-queries">
         <Button

--- a/app/javascript/gobierto_data/webapp/pages/DataSets.vue
+++ b/app/javascript/gobierto_data/webapp/pages/DataSets.vue
@@ -56,13 +56,21 @@ export default {
     },
     getData() {
       this.urlPath = location.origin
-      this.endPoint = '/api/v1/data/datasets/'
+      this.endPoint = `/api/v1/data/datasets/${this.$route.params.id}/meta`
       this.url = `${this.urlPath}${this.endPoint}`
       axios
         .get(this.url)
         .then(response => {
           this.rawData = response.data
-          this.titleDataset = this.rawData.data[0].attributes.name
+          this.titleDataset = this.rawData.data.attributes.name
+          this.idDataset = this.rawData.data.id
+          this.titleDataset = this.rawData.data.attributes.name
+          this.slugDataset = this.rawData.data.attributes.slug
+          this.tableName = this.rawData.data.attributes.table_name
+          this.datasetId = parseInt(this.idDataset)
+
+          this.$root.$emit('nameDataset', this.titleDataset)
+
           this.getQueries()
 
         })


### PR DESCRIPTION
Closes #2807

## :v: What does this PR do?
Enable recent queries by default.
Make more bigger modal.

## :eyes: Screenshots

### Before this PR

![before-modal-recents 2020-01-30 12_27_37](https://user-images.githubusercontent.com/2649175/73445858-ef0e5400-435b-11ea-8574-bd1afe58ac53.gif)

### After this PR

![after-modal-recents 2020-01-30 12_27_17](https://user-images.githubusercontent.com/2649175/73445864-f2094480-435b-11ea-8619-8431f0cba5d0.gif)

