### PR TITLE
Wrap all column names in scripts with double quotes

### DIFF
--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -87,7 +87,7 @@ module GobiertoData
       end
 
       def function_call(attribute)
-        "#{function_name}(#{attribute})"
+        "#{function_name}(\"#{attribute}\")"
       end
 
     end


### PR DESCRIPTION
## :v: What does this PR do?

Fixes errors importing data from datasets when column names use keywords, like Any. The solution is to enclose all column names in import script with double quotes.

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No