### PR TITLE
2809 module configuration in front

### DIFF
--- a/app/controllers/gobierto_common/api/v1/configuration_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/configuration_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module Api
+    module V1
+      class ConfigurationController < ApiBaseController
+        before_action { module_enabled!(current_site, module_name, false) }
+
+        # GET /api/v1/:module_name/configuration
+        def show
+          settings = current_site.module_settings.find_by(module_name: module_name)
+          return unless settings.present?
+
+          render json: settings.public_api_settings
+        end
+
+        private
+
+        def module_name
+          @module_name ||= begin
+                             module_param = params[:module_name].underscore
+                             module_param = /\Agobierto_/.match?(module_param) ? module_param : "gobierto_#{module_param}"
+                             module_param.camelize
+                           end
+        end
+      end
+    end
+  end
+end

--- a/app/models/gobierto_module_settings.rb
+++ b/app/models/gobierto_module_settings.rb
@@ -14,4 +14,12 @@ class GobiertoModuleSettings < ApplicationRecord
     end
   end
 
+  def public_api_settings
+    self.settings ||= {}
+
+    self.settings.select do |_, value|
+      value.is_a?(Hash) && value.fetch("exposed_in_public_api", false)
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -596,6 +596,17 @@ Rails.application.routes.draw do
       end
     end
 
+    # Common API
+    namespace :gobierto_common, path: "/" do
+      constraints GobiertoSiteConstraint.new do
+        namespace :api, path: "/" do
+          namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1" do
+            get ":module_name/configuration" => "configuration#show", as: :configuration
+          end
+        end
+      end
+    end
+
     # Add new modules before this line
 
     # Sidekiq Web UI

--- a/test/controllers/gobierto_common/api/v1/configuration_controller_test.rb
+++ b/test/controllers/gobierto_common/api/v1/configuration_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module Api
+    module V1
+      class ConfigurationControllerTest < GobiertoControllerTest
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def test_show_with_module_disabled
+          with(site: site_with_module_disabled) do
+            get gobierto_common_api_v1_configuration_path(module_name: "gobierto-data"), as: :json
+
+            assert_response :forbidden
+          end
+        end
+
+        def test_show_with_not_existing_module
+          with(site: site_with_module_disabled) do
+            get gobierto_common_api_v1_configuration_path(module_name: "gobierto-wadus"), as: :json
+
+            assert_response :forbidden
+          end
+        end
+
+        def test_show
+          with(site: site) do
+            get gobierto_common_api_v1_configuration_path(module_name: "gobierto-data"), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "api_configuration"
+            refute response_data.has_key? "db_config"
+            refute response_data.has_key? "api_private_configuration"
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/fixtures/gobierto_module_settings.yml
+++ b/test/fixtures/gobierto_module_settings.yml
@@ -154,6 +154,19 @@ gobierto_data_settings_madrid:
     db_config: {
       read_db_config: Rails.configuration.database_configuration["test"],
       write_db_config: Rails.configuration.database_configuration["test"]
+    },
+    api_configuration: {
+      "exposed_in_public_api" => true,
+      "availableFilters" => [
+        { "id" => "daterange", "startKey" => "start-date", "endKey" => "end-date" },
+        { "id" => "status", "multiple" => true },
+        { "id" => "service-name", "multiple" => true },
+        { "id" => "type" },
+        { "id" => "import" }
+      ]
+    },
+    api_private_configuration: {
+      "privateData" => "Secret"
     }
   }.to_json %>
 

--- a/test/models/gobierto_module_settings_test.rb
+++ b/test/models/gobierto_module_settings_test.rb
@@ -7,6 +7,10 @@ class GobiertoModuleSettingsTest < ActiveSupport::TestCase
     @gobierto_people_settings ||= gobierto_module_settings(:gobierto_people_settings_madrid)
   end
 
+  def gobierto_data_settings
+    @gobierto_data_settings ||= gobierto_module_settings(:gobierto_data_settings_madrid)
+  end
+
   def test_dynamic_setters
     module_settings = GobiertoModuleSettings.new
     module_settings.first_setting = "foo"
@@ -27,5 +31,10 @@ class GobiertoModuleSettingsTest < ActiveSupport::TestCase
   def test_dynamic_getters
     assert_equal "Home text English", gobierto_people_settings.home_text_en
     assert_nil gobierto_people_settings.wrong_field
+  end
+
+  def test_public_api_settings
+    assert_includes gobierto_data_settings.public_api_settings.keys, "api_configuration"
+    refute_includes gobierto_data_settings.public_api_settings.keys, "api_private_configuration"
   end
 end


### PR DESCRIPTION
Closes #2809


## :v: What does this PR do?

* Allows to define settings for modules which can be accessed via API
* Includes some tests

## :mag: How should this be manually tested?

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Added https://gobierto.readme.io/docs/gobierto-api-modules-configuration
