### PR TITLE
924 scrutinizer api endpoint

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -99,6 +99,18 @@ module GobiertoData
           )
         end
 
+        def stats
+          find_item
+
+          render(
+            json: @item,
+            serializer: ::GobiertoData::DatasetStatsSerializer,
+            exclude_links: true,
+            links: links(:stats),
+            adapter: :json_api
+          )
+        end
+
         def new
           @form = DatasetForm.new(name_translations: available_locales_hash, site_id: current_site.id)
 
@@ -174,6 +186,7 @@ module GobiertoData
               hash.merge!(
                 data: gobierto_data_api_v1_dataset_path(params.fetch(:slug, slug)),
                 metadata: meta_gobierto_data_api_v1_dataset_path(params.fetch(:slug, slug)),
+                stats: stats_gobierto_data_api_v1_dataset_path(params.fetch(:slug, slug)),
                 queries: gobierto_data_api_v1_queries_path(filter: { dataset_id: id }),
                 visualizations: gobierto_data_api_v1_visualizations_path(filter: { dataset_id: id }),
                 favorites: gobierto_data_api_v1_dataset_favorites_path(@item.slug)

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -49,6 +49,17 @@ module GobiertoData
                        end
     end
 
+    def columns_stats
+      rails_model.columns.inject({}) do |columns, column|
+        columns.update(
+          column.name => {
+            type: column.type,
+            stats: scrutinizer.stats(column)
+          }
+        )
+      end
+    end
+
     def load_data_from_file(file_path, schema_file: nil, csv_separator: ",", append: false)
       schema = if schema_file.blank?
                  {}
@@ -79,6 +90,10 @@ module GobiertoData
 
     def internal_rails_class_name
       @internal_rails_class_name ||= "site_id_#{site.id}_table_#{table_name}".classify
+    end
+
+    def scrutinizer
+      @scrutinizer ||= GobiertoData::Datasets::Scrutinizer.new(dataset: self)
     end
   end
 end

--- a/app/queries/gobierto_data/datasets/scrutinizer.rb
+++ b/app/queries/gobierto_data/datasets/scrutinizer.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Datasets
+    class Scrutinizer
+
+      SORTABLE_TYPES = [
+        :date,
+        :datetime,
+        :time,
+        :timestamp,
+        :integer,
+        :decimal,
+        :float
+      ].freeze
+
+      attr_reader :dataset, :relation
+
+      def initialize(options = {})
+        @dataset = options[:dataset]
+        @relation = dataset.rails_model
+      end
+
+      def stats(column)
+        data = OpenStruct.new
+
+        data[:not_null_count] = aggregated_field(:count, column)
+        data[:distinct_count] = aggregated_field(:count, column, distinct: true)
+        if data[:not_null_count] < 4 || data[:distinct_count].to_f / data[:not_null_count] < 0.75
+          data[:distribution] = distribution(column, limit: 100)
+        end
+
+        if sortable? column
+          data[:quartiles] = quantile(column, 4)
+          data[:min] = data[:quartiles]["q0"]
+          data[:first_quartile] = data[:quartiles]["q1"]
+          data[:median] = data[:quartiles]["q2"]
+          data[:average] = aggregated_field(:avg, column) if [:integer, :decimal, :float].include? column.type
+          data[:third_quartile] = data[:quartiles]["q3"]
+          data[:max] = data[:quartiles]["q4"]
+          data[:histogram] = histogram(column, data)
+        end
+
+        data.to_h
+      end
+
+      private
+
+      def sortable?(column)
+        SORTABLE_TYPES.include? column.type
+      end
+
+      def aggregated_field(aggregate_function, column, distinct: false)
+        aggregate_value = Arel::Nodes::SqlLiteral.new(
+          "#{aggregate_function}(#{"DISTINCT " if distinct}\"#{column.name}\") AS RESULT"
+        )
+
+        query_select(
+          aggregate_value
+        )[0]&.result
+      end
+
+      def quantile(column, buckets)
+        return unless buckets.positive?
+
+        query_attributes = (0..buckets).map { |i| "PERCENTILE_DISC(#{i.to_f / buckets}) WITHIN GROUP(ORDER BY \"#{column.name}\") AS q#{i}" }.join(", ")
+
+        query_select(
+          query_attributes
+        )[0]&.attributes&.except("id")
+      end
+
+      def histogram(column, stats, buckets = nil)
+        return unless stats.min != stats.max && stats.not_null_count > 1
+
+        buckets ||= Math.log(stats.not_null_count, 2).ceil + 1
+
+        bucket_attributes = Arel::Nodes::SqlLiteral.new(
+          if [:date, :datetime, :time, :timestamp].include?(column.type)
+            transform_operator = column.type == :time ? "TIME" : "TIMESTAMP"
+            <<-TEXT
+            WIDTH_BUCKET(
+              EXTRACT(EPOCH FROM \"#{column.name}\"),
+              EXTRACT(EPOCH FROM '#{stats.min}'::#{transform_operator}),
+              EXTRACT(EPOCH FROM '#{stats.max}'::#{transform_operator}),
+              #{buckets}
+            ) AS bucket, COUNT(*)
+            TEXT
+          else
+            "WIDTH_BUCKET(\"#{column.name}\", #{stats.min}, #{stats.max}, #{buckets}) AS bucket, COUNT(*)"
+          end
+        )
+
+        histogram_query = query_select(
+          bucket_attributes
+        ).where.not(column.name => nil).group(:bucket).order(bucket: :asc)
+
+        interval_width = (stats.max - stats.min).to_f / buckets
+
+        (1..buckets).map do |bucket|
+          count = if bucket == buckets
+                    histogram_query.select { |bin_data| bin_data.bucket >= bucket }.map(&:count).sum
+                  else
+                    histogram_query.find { |bin_data| bin_data.bucket == bucket }&.count || 0
+                  end
+          boundaries(stats.min, bucket, interval_width, column.type).merge(
+            bucket: bucket,
+            count: count
+          )
+        end
+      end
+
+      def boundaries(min, bucket, width, column_type)
+        values = {
+          start: (min + width * (bucket - 1)),
+          end: (min + width * bucket)
+        }
+
+        return values if [:date, :datetime, :time, :timestamp].include?(column_type) || width < 2
+
+        values.tap do |val|
+          val[:start] = values[:start].ceil
+          val[:end] = values[:end].floor
+        end
+      end
+
+      def distribution(column, limit: nil)
+        distribution_attributes = Arel::Nodes::SqlLiteral.new(
+          "\"#{column.name}\" AS value, COUNT(*)"
+        )
+
+        distribution_query = query_select(
+          distribution_attributes
+        ).group(:value).order(count: :desc).limit(limit)
+
+        distribution_query.map do |value_data|
+          { value: value_data.value,
+            count: value_data.count }
+        end
+      end
+
+      def query_select(*select_attributes)
+        relation.select(*select_attributes)
+      end
+
+    end
+  end
+end

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -11,7 +11,8 @@ module GobiertoData
       slug = object.slug
       {
         data: gobierto_data_api_v1_dataset_path(slug),
-        metadata: meta_gobierto_data_api_v1_dataset_path(slug)
+        metadata: meta_gobierto_data_api_v1_dataset_path(slug),
+        stats: stats_gobierto_data_api_v1_dataset_path(slug)
       }
     end
 

--- a/app/serializers/gobierto_data/dataset_stats_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_stats_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class DatasetStatsSerializer < DatasetSerializer
+    attribute :columns_stats do
+      object.columns_stats
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -576,6 +576,7 @@ Rails.application.routes.draw do
               end
               member do
                 get "meta" => "datasets#dataset_meta"
+                get "stats" => "datasets#stats"
                 get :download, format: true
               end
             end


### PR DESCRIPTION
Closes PopulateTools/issues#924


## :v: What does this PR do?

* Adds a queries service which inspects table columns and generate statistical data from them depending on the type and distribution of data. The data for each column is:
  * `not_null_count`: Count of not null values
  * `distinct_count`: Count of distinct values
  * `distribution`. Shows the most repeated 100 values ordered by frequency. Only shown If the count of distinct values is below 75% of not null values.
  * If the column elements are numeric or related with time or date:
    * `quartiles`: object with values from `q0` to `q4`
    * `min`: Corresponds to `q0`
    * `first_quartile`: Corresponds to `q1`
    * `median`: Corresponds to `q2`
    * `average`: Only appears if the column has a numeric type
    * `third_quartile`: Corresponds to `q3`
    * `max`: Corresponds to `q4`
    * `histogram`: An histogram including the start and end of each interval, the count of values greater or equal than the start or less than the end (with the exception of the last interval, in this case the count includes the values equal to the end interval) and the bucket number
* Adds an API endpoint to return the stats info   

## :mag: How should this be manually tested?

Visit the stats endpoint of a dataset at `/api/v1/data/datasets/DATASET-SLUG/stats`

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

API documentation updated
