### PR TITLE
2851 datasets columns in index

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -38,6 +38,8 @@ module GobiertoData
 
     def rails_model
       @rails_model ||= begin
+                         return unless internal_rails_class_name
+
                          return Connection.const_get(internal_rails_class_name) if Connection.const_defined?(internal_rails_class_name)
 
                          db_config = Connection.db_config(site)
@@ -93,6 +95,8 @@ module GobiertoData
     end
 
     def internal_rails_class_name
+      return unless site.present? && table_name.present?
+
       @internal_rails_class_name ||= "site_id_#{site.id}_table_#{table_name}".classify
     end
   end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -13,14 +13,6 @@ module GobiertoData
       }
     end
 
-    attribute :columns do
-      object.rails_model.columns.inject({}) do |columns, column|
-        columns.update(
-          column.name => column.type
-        )
-      end
-    end
-
     attribute :formats do
       object.available_formats.inject({}) do |formats, format|
         formats.update(

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -15,12 +15,26 @@ module GobiertoData
       }
     end
 
+    attribute :columns do
+      if model_present?
+        object.rails_model.columns.inject({}) do |columns, column|
+          columns.update(
+            column.name => column.type
+          )
+        end
+      end
+    end
+
     def current_site
       Site.find_by(id: object.site_id) || instance_options[:site]
     end
 
     def exclude_links?
       instance_options[:exclude_links]
+    end
+
+    def model_present?
+      object.rails_model.present? && object.rails_model.table_exists?
     end
 
   end


### PR DESCRIPTION
Closes #2851

## :v: What does this PR do?

* Adds columns attribute to datasets in index
* Avoids serialization errors when the dataset has a table not available in the database.

## :mag: How should this be manually tested?

Visit the index of datasets: one of the datasets attribute should be `columns`


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation updated.
