### PR TITLE
Avoid exceptions on update vocabulary callback

### DIFF
--- a/app/models/gobierto_common/vocabulary.rb
+++ b/app/models/gobierto_common/vocabulary.rb
@@ -39,7 +39,7 @@ module GobiertoCommon
     private
 
     def touch_associated_custom_field_items
-      CustomFieldRecord.where(custom_field: CustomField.vocabulary_options.for_vocabulary(self)).each { |record| record.item.touch }
+      CustomFieldRecord.where(custom_field: CustomField.vocabulary_options.for_vocabulary(self)).each { |record| record&.item&.touch }
     end
   end
 end


### PR DESCRIPTION
## :v: What does this PR do?

There is a callback in vocabularies which touch all items with custom field records using the vocabulary. This PR avoids exceptions if the custom field records associated have blank items

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No