### PR TITLE
921 datasets attachments

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
@@ -131,7 +131,7 @@ module GobiertoAdmin
       def modules_with_collections_options
         current_site.configuration.modules_with_collections.map do |module_name|
           [
-            "#{t("gobierto_admin.shared.module")}: #{t("gobierto_admin.layouts.application.modules.#{module_name.underscore.gsub(/\Agobierto_/,"")}")}",
+            "#{t("gobierto_admin.shared.module")}: #{t("gobierto_admin.layouts.application.modules.#{module_name.underscore.gsub(/\Agobierto_/, "")}")}",
             module_name
           ]
         end

--- a/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/collections_controller.rb
@@ -125,7 +125,16 @@ module GobiertoAdmin
 
       def find_containers
         @containers ||= container_items.map { |item| ["#{item.class.model_name.human}: #{item}", item.to_global_id] }
-        @containers.insert(1, %w(GobiertoParticipation GobiertoParticipation))
+        @containers.insert(1, *modules_with_collections_options)
+      end
+
+      def modules_with_collections_options
+        current_site.configuration.modules_with_collections.map do |module_name|
+          [
+            "#{t("gobierto_admin.shared.module")}: #{t("gobierto_admin.layouts.application.modules.#{module_name.underscore.gsub(/\Agobierto_/,"")}")}",
+            module_name
+          ]
+        end
       end
 
       def type_names

--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -6,6 +6,7 @@ module GobiertoAdmin
       include CustomFieldsHelper
 
       helper_method :preview_url
+      before_action :set_attachments_collection, only: [:new, :create, :edit, :update]
 
       def index
         @datasets = current_site.datasets.order(id: :desc)
@@ -19,8 +20,6 @@ module GobiertoAdmin
 
       def edit
         @dataset = find_dataset
-        @dataset_attachments_collection = ::GobiertoData.attachments_collection!(current_site)
-
         @dataset_form = DatasetForm.new(
           @dataset.attributes.except(*ignored_dataset_attributes).merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
         )
@@ -45,8 +44,6 @@ module GobiertoAdmin
 
       def update
         @dataset = find_dataset
-        @dataset_attachments_collection = ::GobiertoData.attachments_collection!(current_site)
-
         @dataset_form = DatasetForm.new(
           dataset_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
         )
@@ -88,6 +85,10 @@ module GobiertoAdmin
 
       def find_dataset
         current_site.datasets.find(params[:id])
+      end
+
+      def set_attachments_collection
+        @dataset_attachments_collection = ::GobiertoData.attachments_collection!(current_site)
       end
 
       def preview_url(dataset, options = {})

--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -19,6 +19,7 @@ module GobiertoAdmin
 
       def edit
         @dataset = find_dataset
+        @dataset_attachments_collection = @dataset.attachments_collection!
 
         @dataset_form = DatasetForm.new(
           @dataset.attributes.except(*ignored_dataset_attributes).merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
@@ -44,6 +45,7 @@ module GobiertoAdmin
 
       def update
         @dataset = find_dataset
+        @dataset_attachments_collection = @dataset.attachments_collection!
 
         @dataset_form = DatasetForm.new(
           dataset_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
@@ -75,6 +77,7 @@ module GobiertoAdmin
           :table_name,
           :slug,
           :visibility_level,
+          :attachment_ids,
           name_translations: [*I18n.available_locales]
         )
       end

--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -19,7 +19,7 @@ module GobiertoAdmin
 
       def edit
         @dataset = find_dataset
-        @dataset_attachments_collection = @dataset.attachments_collection!
+        @dataset_attachments_collection = ::GobiertoData.attachments_collection!(current_site)
 
         @dataset_form = DatasetForm.new(
           @dataset.attributes.except(*ignored_dataset_attributes).merge(site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
@@ -45,7 +45,7 @@ module GobiertoAdmin
 
       def update
         @dataset = find_dataset
-        @dataset_attachments_collection = @dataset.attachments_collection!
+        @dataset_attachments_collection = ::GobiertoData.attachments_collection!(current_site)
 
         @dataset_form = DatasetForm.new(
           dataset_params.merge(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -93,6 +93,7 @@ module GobiertoData
           render(
             json: @item,
             serializer: ::GobiertoData::DatasetMetaSerializer,
+            include: [:attachments],
             exclude_links: true,
             links: links(:metadata),
             adapter: :json_api

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -12,7 +12,8 @@ module GobiertoAdmin
         :table_name,
         :slug,
         :admin_id,
-        :ip
+        :ip,
+        :attachment_ids
       )
       attr_writer(
         :visibility_level
@@ -70,6 +71,10 @@ module GobiertoAdmin
           attributes.table_name = table_name
           attributes.slug = slug.blank? ? nil : slug
           attributes.visibility_level = visibility_level
+
+          if @dataset.new_record? && attachment_ids.present?
+            attributes.attachment_ids = attachment_ids.is_a?(String) ? attachment_ids.split(",") : attachment_ids
+          end
         end
 
         if @dataset.valid?

--- a/app/models/gobierto_attachments.rb
+++ b/app/models/gobierto_attachments.rb
@@ -6,6 +6,6 @@ module GobiertoAttachments
   end
 
   def self.permitted_attachable_types
-    %w(GobiertoCms::Page GobiertoCalendars::Event)
+    %w(GobiertoCms::Page GobiertoCalendars::Event GobiertoData::Dataset)
   end
 end

--- a/app/models/gobierto_data.rb
+++ b/app/models/gobierto_data.rb
@@ -9,7 +9,28 @@ module GobiertoData
     [GobiertoData::Dataset]
   end
 
-  def self.root_path(current_site)
+  def self.root_path(_current_site)
     Rails.application.routes.url_helpers.gobierto_data_root_path
+  end
+
+  def self.attachments_collection(current_site)
+    current_site.collections.find_by(container_type: "GobiertoData", item_type: "GobiertoAttachments::Attachment")
+  end
+
+  def self.attachments_collection!(current_site)
+    attachments_collection(current_site) || create_attachments_collection(current_site)
+  end
+
+  def self.create_attachments_collection(current_site)
+    current_site.collections.create!(
+      container_type: "GobiertoData",
+      item_type: "GobiertoAttachments::Attachment",
+      slug: "gobierto-data-attachments",
+      title_translations: {
+        "ca" => "Documents de Dades",
+        "en" => "Data documents",
+        "es" => "Documentos de Datos"
+      }.slice(*current_site.configuration.available_locales)
+    )
   end
 end

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -29,8 +29,6 @@ module GobiertoData
     validates :slug, :table_name, uniqueness: { scope: :site_id }
 
     before_save :set_schema, if: :will_save_change_to_visibility_level?
-    after_create :create_attachments_collection
-    after_destroy :delete_attachments_collection
 
     def attributes_for_slug
       [name]
@@ -99,33 +97,7 @@ module GobiertoData
       }
     end
 
-    def attachments_collection!
-      return if new_record?
-
-      attachments_collection || create_attachments_collection
-    end
-
-    def attachments_collection
-      @attachments_collection ||= site.collections.find_by(container: self, item_type: "GobiertoAttachments::Attachment")
-    end
-
     private
-
-    def create_attachments_collection
-      site.collections.create!(
-        container: self,
-        item_type: "GobiertoAttachments::Attachment",
-        slug: "attachments-#{slug}",
-        title_translations: name_translations
-      )
-    end
-
-    def delete_attachments_collection
-      return unless attachments_collection.present?
-
-      site.attachments.where(collection: attachments_collection).destroy_all
-      attachments_collection.destroy
-    end
 
     def set_schema
       if draft?

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -21,7 +21,9 @@ class SiteConfiguration
     :engine_overrides
   ].freeze
 
-  DEFAULT_LOGO_PATH = "sites/logo-default.png".freeze
+  DEFAULT_LOGO_PATH = "sites/logo-default.png"
+  MODULES_WITH_NOTIFICATONS = %w(GobiertoPeople GobiertoBudgetConsultations GobiertoParticipation).freeze
+  MODULES_WITH_COLLECTIONS = %w(GobiertoParticipation GobiertoData).freeze
 
   MODULES_WITH_NOTIFICATONS = ["GobiertoPeople", "GobiertoBudgetConsultations", "GobiertoParticipation"]
   MODULES_WITH_COLLECTIONS = ["GobiertoParticipation", "GobiertoData"]

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -24,6 +24,7 @@ class SiteConfiguration
   DEFAULT_LOGO_PATH = "sites/logo-default.png".freeze
 
   MODULES_WITH_NOTIFICATONS = ["GobiertoPeople", "GobiertoBudgetConsultations", "GobiertoParticipation"]
+  MODULES_WITH_COLLECTIONS = ["GobiertoParticipation", "GobiertoData"]
 
   attr_accessor *PROPERTIES
 
@@ -91,6 +92,10 @@ class SiteConfiguration
 
   def modules_with_notifications
     modules_with_frontend_enabled & MODULES_WITH_NOTIFICATONS
+  end
+
+  def modules_with_collections
+    modules & MODULES_WITH_COLLECTIONS
   end
 
   def default_modules

--- a/app/serializers/gobierto_attachments/attachment_serializer.rb
+++ b/app/serializers/gobierto_attachments/attachment_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module GobiertoAttachments
+  class AttachmentSerializer < ActiveModel::Serializer
+    attributes(
+      :name,
+      :description,
+      :file_name,
+      :file_digest,
+      :url,
+      :human_readable_url,
+      :file_size,
+      :current_version,
+      :created_at,
+      :updated_at
+    )
+  end
+end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -6,6 +6,7 @@ module GobiertoData
 
     has_many :queries
     has_many :visualizations
+    has_many :attachments
 
     attribute :data_summary do
       {

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_localized_item.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/forms/_localized_item.html.erb
@@ -4,5 +4,5 @@
     <%= attribute_indication_tag required: record.required? %>
   <% end %>
   <%= hidden_field_tag "#{ input_base_name }[#{ record.uid }][custom_field_id]", record.custom_field_id %>
-  <%= send(record.field_tag, "#{ input_base_name }[#{ record.uid }][value][#{ locale }]", record.input_content[locale], record.tag_attributes) %>
+  <%= send(record.field_tag, "#{ input_base_name }[#{ record.uid }][value][#{ locale }]", record.input_content[locale], record.tag_attributes.merge(lang: locale)) %>
 </div>

--- a/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
@@ -48,12 +48,10 @@
     <div class="pure-u-1 pure-u-md-2-24"></div>
 
     <%= render layout: 'gobierto_admin/shared/save_widget', locals: { f: f, levels: @dataset_form.available_visibility_levels } do %>
-      <% if @dataset_form.persisted? %>
-        <div class="admin_side_actions">
-          <%= render "gobierto_admin/shared/admin_widget_attachment", { attachable_type: @dataset_form.dataset.class.name, attachable_id: @dataset_form.dataset.id } %>
-          <%= f.hidden_field :attachment_ids, id: "attachmentsIdsAfterCreated" %>
-        </div>
-      <% end %>
+      <div class="admin_side_actions">
+        <%= render "gobierto_admin/shared/admin_widget_attachment", { attachable_type: @dataset_form.dataset.class.name, attachable_id: @dataset_form.dataset.id } %>
+        <%= f.hidden_field :attachment_ids, id: "attachmentsIdsAfterCreated" %>
+      </div>
     <% end %>
 
   </div>

--- a/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/datasets/_form.html.erb
@@ -47,7 +47,20 @@
 
     <div class="pure-u-1 pure-u-md-2-24"></div>
 
-    <%= render partial: 'gobierto_admin/shared/save_widget', locals: { f: f, levels: @dataset_form.available_visibility_levels } %>
+    <%= render layout: 'gobierto_admin/shared/save_widget', locals: { f: f, levels: @dataset_form.available_visibility_levels } do %>
+      <% if @dataset_form.persisted? %>
+        <div class="admin_side_actions">
+          <%= render "gobierto_admin/shared/admin_widget_attachment", { attachable_type: @dataset_form.dataset.class.name, attachable_id: @dataset_form.dataset.id } %>
+          <%= f.hidden_field :attachment_ids, id: "attachmentsIdsAfterCreated" %>
+        </div>
+      <% end %>
+    <% end %>
 
   </div>
+<% end %>
+
+<% content_for :javascript_hook do %>
+  <%= javascript_tag do %>
+    window.GobiertoAdmin.gobierto_attachments_controller.index(<%= @dataset_attachments_collection.try(:id) %>);
+  <% end %>
 <% end %>

--- a/app/views/gobierto_admin/shared/_save_widget.html.erb
+++ b/app/views/gobierto_admin/shared/_save_widget.html.erb
@@ -1,26 +1,33 @@
 <div class="pure-u-1 pure-u-md-1-4 ">
 
-  <div class="widget_save stick_in_parent">
+  <div class="stick_in_parent">
 
-    <% if levels.any? %>
-      <div class="form_item person-visibility-level-radio-buttons">
+    <div class="widget_save">
 
-        <div class="options compact">
-          <%= f.collection_radio_buttons(:visibility_level, levels, :first, :first) do |b| %>
-            <div class="option">
-              <%= b.radio_button %>
-              <%= b.label do %>
-                <span></span>
-                <%= t(".visibility_level.#{b.text}") %>
-              <% end %>
-            </div>
-          <% end %>
+      <% if levels.any? %>
+        <div class="form_item person-visibility-level-radio-buttons">
+
+          <div class="options compact">
+            <%= f.collection_radio_buttons(:visibility_level, levels, :first, :first) do |b| %>
+              <div class="option">
+                <%= b.radio_button %>
+                <%= b.label do %>
+                  <span></span>
+                  <%= t(".visibility_level.#{b.text}") %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+
         </div>
+      <% end %>
 
-      </div>
-    <% end %>
+      <%= f.submit defined?(custom_submit_text) ? custom_submit_text : nil, class: "button" %>
 
-    <%= f.submit defined?(custom_submit_text) ? custom_submit_text : nil, class: "button" %>
+    </div>
+
+    <%= yield %>
+
   </div>
 
 </div>

--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -67,6 +67,7 @@ ca:
         see_all: veure totes
         send: Enviar
         unpublish: Despublicar
+      module: Mòdul
       recover:
         confirm: Si es recupera un element, es tornarà a llistar de nou.
         element: Recuperar element

--- a/config/locales/gobierto_admin/views/shared/en.yml
+++ b/config/locales/gobierto_admin/views/shared/en.yml
@@ -66,6 +66,7 @@ en:
         see_all: see all
         send: Send
         unpublish: Unpublish
+      module: Module
       recover:
         confirm: If you recover an element, it will be listed again
         element: Recover element

--- a/config/locales/gobierto_admin/views/shared/es.yml
+++ b/config/locales/gobierto_admin/views/shared/es.yml
@@ -67,6 +67,7 @@ es:
         see_all: ver todas
         send: Enviar
         unpublish: Despublicar
+      module: Módulo
       recover:
         confirm: Si recuperas un elemento, se volverá a listar de nuevo.
         element: Recuperar elemento

--- a/db/seeds/modules/gobierto_data/seeds.rb
+++ b/db/seeds/modules/gobierto_data/seeds.rb
@@ -3,27 +3,27 @@
 module GobiertoSeeds
   class Recipe
     DEFAULT_CATEGORY_NAMES = [
-      "Sector público",
-      "Transporte",
-      "Medio ambiente",
       "Ciencia y tecnología",
-      "Economía",
-      "Medio Rural",
-      "Demografía",
-      "Hacienda",
-      "Educación",
-      "Cultura y ocio",
-      "Turismo",
-      "Empleo",
-      "Sociedad y bienestar",
-      "Urbanismo e infraestructuras",
       "Comercio",
-      "Legislación y justicia",
-      "Salud",
-      "Seguridad",
-      "Industria",
-      "Energía",
+      "Cultura y ocio",
+      "Demografía",
       "Deporte",
+      "Economía",
+      "Educación",
+      "Empleo",
+      "Energía",
+      "Hacienda",
+      "Industria",
+      "Legislación y justicia",
+      "Medio Rural",
+      "Medio ambiente",
+      "Salud",
+      "Sector público",
+      "Seguridad",
+      "Sociedad y bienestar",
+      "Transporte",
+      "Turismo",
+      "Urbanismo e infraestructuras",
       "Vivienda"
     ].freeze
 
@@ -36,46 +36,47 @@ module GobiertoSeeds
         description.save
       end
 
-      frequency = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "frequency")
-      if frequency.new_record?
-        vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-frequency")
+      category = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "category")
+      if category.new_record?
+        vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-category")
         if vocabulary.new_record?
-          vocabulary.name_translations = { ca: "Freqüència de conjunt de dades", en: "Dataset frequency", es: "Frecuencia de conjunto de datos" }
+          vocabulary.name_translations = { ca: "Categoria de conjunt de dades", en: "Dataset Category", es: "Categoría de conjunto de datos" }
           vocabulary.save
-          vocabulary.terms.create(name_translations: { ca: "Anual", en: "Annual", es: "Anual" })
-          vocabulary.terms.create(name_translations: { ca: "Trimestral", en: "Quarterly", es: "Trimestral" })
-          vocabulary.terms.create(name_translations: { ca: "Mensual", en: "Monthly", es: "Mensual" })
-          vocabulary.terms.create(name_translations: { ca: "Diària", en: "Daily", es: "Diaria" })
+          DEFAULT_CATEGORY_NAMES.each_with_index do |category_name, index|
+            vocabulary.terms.create(
+              name_translations: Hash[site.configuration.available_locales.product([category_name])],
+              position: index + 1
+            )
+          end
         end
-        frequency.name_translations = { ca: "Freqüència", en: "Frequency", es: "Frecuencia" }
-        frequency.position = 2
-        frequency.options = {
-          configuration: { vocabulary_type: "single_select" },
+        category.name_translations = { ca: "Categoria", en: "Category", es: "Categoría" }
+        category.position = 3
+        category.options = {
+          configuration: { vocabulary_type: "multiple_select" },
           vocabulary_id: vocabulary.id.to_s
         }
-        frequency.save
+        category.save
       end
 
-      category = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "category")
-      return unless category.new_record?
+      frequency = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "frequency")
+      return unless frequency.new_record?
 
-      vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-category")
+      vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-frequency")
       if vocabulary.new_record?
-        vocabulary.name_translations = { ca: "Categoria de conjunt de dades", en: "Dataset Category", es: "Categoría de conjunto de datos" }
+        vocabulary.name_translations = { ca: "Freqüència de conjunt de dades", en: "Dataset frequency", es: "Frecuencia de conjunto de datos" }
         vocabulary.save
-        DEFAULT_CATEGORY_NAMES.each do |category_name|
-          vocabulary.terms.create(
-            name_translations: Hash[site.configuration.available_locales.product([category_name])]
-          )
-        end
+        vocabulary.terms.create(name_translations: { ca: "Anual", en: "Annual", es: "Anual" }, position: 1)
+        vocabulary.terms.create(name_translations: { ca: "Trimestral", en: "Quarterly", es: "Trimestral" }, position: 2)
+        vocabulary.terms.create(name_translations: { ca: "Mensual", en: "Monthly", es: "Mensual" }, position: 3)
+        vocabulary.terms.create(name_translations: { ca: "Diària", en: "Daily", es: "Diaria" }, position: 4)
       end
-      category.name_translations = { ca: "Categoria", en: "Category", es: "Categoría" }
-      category.position = 3
-      category.options = {
-        configuration: { vocabulary_type: "multiple_select" },
+      frequency.name_translations = { ca: "Freqüència", en: "Frequency", es: "Frecuencia" }
+      frequency.position = 2
+      frequency.options = {
+        configuration: { vocabulary_type: "single_select" },
         vocabulary_id: vocabulary.id.to_s
       }
-      category.save
+      frequency.save
     end
   end
 end

--- a/db/seeds/modules/gobierto_data/seeds.rb
+++ b/db/seeds/modules/gobierto_data/seeds.rb
@@ -28,7 +28,7 @@ module GobiertoSeeds
     ].freeze
 
     def self.run(site)
-      description = site.custom_fields.localized_string.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "description")
+      description = site.custom_fields.localized_paragraph.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "description")
       if description.new_record?
         description.name_translations = { ca: "Descripció", en: "Description", es: "Descripción" }
         description.position = 1

--- a/db/seeds/modules/gobierto_data/seeds.rb
+++ b/db/seeds/modules/gobierto_data/seeds.rb
@@ -28,6 +28,9 @@ module GobiertoSeeds
     ].freeze
 
     def self.run(site)
+      # Initialize module collection
+      GobiertoData.attachments_collection!(site)
+
       description = site.custom_fields.localized_paragraph.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "description")
       if description.new_record?
         description.name_translations = { ca: "Descripció", en: "Description", es: "Descripción" }

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -35,6 +35,10 @@ module GobiertoData
           @other_site_dataset ||= gobierto_data_datasets(:santander_dataset)
         end
 
+        def attachment
+          @attachment ||= gobierto_attachments_attachments(:txt_pdf_attachment)
+        end
+
         def array_data(dataset)
           [
             dataset.id.to_s,
@@ -205,6 +209,15 @@ module GobiertoData
             resource_relationships = resource_data["relationships"]
             assert resource_relationships.has_key? "queries"
             assert resource_relationships.has_key? "visualizations"
+            assert resource_relationships.has_key? "attachments"
+
+            # included
+            assert response_data.has_key? "included"
+            included = response_data["included"]
+
+            # datasets
+            attachments_names = included.select { |item| item["type"] = "gobierto_attachments-attachments" }.map { |attachment| attachment.dig("attributes", "name") }
+            assert_includes attachments_names, attachment.name
 
             # links
             assert response_data.has_key? "links"

--- a/test/fixtures/gobierto_attachments/attachings.yml
+++ b/test/fixtures/gobierto_attachments/attachings.yml
@@ -22,4 +22,7 @@ xlsx_attachment_event_reading_club:
   attachable: reading_club
   attachable_type: GobiertoCalendars::Event
 
-
+users_dataset_pdf_attachment:
+  site: madrid
+  attachment: txt_pdf_attachment
+  attachable: users_dataset (GobiertoData::Dataset)

--- a/test/fixtures/gobierto_common/collections.yml
+++ b/test/fixtures/gobierto_common/collections.yml
@@ -495,3 +495,33 @@ santander_cms_pages:
   slug: santander-cms-pages
   container: santander (Site)
   item_type: GobiertoCms::Page
+
+## Gobierto Data collections
+
+users_dataset_attachments_collection:
+  site: madrid
+  title_translations: <%= {"en" => "Users attachments", "es" => "Adjuntos de usuarios" }.to_json %>
+  slug: users-dataset-attachments
+  container: users_dataset (GobiertoData::Dataset)
+  item_type: GobiertoAttachments::Attachment
+
+events_dataset_attachments_collection:
+  site: madrid
+  title_translations: <%= {"en" => "Events attachments", "es" => "Adjuntos de eventos" }.to_json %>
+  slug: events-dataset-attachments
+  container: events_dataset (GobiertoData::Dataset)
+  item_type: GobiertoAttachments::Attachment
+
+draft_dataset_attachments_collection:
+  site: madrid
+  title_translations: <%= {"en" => "Interest groups attachments", "es" => "Adjuntos de grupos de interés" }.to_json %>
+  slug: interest-groups-dataset-attachments
+  container: draft_dataset (GobiertoData::Dataset)
+  item_type: GobiertoAttachments::Attachment
+
+santander_dataset_attachments_collection:
+  site: santander
+  title_translations: <%= {"en" => "Santander dataset attachments", "es" => "Adjuntos de conjunto de datos de Santander" }.to_json %>
+  slug: santander-dataset-attachments
+  container: santander_dataset (GobiertoData::Dataset)
+  item_type: GobiertoAttachments::Attachment

--- a/test/fixtures/gobierto_common/collections.yml
+++ b/test/fixtures/gobierto_common/collections.yml
@@ -498,30 +498,16 @@ santander_cms_pages:
 
 ## Gobierto Data collections
 
-users_dataset_attachments_collection:
+gobierto_data_madrid_attachments:
   site: madrid
-  title_translations: <%= {"en" => "Users attachments", "es" => "Adjuntos de usuarios" }.to_json %>
-  slug: users-dataset-attachments
-  container: users_dataset (GobiertoData::Dataset)
+  title_translations: <%= {"en" => "Madrid data documents", "es" => "Documentos de datos de Madrid" }.to_json %>
+  slug: madrid-data-attachments
+  container_type: GobiertoData
   item_type: GobiertoAttachments::Attachment
 
-events_dataset_attachments_collection:
-  site: madrid
-  title_translations: <%= {"en" => "Events attachments", "es" => "Adjuntos de eventos" }.to_json %>
-  slug: events-dataset-attachments
-  container: events_dataset (GobiertoData::Dataset)
-  item_type: GobiertoAttachments::Attachment
-
-draft_dataset_attachments_collection:
-  site: madrid
-  title_translations: <%= {"en" => "Interest groups attachments", "es" => "Adjuntos de grupos de interés" }.to_json %>
-  slug: interest-groups-dataset-attachments
-  container: draft_dataset (GobiertoData::Dataset)
-  item_type: GobiertoAttachments::Attachment
-
-santander_dataset_attachments_collection:
+gobierto_data_santander_attachments:
   site: santander
-  title_translations: <%= {"en" => "Santander dataset attachments", "es" => "Adjuntos de conjunto de datos de Santander" }.to_json %>
-  slug: santander-dataset-attachments
-  container: santander_dataset (GobiertoData::Dataset)
+  title_translations: <%= {"en" => "Santander data documents", "es" => "Documentos de datos de Santander" }.to_json %>
+  slug: santander-data-attachments
+  container_type: GobiertoData
   item_type: GobiertoAttachments::Attachment

--- a/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/create_cms_pages_collection_test.rb
@@ -78,7 +78,7 @@ module GobiertoAdmin
       def test_create_edit_participation_collection
         with_javascript do
           with_signed_in_admin(admin) do
-            with_current_site(site_santander) do
+            with_current_site(site_madrid) do
               visit @path
 
               within "#new-page" do
@@ -105,6 +105,24 @@ module GobiertoAdmin
               end
 
               assert has_message?("Collection was successfully updated.")
+            end
+          end
+        end
+      end
+
+      def test_create_participation_collection_not_available
+        with_javascript do
+          with_signed_in_admin(admin) do
+            with_current_site(site_santander) do
+              visit @path
+
+              within "#new-page" do
+                click_link "New"
+              end
+
+              within("select#collection_container_global_id") do
+                assert has_no_css? "option[value='GobiertoParticipation']"
+              end
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
@@ -36,6 +36,10 @@ module GobiertoAdmin
           @draft_dataset ||= gobierto_data_datasets(:draft_dataset)
         end
 
+        def attachment
+          @attachment ||= gobierto_attachments_attachments(:xlsx_attachment)
+        end
+
         def test_regular_admin_permissions_not_authorized
           with(site: site, admin: unauthorized_regular_admin) do
             visit @path
@@ -110,14 +114,38 @@ module GobiertoAdmin
           end
         end
 
-        def publish_dataset
+        def test_publish_dataset
           with(site: site, admin: admin, js: true) do
+            visit @path
+
             within ".widget_save" do
               find("label", text: "Published").click
             end
             click_button "Update"
 
             assert has_message?("Dataset updated correctly.")
+          end
+        end
+
+        def test_dataset_attachments
+          with(site: site, admin: admin, js: true) do
+            visit @path
+
+            within "#gobierto-attachment" do
+              assert has_content?("TXT PDF Attachment Name")
+              assert has_no_content?("XLSX Attachment Name")
+            end
+
+            click_button "Include file"
+
+            assert has_content?("XLSX Attachment Name")
+            click_link("XLSX Attachment Name")
+
+            within "#gobierto-attachment" do
+              assert has_content?("XLSX Attachment Name")
+            end
+
+            assert_includes dataset.attachments, attachment
           end
         end
       end

--- a/test/models/gobierto_data/dataset_test.rb
+++ b/test/models/gobierto_data/dataset_test.rb
@@ -12,31 +12,8 @@ module GobiertoData
       @site ||= sites(:madrid)
     end
 
-    def attachments_collection
-      @attachments_collection ||= gobierto_common_collections(:users_dataset_attachments_collection)
-    end
-
     def test_valid
       assert subject.valid?
-    end
-
-    def test_attachments_collection
-      dataset = site.datasets.create(
-        name_translations: { en: "Departments", es: "Departamentos" },
-        table_name: "gp_departments"
-      )
-
-      assert dataset.attachments_collection.present?
-      assert_equal dataset.attachments_collection, dataset.attachments_collection!
-    end
-
-    def test_attachments_collection!
-      attachments_collection.destroy
-
-      assert_nil subject.attachments_collection
-      subject.attachments_collection!
-      assert subject.attachments_collection.present?
-      assert_equal subject.attachments_collection, subject.attachments_collection!
     end
   end
 end

--- a/test/models/gobierto_data/dataset_test.rb
+++ b/test/models/gobierto_data/dataset_test.rb
@@ -12,6 +12,10 @@ module GobiertoData
       @site ||= sites(:madrid)
     end
 
+    def attachments_collection
+      @attachments_collection ||= gobierto_common_collections(:users_dataset_attachments_collection)
+    end
+
     def test_valid
       assert subject.valid?
     end
@@ -27,6 +31,8 @@ module GobiertoData
     end
 
     def test_attachments_collection!
+      attachments_collection.destroy
+
       assert_nil subject.attachments_collection
       subject.attachments_collection!
       assert subject.attachments_collection.present?

--- a/test/models/gobierto_data/dataset_test.rb
+++ b/test/models/gobierto_data/dataset_test.rb
@@ -8,8 +8,29 @@ module GobiertoData
       @subject ||= gobierto_data_datasets(:users_dataset)
     end
 
+    def site
+      @site ||= sites(:madrid)
+    end
+
     def test_valid
       assert subject.valid?
+    end
+
+    def test_attachments_collection
+      dataset = site.datasets.create(
+        name_translations: { en: "Departments", es: "Departamentos" },
+        table_name: "gp_departments"
+      )
+
+      assert dataset.attachments_collection.present?
+      assert_equal dataset.attachments_collection, dataset.attachments_collection!
+    end
+
+    def test_attachments_collection!
+      assert_nil subject.attachments_collection
+      subject.attachments_collection!
+      assert subject.attachments_collection.present?
+      assert_equal subject.attachments_collection, subject.attachments_collection!
     end
   end
 end


### PR DESCRIPTION
Closes PopulateTools/issues#921

## :v: What does this PR do?

Adds attachments feature to gobierto data datasets:
* Includes attachments widget in backoffice
* Adds attachments info to datasets meta endpoint in `included` section

## :mag: How should this be manually tested?

Edit an existing dataset in backoffice. Send API requests to meta endpoint of datasets with attachments 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Pending