### PR TITLE
Sanitize table name in dataset form to avoid invalid names

### DIFF
--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -45,7 +45,7 @@ module GobiertoData
     end
 
     def table_name
-      @table_name ||= resource.table_name
+      @table_name.present? ? @table_name.parameterize.underscore : resource.table_name
     end
 
     def append


### PR DESCRIPTION
Closes PopulateTools/issues#942


## :v: What does this PR do?

* Sanitizes table name sent with the API transforming it if necessary in a valid name, by replacing spaces, '-' and invalid characters with '_' and using downcases.

## :mag: How should this be manually tested?

Create a dataset with the API and send in the table_name attribute something like "WADUS-WADUS". The dataset should be created (if no other errors present) with "wadus_wadus" table name

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
