### PR TITLE
Set POSTGTES_PASSWORD in circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ defaults: &defaults
       environment:
         POSTGRES_USER: gobierto
         POSTGRES_DB: gobierto_test
-        POSTGRES_PASSWORD: ""
+        POSTGRES_PASSWORD: gobierto
     - image: elasticsearch:2.4.1
     - image: redis:4.0.9
 


### PR DESCRIPTION
Related: docker-library/postgres#681

## :v: What does this PR do?

Fixes postgres docker image configuration in CircleCI that prevented the tests from working.

## :shipit: Does this PR changes any configuration file?

Only CircleCI configuration file

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No