### PR TITLE
Restore seeds with correct categories order

### DIFF
--- a/db/seeds/modules/gobierto_data/seeds.rb
+++ b/db/seeds/modules/gobierto_data/seeds.rb
@@ -3,27 +3,27 @@
 module GobiertoSeeds
   class Recipe
     DEFAULT_CATEGORY_NAMES = [
-      "Sector público",
-      "Transporte",
-      "Medio ambiente",
       "Ciencia y tecnología",
-      "Economía",
-      "Medio Rural",
-      "Demografía",
-      "Hacienda",
-      "Educación",
-      "Cultura y ocio",
-      "Turismo",
-      "Empleo",
-      "Sociedad y bienestar",
-      "Urbanismo e infraestructuras",
       "Comercio",
-      "Legislación y justicia",
-      "Salud",
-      "Seguridad",
-      "Industria",
-      "Energía",
+      "Cultura y ocio",
+      "Demografía",
       "Deporte",
+      "Economía",
+      "Educación",
+      "Empleo",
+      "Energía",
+      "Hacienda",
+      "Industria",
+      "Legislación y justicia",
+      "Medio Rural",
+      "Medio ambiente",
+      "Salud",
+      "Sector público",
+      "Seguridad",
+      "Sociedad y bienestar",
+      "Transporte",
+      "Turismo",
+      "Urbanismo e infraestructuras",
       "Vivienda"
     ].freeze
 
@@ -36,46 +36,47 @@ module GobiertoSeeds
         description.save
       end
 
-      frequency = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "frequency")
-      if frequency.new_record?
-        vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-frequency")
+      category = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "category")
+      if category.new_record?
+        vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-category")
         if vocabulary.new_record?
-          vocabulary.name_translations = { ca: "Freqüència de conjunt de dades", en: "Dataset frequency", es: "Frecuencia de conjunto de datos" }
+          vocabulary.name_translations = { ca: "Categoria de conjunt de dades", en: "Dataset Category", es: "Categoría de conjunto de datos" }
           vocabulary.save
-          vocabulary.terms.create(name_translations: { ca: "Anual", en: "Annual", es: "Anual" })
-          vocabulary.terms.create(name_translations: { ca: "Trimestral", en: "Quarterly", es: "Trimestral" })
-          vocabulary.terms.create(name_translations: { ca: "Mensual", en: "Monthly", es: "Mensual" })
-          vocabulary.terms.create(name_translations: { ca: "Diària", en: "Daily", es: "Diaria" })
+          DEFAULT_CATEGORY_NAMES.each_with_index do |category_name, index|
+            vocabulary.terms.create(
+              name_translations: Hash[site.configuration.available_locales.product([category_name])],
+              position: index + 1
+            )
+          end
         end
-        frequency.name_translations = { ca: "Freqüència", en: "Frequency", es: "Frecuencia" }
-        frequency.position = 2
-        frequency.options = {
-          configuration: { vocabulary_type: "single_select" },
+        category.name_translations = { ca: "Categoria", en: "Category", es: "Categoría" }
+        category.position = 3
+        category.options = {
+          configuration: { vocabulary_type: "multiple_select" },
           vocabulary_id: vocabulary.id.to_s
         }
-        frequency.save
+        category.save
       end
 
-      category = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "category")
-      return unless category.new_record?
+      frequency = site.custom_fields.vocabulary_options.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: "frequency")
+      return unless frequency.new_record?
 
-      vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-category")
+      vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-frequency")
       if vocabulary.new_record?
-        vocabulary.name_translations = { ca: "Categoria de conjunt de dades", en: "Dataset Category", es: "Categoría de conjunto de datos" }
+        vocabulary.name_translations = { ca: "Freqüència de conjunt de dades", en: "Dataset frequency", es: "Frecuencia de conjunto de datos" }
         vocabulary.save
-        DEFAULT_CATEGORY_NAMES.each do |category_name|
-          vocabulary.terms.create(
-            name_translations: Hash[site.configuration.available_locales.product([category_name])]
-          )
-        end
+        vocabulary.terms.create(name_translations: { ca: "Anual", en: "Annual", es: "Anual" }, position: 1)
+        vocabulary.terms.create(name_translations: { ca: "Trimestral", en: "Quarterly", es: "Trimestral" }, position: 2)
+        vocabulary.terms.create(name_translations: { ca: "Mensual", en: "Monthly", es: "Mensual" }, position: 3)
+        vocabulary.terms.create(name_translations: { ca: "Diària", en: "Daily", es: "Diaria" }, position: 4)
       end
-      category.name_translations = { ca: "Categoria", en: "Category", es: "Categoría" }
-      category.position = 3
-      category.options = {
-        configuration: { vocabulary_type: "multiple_select" },
+      frequency.name_translations = { ca: "Freqüència", en: "Frequency", es: "Frecuencia" }
+      frequency.position = 2
+      frequency.options = {
+        configuration: { vocabulary_type: "single_select" },
         vocabulary_id: vocabulary.id.to_s
       }
-      category.save
+      frequency.save
     end
   end
 end


### PR DESCRIPTION
##  :v: What does this PR do?

* Restores reordering of categories and custom fields in gobierto data module seeds, present in staging but missing in master

## :mag: How should this be manually tested?

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No