### PR TITLE
857 large downloads stream

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -38,7 +38,7 @@ module GobiertoData
         def show
           find_item
           relation = @item.rails_model.all
-          query_result = execute_query relation
+          query_result = execute_query relation.to_sql
           respond_to do |format|
             format.json do
               render(
@@ -68,7 +68,7 @@ module GobiertoData
         def download
           find_item
           relation = @item.rails_model.all
-          query_result = execute_query relation
+          query_result = execute_query relation.to_sql
           basename = @item.slug
           respond_to do |format|
             format.json do
@@ -166,10 +166,6 @@ module GobiertoData
 
         def find_item
           @item = base_relation.find_by!(slug: params[:slug])
-        end
-
-        def execute_query(relation)
-          GobiertoData::Connection.execute_query(current_site, relation.to_sql, include_draft: valid_preview_token?)
         end
 
         def links(self_key = nil)

--- a/app/controllers/gobierto_data/api/v1/live_stream_query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/live_stream_query_controller.rb
@@ -36,24 +36,24 @@ module GobiertoData
         def json_live_stream_data(sql, total_rows)
           row_num = 0
           response.stream.write "{\"data\":["
-          execute_stream_query(sql) do |execution|
+          with_query(sql) do |execution|
             time = Benchmark.measure do
-              execution.stream_each do |row|
+              execution.each do |row|
                 row_num += 1
                 response.stream.write row.to_json
                 response.stream.write "," unless row_num == total_rows
               end
             end
-            response.stream.write "],\"meta\":{\"duration\":#{time.real},\"rows\":#{total_rows},\"status\":\"#{execution.cmd_status}\"}}"
+            response.stream.write "],\"meta\":{\"duration\":#{1_000 * time.real},\"rows\":#{total_rows},\"status\":\"#{execution.cmd_status}\"}}"
           end
         ensure
           response.stream.close
         end
 
         def csv_live_stream_data(sql, options = {})
-          execute_stream_query(sql) do |execution|
+          with_query(sql) do |execution|
             response.stream.write CSV.generate_line(execution.fields, **options)
-            execution.stream_each_row do |row|
+            execution.each_row do |row|
               response.stream.write CSV.generate_line(row, **options)
             end
           end

--- a/app/controllers/gobierto_data/api/v1/live_stream_query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/live_stream_query_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module Api
+    module V1
+      class LiveStreamQueryController < BaseController
+        include ActionController::Live
+
+        # GET /api/v1/live_stream_data?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/live_stream_data.json?sql=SELECT%20%2A%20FROM%20table_name
+        # GET /api/v1/live_stream_data.csv?sql=SELECT%20%2A%20FROM%20table_name
+        def index
+          total_rows = query_rows_count(params[:sql])
+
+          if total_rows.is_a?(Hash)
+            render json: total_rows.slice(:errors), status: :bad_request, adapter: :json_api
+          else
+            set_streaming_headers
+            response.status = 200
+
+            respond_to do |format|
+              format.json do
+                json_live_stream_data(params[:sql], total_rows)
+              end
+
+              format.csv do
+                set_csv_headers
+                csv_live_stream_data(params[:sql], csv_options_params)
+              end
+            end
+          end
+        end
+
+        private
+
+        def json_live_stream_data(sql, total_rows)
+          row_num = 0
+          response.stream.write "{\"data\":["
+          execute_stream_query(sql) do |execution|
+            time = Benchmark.measure do
+              execution.stream_each do |row|
+                row_num += 1
+                response.stream.write row.to_json
+                response.stream.write "," unless row_num == total_rows
+              end
+            end
+            response.stream.write "],\"meta\":{\"duration\":#{time.real},\"rows\":#{total_rows},\"status\":\"#{execution.cmd_status}\"}}"
+          end
+        ensure
+          response.stream.close
+        end
+
+        def csv_live_stream_data(sql, options = {})
+          execute_stream_query(sql) do |execution|
+            response.stream.write CSV.generate_line(execution.fields, **options)
+            execution.stream_each_row do |row|
+              response.stream.write CSV.generate_line(row, **options)
+            end
+          end
+        ensure
+          response.stream.close
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -53,12 +53,6 @@ module GobiertoData
           end
         end
 
-        private
-
-        def execute_query(sql)
-          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql), include_draft: valid_preview_token?)
-        end
-
       end
     end
   end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -31,6 +31,28 @@ module GobiertoData
           end
         end
 
+        def stream_data
+          total_rows = query_rows_count(params[:sql])
+
+          if total_rows.is_a?(Hash)
+            render json: total_rows.slice(:errors), status: :bad_request, adapter: :json_api
+          else
+            set_streaming_headers
+            response.status = 200
+
+            respond_to do |format|
+              format.json do
+                self.response_body = json_stream_data(params[:sql], total_rows)
+              end
+
+              format.csv do
+                set_csv_headers
+                self.response_body = csv_stream_data(params[:sql], csv_options_params)
+              end
+            end
+          end
+        end
+
         private
 
         def execute_query(sql)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -568,6 +568,7 @@ Rails.application.routes.draw do
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
+            get "stream_data" => "query#stream_data", defaults: { format: "json" }
             resources :datasets, param: :slug, defaults: { format: "json" } do
               resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,6 +569,7 @@ Rails.application.routes.draw do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
             get "stream_data" => "query#stream_data", defaults: { format: "json" }
+            get "live_stream_data" => "live_stream_query#index", defaults: { format: "json" }
             resources :datasets, param: :slug, defaults: { format: "json" } do
               resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]


### PR DESCRIPTION
Related to #2774


## :v: What does this PR do?

* Tests different alternatives to download large query results, using streaming:
  * With an enumerator
  * Using `ActionController::Live`
* The streaming option is only available for json and csv formats

## :mag: How should this be manually tested?

In addition to the normal endpoint there are two new endpoints that return the data in streaming:
For example:
* Normal request: `/api/v1/data/data.{csv|json}?sql=select%20*%20from%20renfe_ave%20limit%202000`
* Stream with enumerator request: `/api/v1/data/stream_data.{csv|json}?sql=select%20*%20from%20renfe_ave%20limit%202000`
* Stream using `ActionController::Live`:  `/api/v1/data/live_stream_data.{csv|json}?sql=select%20*%20from%20renfe_ave%20limit%202000`

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
