### PR TITLE
2879 api data preview param

### DIFF
--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -8,9 +8,27 @@ module GobiertoData
         include ::User::ApiAuthenticationHelper
         include ::PreviewTokenHelper
 
+        DEFAULT_PREVIEW_LIMIT = 50
+
         before_action { module_enabled!(current_site, "GobiertoData", false) }
 
         private
+
+        def extract_preview(query_result)
+          query_result.delete(:result).tap do |data|
+            return data.first(preview_limit) if preview_limit
+          end
+        end
+
+        def default_preview_limit
+          @default_preview_limit ||= current_site.gobierto_data_settings.default_preview_limit || DEFAULT_PREVIEW_LIMIT
+        end
+
+        def preview_limit
+          return if params[:data_preview] == "false"
+
+          default_preview_limit
+        end
 
         def csv_options_params
           separator_tr = {

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -44,7 +44,7 @@ module GobiertoData
               render(
                 json:
                 {
-                  data: query_result.delete(:result),
+                  data: extract_preview(query_result),
                   meta: query_result,
                   links: links(:data)
                 },

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -40,7 +40,7 @@ module GobiertoData
               render(
                 json:
                 {
-                  data: query_result.delete(:result),
+                  data: extract_preview(query_result),
                   meta: query_result,
                   links: links(:data)
                 },

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -17,7 +17,7 @@ module GobiertoData
           else
             respond_to do |format|
               format.json do
-                render json: { data: query_result.delete(:result), meta: query_result }, adapter: :json_api
+                render json: { data: extract_preview(query_result), meta: query_result }, adapter: :json_api
               end
 
               format.csv do

--- a/test/controllers/gobierto_data/api/v1/query_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/query_controller_test.rb
@@ -110,6 +110,38 @@ module GobiertoData
           end
         end
 
+        def test_index_with_default_preview_limit
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT * FROM users"), as: :json
+
+            assert_response :success
+            assert_equal users_count, response.parsed_body["data"].count
+
+            get gobierto_data_api_v1_root_path(sql: "SELECT * FROM users", format: :csv), as: :csv
+
+            assert_response :success
+            parsed_csv = CSV.parse(response.parsed_body)
+            assert_equal users_count + 1, parsed_csv.count
+          end
+
+          module_settings = site.gobierto_data_settings
+          module_settings.default_preview_limit = users_count - 1
+          module_settings.save
+
+          with(site: site) do
+            get gobierto_data_api_v1_root_path(sql: "SELECT * FROM users"), as: :json
+
+            assert_response :success
+            assert_equal users_count - 1, response.parsed_body["data"].count
+
+            get gobierto_data_api_v1_root_path(sql: "SELECT * FROM users", format: :csv), as: :csv
+
+            assert_response :success
+            parsed_csv = CSV.parse(response.parsed_body)
+            assert_equal users_count + 1, parsed_csv.count
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
Closes #2879


## :v: What does this PR do?

* Makes by default to API to return a small preview of results of queries sent to the GobiertoData module database instead of the whole result for JSON requests. This affects to endpoints with JSON response:
  * **`GET`** `api/v1/data/datasets/DATASET-SLUG`
  * **`GET`** `api/v1/data/queries/QUERY-ID`
  * **`GET`** `api/v1/data/data?sql=···`
* By default the result is limited to the first 50 results, but this can be changed by adding a `default_preview_limit` value to gobierto data module settings.
* The preview can be ignored in the response if the request have a `data_preview` set to `false`

## :mag: How should this be manually tested?

Visit the endpoints and make requests in JSON response


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Update suggestion sent to gobierto.readme.io
