### PR TITLE
Use owned_attending_events in people controllers related with events

### DIFF
--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -7,10 +7,10 @@ module GobiertoPeople
       def index
         if params[:date]
           @filtering_date = Date.parse(params[:date])
-          @events = @person.attending_events.by_date(@filtering_date).published
+          @events = @person.owned_attending_events.by_date(@filtering_date).published
           @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         else
-          @events = QueryWithEvents.new(source: @person.attending_events.published,
+          @events = QueryWithEvents.new(source: @person.owned_attending_events.published,
                                         start_date: filter_start_date,
                                         end_date: filter_end_date).upcoming.sorted.page params[:page]
         end
@@ -39,7 +39,7 @@ module GobiertoPeople
       def fullcalendar_events
         starts = Time.zone.parse(params[:start])
         ends   = Time.zone.parse(params[:end])
-        events = @person.attending_events.published.where('starts_at >= ? AND ends_at <= ?', starts, ends)
+        events = @person.owned_attending_events.published.where('starts_at >= ? AND ends_at <= ?', starts, ends)
         events.map do |event|
           ::GobiertoCalendars::FullcalendarEventSerializer.new(
             event,
@@ -54,11 +54,11 @@ module GobiertoPeople
       end
 
       def set_calendar_events
-        @calendar_events = @person.attending_events.published
+        @calendar_events = @person.owned_attending_events.published
       end
 
       def person_events_scope
-        valid_preview_token? ? @person.attending_events : @person.attending_events.published
+        valid_preview_token? ? @person.owned_attending_events : @person.owned_attending_events.published
       end
 
       def manage_event?

--- a/app/controllers/gobierto_people/people_controller.rb
+++ b/app/controllers/gobierto_people/people_controller.rb
@@ -48,12 +48,12 @@ module GobiertoPeople
         redirect_to gobierto_people_person_events_path(@person.slug) and return
       end
 
-      @upcoming_events = @person.attending_events.upcoming.sorted.first(3)
+      @upcoming_events = @person.owned_attending_events.upcoming.sorted.first(3)
       @latest_activity = ActivityCollectionDecorator.new(Activity.for_recipient(@person).limit(30).sorted.page(params[:page]))
 
       # custom engine
       @last_events = QueryWithEvents.new(
-        source: @person.attending_events
+        source: @person.owned_attending_events
                        .published
                        .with_interest_group
                        .sorted_backwards

--- a/app/models/gobierto_people/person.rb
+++ b/app/models/gobierto_people/person.rb
@@ -60,6 +60,10 @@ module GobiertoPeople
       end
     end
 
+    def owned_attending_events
+      attending_events.person_events.where(collection_items: { container_id: id })
+    end
+
     def as_csv
       political_group_name = political_group.try(:name)
 

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -97,6 +97,25 @@ module GobiertoPeople
         end
       end
 
+      def test_person_events_present_in_other_agendas
+        attributes = {
+          start_date: Time.now.tomorrow,
+          title: "Duplicated event",
+          external_id: "duplicated-event"
+        }
+        richard_event = create_event(attributes.merge(person: richard))
+        richard_event.attendees.create(person: nelson)
+        nelson_event = create_event(attributes.merge(person: nelson))
+        nelson_event.attendees.create(person: richard)
+
+        with(site: site, js: true) do
+          visit gobierto_people_person_events_path(richard.slug)
+
+          assert has_content? richard_event.title
+          assert_equal 1, page.all("div.fc-title", text: richard_event.title).count
+        end
+      end
+
       def test_person_events_index_pagination
         # SKIP: with_javascript is causing concurrency problems with the create_event() helper, since this
         # events are not visible form the test. A solution is to use fixtures as in other test in this file,


### PR DESCRIPTION
Closes #2884


## :v: What does this PR do?

* Avoids appearing of the same event multiple times on the calendar and events list when the event has other people as attendees.

## :mag: How should this be manually tested?

Visit calendar of a person with an event present in other people calendars. The event should appear once.

## :eyes: Screenshots

### Before this PR

![2884_before](https://user-images.githubusercontent.com/446459/75552837-77eddd80-5a37-11ea-942a-4e73e2256a50.gif)


### After this PR

![2884_after](https://user-images.githubusercontent.com/446459/75558869-c05ec880-5a42-11ea-874e-ff5eb27d81f5.gif)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
