### PR TITLE
Remove duplicated definition of constants in SiteConfiguration model

### DIFF
--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -25,9 +25,6 @@ class SiteConfiguration
   MODULES_WITH_NOTIFICATONS = %w(GobiertoPeople GobiertoBudgetConsultations GobiertoParticipation).freeze
   MODULES_WITH_COLLECTIONS = %w(GobiertoParticipation GobiertoData).freeze
 
-  MODULES_WITH_NOTIFICATONS = ["GobiertoPeople", "GobiertoBudgetConsultations", "GobiertoParticipation"]
-  MODULES_WITH_COLLECTIONS = ["GobiertoParticipation", "GobiertoData"]
-
   attr_accessor *PROPERTIES
 
   alias :site_modules :modules


### PR DESCRIPTION
## :v: What does this PR do?

Fixes a wrong conflict resolution  that caused a duplicated definition of `MODULES_WITH_NOTIFICATONS` and `MODULES_WITH_COLLECTIONS ` constants in `SiteConfiguration` model

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
