### PR TITLE
2900 visualizations sql attribute

### DIFF
--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -122,7 +122,7 @@ module GobiertoData
         end
 
         def visualization_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:query_id, :name_translations, :name, :privacy_status, :spec])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:query_id, :name_translations, :name, :privacy_status, :spec, :sql])
         end
 
         def filter_params

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -122,7 +122,7 @@ module GobiertoData
         end
 
         def visualization_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:query_id, :name_translations, :name, :privacy_status, :spec, :sql])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:query_id, :dataset_id, :name_translations, :name, :privacy_status, :spec, :sql])
         end
 
         def filter_params

--- a/app/forms/concerns/gobierto_data/has_sql_attribute.rb
+++ b/app/forms/concerns/gobierto_data/has_sql_attribute.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module HasSqlAttribute
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :sql
+
+      validate :sql_validation
+    end
+
+    def sql_validation
+      return if sql.blank?
+
+      query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
+      if query_test.has_key? :errors
+        errors.add(:sql, query_test[:errors].map { |error| error[:sql] }.join("\n"))
+      end
+    end
+  end
+end

--- a/app/forms/concerns/gobierto_data/has_sql_attribute.rb
+++ b/app/forms/concerns/gobierto_data/has_sql_attribute.rb
@@ -11,7 +11,7 @@ module GobiertoData
     end
 
     def sql_validation
-      return if sql.blank?
+      return if site.blank? || sql.blank?
 
       query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
       if query_test.has_key? :errors

--- a/app/forms/gobierto_data/query_form.rb
+++ b/app/forms/gobierto_data/query_form.rb
@@ -3,14 +3,14 @@
 module GobiertoData
   class QueryForm < BaseForm
     include ::GobiertoCore::TranslationsHelpers
+    include HasSqlAttribute
 
     attr_accessor(
       :id,
       :site_id,
       :dataset_id,
       :user_id,
-      :name,
-      :sql
+      :name
     )
 
     attr_writer(
@@ -20,7 +20,6 @@ module GobiertoData
 
     validates :dataset, :site, :user, :sql, presence: true
     validates :name_translations, translated_attribute_presence: true
-    validate :sql_validation
 
     delegate :persisted?, to: :query
 
@@ -80,15 +79,6 @@ module GobiertoData
       promote_errors(@query.errors)
 
       false
-    end
-
-    def sql_validation
-      return if sql.blank?
-
-      query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
-      if query_test.has_key? :errors
-        errors.add(:sql, query_test[:errors].map { |error| error[:sql] }.join("\n"))
-      end
     end
   end
 end

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -19,7 +19,7 @@ module GobiertoData
       :spec
     )
 
-    validates :query, :site, :user, :spec, presence: true
+    validates :site, :user, :spec, presence: true
     validates :name_translations, translated_attribute_presence: true
     validate :spec_validation
 
@@ -73,7 +73,7 @@ module GobiertoData
 
     def save_visualization
       @visualization = visualization.tap do |attributes|
-        attributes.query_id = query.id
+        attributes.query_id = query&.id
         attributes.sql = sql
         attributes.user_id = user.id
         attributes.name_translations = name_translations

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -3,6 +3,7 @@
 module GobiertoData
   class VisualizationForm < BaseForm
     include ::GobiertoCore::TranslationsHelpers
+    include HasSqlAttribute
 
     attr_accessor(
       :id,
@@ -73,6 +74,7 @@ module GobiertoData
     def save_visualization
       @visualization = visualization.tap do |attributes|
         attributes.query_id = query.id
+        attributes.sql = sql
         attributes.user_id = user.id
         attributes.name_translations = name_translations
         attributes.privacy_status = privacy_status

--- a/app/forms/gobierto_data/visualization_form.rb
+++ b/app/forms/gobierto_data/visualization_form.rb
@@ -9,6 +9,7 @@ module GobiertoData
       :id,
       :site_id,
       :query_id,
+      :dataset_id,
       :user_id,
       :name
     )
@@ -19,7 +20,7 @@ module GobiertoData
       :spec
     )
 
-    validates :site, :user, :spec, presence: true
+    validates :site, :user, :spec, :dataset, presence: true
     validates :name_translations, translated_attribute_presence: true
     validate :spec_validation
 
@@ -31,6 +32,10 @@ module GobiertoData
 
     def query
       @query ||= site.presence && site.queries.find_by(id: query_id) || visualization.query
+    end
+
+    def dataset
+      @dataset ||= query.present? ? query.dataset : site.presence && site.datasets.find_by(id: dataset_id) || visualization.dataset
     end
 
     def user
@@ -73,6 +78,7 @@ module GobiertoData
 
     def save_visualization
       @visualization = visualization.tap do |attributes|
+        attributes.dataset_id = dataset.id
         attributes.query_id = query&.id
         attributes.sql = sql
         attributes.user_id = user.id

--- a/app/models/gobierto_data/visualization.rb
+++ b/app/models/gobierto_data/visualization.rb
@@ -17,5 +17,11 @@ module GobiertoData
 
     validates :query, :user, :name, presence: true
     delegate :site, :dataset, :visibility_level, to: :query
+
+    def result(include_draft: false)
+      return unless sql.present?
+
+      Connection.execute_query(site, sql, include_draft: include_draft)
+    end
   end
 end

--- a/app/models/gobierto_data/visualization.rb
+++ b/app/models/gobierto_data/visualization.rb
@@ -6,17 +6,17 @@ module GobiertoData
   class Visualization < ApplicationRecord
     include GobiertoData::Favoriteable
 
+    belongs_to :dataset
     belongs_to :query
     belongs_to :user
-    has_one :dataset, through: :query
     enum privacy_status: { open: 0, closed: 1 }
 
     translates :name
 
     scope :active, -> { joins(:dataset).where(GobiertoData::Dataset.table_name => { visibility_level: GobiertoData::Dataset.visibility_levels[:active] }) }
 
-    validates :query, :user, :name, presence: true
-    delegate :site, :dataset, :visibility_level, to: :query
+    validates :dataset, :user, :name, presence: true
+    delegate :site, :visibility_level, to: :dataset
 
     def result(include_draft: false)
       return unless sql.present?

--- a/app/serializers/gobierto_data/visualization_serializer.rb
+++ b/app/serializers/gobierto_data/visualization_serializer.rb
@@ -7,7 +7,7 @@ module GobiertoData
     attributes :id
     attribute :name, unless: :with_translations?
     attribute :name_translations, if: :with_translations?
-    attributes :privacy_status, :spec, :query_id, :user_id
+    attributes :privacy_status, :spec, :sql, :query_id, :user_id
     belongs_to :query, unless: :exclude_relationships?
     belongs_to :user, unless: :exclude_relationships?
 

--- a/app/serializers/gobierto_data/visualization_serializer.rb
+++ b/app/serializers/gobierto_data/visualization_serializer.rb
@@ -7,8 +7,9 @@ module GobiertoData
     attributes :id
     attribute :name, unless: :with_translations?
     attribute :name_translations, if: :with_translations?
-    attributes :privacy_status, :spec, :sql, :query_id, :user_id
+    attributes :privacy_status, :spec, :sql, :query_id, :dataset_id, :user_id
     belongs_to :query, unless: :exclude_relationships?
+    belongs_to :dataset, unless: :exclude_relationships?
     belongs_to :user, unless: :exclude_relationships?
 
     attribute :links, unless: :exclude_links? do

--- a/db/migrate/20200309131827_add_sql_to_gdata_visualizations.rb
+++ b/db/migrate/20200309131827_add_sql_to_gdata_visualizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSqlToGdataVisualizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :gdata_visualizations, :sql, :string
+  end
+end

--- a/db/migrate/20200309152257_change_query_id_in_gdata_visualizations.rb
+++ b/db/migrate/20200309152257_change_query_id_in_gdata_visualizations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeQueryIdInGdataVisualizations < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :gdata_visualizations, :dataset, index: true
+
+    ::GobiertoData::Visualization.all.each do |visualization|
+      visualization.update_attribute(:dataset_id, visualization.query.dataset_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_09_131827) do
+ActiveRecord::Schema.define(version: 2020_03_09_152257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -559,7 +559,6 @@ ActiveRecord::Schema.define(version: 2020_03_09_131827) do
   end
 
   create_table "gdata_visualizations", force: :cascade do |t|
-    t.bigint "query_id"
     t.bigint "user_id"
     t.jsonb "name_translations"
     t.integer "privacy_status", default: 0, null: false
@@ -567,6 +566,9 @@ ActiveRecord::Schema.define(version: 2020_03_09_131827) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "sql"
+    t.bigint "query_id"
+    t.bigint "dataset_id"
+    t.index ["dataset_id"], name: "index_gdata_visualizations_on_dataset_id"
     t.index ["query_id"], name: "index_gdata_visualizations_on_query_id"
     t.index ["user_id"], name: "index_gdata_visualizations_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_14_113010) do
+ActiveRecord::Schema.define(version: 2020_03_09_131827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -566,6 +566,7 @@ ActiveRecord::Schema.define(version: 2020_02_14_113010) do
     t.jsonb "spec"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sql"
     t.index ["query_id"], name: "index_gdata_visualizations_on_query_id"
     t.index ["user_id"], name: "index_gdata_visualizations_on_user_id"
   end

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -87,6 +87,7 @@ module GobiertoData
             name_translations: visualization.name_translations,
             privacy_status: visualization.privacy_status,
             spec: visualization.spec,
+            sql: visualization.sql,
             query_id: visualization.query_id,
             user_id: visualization.user_id
           }.with_indifferent_access
@@ -99,6 +100,7 @@ module GobiertoData
             attributes[:name],
             attributes[:privacy_status],
             attributes[:spec].to_s,
+            attributes[:sql],
             attributes[:query_id].to_s,
             attributes[:user_id].to_s
           ]
@@ -116,6 +118,7 @@ module GobiertoData
                   es: "Nueva visualización"
                 },
                 privacy_status: "open",
+                sql: "select count(*) from users where bio is not null",
                 spec: {
                   "x" => 1,
                   "y" => 2,
@@ -169,7 +172,8 @@ module GobiertoData
 
             refute_equal active_visualizations_count + 1, parsed_csv.count
             assert_equal open_active_visualizations_count + 1, parsed_csv.count
-            assert_equal %w(id name privacy_status spec query_id user_id), parsed_csv.first
+            assert_equal %w(id name privacy_status spec sql query_id user_id), parsed_csv.first
+
             assert_includes parsed_csv, array_data(open_visualization)
             refute_includes parsed_csv, array_data(closed_visualization)
           end
@@ -203,12 +207,12 @@ module GobiertoData
             assert_equal 1, parsed_xlsx.worksheets.count
             sheet = parsed_xlsx.worksheets.first
             assert_nil sheet[open_active_visualizations_count + 1]
-            assert_equal %w(id name privacy_status spec query_id user_id), sheet[0].cells.map(&:value)
+            assert_equal %w(id name privacy_status spec sql query_id user_id), sheet[0].cells.map(&:value)
             values = (1..open_active_visualizations_count).map do |row_number|
               sheet[row_number].cells.map { |cell| cell.value.to_s }
             end
-            assert_includes values, array_data(open_visualization)
-            refute_includes values, array_data(closed_visualization)
+            assert_includes values, array_data(open_visualization).map(&:to_s)
+            refute_includes values, array_data(closed_visualization).map(&:to_s)
           end
         end
 
@@ -402,7 +406,7 @@ module GobiertoData
 
               # attributes
               attributes = attributes_data(new_visualization)
-              %w(name_translations privacy_status spec query_id).each do |attribute|
+              %w(name_translations privacy_status spec sql query_id).each do |attribute|
                 assert resource_data["attributes"].has_key? attribute
                 assert_equal attributes[attribute], resource_data["attributes"][attribute]
               end
@@ -476,7 +480,7 @@ module GobiertoData
 
               # attributes
               attributes = valid_params[:data][:attributes].with_indifferent_access
-              %w(name_translations privacy_status spec query_id).each do |attribute|
+              %w(name_translations privacy_status spec sql query_id).each do |attribute|
                 assert resource_data["attributes"].has_key? attribute
                 assert_equal attributes[attribute], resource_data["attributes"][attribute]
               end

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -1,5 +1,6 @@
 users_count_visualization:
   query: users_count_query
+  dataset: users_dataset
   user: dennis
   name_translations: <%= { en: "Users count visualization", es: "Visualización de cuenta de usuarios" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
@@ -21,6 +22,7 @@ users_count_visualization:
 
 census_verified_users_visualization:
   query: census_verified_users_query
+  dataset: users_dataset
   user: peter
   name_translations: <%= { en: "Verified users", es: "Usuarios verificados" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
@@ -42,12 +44,14 @@ census_verified_users_visualization:
 
 events_count_open_visualization:
   query: events_count_query
+  dataset: events_dataset
   user: dennis
   name_translations: <%= { en: "Events count visualization open", es: "Visualización de cuenta de eventos abierta" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
   spec: "{}"
 
 visualization_with_sql_and_blank_query:
+  dataset: users_dataset
   user: dennis
   name_translations: <%= { en: "Users by gender", es: "Usuarios por género"}.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
@@ -70,6 +74,7 @@ visualization_with_sql_and_blank_query:
 
 events_count_closed_visualization:
   query: events_count_query
+  dataset: events_dataset
   user: dennis
   name_translations: <%= { en: "Events count visualization closed", es: "Visualización de cuenta de eventos cerrada" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["closed"] %>
@@ -77,6 +82,7 @@ events_count_closed_visualization:
 
 draft_dataset_visualization:
   query: draft_dataset_query
+  dataset: draft_dataset
   user: dennis
   name_translations: <%= { en: "Interest Groups by domain visualization", es: "Visualización de grupos de interés por dominio" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -47,6 +47,27 @@ events_count_open_visualization:
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
   spec: "{}"
 
+visualization_with_sql_and_blank_query:
+  user: dennis
+  name_translations: <%= { en: "Users by gender", es: "Usuarios por género"}.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
+  sql: "select gender, count(id) from users group by gender"
+  spec: <%= {
+    "$schema" => "https://vega.github.io/schema/vega/v5.json",
+    "description" => "A specification outline example.",
+    "width" => 500,
+    "height" => 200,
+    "padding" => 5,
+    "autosize" => "pad",
+    "signals" => [],
+    "data" => [],
+    "scales" => [],
+    "projections" => [],
+    "axes" => [],
+    "legends" => [],
+    "marks" => []
+  }.to_json %>
+
 events_count_closed_visualization:
   query: events_count_query
   user: dennis

--- a/test/forms/gobierto_data/visualization_form_test.rb
+++ b/test/forms/gobierto_data/visualization_form_test.rb
@@ -97,10 +97,10 @@ module GobiertoData
     end
 
     def test_invalid_missing_attributes
-      form = subject.new(valid_attributes.except(:site_id, :query_id, :user_id, :spec, :name, :name_translations))
+      form = subject.new(valid_attributes.except(:site_id, :user_id, :spec, :name, :name_translations))
 
       refute form.valid?
-      %w(site query user spec name_translations).each do |attribute|
+      %w(site user spec name_translations).each do |attribute|
         assert form.errors[attribute].include? "can't be blank"
       end
     end


### PR DESCRIPTION
Closes #2900


## :v: What does this PR do?

* Allows to define a sql attribute in visualizations and make them independent of a query.
* Adds an association of visualizations with datasets. If a query is specified in a visualization the dataset is inferred from it.

## :mag: How should this be manually tested?

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation updated
