### PR TITLE
Change association of visualizations with site via datasets instead …

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -90,7 +90,7 @@ class Site < ApplicationRecord
   # GobiertoData integration
   has_many :datasets, dependent: :destroy, class_name: "GobiertoData::Dataset"
   has_many :queries, through: :datasets, class_name: "GobiertoData::Query"
-  has_many :visualizations, through: :queries, class_name: "GobiertoData::Visualization"
+  has_many :visualizations, through: :datasets, class_name: "GobiertoData::Visualization"
 
   serialize :configuration_data
 


### PR DESCRIPTION


## :v: What does this PR do?

Fixes a bug where the relation defined between site and visualizations is made with queries instead of datasets. In this way, the visualizations API controller index without parameters was only returning visualizations for the site with a `query_id`.

## :mag: How should this be manually tested?

Visit the endpoint of API index visualizations or the show endpoint of an open visualization with blank query association. The API should return data

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
