### PR TITLE
Take out specific module CSS from the main bundle (data)

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -108,8 +108,6 @@
 @import "module-citizens-charters";
 @import "module-citizens-charters-custom";
 
-@import "module-data";
-
 /*
  * Gobierto themes
  *

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -1,3 +1,8 @@
+@import "css-conf";
+@import "mixins";
+@import "comp-block-checkbox";
+@import "comp-block-header";
+
 :root {
   --transition: .1s ease-in;
   --shadow: 0 2px 20px rgba(0, 0, 0, .3);

--- a/app/javascript/gobierto_data/index.js
+++ b/app/javascript/gobierto_data/index.js
@@ -1,7 +1,5 @@
+import "../../assets/stylesheets/module-data.scss"
 import { GobiertoDataController } from "./modules/gobierto_data_controller.js";
-import "../../assets/stylesheets/comp-block-checkbox.scss"
-import "../../assets/stylesheets/comp-block-header.scss"
-
 
 document.addEventListener('DOMContentLoaded', () => {
   const appNode = document.getElementById("gobierto-datos-app");

--- a/app/javascript/gobierto_data/webapp/pages/Home.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Home.vue
@@ -20,7 +20,6 @@ import { store } from "./../../lib/store";
 import CONFIGURATION from "./../../lib/gobierto-data.conf.js";
 import axios from "axios";
 
-
 export default {
   name: "Home",
   components: {


### PR DESCRIPTION
## :v: What does this PR do?
Removes any reference of a specific module CSS from the main CSS bundle. That will shrink the bundle size, bringing only those specific CSS files the module requires.

In this PR, it only includes `gobierto-data` files.

Related to #2801 #2806 

Results of XHR requests, when the module css is isolated:
![imagen](https://user-images.githubusercontent.com/817526/76537251-cced1300-647d-11ea-8af7-85bf5dcd1f0d.png)

## :book: Does this PR require updating the documentation?
Yes, about how to add CSS from now on.
