### PR TITLE
2888 select2 on projects category

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
@@ -124,7 +124,7 @@ module GobiertoAdmin
 
       def parent_terms_for_select(relation)
         flatten_tree(relation).map do |term|
-          ["#{"--" * term.level} #{term.name}".strip, term.id]
+          [ActiveSupport::SafeBuffer.new("#{"&nbsp;" * 6 * term.level} #{term.name}".strip), term.id]
         end
       end
 

--- a/app/decorators/gobierto_common/custom_field_record_decorator.rb
+++ b/app/decorators/gobierto_common/custom_field_record_decorator.rb
@@ -53,7 +53,7 @@ module GobiertoCommon
         tag_attributes: {}
       },
       vocabulary_options: {
-        class_names: ->(record) { record.vocabulary_class_names },
+        class_names: "form_item select_control p_1",
         field_tag: :select_tag,
         partial: "vocabulary",
         tag_attributes: ->(record) { record.vocabulary_type_attributes }
@@ -138,10 +138,6 @@ module GobiertoCommon
         include_blank: !required?,
         data: { behavior: custom_field.configuration.vocabulary_type }
       }
-    end
-
-    def vocabulary_class_names
-      "form_item select_control #{"p_1" unless vocabulary_single_select?}"
     end
 
     def vocabulary_single_select?

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -77,7 +77,7 @@ module GobiertoAdmin
         @category_options ||= begin
                                 enabled_level = plan.categories_vocabulary.maximum_level
                                 plan.categories_vocabulary.ordered_flatten_terms_tree.map do |term|
-                                  ["#{"--" * term.level} #{term.name}".strip, term.level == enabled_level ? term.id : "disabled"]
+                                  [ActiveSupport::SafeBuffer.new("#{"&nbsp;" * 6 * term.level} #{term.name}".strip), term.level == enabled_level ? term.id : "disabled"]
                                 end
                               end
       end

--- a/app/javascript/gobierto_admin/modules/gobierto_common_custom_field_records_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_common_custom_field_records_controller.js
@@ -153,6 +153,7 @@ window.GobiertoAdmin.GobiertoCommonCustomFieldRecordsController = (function() {
   }
 
   function _handleSelectBehaviors() {
+    $("[data-behavior=single_select]").select2()
     $("[data-behavior=multiple_select]").select2()
     $("[data-behavior=tags]").select2({
       tags: true,

--- a/app/javascript/gobierto_admin/modules/gobierto_plans_plan_projects_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_plans_plan_projects_controller.js
@@ -21,6 +21,13 @@ window.GobiertoAdmin.GobiertoPlansPlanProjectsController = (function() {
     })
   }
 
+  function _handleCategoriesSelectBehaviors() {
+    $("select#project_category_id").select2()
+
+    // This should be controlled via css
+    $(".select2-container").css("padding-top", "22px");
+  }
+
   GobiertoPlansPlanProjectsController.prototype.form = function(opts) {
     $(".js-admin-widget-save label").click(function(e) {
       var styleClass = $(e.target).attr("data-status-style")
@@ -32,6 +39,7 @@ window.GobiertoAdmin.GobiertoPlansPlanProjectsController = (function() {
       var newStateText = e.target.textContent.trim();
       $(".g_popup_context .i_p_status a").text(newStateText);
     })
+    _handleCategoriesSelectBehaviors()
   };
 
   return GobiertoPlansPlanProjectsController;

--- a/app/javascript/gobierto_admin/modules/terms_controller.js
+++ b/app/javascript/gobierto_admin/modules/terms_controller.js
@@ -101,6 +101,17 @@ window.GobiertoAdmin.TermsController = (function() {
     });
   }
 
+  TermsController.prototype.form = function() {
+    _handleTermsSelectBehaviors()
+  }
+
+  function _handleTermsSelectBehaviors() {
+    $("select#term_term_id").select2()
+
+    // This should be controlled via css
+    $(".select2-container").css("padding-top", "22px");
+  }
+
   return TermsController;
 })();
 

--- a/app/javascript/lib/shared/modules/globals.js
+++ b/app/javascript/lib/shared/modules/globals.js
@@ -36,6 +36,9 @@ $(document).on("turbolinks:load ajax:complete ajaxSuccess", function() {
         if (window.GobiertoAdmin && window.GobiertoAdmin.admin_groups_admins_controller) {
           window.GobiertoAdmin.admin_groups_admins_controller.index();
         }
+        if (window.GobiertoAdmin && window.GobiertoAdmin.terms_controller) {
+          window.GobiertoAdmin.terms_controller.form()
+        }
       }
     }
   });

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
@@ -27,7 +27,7 @@
       <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
     </div>
 
-    <div class="form_item select_control">
+    <div class="form_item select_control p_1">
       <%= f.label :term_id %>
       <%= f.select :term_id,
         options_for_select(@parent_terms, selected: @term_form.term.term_id, disabled: @leaf_terms || []),
@@ -39,4 +39,10 @@
     <%= f.submit %>
   </div>
 
+<% end %>
+
+<% content_for :javascript_hook do %>
+  <%= javascript_tag do %>
+    window.GobiertoAdmin.terms_controller.form()
+  <% end %>
 <% end %>

--- a/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/_form.html.erb
@@ -4,7 +4,7 @@
 
 <div class="pure-g">
   <div class="pure-u-1 pure-u-md-17-24">
-    <div class="form_item select_control">
+    <div class="form_item select_control p_1">
       <%= label_tag "project[category_id]" do %>
         <%= @project_form.class.human_attribute_name(:category_id) %>
         <%= attribute_indication_tag required: true %>

--- a/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
@@ -80,7 +80,7 @@ module GobiertoCommon
               assert has_field? "term_name_translations_en", with: "Dog updated"
               assert has_field? "term_description_translations_en", with: "Dog description updated"
               assert has_field? "term_slug", with: "dog-updated"
-              assert has_select? "term_term_id", selected: "-- Cat"
+              assert has_select? "term_term_id", selected: "#{" " * 6} Cat"
 
               activity = Activity.last
               assert_equal term, activity.subject


### PR DESCRIPTION
Closes #2888


## :v: What does this PR do?

Replaces categories select on projects with select2

## :mag: How should this be manually tested?

Visit edition or new project form in admin

## :eyes: Screenshots

### Before this PR

![2888_before](https://user-images.githubusercontent.com/446459/77304334-95d7f680-6cf4-11ea-8931-6917efae936d.gif)


### After this PR

![2888_after](https://user-images.githubusercontent.com/446459/77304362-9d979b00-6cf4-11ea-8995-f0e327c59829.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
