### PR TITLE
2931 terms external

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
@@ -109,6 +109,7 @@ module GobiertoAdmin
         params.require(:term).permit(
           :slug,
           :term_id,
+          :external_id,
           name_translations: [*I18n.available_locales],
           description_translations: [*I18n.available_locales]
         )

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -18,6 +18,7 @@ module GobiertoAdmin
       delegate :persisted?, to: :term
 
       validates :name_translations, :site, :vocabulary, presence: true
+      validate :external_id_uniqueness_by_vocabulary
 
       def term
         @term ||= term_relation.find_by(id: id) || build_term
@@ -67,6 +68,12 @@ module GobiertoAdmin
 
       def site
         @site ||= Site.find_by(id: site_id)
+      end
+
+      def external_id_uniqueness_by_vocabulary
+        return unless vocabulary.present?
+
+        errors.add :external_id, I18n.t("errors.messages.taken") if vocabulary.terms.where.not(id: term.id).where(external_id: external_id).exists?
       end
     end
   end

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -11,7 +11,8 @@ module GobiertoAdmin
         :name_translations,
         :description_translations,
         :slug,
-        :term_id
+        :term_id,
+        :external_id
       )
 
       delegate :persisted?, to: :term
@@ -35,6 +36,7 @@ module GobiertoAdmin
       def vocabulary
         @vocabulary ||= begin
                           return unless site
+
                           if vocabulary_id
                             site.vocabularies.find_by_id(vocabulary_id)
                           else
@@ -50,6 +52,7 @@ module GobiertoAdmin
           attributes.description_translations = description_translations
           attributes.slug = slug
           attributes.term_id = term_id
+          attributes.external_id = external_id if external_id.present?
         end
 
         return @term if @term.save

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -71,7 +71,7 @@ module GobiertoAdmin
       end
 
       def external_id_uniqueness_by_vocabulary
-        return unless vocabulary.present?
+        return unless vocabulary.present? && external_id.present?
 
         errors.add :external_id, I18n.t("errors.messages.taken") if vocabulary.terms.where.not(id: term.id).where(external_id: external_id).exists?
       end

--- a/app/models/concerns/gobierto_common/has_external_id.rb
+++ b/app/models/concerns/gobierto_common/has_external_id.rb
@@ -8,15 +8,27 @@ module GobiertoCommon
       before_validation :set_external_id
     end
 
+    module ClassMethods
+      def external_id_scope(method)
+        @external_id_method = method
+      end
+
+      def external_id_method
+        @external_id_method
+      end
+    end
+
     def set_external_id
       return if external_id.present?
 
-      self.external_id = new_external_id
+      self.external_id = self.class.external_id_method.present? ? scoped_new_external_id(send(self.class.external_id_method)) : new_external_id
     end
 
     def new_external_id
+      table_name = self.class.table_name
+
       base_id = id || self.class.maximum(:id) + 1
-      if (related_external_ids = self.class.where("external_id ~* ?", "#{base_id}-\\d+$")).exists?
+      if (related_external_ids = self.class.where("#{table_name}.external_id ~* ?", "#{base_id}-\\d+$")).exists?
         max_count = related_external_ids.pluck(:external_id).map { |related_id| related_id.scan(/\d+$/).first.to_i }.max
         "#{base_id}-#{max_count + 1}"
       elsif self.class.exists?(external_id: base_id)
@@ -28,11 +40,11 @@ module GobiertoCommon
 
     def scoped_new_external_id(relation = nil)
       relation ||= self.class.all
-
+      table_name = self.class.table_name
       base_id = (relation.where.not(external_id: nil).count + 1).to_s
       return base_id unless relation.where(external_id: base_id).exists?
 
-      max_numeric_external_id = relation.where("external_id ~* ?", "^\\d+$").pluck(:external_id).map(&:to_i).max
+      max_numeric_external_id = relation.where("#{table_name}.external_id ~* ?", "^\\d+$").pluck(:external_id).map(&:to_i).max
 
       return (max_numeric_external_id + 1).to_s unless max_numeric_external_id.blank? || relation.where(external_id: max_numeric_external_id + 1).exists?
 

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -7,7 +7,6 @@ module GobiertoCommon
     include GobiertoCommon::ActsAsTree
     include User::Subscribable
     include GobiertoCommon::Sluggable
-    include GobiertoCommon::HasExternalId
     after_save :update_children_levels
     before_destroy :free_children
     before_validation :clear_parent_if_itself
@@ -28,8 +27,6 @@ module GobiertoCommon
       terms.name_translations ->> 'es' ILIKE :name OR
       terms.name_translations ->> 'ca' ILIKE :name), name: name.to_s)
     }
-
-    external_id_scope :same_vocabulary_terms
 
     translates :name, :description
 
@@ -75,10 +72,6 @@ module GobiertoCommon
     end
 
     private
-
-    def same_vocabulary_terms
-      vocabulary.terms
-    end
 
     def calculate_level
       self.level = parent_term.present? ? parent_term.level + 1 : 0

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -111,7 +111,7 @@ module GobiertoCommon
 
     def clear_parent_if_itself
       if parent_term == self
-        term_id = nil
+        self.term_id = nil
         errors.add(:term_id)
       end
     end

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -7,6 +7,7 @@ module GobiertoCommon
     include GobiertoCommon::ActsAsTree
     include User::Subscribable
     include GobiertoCommon::Sluggable
+    include GobiertoCommon::HasExternalId
     after_save :update_children_levels
     before_destroy :free_children
     before_validation :clear_parent_if_itself
@@ -27,6 +28,8 @@ module GobiertoCommon
       terms.name_translations ->> 'es' ILIKE :name OR
       terms.name_translations ->> 'ca' ILIKE :name), name: name.to_s)
     }
+
+    external_id_scope :same_vocabulary_terms
 
     translates :name, :description
 
@@ -72,6 +75,10 @@ module GobiertoCommon
     end
 
     private
+
+    def same_vocabulary_terms
+      vocabulary.terms
+    end
 
     def calculate_level
       self.level = parent_term.present? ? parent_term.level + 1 : 0

--- a/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/ordered_terms/_form.html.erb
@@ -27,6 +27,11 @@
       <%= f.text_field :slug, placeholder: t(".placeholders.slug") %>
     </div>
 
+    <div class="form_item input_text">
+      <%= f.label :external_id %>
+      <%= f.text_field :external_id, placeholder: t(".placeholders.external_id") %>
+    </div>
+
     <div class="form_item select_control p_1">
       <%= f.label :term_id %>
       <%= f.select :term_id,

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -26,6 +26,7 @@ ca:
         vocabulary_options: Vocabulari
       gobierto_admin/gobierto_common/term_form:
         description: Descripció
+        external_id: ID externo
         name: Nom
         slug: Slug
         term_id: Térme Pare

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -26,7 +26,7 @@ ca:
         vocabulary_options: Vocabulari
       gobierto_admin/gobierto_common/term_form:
         description: Descripció
-        external_id: ID externo
+        external_id: ID extern
         name: Nom
         slug: Slug
         term_id: Térme Pare

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -26,6 +26,7 @@ en:
         vocabulary_options: Vocabulary
       gobierto_admin/gobierto_common/term_form:
         description: Description
+        external_id: External ID
         name: Name
         slug: Slug
         term_id: Parent Term

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -26,7 +26,7 @@ es:
         vocabulary_options: Vocabulario
       gobierto_admin/gobierto_common/term_form:
         description: Descripción
-        external_id: ID extern
+        external_id: ID externo
         name: Nombre
         slug: Slug
         term_id: Término Padre

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -26,6 +26,7 @@ es:
         vocabulary_options: Vocabulario
       gobierto_admin/gobierto_common/term_form:
         description: Descripción
+        external_id: ID extern
         name: Nombre
         slug: Slug
         term_id: Término Padre

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/ca.yml
@@ -8,6 +8,7 @@ ca:
         form:
           placeholders:
             description: Descripció del terme
+            external_id: ID001
             name: Nom del terme
             slug: terme
         index:

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/en.yml
@@ -8,6 +8,7 @@ en:
         form:
           placeholders:
             description: Term description
+            external_id: ID001
             name: Term name
             slug: term
         index:

--- a/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/views/es.yml
@@ -8,6 +8,7 @@ es:
         form:
           placeholders:
             description: Descripción del término
+            external_id: ID001
             name: Nombre del término
             slug: termino
         index:

--- a/db/migrate/20200327131311_add_external_id_to_terms.rb
+++ b/db/migrate/20200327131311_add_external_id_to_terms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExternalIdToTerms < ActiveRecord::Migration[5.2]
+  def change
+    add_column :terms, :external_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_09_152257) do
+ActiveRecord::Schema.define(version: 2020_03_27_131311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -1019,6 +1019,7 @@ ActiveRecord::Schema.define(version: 2020_03_09_152257) do
     t.bigint "term_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_id"
     t.index ["slug", "vocabulary_id"], name: "index_terms_on_slug_and_vocabulary_id"
     t.index ["term_id"], name: "index_terms_on_term_id"
     t.index ["vocabulary_id"], name: "index_terms_on_vocabulary_id"

--- a/test/fixtures/gobierto_common/terms.yml
+++ b/test/fixtures/gobierto_common/terms.yml
@@ -7,6 +7,7 @@ mammal:
   slug: <%= "animals-mammal" %>
   position: 0
   level: 0
+  external_id: 1
 
 dog:
   vocabulary: animals
@@ -16,6 +17,7 @@ dog:
   position: 0
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:mammal) %>
+  external_id: 2
 
 cat:
   vocabulary: animals
@@ -25,6 +27,7 @@ cat:
   position: 1
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:mammal) %>
+  external_id: 3
 
 bird:
   vocabulary: animals
@@ -33,6 +36,7 @@ bird:
   slug: <%= "animals-bird" %>
   position: 0
   level: 0
+  external_id: 4
 
 swift:
   vocabulary: animals
@@ -42,6 +46,7 @@ swift:
   position: 0
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>
+  external_id: 5
 
 pigeon:
   vocabulary: animals
@@ -51,6 +56,7 @@ pigeon:
   position: 1
   level: 1
   term_id: <%= ActiveRecord::FixtureSet.identify(:bird) %>
+  external_id: 6
 
 ## issues_vocabulary
 
@@ -61,6 +67,7 @@ culture_term:
   slug: culture
   position: 1
   level: 0
+  external_id: 1
 
 women_term:
   vocabulary: issues_vocabulary
@@ -69,6 +76,7 @@ women_term:
   slug: women
   position: 2
   level: 0
+  external_id: 2
 
 economy_term:
   vocabulary: issues_vocabulary
@@ -77,6 +85,7 @@ economy_term:
   slug: economy
   position: 3
   level: 0
+  external_id: 3
 
 sports_term:
   vocabulary: issues_vocabulary
@@ -85,6 +94,7 @@ sports_term:
   slug: sport
   position: 4
   level: 0
+  external_id: 4
 
 center_term:
   vocabulary: scopes_vocabulary
@@ -93,6 +103,7 @@ center_term:
   slug: center
   position: 1
   level: 0
+  external_id: 1
 
 old_town_term:
   vocabulary: scopes_vocabulary
@@ -101,6 +112,7 @@ old_town_term:
   slug: old-town
   position: 2
   level: 0
+  external_id: 2
 
 ## madrid_political_groups_vocabulary
 
@@ -110,6 +122,7 @@ marvel_term:
   slug: marvel
   position: 1
   level: 0
+  external_id: 1
 
 dc_term:
   vocabulary: madrid_political_groups_vocabulary
@@ -117,6 +130,7 @@ dc_term:
   slug: dc
   position: 2
   level: 0
+  external_id: 2
 
 ## plan_categories_vocabulary
 
@@ -129,6 +143,7 @@ people_and_families_plan_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 1
 
 welfare_payments_plan_term:
   vocabulary: plan_categories_vocabulary
@@ -140,6 +155,7 @@ welfare_payments_plan_term:
   position: 1
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 2
 
 center_scholarships_plan_term:
   vocabulary: plan_categories_vocabulary
@@ -151,6 +167,7 @@ center_scholarships_plan_term:
   position: 2
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 3
 
 center_basic_needs_plan_term:
   vocabulary: plan_categories_vocabulary
@@ -162,6 +179,7 @@ center_basic_needs_plan_term:
   position: 3
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 4
 
 economy_plan_term:
   vocabulary: plan_categories_vocabulary
@@ -172,6 +190,7 @@ economy_plan_term:
   position: 4
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 5
 
 city_plan_term:
   vocabulary: plan_categories_vocabulary
@@ -182,6 +201,7 @@ city_plan_term:
   position: 5
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 6
 
 ## plan_projects_statuses_vocabulary
 
@@ -194,6 +214,7 @@ not_started_plan_status_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 1
 
 in_progress_plan_status_term:
   vocabulary: plan_projects_statuses_vocabulary
@@ -204,6 +225,7 @@ in_progress_plan_status_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 2
 
 active_plan_status_term:
   vocabulary: plan_projects_statuses_vocabulary
@@ -214,6 +236,7 @@ active_plan_status_term:
   position: 1
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 3
 
 ## plan_projects_statuses_vocabulary
 
@@ -226,6 +249,7 @@ pending_imported_plan_status_term:
   position: 1
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 1
 
 started_imported_plan_status_term:
   vocabulary: plan_csv_import_statuses_vocabulary
@@ -236,6 +260,7 @@ started_imported_plan_status_term:
   position: 2
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 2
 
 active_imported_plan_status_term:
   vocabulary: plan_csv_import_statuses_vocabulary
@@ -246,6 +271,7 @@ active_imported_plan_status_term:
   position: 3
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 3
 
 finished_imported_plan_status_term:
   vocabulary: plan_csv_import_statuses_vocabulary
@@ -256,6 +282,7 @@ finished_imported_plan_status_term:
   position: 4
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 4
 
 blank_imported_plan_status_term:
   vocabulary: plan_csv_import_statuses_vocabulary
@@ -266,6 +293,7 @@ blank_imported_plan_status_term:
   position: 5
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 5
 
 ## citizen_services_categories
 
@@ -277,6 +305,7 @@ social_services_term:
   position: 0
   created_at: 2018-09-10 00:00:00
   updated_at: 2018-09-10 00:00:00
+  external_id: 1
 
 culture_service_term:
   vocabulary: citizens_services_categories
@@ -286,6 +315,7 @@ culture_service_term:
   position: 1
   created_at: 2018-09-10 00:00:00
   updated_at: 2018-09-1 0 00:00:00
+  external_id: 2
 
 sports_service_term:
   vocabulary: citizens_services_categories
@@ -295,6 +325,7 @@ sports_service_term:
   position: 2
   created_at: 2018-09-10 00:00:00
   updated_at: 2018-09-10 00:00:00
+  external_id: 3
 
 ## new_plan_categories_vocabulary
 
@@ -307,6 +338,7 @@ economy_new_plan_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 1
 
 taxes_new_plan_term:
   vocabulary: new_plan_categories_vocabulary
@@ -318,6 +350,7 @@ taxes_new_plan_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 2
 
 public_facilities_new_plan_term:
   vocabulary: new_plan_categories_vocabulary
@@ -328,6 +361,7 @@ public_facilities_new_plan_term:
   position: 1
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 3
 
 sports_facilities_new_plan_term:
   vocabulary: new_plan_categories_vocabulary
@@ -339,6 +373,7 @@ sports_facilities_new_plan_term:
   position: 0
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 4
 
 libraries_new_plan_term:
   vocabulary: new_plan_categories_vocabulary
@@ -350,6 +385,7 @@ libraries_new_plan_term:
   position: 1
   created_at: 2016-11-01 00:02:00
   updated_at: 2016-11-01 00:02:00
+  external_id: 5
 
 ## indicators_vocabulary
 
@@ -363,6 +399,7 @@ indicators_raw_savings:
   slug: indicators-raw-savings
   level: 0
   position: 0
+  external_id: 1
 
 indicators_net_savings:
   vocabulary: indicators_vocabulary
@@ -374,6 +411,7 @@ indicators_net_savings:
   slug: indicators-net-savings
   level: 0
   position: 1
+  external_id: 2
 
 indicators_births:
   vocabulary: indicators_vocabulary
@@ -385,6 +423,7 @@ indicators_births:
   slug: indicators-births
   level: 0
   position: 2
+  external_id: 3
 
 indicators_deaths:
   vocabulary: indicators_vocabulary
@@ -396,6 +435,7 @@ indicators_deaths:
   slug: indicators-deaths
   level: 0
   position: 3
+  external_id: 4
 
 ## human_resources_vocabulary
 
@@ -405,6 +445,7 @@ human_resources_supervisor:
   slug: human-resources-supervisor
   level: 0
   position: 0
+  external_id: 1
 
 human_resources_employee:
   vocabulary: human_resources_vocabulary
@@ -412,6 +453,7 @@ human_resources_employee:
   slug: human-resources-employee
   level: 0
   position: 1
+  external_id: 2
 
 ## economic_plan_categories_vocabulary
 
@@ -424,3 +466,4 @@ economy_economic_plan_term:
   slug: economy-economic-plan-term
   level: 0
   position: 0
+  external_id: 1

--- a/test/forms/gobierto_admin/gobierto_common/term_form_test.rb
+++ b/test/forms/gobierto_admin/gobierto_common/term_form_test.rb
@@ -11,7 +11,8 @@ module GobiertoAdmin
           name_translations: { I18n.locale => "test" },
           description_translations: { I18n.locale => "test description" },
           vocabulary_id: vocabulary.id,
-          slug: nil
+          slug: nil,
+          external_id: nil
         )
       end
 
@@ -21,7 +22,8 @@ module GobiertoAdmin
           name_translations: nil,
           description_translations: nil,
           vocabulary_id: nil,
-          slug: nil
+          slug: nil,
+          external_id: nil
         )
       end
 

--- a/test/integration/gobierto_admin/gobierto_common/terms/create_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/create_term_test.rb
@@ -63,6 +63,7 @@ module GobiertoAdmin
                 fill_in "term_name_translations_en", with: "Goat"
                 fill_in "term_description_translations_en", with: "The goat is an animal"
                 fill_in "term_slug", with: "new-goat"
+                fill_in "term_external_id", with: "animal_1"
 
                 switch_locale "ES"
                 fill_in "term_name_translations_es", with: "Cabra"
@@ -80,6 +81,7 @@ module GobiertoAdmin
                 assert has_field?("term_name_translations_en", with: "Goat")
                 assert has_field?("term_description_translations_en", with: "The goat is an animal")
                 assert has_field?("term_slug", with: "new-goat")
+                assert has_field?("term_external_id", with: "animal_1")
 
                 switch_locale "ES"
 

--- a/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/update_term_test.rb
@@ -66,6 +66,7 @@ module GobiertoCommon
                 fill_in "term_name_translations_en", with: "Dog updated"
                 fill_in "term_description_translations_en", with: "Dog description updated"
                 fill_in "term_slug", with: "dog-updated"
+                fill_in "term_external_id", with: "animal-updated"
                 select other_term.name, from: "term_term_id"
 
                 click_button "Update"
@@ -80,6 +81,7 @@ module GobiertoCommon
               assert has_field? "term_name_translations_en", with: "Dog updated"
               assert has_field? "term_description_translations_en", with: "Dog description updated"
               assert has_field? "term_slug", with: "dog-updated"
+              assert has_field? "term_external_id", with: "animal-updated"
               assert has_select? "term_term_id", selected: "#{" " * 6} Cat"
 
               activity = Activity.last

--- a/test/models/gobierto_common/term_test.rb
+++ b/test/models/gobierto_common/term_test.rb
@@ -85,6 +85,13 @@ class TermTest < ActiveSupport::TestCase
     assert_equal "term-with-long-name", new_term.slug
   end
 
+  def test_create_term_external_id
+    new_term = vocabulary.terms.new(name_translations: { en: "Term with external ID", es: "Término con ID externo" }, external_id: "wadus")
+    assert new_term.valid?
+    new_term.save
+    assert_equal "wadus", new_term.external_id
+  end
+
   def test_assign_itself_as_parent
     dog.parent_term = dog
     refute dog.valid?


### PR DESCRIPTION
Closes #2931


## :v: What does this PR do?

* Adds a configuration to `HasExternalId` concern to set the scope to calculate automatically the `external_id` attribute if not present
* Migrates the `terms` table adding an `external_id` attribute and uses the `HasExternalId` scoped to the terms of the vocabulary
* Adds management of `external_id` attribute from admin of terms

## :mag: How should this be manually tested?

Visit admin section of terms of a vocabulary, add terms and edit existing ones.

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
