### PR TITLE
Set position of new terms in TermForm

### DIFF
--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -25,7 +25,7 @@ module GobiertoAdmin
       end
 
       def build_term
-        vocabulary.terms.new
+        vocabulary.terms.new(position: next_position)
       end
 
       def save
@@ -33,6 +33,10 @@ module GobiertoAdmin
       end
 
       private
+
+      def next_position
+        (vocabulary.terms.maximum(:position) || -1) + 1
+      end
 
       def vocabulary
         @vocabulary ||= begin


### PR DESCRIPTION
Closes PopulateTools/issues#694


## :v: What does this PR do?

Fixes a bug ordering new vocabulary terms from admin.

## :mag: How should this be manually tested?

Visit a vocabulary, create terms and reorder them. Always the new terms should appear at the end of the level of the vocabulary they belongs to

## :eyes: Screenshots

### Before this PR

![694-before](https://user-images.githubusercontent.com/446459/78290365-f3094e80-7523-11ea-8ca8-9396b989d76f.gif)

### After this PR

![694-after](https://user-images.githubusercontent.com/446459/78290923-cefa3d00-7524-11ea-9eb6-cb5c99af29b4.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No