### PR TITLE
2894 delete plan contents

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/ordered_terms_controller.rb
@@ -70,7 +70,7 @@ module GobiertoAdmin
       def destroy
         @term = find_term
 
-        if current_site.processes.where(issue: @term).blank? && @term.destroy
+        if @term.destroy
           redirect_to(
             index_path,
             notice: t(".success")
@@ -78,7 +78,7 @@ module GobiertoAdmin
         else
           redirect_to(
             index_path,
-            alert: t(".destroy_failed")
+            alert: t(".destroy_failed", validation_errors: @term.errors.full_messages.to_sentence)
           )
         end
       end

--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -79,6 +79,24 @@ module GobiertoAdmin
         redirect_to admin_plans_plans_path, notice: t(".success")
       end
 
+      def delete_contents
+        @plan = find_plan
+
+        @plan.nodes.destroy_all
+        @plan.categories_vocabulary.terms.destroy_all
+        @plan.statuses_vocabulary.terms.destroy_all
+        @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(
+          site_id: current_site.id,
+          item: @plan.nodes.new,
+          instance: @plan
+        )
+        @custom_fields_form.empty_associated_vocabularies!
+        redirect_to(
+          edit_admin_plans_plan_path(@plan),
+          notice: t(".success")
+        )
+      end
+
       def recover
         @plan = find_archived_plan
         @plan.restore

--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -3,6 +3,8 @@
 module GobiertoAdmin
   module GobiertoPlans
     class PlansController < GobiertoAdmin::GobiertoPlans::BaseController
+      class HasDependentResources < StandardError; end
+
       before_action -> { module_allowed_action!(current_admin, current_admin_module, :manage) }, except: [:index, :plan]
 
       def index
@@ -82,18 +84,28 @@ module GobiertoAdmin
       def delete_contents
         @plan = find_plan
 
-        @plan.nodes.destroy_all
-        @plan.categories_vocabulary.terms.destroy_all
-        @plan.statuses_vocabulary.terms.destroy_all
-        @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(
-          site_id: current_site.id,
-          item: @plan.nodes.new,
-          instance: @plan
-        )
-        @custom_fields_form.empty_associated_vocabularies!
+        ActiveRecord::Base.transaction do
+          @plan.nodes.destroy_all
+          destroy_terms(@plan.categories_vocabulary)
+          destroy_terms(@plan.statuses_vocabulary)
+          @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(
+            site_id: current_site.id,
+            item: @plan.nodes.new,
+            instance: @plan
+          )
+          @custom_fields_form.associated_vocabularies.each do |vocabulary|
+            destroy_terms(vocabulary)
+          end
+        end
+
         redirect_to(
           edit_admin_plans_plan_path(@plan),
           notice: t(".success")
+        )
+      rescue HasDependentResources => e
+        redirect_to(
+          edit_admin_plans_plan_path(@plan),
+          alert: e.message
         )
       end
 
@@ -150,6 +162,19 @@ module GobiertoAdmin
 
       def track_create_activity
         Publishers::GobiertoPlansPlanActivity.broadcast_event("plan_created", default_activity_params.merge(subject: @plan_form.plan))
+      end
+
+      def destroy_terms(vocabulary)
+        vocabulary.terms.each do |term|
+          next if term.destroy
+
+          raise HasDependentResources, t(
+            "gobierto_admin.gobierto_plans.plans.delete_contents.term_deletion_failed_html",
+            vocabulary: term.vocabulary.name,
+            term: term.name,
+            message: term.errors.full_messages.to_sentence
+          )
+        end
       end
 
       def track_update_activity

--- a/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/plans_controller.rb
@@ -98,6 +98,9 @@ module GobiertoAdmin
           end
         end
 
+        # Update plan cache
+        @plan.touch
+
         redirect_to(
           edit_admin_plans_plan_path(@plan),
           notice: t(".success")

--- a/app/decorators/gobierto_common/term_dependent_resources_decorator.rb
+++ b/app/decorators/gobierto_common/term_dependent_resources_decorator.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class TermDependentResourcesDecorator < BaseDecorator
+    def initialize(term)
+      @object = term
+    end
+
+    def has_dependent_resources?
+      dependent_associations.present? ||
+        dependent_custom_fields_with_records.present? ||
+        dependent_plans_categories.present?
+    end
+
+    def dependencies_list
+      [
+        dependent_associations_string,
+        dependent_custom_fields_with_records_string,
+        dependent_plans_categories_string
+      ].map(&:presence).compact.join("\n")
+    end
+
+    private
+
+    def dependent_associations_string
+      dependent_associations.map do |association|
+        "#{association.class_name}: Attribute #{association.attribute} on instances with ids #{association.ids.join(", ")}"
+      end.join("\n")
+    end
+
+    def dependent_custom_fields_with_records_string
+      dependent_custom_fields_with_records.map do |custom_field|
+        <<-TEXT
+        #{custom_field.class_name}: CustomField with uid #{custom_field.uid} and name #{custom_field.name}
+        #{" (on instance of #{custom_field.instance_type} with id #{custom_field.instance_id})" if custom_field.instance.present?}
+        TEXT
+      end.join("\n")
+    end
+
+    def dependent_plans_categories_string
+      return unless dependent_plans_categories.present?
+
+      "GobiertoPlans::Plan: Attribute category_ids on projects of plans with ids: #{dependent_plans_categories.pluck(:id).join(", ")}"
+    end
+
+    def dependent_associations
+      @dependent_associations ||= enabled_classes_with_vocabularies.map do |klass|
+        klass.vocabularies.keys.map do |association|
+          foreign_key = klass.reflections[association.to_s].foreign_key
+          next unless klass.where(foreign_key => id).exists?
+
+          OpenStruct.new(
+            class_name: klass.name,
+            attribute: foreign_key,
+            ids: klass.where(foreign_key => id).pluck(:id)
+          )
+        end.compact.presence
+      end.compact.flatten
+    end
+
+    def dependent_plans_categories
+      @dependent_plans_categories ||= site.plans.where(vocabulary_id: vocabulary_id).select do |plan|
+        GobiertoPlans::CategoryTermDecorator.new(self, plan: plan).has_dependent_resources?
+      end
+    end
+
+    def dependent_custom_fields_with_records
+      @dependent_custom_fields_with_records ||= site.custom_fields.vocabulary_options.for_vocabulary(vocabulary).select do |custom_field|
+        filter_value = custom_field.configuration.vocabulary_type == "single_select" ? id.to_s : [id.to_s]
+        custom_field.records.where("payload @> ?", { custom_field.uid => filter_value }.to_json).exists?
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
@@ -54,6 +54,7 @@ module GobiertoAdmin
           ActiveRecord::Base.transaction do
             clear_categories_vocabulary unless has_previous_nodes?
             import_nodes
+            @plan.touch
           end
         end
       rescue CSVRowInvalid => e

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -60,12 +60,8 @@ module GobiertoCommon
       custom_field_records.any? { |custom_field| version_changed?(custom_field) }
     end
 
-    def empty_associated_vocabularies!
-      available_custom_fields.select(&:has_vocabulary?).each do |custom_field|
-        next unless (vocabulary = custom_field.vocabulary).present?
-
-        vocabulary.terms.destroy_all
-      end
+    def associated_vocabularies
+      available_custom_fields.select(&:has_vocabulary?).map(&:vocabulary).compact
     end
 
     private

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -60,6 +60,12 @@ module GobiertoCommon
       custom_field_records.any? { |custom_field| version_changed?(custom_field) }
     end
 
+    def empty_associated_vocabularies!
+      available_custom_fields.select(&:has_vocabulary?).each do |custom_field|
+        custom_field.vocabulary.terms.destroy_all
+      end
+    end
+
     private
 
     def version_changed?(custom_field)

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -62,7 +62,9 @@ module GobiertoCommon
 
     def empty_associated_vocabularies!
       available_custom_fields.select(&:has_vocabulary?).each do |custom_field|
-        custom_field.vocabulary.terms.destroy_all
+        next unless (vocabulary = custom_field.vocabulary).present?
+
+        vocabulary.terms.destroy_all
       end
     end
 

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -28,7 +28,7 @@ module GobiertoCommon
     scope :not_localized, -> { where.not(field_type: [:localized_string, :localized_paragraph]) }
     scope :with_plugin_type, ->(plugin_type) { plugin.where("options @> ?", { configuration: { plugin_type: plugin_type } }.to_json) }
     scope :for_class, ->(klass) { klass.present? ? where(class_name: klass.name).all : all }
-    scope :for_vocabulary, ->(vocabulary) { where("options @> ?", { vocabulary_id: vocabulary.id }.to_json) }
+    scope :for_vocabulary, ->(vocabulary) { where("options @> ?", { vocabulary_id: vocabulary.id.to_s }.to_json) }
 
     translates :name
 

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -43,18 +43,13 @@ module GobiertoCommon
     end
 
     def destroy
-      return false if has_dependent_resources?
+      dependent_resources_decorator = TermDependentResourcesDecorator.new(self)
+      if dependent_resources_decorator.has_dependent_resources?
+        errors.add(:base, :has_dependent_resources_html, dependencies_list: dependent_resources_decorator.dependencies_list)
+        return false
+      end
 
       super
-    end
-
-    def has_dependent_resources?
-      enabled_classes_with_vocabularies.any? do |klass|
-        klass.vocabularies.keys.any? do |association|
-          klass.where(klass.reflections[association.to_s].foreign_key => id).exists?
-        end
-      end ||
-        GobiertoPlans::CategoryTermDecorator.new(self).has_dependent_resources?
     end
 
     def last_descendants

--- a/app/views/gobierto_admin/gobierto_plans/plans/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/_form.html.erb
@@ -134,6 +134,15 @@
               <% end %>
             </div>
           </div>
+          <div class="m_v_1">
+            <%= link_to admin_plans_plan_delete_contents_path(@plan),
+                        title: t(".delete_contents"),
+                        method: :delete,
+                        data: { confirm: t(".delete_contents_confirm") } do %>
+              <i class="fas fa-undo"></i>
+              <%= t(".delete_contents") %>
+            <% end %>
+          </div>
         <% end %>
 
       </div>

--- a/config/locales/gobierto_admin/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/ca.yml
@@ -43,3 +43,7 @@ ca:
           attributes:
             item:
               wrong_item_class: no està associat a un item de la classe adequada
+        gobierto_common/term:
+          attributes:
+            base:
+              has_dependent_resources_html: Està sent usat pels recursos:</br> %{dependencies_list}

--- a/config/locales/gobierto_admin/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/en.yml
@@ -43,3 +43,8 @@ en:
           attributes:
             item:
               wrong_item_class: not associated with an item of the appropriate class
+        gobierto_common/term:
+          attributes:
+            base:
+              has_dependent_resources_html: Is being used by the following resources:</br>
+                %{dependencies_list}

--- a/config/locales/gobierto_admin/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/models/es.yml
@@ -43,3 +43,8 @@ es:
           attributes:
             item:
               wrong_item_class: no está asociado a un item de la clase adecuada
+        gobierto_common/term:
+          attributes:
+            base:
+              has_dependent_resources_html: Está siendo usado por los siguientes recursos:</br>
+                %{dependencies_list}

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/ca.yml
@@ -6,7 +6,7 @@ ca:
         create:
           success: El terme s'ha creat correctament.
         destroy:
-          destroy_failed: No pots esborrar un terme mentre tingui elements associats.
+          destroy_failed: 'El terme no ha pogut ser eliminat: %{validation_errors}'
           success: El terme ha estat eliminat correctament.
         update:
           success: El terme s'ha actualitzat correctament.

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/en.yml
@@ -6,7 +6,7 @@ en:
         create:
           success: Term created successfully.
         destroy:
-          destroy_failed: You can't delete a term while it has associated elements.
+          destroy_failed: 'The term couldn''t be deleted: %{validation_errors}'
           success: Term deleted successfully.
         update:
           success: Term updated successfully.

--- a/config/locales/gobierto_admin/gobierto_common/terms/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/terms/controllers/es.yml
@@ -6,7 +6,7 @@ es:
         create:
           success: El término se ha creado correctamente.
         destroy:
-          destroy_failed: El término no ha podido ser eliminado.
+          destroy_failed: 'El término no ha podido ser eliminado: %{validation_errors}'
           success: El término ha sido eliminado correctamente.
         update:
           success: El término se ha actualizado correctamente.

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/plans/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/plans/ca.yml
@@ -5,6 +5,8 @@ ca:
       plans:
         create:
           success_html: Pla s'ha creat correctament. <a href="%{link}">Veure el pla</a>.
+        delete_contents:
+          success: Els projectes de el pla han estat correctament eliminats
         destroy:
           success: El pla s'ha esborrat correctament.
         import_data:

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/plans/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/plans/ca.yml
@@ -7,6 +7,8 @@ ca:
           success_html: Pla s'ha creat correctament. <a href="%{link}">Veure el pla</a>.
         delete_contents:
           success: Els projectes de el pla han estat correctament eliminats
+          term_deletion_failed_html: 'El terme "%{term}" de l''vocabulari "%{vocabulary}"
+            no pot ser esborrat: %{message}'
         destroy:
           success: El pla s'ha esborrat correctament.
         import_data:

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/plans/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/plans/en.yml
@@ -5,6 +5,8 @@ en:
       plans:
         create:
           success_html: Plan created successfully. <a href="%{link}">View the plan</a>.
+        delete_contents:
+          success: Plan projects has been successfully deleted
         destroy:
           success: Plan archived successfully.
         import_data:

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/plans/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/plans/en.yml
@@ -7,6 +7,8 @@ en:
           success_html: Plan created successfully. <a href="%{link}">View the plan</a>.
         delete_contents:
           success: Plan projects has been successfully deleted
+          term_deletion_failed_html: 'The term "%{term}" of "%{vocabulary}" vocabulary
+            can''t be deleted: %{message}'
         destroy:
           success: Plan archived successfully.
         import_data:

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/plans/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/plans/es.yml
@@ -6,6 +6,8 @@ es:
         create:
           success_html: El plan ha sido creado correctamente. <a href="%{link}">Ver
             el plan</a>.
+        delete_contents:
+          success: Los proyectos del plan han sido correctamente eliminados
         destroy:
           success: El plan ha sido eliminado correctamente.
         import_data:

--- a/config/locales/gobierto_admin/gobierto_plans/controllers/plans/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/controllers/plans/es.yml
@@ -8,6 +8,8 @@ es:
             el plan</a>.
         delete_contents:
           success: Los proyectos del plan han sido correctamente eliminados
+          term_deletion_failed_html: 'El término "%{term}" del vocabulario "%{vocabulary}"
+            no puede ser borrado: %{message}'
         destroy:
           success: El plan ha sido eliminado correctamente.
         import_data:

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -28,6 +28,9 @@ ca:
         edit:
           title: Configuració
         form:
+          delete_contents: Eliminar els projectes d'aquest pla
+          delete_contents_confirm: Confirma que vols eliminar els projectes d'aquest
+            pla
           export_csv: Exportar a CSV
           import_csv: Importar des CSV
           placeholders:

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -28,6 +28,8 @@ en:
         edit:
           title: Configuration
         form:
+          delete_contents: Delete projects of this plan
+          delete_contents_confirm: Confirm you want to delete projects from this plan
           export_csv: Export to CSV
           import_csv: Import from CSV
           placeholders:

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -28,6 +28,9 @@ es:
         edit:
           title: Configuración
         form:
+          delete_contents: Borrar proyectos de este plan
+          delete_contents_confirm: Confirma que quieres borrar los proyectos de este
+            plan
           export_csv: Exportar a CSV
           import_csv: Importar desde CSV
           placeholders:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,7 @@ Rails.application.routes.draw do
           end
           get :import_csv
           get :export_csv, defaults: { format: "csv" }
+          delete :delete_contents
           put :recover
           patch :import_data
         end

--- a/test/integration/gobierto_admin/gobierto_common/terms/delete_term_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/terms/delete_term_test.rb
@@ -35,6 +35,10 @@ module GobiertoCommon
         @term_with_associated_items ||= gobierto_common_terms(:culture_term)
       end
 
+      def term_associated_process
+        @term_associated_process ||= gobierto_participation_processes(:dance_studio_group_ended)
+      end
+
       def plan_vocabulary
         @plan_vocabulary ||= gobierto_common_vocabularies(:plan_categories_vocabulary)
       end
@@ -45,6 +49,10 @@ module GobiertoCommon
 
       def term_in_plan_with_nodes
         @term_in_plan_with_nodes ||= gobierto_common_terms(:people_and_families_plan_term)
+      end
+
+      def term_associated_plan
+        @term_associated_plan ||= gobierto_plans_plans(:strategic_plan)
       end
 
       def term_in_plan_without_nodes
@@ -86,7 +94,9 @@ module GobiertoCommon
               click_link "Delete", visible: false
             end
 
-            assert has_message?("You can't delete a term while it has associated elements.")
+            assert has_message?("The term couldn't be deleted")
+            assert has_message?("GobiertoParticipation::Process: Attribute issue_id on instances with ids")
+            assert has_message?(term_associated_process.id)
 
             assert vocabulary.terms.exists?(id: term_with_associated_items.id)
           end
@@ -102,7 +112,8 @@ module GobiertoCommon
               click_link "Delete", visible: false
             end
 
-            assert has_message?("You can't delete a term while it has associated elements.")
+            assert has_message?("The term couldn't be deleted")
+            assert has_message?("GobiertoPlans::Plan: Attribute category_ids on projects of plans with ids: #{term_associated_plan.id}")
 
             assert plan_vocabulary.terms.exists?(id: term_in_plan_with_nodes.id)
           end

--- a/test/integration/gobierto_admin/gobierto_plans/plans/delete_contents_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/delete_contents_plan_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPlans
+    class DeleteContentsPlanTest < ActionDispatch::IntegrationTest
+      include Integration::AdminGroupsConcern
+
+      attr_reader :plan, :path
+
+      def setup
+        super
+        @plan = gobierto_plans_plans(:strategic_plan)
+        @path = edit_admin_plans_plan_path(plan)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def custom_field_vocabulary
+        @custom_field_vocabulary ||= gobierto_common_vocabularies(:animals)
+      end
+
+      def vocabulary_used_in_other_context
+        @vocabulary_used_in_other_context ||= gobierto_common_vocabularies(:issues_vocabulary)
+      end
+
+      def statuses_vocabulary
+        @statuses_vocabulary ||= gobierto_common_vocabularies(:plan_projects_statuses_vocabulary)
+      end
+
+      def status_term
+        @status_term ||= gobierto_common_terms(:not_started_plan_status_term)
+      end
+
+      def test_delete_contents
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit path
+
+            click_link "Delete projects of this plan"
+
+            assert has_message? "Plan projects has been successfully deleted"
+
+            assert plan.nodes.blank?
+            assert plan.categories_vocabulary.terms.blank?
+            assert custom_field_vocabulary.terms.blank?
+            assert statuses_vocabulary.terms.blank?
+          end
+        end
+      end
+
+      def test_delete_contents_with_other_empty_plan_with_same_statuses_vocabulary
+        site.plans.create(plan.attributes.slice("title_translations", "introduction_translations", "plan_type_id", "statuses_vocabulary_id").merge(year: plan.year + 1))
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit path
+
+            click_link "Delete projects of this plan"
+
+            assert has_message? "Plan projects has been successfully deleted"
+          end
+        end
+      end
+
+      def test_delete_contents_with_other_not_empty_plan_with_same_statuses_vocabulary
+        new_plan = site.plans.create(
+          plan.attributes.slice(
+            "title_translations",
+            "introduction_translations",
+            "plan_type_id",
+            "statuses_vocabulary_id"
+          ).merge(year: plan.year + 1)
+        )
+        new_node = new_plan.nodes.create(name: "Wadus", status: status_term, external_id: "wadus")
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit path
+
+            click_link "Delete projects of this plan"
+
+            assert has_alert? "The term \"#{status_term.name}\" of \"#{statuses_vocabulary.name}\" vocabulary can't be deleted"
+            assert has_alert? "GobiertoPlans::Node: Attribute status_id on instances with ids #{new_node.id}"
+          end
+        end
+      end
+
+      def test_delete_contents_with_vocabulary_used_in_other_context
+        plan.update_attribute(:statuses_vocabulary_id, vocabulary_used_in_other_context.id)
+        with_signed_in_admin(admin) do
+          with_current_site(site) do
+            visit path
+
+            click_link "Delete projects of this plan"
+
+            assert has_alert?(/The term \".*\" of \"#{vocabulary_used_in_other_context.name}\" vocabulary can't be deleted/)
+            assert has_alert? "GobiertoParticipation::Process: Attribute issue_id on instances with ids"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/gobierto_plans/plans/delete_projects_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/delete_projects_plan_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  module GobiertoPlans
+    class ImportCsvPlanTest < ActionDispatch::IntegrationTest
+      include Integration::AdminGroupsConcern
+
+      attr_reader :plan, :path, :statuses_vocabulary
+
+      def setup
+        super
+        @statuses_vocabulary = gobierto_common_vocabularies(:plan_csv_import_statuses_vocabulary)
+        @plan = gobierto_plans_plans(:strategic_plan)
+        @plan.update_attribute(:statuses_vocabulary_id, statuses_vocabulary.id)
+        @path = edit_admin_plans_plan_path(plan)
+      end
+
+      def admin
+        @admin ||= gobierto_admin_admins(:nick)
+      end
+
+      def site
+        @site ||= sites(:madrid)
+      end
+
+      def custom_field_vocabulary
+        @custom_field_vocabulary ||= gobierto_common_vocabularies(:animals)
+      end
+
+      def test_delete_projects
+        with(admin: admin, site: site) do
+          visit path
+
+          click_link "Delete projects of this plan"
+
+          assert has_message?("Plan projects has been successfully deleted")
+
+          assert @plan.nodes.blank?
+          assert @plan.categories_vocabulary.terms.blank?
+          assert @plan.statuses_vocabulary.terms.blank?
+          assert custom_field_vocabulary.terms.blank?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2894
Closes #2952

## :v: What does this PR do?

* Adds a link to plans configuration to delete all projects of a plan and empty all related vocabularies, including:
  * Categories vocabulary
  * Statuses vocabulary
  * All vocabularies related with custom fields defined for the plan
* The associated vocabularies term deletion is performed in a transaction. If there is a term which can't be deleted because it's in use by another resource the transaction is rolled back and an alert is displayed with information about the first term found with and the resources using it.
* Adds integration tests
* Expand verifications before deleting a term and prevent deletion of terms used in custom fields of type vocabulary 

## :mag: How should this be manually tested?

Visit a plan, go to configuration tab and click on "Delete projects of this plan" link.

Also go to terms and vocabularies admin and try to delete a term in use and the vocabulary the term belongs to.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
