### PR TITLE
Update rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,7 +87,7 @@ Style/Alias:
     - prefer_alias_method
 
 # Align the elements of a hash literal if they span more than one line.
-Layout/AlignHash:
+Layout/HashAlignment:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #
   # key - left alignment of keys
@@ -150,7 +150,7 @@ Layout/AlignHash:
     - ignore_implicit
     - ignore_explicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   # Alignment of parameters in multi-line method calls.
   #
   # The `with_first_parameter` style aligns the following lines along the same
@@ -260,20 +260,6 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
 
 # Indentation of `when`.
 Layout/CaseIndentation:
@@ -457,7 +443,7 @@ Naming/FileName:
   # files with a shebang in the first line).
   IgnoreExecutableScripts: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
     # The first parameter should always be indented one step more than the
@@ -535,7 +521,7 @@ Layout/IndentationWidth:
   Width: 2
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -557,13 +543,13 @@ Layout/IndentFirstArrayElement:
   IndentationWidth: ~
 
 # Checks the indentation of assignment RHS, when on a different line from LHS
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
 # Checks the indentation of the first key in a hash literal.
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
@@ -766,14 +752,6 @@ Naming/PredicateName:
     - is_
     - has_
     - have_
-  # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
-    - is_
-    - have_
-  # Predicate names which, despite having a blacklisted prefix, or no ?,
-  # should still be accepted
-  NameWhitelist:
-    - is_a?
   # Exclude Rspec specs because there is a strong convetion to write spec
   # helpers in the form of `have_something` or `be_something`.
   Exclude:
@@ -941,7 +919,7 @@ Style/TernaryParentheses:
     - require_no_parentheses
   AllowSafeAssignment: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
     - final_newline
@@ -977,24 +955,6 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
-    - to_ary
-    - to_a
-    - to_c
-    - to_enum
-    - to_h
-    - to_hash
-    - to_i
-    - to_int
-    - to_io
-    - to_open
-    - to_path
-    - to_proc
-    - to_r
-    - to_regexp
-    - to_str
-    - to_s
-    - to_sym
 
 Naming/VariableName:
   EnforcedStyle: snake_case
@@ -1051,16 +1011,6 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Max: 9
 
-Metrics/LineLength:
-  Max: 180
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # containing a URI to be longer than Max.
-  AllowHeredoc: true
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
-
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 15
@@ -1112,6 +1062,16 @@ Layout/DefEndAlignment:
   EnforcedStyleAlignWith: start_of_line
   AutoCorrect: false
 
+Layout/LineLength:
+  Max: 180
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+
 Lint/InheritException:
   # The default base class in favour of `Exception`.
   EnforcedStyle: runtime_error
@@ -1128,3 +1088,18 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates Rubocop configuration. The current configuration was raising a few errors:

```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Layout/IndentFirstArrayElement` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/BracesAroundHashParameters` cop has been removed.
(obsolete configuration found in .rubocop.yml, please update it)
obsolete parameter Whitelist (for Style/TrivialAccessors) found in .rubocop.yml
`Whitelist` has been renamed to `AllowedMethods`.
obsolete parameter NamePrefixBlacklist (for Naming/PredicateName) found in .rubocop.yml
`NamePrefixBlacklist` has been renamed to `ForbiddenPrefixes`.
obsolete parameter NameWhitelist (for Naming/PredicateName) found in .rubocop.yml
`NameWhitelist` has been renamed to `AllowedMethods`.
```

## :mag: How should this be manually tested?

You should be able to run Rubocop.

