### PR TITLE
Add cache to DatasetSerializer

### DIFF
--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -110,10 +110,9 @@ module GobiertoData
         def send_download(content, format, base_filename)
           case format
           when :json
+            content = ActiveModelSerializers::SerializableResource.new(content).to_json unless content.is_a? String
             send_data(
-              ActiveModelSerializers::SerializableResource.new(
-                content
-              ).to_json,
+              content,
               filename: "#{base_filename}.json"
             )
           when :csv

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -19,7 +19,7 @@ module GobiertoData
           respond_to do |format|
             format.json do
               json = if base_relation.exists?
-                       Rails.cache.fetch("#{base_relation.order(:updated_at).last.cache_key}/#{valid_preview_token? ? "all" : "active"}/datasets_collection") do
+                       Rails.cache.fetch("#{filtered_relation.cache_key}/#{valid_preview_token? ? "all" : "active"}/datasets_collection") do
                          render_to_string json: relation, links: links(:index), each_serializer: DatasetSerializer, adapter: :json_api
                        end
                      else

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -18,7 +18,14 @@ module GobiertoData
           relation = filtered_relation
           respond_to do |format|
             format.json do
-              render json: relation, links: links(:index), adapter: :json_api
+              json = if base_relation.exists?
+                       Rails.cache.fetch("#{base_relation.order(:updated_at).last.cache_key}/#{valid_preview_token? ? "all" : "active"}/datasets_collection") do
+                         render_to_string json: relation, links: links(:index), each_serializer: DatasetSerializer, adapter: :json_api
+                       end
+                     else
+                       render_to_string json: relation, links: links(:index), each_serializer: DatasetSerializer, adapter: :json_api
+                     end
+              render json: json
             end
 
             format.csv do

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -16,6 +16,8 @@ module GobiertoData
         # GET /api/v1/data/datasets.xlsx
         def index
           relation = filtered_relation
+          return unless stale? filtered_relation
+
           respond_to do |format|
             format.json do
               json = if base_relation.exists?
@@ -44,6 +46,8 @@ module GobiertoData
         # GET /api/v1/data/datasets/dataset-slug.xlsx
         def show
           find_item
+          return unless stale? @item
+
           relation = @item.rails_model.all
           query_result = execute_query relation
           respond_to do |format|
@@ -96,6 +100,7 @@ module GobiertoData
         # GET /api/v1/data/datasets/dataset-slug/metadata.json
         def dataset_meta
           find_item
+          return unless stale? @item
 
           render(
             json: @item,
@@ -109,6 +114,7 @@ module GobiertoData
 
         def stats
           find_item
+          return unless stale? @item
 
           render(
             json: @item,

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -72,7 +72,7 @@ module GobiertoData
 
           respond_to do |format|
             format.json do
-              send_download(cached_item_json, :json, basename)
+              send_download(cached_item_download_json, :json, basename)
             end
 
             format.csv do
@@ -171,6 +171,12 @@ module GobiertoData
               meta: query_result,
               links: links(:data)
             }.to_json
+          end
+        end
+
+        def cached_item_download_json
+          Rails.cache.fetch("#{@item.cache_key}/download.json") do
+            execute_query(@item.rails_model.all).fetch(:result, "").to_json
           end
         end
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -48,27 +48,17 @@ module GobiertoData
           find_item
           return unless stale? @item
 
-          relation = @item.rails_model.all
-          query_result = execute_query relation
           respond_to do |format|
             format.json do
-              render(
-                json:
-                {
-                  data: query_result.delete(:result),
-                  meta: query_result,
-                  links: links(:data)
-                },
-                adapter: :json_api
-              )
+              render json: cached_item_json
             end
 
             format.csv do
-              render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+              render_csv cached_item_csv
             end
 
             format.xlsx do
-              send_data xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, filename: "#{@item.slug}.xlsx"
+              send_data cached_item_xlsx, filename: "#{@item.slug}.xlsx"
             end
           end
         end
@@ -78,20 +68,19 @@ module GobiertoData
         # GET /api/v1/data/datasets/dataset-slug/download.xlsx
         def download
           find_item
-          relation = @item.rails_model.all
-          query_result = execute_query relation
           basename = @item.slug
+
           respond_to do |format|
             format.json do
-              send_download(query_result.fetch(:result, ""), :json, basename)
+              send_download(cached_item_json, :json, basename)
             end
 
             format.csv do
-              send_download(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params), :csv, basename)
+              send_download(cached_item_csv, :csv, basename)
             end
 
             format.xlsx do
-              send_download(xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, :xlsx, basename)
+              send_download(cached_item_xlsx, :xlsx, basename)
             end
           end
         end
@@ -173,6 +162,29 @@ module GobiertoData
         end
 
         private
+
+        def cached_item_json
+          Rails.cache.fetch("#{@item.cache_key}/show.json") do
+            query_result = execute_query @item.rails_model.all
+            {
+              data: query_result.delete(:result),
+              meta: query_result,
+              links: links(:data)
+            }.to_json
+          end
+        end
+
+        def cached_item_csv
+          Rails.cache.fetch("#{@item.cache_key}/show.csv?#{csv_options_params.to_json}") do
+            csv_from_query_result(execute_query(@item.rails_model.all).fetch(:result, ""), csv_options_params)
+          end
+        end
+
+        def cached_item_xlsx
+          Rails.cache.fetch("#{@item.cache_key}/show.xlsx") do
+            xlsx_from_query_result(execute_query(@item.rails_model.all).fetch(:result, ""), name: @item.name).read
+          end
+        end
 
         def base_relation
           current_site.datasets.send(valid_preview_token? ? :itself : :active)

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -34,7 +34,10 @@ module GobiertoData
 
     attribute :data_summary do
       {
-        number_of_rows: object.rails_model.count
+        number_of_rows: ::GobiertoData::Connection.execute_query(
+          object.site,
+          Arel.sql("SELECT COUNT(*) FROM #{object.table_name} LIMIT 1"), include_draft: true
+        ).dig(:result)&.first&.dig("count")
       }
     end
 

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -1,12 +1,34 @@
 # frozen_string_literal: true
 
 module GobiertoData
-  class DatasetMetaSerializer < DatasetSerializer
+  class DatasetMetaSerializer < ActiveModel::Serializer
     include Rails.application.routes.url_helpers
+    include ::GobiertoCommon::HasCustomFieldsAttributes
+
+    attributes :id, :name, :slug, :table_name, :data_updated_at
 
     has_many :queries
     has_many :visualizations
     has_many :attachments
+
+    attribute :links, unless: :exclude_links? do
+      slug = object.slug
+      {
+        data: gobierto_data_api_v1_dataset_path(slug),
+        metadata: meta_gobierto_data_api_v1_dataset_path(slug),
+        stats: stats_gobierto_data_api_v1_dataset_path(slug)
+      }
+    end
+
+    attribute :columns do
+      if model_present?
+        object.rails_model.columns.inject({}) do |columns, column|
+          columns.update(
+            column.name => column.type
+          )
+        end
+      end
+    end
 
     attribute :data_summary do
       {
@@ -25,5 +47,18 @@ module GobiertoData
     attribute :data_preview do
       object.rails_model.first(50)
     end
+
+    def current_site
+      Site.find_by(id: object.site_id) || instance_options[:site]
+    end
+
+    def exclude_links?
+      instance_options[:exclude_links]
+    end
+
+    def model_present?
+      object.rails_model.present? && object.rails_model.table_exists?
+    end
+
   end
 end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -49,10 +49,6 @@ module GobiertoData
       end
     end
 
-    attribute :data_preview do
-      object.rails_model.first(50)
-    end
-
     def current_site
       Site.find_by(id: object.site_id) || instance_options[:site]
     end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -5,6 +5,8 @@ module GobiertoData
     include Rails.application.routes.url_helpers
     include ::GobiertoCommon::HasCustomFieldsAttributes
 
+    cache key: "dataset_meta"
+
     attributes :id, :name, :slug, :table_name, :data_updated_at
 
     has_many :queries

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -5,6 +5,8 @@ module GobiertoData
     include Rails.application.routes.url_helpers
     include ::GobiertoCommon::HasCustomFieldsAttributes
 
+    cache key: "dataset"
+
     attributes :id, :name, :slug, :table_name, :data_updated_at
 
     attribute :links, unless: :exclude_links? do

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -199,7 +199,7 @@ module GobiertoData
 
             # attributes
             attributes_keys = resource_data["attributes"].keys
-            %w(name slug data_updated_at data_summary columns formats data_preview).each do |attribute|
+            %w(name slug data_updated_at data_summary columns formats).each do |attribute|
               assert_includes attributes_keys, attribute
             end
             assert resource_data["attributes"].has_key?(datasets_category.uid)


### PR DESCRIPTION
Closes #2930
Closes #2967

## :v: What does this PR do?

Adds cache to `DatasetSerializer` improving response time of datasets index. Testing in staging response times are reduced from times on the order of 1 second to 100-200 ms (demo-data example).

From the guides the caching of ActiveModelSerializers seems to have some performance issues (https://github.com/rails-api/active_model_serializers/issues/1586), but the performance in staging seems to be improved after the cache enabling.

With last changes it seems that issue described in #2967 is solved. The problem was the use of caching in `DatasetSerializer` and inheritance from it in `DatasetMetaSerializer`. Now both serializers are independent and have their own cache.

## :mag: How should this be manually tested?

Visit main page of gobierto data module or send a GET request to /api/v1/data/datasets directly

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
