### PR TITLE
2964 sectionable invalid section

### DIFF
--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -60,6 +60,10 @@ module GobiertoAdmin
 
       private
 
+      def section_instance
+        site.sections.find_by(id: section)
+      end
+
       def build_page
         page_class.new
       end
@@ -73,6 +77,8 @@ module GobiertoAdmin
       end
 
       def save_section_item(id, section, parent)
+        return if section_instance.blank? && page.section.blank?
+
         parent ||= 0
         parent_node = ::GobiertoCms::SectionItem.find_by(id: parent, section: section)
         position = if @page.parent_id == parent.to_i
@@ -83,7 +89,7 @@ module GobiertoAdmin
 
         section_item = ::GobiertoCms::SectionItem.find_or_initialize_by(item_id: id,
                                                                         item_type: "GobiertoCms::Page")
-        if section == "" && section_item.present?
+        if section_instance.blank? && section_item.present?
           section_item.destroy
         else
           section_item.update_attributes(parent_id: parent,

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -6,19 +6,22 @@ module GobiertoAdmin
 
       attr_accessor(
         :id,
-        :admin_id,
-        :site_id,
         :collection_id,
-        :visibility_level,
         :title_translations,
         :body_translations,
         :body_source_translations,
         :slug,
         :attachment_ids,
         :section,
-        :published_on,
         :template,
         :parent
+      )
+
+      attr_writer(
+        :admin_id,
+        :site_id,
+        :visibility_level,
+        :published_on
       )
 
       delegate :persisted?, to: :page
@@ -111,11 +114,7 @@ module GobiertoAdmin
           page_attributes.visibility_level = visibility_level
           page_attributes.published_on = published_on
           if page.new_record? && attachment_ids.present?
-            if attachment_ids.is_a?(String)
-              page_attributes.attachment_ids = attachment_ids.split(",")
-            else
-              page_attributes.attachment_ids = attachment_ids
-            end
+            page_attributes.attachment_ids = attachment_ids.is_a?(String) ? attachment_ids.split(",") : attachment_ids
           end
         end
 

--- a/app/models/concerns/gobierto_common/sectionable.rb
+++ b/app/models/concerns/gobierto_common/sectionable.rb
@@ -6,11 +6,9 @@ module GobiertoCommon
 
     included do
       def section_id
-        unless GobiertoCms::SectionItem.where(item: self).empty?
-          GobiertoCms::SectionItem.where(item: self).first.section.id
-        else
-          nil
-        end
+        return if GobiertoCms::SectionItem.where(item: self).joins(:section).empty?
+
+        GobiertoCms::SectionItem.where(item: self).first.section.id
       end
 
       def parent_id


### PR DESCRIPTION
Closes #2964


## :v: What does this PR do?

* Avoids errors in `Sectionable` concern trying to find not existing sections
* Prevents the inclusion of pages into not existing sections in admin page edition form
* Fixes some rubocop offenses

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

![2964_before](https://user-images.githubusercontent.com/446459/79209821-3200a380-7e44-11ea-891d-5a9474ff3325.gif)


### After this PR

![2964_after](https://user-images.githubusercontent.com/446459/79209834-388f1b00-7e44-11ea-80de-c4a43baa29b8.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No