### PR TITLE
2957 append data to table using existing schema

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -72,7 +72,7 @@ module GobiertoData
 
     def load_data_from_file(file_path, schema_file: nil, csv_separator: ",", append: false)
       schema = if schema_file.blank?
-                 {}
+                 append ? table_schema : {}
                elsif schema_file.is_a? Hash
                  schema_file.deep_symbolize_keys
                else
@@ -98,6 +98,13 @@ module GobiertoData
     end
 
     private
+
+    def table_schema
+      table_columns = Connection.execute_query(site, "SELECT column_name, data_type FROM information_schema.COLUMNS WHERE table_name='#{table_name}'", write: true)
+      table_columns[:result].inject({}) do |schema, column|
+        schema.update(column["column_name"] => { "original_name" => column["column_name"], "type" => column["data_type"] })
+      end
+    end
 
     def set_schema
       if draft?

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -89,7 +89,7 @@ module GobiertoData
 
       query_result = Connection.execute_write_query_from_file_using_stdin(site, statements.sql_code, file_path: file_path)
       set_schema
-      touch(:data_updated_at) unless query_result.has_key?(:errors)
+      touch(:data_updated_at) unless query_result.blank? || query_result.has_key?(:errors)
       {
         db_result: query_result,
         schema: statements.schema,

--- a/app/queries/gobierto_data/datasets/creation_statements.rb
+++ b/app/queries/gobierto_data/datasets/creation_statements.rb
@@ -57,7 +57,7 @@ module GobiertoData
         default_schema = inspect_csv_schema(source_file, csv_separator: @csv_separator)
         schema_definition = (schema_definition || {}).deep_symbolize_keys
         default_schema.map do |default_column, default_value|
-          schema_definition.find { |_, value| value[:original_name] == default_value[:original_name] } || [default_column, default_value]
+          schema_definition.find { |_, value| value[:original_name].casecmp?(default_value[:original_name]) } || [default_column, default_value]
         end.to_h
       end
 

--- a/app/queries/gobierto_data/datasets/creation_statements.rb
+++ b/app/queries/gobierto_data/datasets/creation_statements.rb
@@ -57,7 +57,9 @@ module GobiertoData
         default_schema = inspect_csv_schema(source_file, csv_separator: @csv_separator)
         schema_definition = (schema_definition || {}).deep_symbolize_keys
         default_schema.map do |default_column, default_value|
-          schema_definition.find { |_, value| value[:original_name].casecmp?(default_value[:original_name]) } || [default_column, default_value]
+          schema_definition.find do |key, value|
+            default_value[:original_name].casecmp?(value.has_key?(:original_name) ? value[:original_name] : key.to_s)
+          end || [default_column, default_value]
         end.to_h
       end
 

--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -35,7 +35,7 @@ module GobiertoData
           input_type: "text",
           output_type: "date",
           sql: "select (to_date(nullif(trim($1), '#null_value'), '#date_format'));",
-          optional_params: { date_format: "DD-MON-YYY", null_value: "" }
+          optional_params: { date_format: "YYY-MM-DD", null_value: "" }
         },
         time: {
           input_type: "text",
@@ -47,13 +47,13 @@ module GobiertoData
           input_type: "text",
           output_type: "timestamp",
           sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format')::timestamp without time zone);",
-          optional_params: { date_format: "DD-MON-YYY", null_value: "" }
+          optional_params: { date_format: "YYY-MM-DD", null_value: "" }
         },
         timestamptz: {
           input_type: "text",
           output_type: "timestamptz",
           sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format'));",
-          optional_params: { date_format: "DD-MON-YYY", null_value: "" }
+          optional_params: { date_format: "YYY-MM-DD", null_value: "" }
         },
         boolean: {
           input_type: "text",

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class DatasetsControllerTest < GobiertoControllerTest
+        self.use_transactional_tests = false
+
+        attr_reader :default_secret, :token_service
+
+        def setup
+          super
+
+          @default_secret = "S3cr3t"
+          @token_service = with_stubbed_jwt_default_secret(default_secret) do
+            GobiertoCommon::TokenService.new
+          end
+        end
+
+        def auth_header
+          "Bearer #{token_service.encode(sub: "login", api_token: admin.api_token)}"
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def site_with_module_disabled
+          @site_with_module_disabled ||= sites(:santander)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        def multipart_form_params(file = "dataset1.csv")
+          {
+            dataset: {
+              name: "Uploaded dataset",
+              table_name: "uploaded_dataset",
+              data_file: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/files/gobierto_data/#{file}"),
+              visibility_level: "active"
+            }
+          }
+        end
+
+        # POST /api/v1/data/datasets
+        #
+        def test_dataset_creation_with_file_upload
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              post(
+                gobierto_data_api_v1_datasets_path,
+                params: multipart_form_params("dataset1.csv"),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :created
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+
+              [:name, :table_name, :visibility_level].each do |attribute|
+                assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
+              end
+
+              query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+              assert_equal 4, query_result[:rows]
+              query_result[:result].first.each_value do |value|
+                assert value.is_a? String
+              end
+            end
+          end
+        end
+
+        # POST /api/v1/data/datasets
+        #
+        def test_dataset_creation_with_file_upload_and_schema_file_renaming_columns
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              post(
+                gobierto_data_api_v1_datasets_path,
+                params: multipart_form_params("dataset1.csv").deep_merge(
+                  dataset: { schema_file: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/files/gobierto_data/schema_rename_columns.json") }
+                ),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :created
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+
+              [:name, :table_name, :visibility_level].each do |attribute|
+                assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
+              end
+
+              query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+              assert_equal 4, query_result[:rows]
+
+              query_result[:result].first.each_key do |column_name|
+                assert_match(/_changed\Z/, column_name)
+              end
+            end
+          end
+        end
+
+        # PUT /api/v1/data/datasets/dataset-slug
+        #
+        def test_dataset_update_with_file_upload
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              post(
+                gobierto_data_api_v1_datasets_path,
+                params: multipart_form_params("dataset1.csv"),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :created
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+              slug = response_data["data"]["attributes"]["slug"]
+
+              put(
+                gobierto_data_api_v1_dataset_path(slug),
+                params: multipart_form_params("dataset2.csv"),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :success
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+
+              [:name, :table_name, :visibility_level].each do |attribute|
+                assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
+              end
+
+              query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+              assert_equal 1, query_result[:rows]
+              query_result[:result].first.each_value do |value|
+                assert value.is_a? String
+              end
+            end
+          end
+        end
+
+        # PUT /api/v1/data/datasets/dataset-slug
+        #
+        def test_dataset_update_with_file_upload_append
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              post(
+                gobierto_data_api_v1_datasets_path,
+                params: multipart_form_params("dataset1.csv"),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :created
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+              slug = response_data["data"]["attributes"]["slug"]
+
+              put(
+                gobierto_data_api_v1_dataset_path(slug),
+                params: multipart_form_params("dataset2.csv").deep_merge(dataset: { append: "true" }),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :success
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+
+              [:name, :table_name, :visibility_level].each do |attribute|
+                assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
+              end
+
+              query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+              assert_equal 5, query_result[:rows]
+              query_result[:result].first.each_value do |value|
+                assert value.is_a? String
+              end
+            end
+          end
+        end
+
+        # PUT /api/v1/data/datasets/dataset-slug
+        #
+        def test_dataset_update_with_file_upload_append_with_schema
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              post(
+                gobierto_data_api_v1_datasets_path,
+                params: multipart_form_params("dataset1.csv").deep_merge(
+                  dataset: { schema_file: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/files/gobierto_data/schema.json") }
+                ),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :created
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+              slug = response_data["data"]["attributes"]["slug"]
+
+              put(
+                gobierto_data_api_v1_dataset_path(slug),
+                params: multipart_form_params("dataset2.csv").deep_merge(dataset: { append: "true" }),
+                headers: { "Authorization" => auth_header }
+              )
+
+              assert_response :success
+              response_data = response.parsed_body
+              attributes = response_data["data"]["attributes"].with_indifferent_access
+
+              [:name, :table_name, :visibility_level].each do |attribute|
+                assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
+              end
+
+              query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+              assert_equal 5, query_result[:rows]
+
+              schema = Dataset.find_by_slug(slug).send(:table_schema)
+              assert_equal "integer", schema["integer_column"]["type"]
+              assert_equal "numeric", schema["decimal_column"]["type"]
+              assert_equal "text", schema["text_column"]["type"]
+              assert_equal "date", schema["date_column"]["type"]
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/fixtures/files/gobierto_data/dataset1.csv
+++ b/test/fixtures/files/gobierto_data/dataset1.csv
@@ -1,0 +1,5 @@
+integer_column,decimal_column,text_column,date_column
+1,3.1416,Dog,2020-01-01
+2,2.7183,Cat,2019-01-01
+3,1.4142,Horse,2019-12-31
+4,10,Some words,2000-01-01

--- a/test/fixtures/files/gobierto_data/dataset2.csv
+++ b/test/fixtures/files/gobierto_data/dataset2.csv
@@ -1,0 +1,2 @@
+integer_column,decimal_column,text_column,date_column
+5,6.66667,Pig,2020-02-29

--- a/test/fixtures/files/gobierto_data/schema.json
+++ b/test/fixtures/files/gobierto_data/schema.json
@@ -1,0 +1,6 @@
+{
+  "integer_column":{"type":"integer"},
+  "decimal_column":{"type":"numeric"},
+  "text_column":{"type":"text"},
+  "date_column":{"type":"date"}
+}

--- a/test/fixtures/files/gobierto_data/schema_rename_columns.json
+++ b/test/fixtures/files/gobierto_data/schema_rename_columns.json
@@ -1,0 +1,6 @@
+{
+  "integer_column_changed":{"original_name":"integer_column", "type":"integer"},
+  "decimal_column_changed":{"original_name":"decimal_column", "type":"numeric"},
+  "text_column_changed":{"original_name":"text_column", "type":"text"},
+  "date_column_changed":{"original_name":"date_column", "type":"date"}
+}


### PR DESCRIPTION
Closes #2957


## :v: What does this PR do?

* Fixes an exception generated when write queries are sent to module database and configuration for queries with writing permissions fails.
* Makes custom schema parsing more flexible to detect custom configuration for CSV columns using a case-insensitive lookup.
* Makes import from CSV dataset method to make use of a custom schema based on existing table columns types when used with append option enabled and no schema configuration is provided.
* Changes the default date format importing from csv to "YYY-MM-DD"
* Allows the omission of `original_name` in schema JSON file. If omitted it's assumed that the 
`original_name` the same as the destination name 
* Adds some tests

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No