### PR TITLE
2946 create datasets with data path and schema uploaded file

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -202,6 +202,7 @@ module GobiertoData
           if request.content_mime_type.symbol == :multipart_form
             params.require(:dataset).permit(
               :data_file,
+              :data_path,
               :name,
               :table_name,
               :slug,

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -162,7 +162,7 @@ module GobiertoData
         private
 
         def base_relation
-          current_site.datasets.send(valid_preview_token? ? :itself : :active)
+          current_site.datasets.send(current_admin.present? || valid_preview_token? ? :itself : :active)
         end
 
         def find_item

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -69,7 +69,7 @@ module GobiertoData
     end
 
     def visibility_level
-      @visibility_level ||= "draft"
+      @visibility_level ||= resource.visibility_level
     end
 
     def save


### PR DESCRIPTION
Closes #2946


## :v: What does this PR do?

* Allows to include a `data_path` param in multipart form option of API requests to create/update datasets. This permit us to provide an schema file and also a path to download directly the csv to be load
* Also fixes a pair of bugs:
  * Allows updating of datasets in draft status if the request includes valid admin credentials (previously the response of the API was a 404 Not found)
  * The visibility level is not changed to draft on updates if the corresponding param is not sent in the request


## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
