### PR TITLE
2976 transactional datasets creation

### DIFF
--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -81,6 +81,9 @@ module GobiertoData
     rescue CSV::MalformedCSVError
       errors.add(data_file.present? ? :data_file : :data_path, "CSV file malformed or with wrong encoding (expected UTF-8)")
       false
+    rescue PG::Error => e
+      errors.add(data_file.present? ? :data_file : :data_path, "Database error loading CSV: #{e.message}")
+      false
     end
 
     def csv_separator

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -73,7 +73,14 @@ module GobiertoData
     end
 
     def save
-      save_resource if valid?
+      if valid?
+        ActiveRecord::Base.transaction do
+          save_resource
+        end
+      end
+    rescue CSV::MalformedCSVError
+      errors.add(data_file.present? ? :data_file : :data_path, "CSV file malformed or with wrong encoding (expected UTF-8)")
+      false
     end
 
     def csv_separator
@@ -152,9 +159,6 @@ module GobiertoData
         else
           true
         end
-      rescue CSV::MalformedCSVError
-        errors.add(data_file.present? ? :data_file : :data_path, "CSV file malformed or with wrong encoding (expected UTF-8)")
-        false
       ensure
         temp_file.close
         temp_file.unlink

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -52,8 +52,6 @@ module GobiertoData
         end
       rescue ActiveRecord::StatementInvalid => e
         failed_query(e.message)
-      rescue PG::Error => e
-        failed_query(e.message)
       end
 
       def tables(site, include_draft: false)

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -52,6 +52,8 @@ module GobiertoData
         end
       rescue ActiveRecord::StatementInvalid => e
         failed_query(e.message)
+      rescue PG::Error => e
+        failed_query(e.message)
       end
 
       def tables(site, include_draft: false)

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -48,6 +48,48 @@ module GobiertoData
 
         # POST /api/v1/data/datasets
         #
+        def test_dataset_creation_with_missing_params
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              assert_no_difference "GobiertoData::Dataset.count" do
+                post(
+                  gobierto_data_api_v1_datasets_path,
+                  params: multipart_form_params("dataset1.csv").deep_merge(
+                    dataset: { name: nil, table_name: nil }
+                  ),
+                  headers: { "Authorization" => auth_header }
+                )
+
+                assert_response :unprocessable_entity
+                response_data = response.parsed_body
+                assert_match(/can't be blank/, response_data.to_s)
+              end
+            end
+          end
+        end
+
+        # POST /api/v1/data/datasets
+        #
+        def test_dataset_creation_with_invalid_file_upload
+          with(site: site) do
+            with_stubbed_jwt_default_secret(default_secret) do
+              assert_no_difference "GobiertoData::Dataset.count" do
+                post(
+                  gobierto_data_api_v1_datasets_path,
+                  params: multipart_form_params("schema.json"),
+                  headers: { "Authorization" => auth_header }
+                )
+
+                assert_response :unprocessable_entity
+                response_data = response.parsed_body
+                assert_match(/CSV file malformed or with wrong encoding/, response_data.to_s)
+              end
+            end
+          end
+        end
+
+        # POST /api/v1/data/datasets
+        #
         def test_dataset_creation_with_file_upload
           with(site: site) do
             with_stubbed_jwt_default_secret(default_secret) do


### PR DESCRIPTION
Closes #2976


## :v: What does this PR do?

* Wraps datasets creation in FormObject used by the API in a transaction to roll back the creation of a dataset when the load of csv fails
* Adds some tests

## :mag: How should this be manually tested?

Upload a dataset with a wrong CSV or schema

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No