### PR TITLE
1000 Apply styles to the queries component

### DIFF
--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -252,6 +252,14 @@
   &-summary-queries {
     width: 100%;
     letter-spacing: 0;
+
+    .gobierto-data-summary-queries-sql-code {
+
+      .CodeMirror {
+        background-color: transparent !important;
+        padding: 0;
+      }
+    }
   }
 
   &-summary-queries-panel {
@@ -268,6 +276,11 @@
       left: 50%;
       background-color: rgba(var(--color-base-string), .3);
     }
+
+    .gobierto-vue-dropdown {
+      margin-bottom: 2rem;
+    }
+
   }
 
   &-summary-queries-panel-title {
@@ -277,13 +290,14 @@
     line-height: 20px;
     color: rgba(102, 102, 102, .75);
     display: inline-block;
-    margin-top: 10px;
+    margin-top: 12px;
     margin-bottom: 6px;
     padding-left: 1rem;
   }
 
   &-summary-queries-sql-code {
-    padding: 1rem;
+    padding: 12px 1rem 1rem;
+    margin-top: 0;
     font-family: monospace;
     font-size: 12px;
     color: #666;
@@ -814,8 +828,7 @@
   }
 
   &-summary-queries-container {
-    padding: .25rem 2rem;
-    padding-top: 0;
+    padding: .25rem .5rem .25rem 2rem;
     cursor: pointer;
     transition: background-color var(--transition);
 
@@ -828,6 +841,7 @@
     font-size: 14px;
     color: #666;
     display: inline-block;
+    vertical-align: middle;
     width: 78%;
     position: relative;
     z-index: 1;
@@ -835,7 +849,9 @@
 
   &-summary-queries-container-icon {
     display: inline-block;
+    vertical-align: middle;
     width: 20%;
+    text-align: right;
   }
 
   .icons-your-queries {

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -256,7 +256,7 @@
     .gobierto-data-summary-queries-sql-code {
 
       .CodeMirror {
-        background-color: transparent !important;
+        background-color: transparent;
         padding: 0;
       }
 
@@ -304,10 +304,6 @@
     margin-top: 12px;
     margin-bottom: 6px;
     padding-left: 1rem;
-
-    i {
-      cursor: pointer;
-    }
   }
 
   &-summary-queries-sql-code {
@@ -528,7 +524,7 @@
   }
 
   .CodeMirror {
-    background-color: rgba(#666, .05) !important;
+    background-color: rgba(#666, .05);
     border: 0;
     padding: .5rem;
     height: auto !important;

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -277,8 +277,10 @@
       background-color: rgba(var(--color-base-string), .3);
     }
 
-    .gobierto-vue-dropdown {
-      margin-bottom: 2rem;
+    .gobierto-vue-dropdown--content {
+      &:not(:empty) {
+        margin-bottom: 2rem;
+      }
     }
 
   }
@@ -293,6 +295,10 @@
     margin-top: 12px;
     margin-bottom: 6px;
     padding-left: 1rem;
+
+    i {
+      cursor: pointer;
+    }
   }
 
   &-summary-queries-sql-code {
@@ -845,6 +851,10 @@
     width: 78%;
     position: relative;
     z-index: 1;
+
+    &:hover {
+      color: inherit;
+    }
   }
 
   &-summary-queries-container-icon {

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -259,6 +259,15 @@
         background-color: transparent !important;
         padding: 0;
       }
+
+      .CodeMirror-line {
+        white-space: normal;
+        width: 100%;
+      }
+
+      .CodeMirror-sizer {
+        width: 90%;
+      }
     }
   }
 

--- a/app/javascript/gobierto_data/webapp/components/commons/Caret.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Caret.vue
@@ -2,6 +2,7 @@
   <i
     :class="rotate ? '' : 'rotate-caret'"
     class="fas fa-caret-down"
+    style="color: var(--color-base)"
   />
 </template>
 

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -143,8 +143,6 @@ export default {
       autoIndent: true
     };
 
-    console.log(this.sqlCode)
-
     this.editor = CodeMirror.fromTextArea(this.$refs.querySnippet, cmOption);
   },
   methods: {
@@ -153,7 +151,6 @@ export default {
     },
     showSQLCode(code) {
       this.sqlCode = code
-      console.log(this.sqlCode)
       this.editor.setValue(this.sqlCode);
     },
     removeSQLCode() {

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -88,9 +88,7 @@
 
       <div class="pure-u-1-2 border-color-queries">
         <p class="gobierto-data-summary-queries-sql-code">
-          <transition name="fade">
-            <textarea ref="querySnippet" />
-          </transition>
+          <textarea ref="querySnippet" />
         </p>
       </div>
     </div>

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -87,7 +87,7 @@
       </div>
 
       <div class="pure-u-1-2 border-color-queries">
-        <p v-if="sqlCode" class="gobierto-data-summary-queries-sql-code">
+        <p class="gobierto-data-summary-queries-sql-code">
           <transition name="fade">
             <textarea ref="querySnippet" />
           </transition>

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -17,8 +17,8 @@
                 v-for="{ id, attributes: { sql, name, privacy_status }} in privateQueries"
                 :key="id"
                 class="gobierto-data-summary-queries-container"
-                @mouseover="sqlCode = sql"
-                @mouseleave="sqlCode = null"
+                @mouseover="showSQLCode(sql)"
+                @mouseleave="removeSQLCode()"
               >
                 <router-link
                   :to="`/datos/${$route.params.id}/q/${id}`"
@@ -72,8 +72,8 @@
               v-for="{ id, attributes: { sql, name }} in publicQueries"
               :key="id"
               class="gobierto-data-summary-queries-container"
-              @mouseover="sqlCode = sql"
-              @mouseleave="sqlCode = null"
+              @mouseover="showSQLCode(sql)"
+              @mouseleave="removeSQLCode()"
             >
               <router-link
                 :to="`/datos/${$route.params.id}/q/${id}`"
@@ -89,7 +89,7 @@
       <div class="pure-u-1-2 border-color-queries">
         <p class="gobierto-data-summary-queries-sql-code">
           <transition name="fade">
-            <span v-if="sqlCode"> {{ sqlCode }}</span>
+            <textarea ref="querySnippet" />
           </transition>
         </p>
       </div>
@@ -100,6 +100,8 @@
 import { Dropdown } from "lib/vue-components";
 import Caret from "./Caret.vue";
 import PrivateIcon from './PrivateIcon.vue';
+import CodeMirror from "codemirror";
+import "codemirror/mode/sql/sql.js";
 
 export default {
   name: "Queries",
@@ -129,9 +131,33 @@ export default {
       showPublicQueries: true,
     };
   },
+  mounted() {
+    const cmOption = {
+      tabSize: 2,
+      styleActiveLine: false,
+      lineNumbers: false,
+      styleSelectedText: false,
+      line: true,
+      foldGutter: true,
+      mode: "text/x-sql",
+      showCursorWhenSelecting: true,
+      theme: "default",
+      autoIndent: true
+    };
+
+    this.editor = CodeMirror.fromTextArea(this.$refs.querySnippet, cmOption);
+  },
   methods: {
     clickDeleteQueryHandler(id) {
       this.$root.$emit('deleteSavedQuery', id)
+    },
+    showSQLCode(code) {
+      this.sqlCode = code
+      this.editor.setValue(this.sqlCode);
+    },
+    removeSQLCode() {
+      this.sqlCode = ''
+      this.editor.setValue(this.sqlCode);
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -87,7 +87,7 @@
       </div>
 
       <div class="pure-u-1-2 border-color-queries">
-        <p class="gobierto-data-summary-queries-sql-code">
+        <p v-if="sqlCode" class="gobierto-data-summary-queries-sql-code">
           <transition name="fade">
             <textarea ref="querySnippet" />
           </transition>
@@ -145,6 +145,8 @@ export default {
       autoIndent: true
     };
 
+    console.log(this.sqlCode)
+
     this.editor = CodeMirror.fromTextArea(this.$refs.querySnippet, cmOption);
   },
   methods: {
@@ -153,6 +155,7 @@ export default {
     },
     showSQLCode(code) {
       this.sqlCode = code
+      console.log(this.sqlCode)
       this.editor.setValue(this.sqlCode);
     },
     removeSQLCode() {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1000


## :v: What does this PR do?

Correct styles.
Overflow for big queries.
Apply same highlight syntax for code like in the editor.

## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### Before this PR

![before_queries 2020-04-20 15_54_48](https://user-images.githubusercontent.com/2649175/79759691-4bf82580-831f-11ea-8600-1d46a7cafd3a.gif)

### After this PR

![after_queries 2020-04-20 17_29_09](https://user-images.githubusercontent.com/2649175/79769502-7f8d7c80-832c-11ea-9aa5-775725f5c392.gif)
