### PR TITLE
Ignore blank lines of csv importing datasets

### DIFF
--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -45,6 +45,8 @@ module GobiertoData
 
           execution = raw_connection.copy_data(query) do
             File.open(file_path, "r").each do |line|
+              next if line.blank?
+
               raw_connection.put_copy_data line
             end
           end


### PR DESCRIPTION
## :v: What does this PR do?

Prevents errors trying to import datasets from CSVs which include blank lines. The error happens in the psql server running the import script

## :mag: How should this be manually tested?

Edit a valid csv and add some blank lines at the end. The file should be imported without problems 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
