### PR TITLE
Add column types to datasets sidebar

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -124,7 +124,11 @@ export default {
       }
     },
     handleToggle(slug) {
-      this.currentDatasetSlug = slug
+      if (slug !== this.currentDatasetSlug) {
+        this.currentDatasetSlug = slug
+      } else {
+        this.currentDatasetSlug = null
+      }
     }
   },
   filters: {

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -21,7 +21,7 @@
         </router-link>
 
         <div
-          v-show="currentDatasetSlug === slug"
+          v-if="currentDatasetSlug === slug"
           class="gobierto-data-sidebar-datasets-container-columns"
         >
           <template v-for="(type, column) in activeDatasetVisibleColumns">

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -1,27 +1,27 @@
 <template>
   <div v-if="listDatasets.length">
     <div
-      v-for="({ id, attributes: { slug, name }}, index) in listDatasets"
+      v-for="({ attributes: { slug, name }}) in listDatasets"
       :key="slug"
       class="gobierto-data-sidebar-datasets"
     >
       <div class="gobierto-data-sidebar-datasets-links-container">
         <i
-          :class="{'rotate-caret': currentDatasetIndex !== index }"
+          :class="{'rotate-caret': currentDatasetSlug !== slug }"
           class="fas fa-caret-down gobierto-data-sidebar-icon"
-          @click="handleToggle(index)"
+          @click="handleToggle(slug)"
         />
 
         <router-link
           :to="`/datos/${slug}`"
          class="gobierto-data-sidebar-datasets-name"
-         @click.native="selectCurrentDataset"
+         @click.native="selectCurrentDataset(slug)"
         >
           {{ name }}
         </router-link>
 
         <div
-          v-show="currentDatasetIndex === index"
+          v-show="currentDatasetSlug === slug"
           class="gobierto-data-sidebar-datasets-container-columns"
         >
           <template v-for="(type, column) in activeDatasetVisibleColumns">
@@ -69,7 +69,7 @@ export default {
       labelshowLess: "",
       sortedItems: [],
       listDatasets: [],
-      currentDatasetIndex: null,
+      currentDatasetSlug: null,
       showMaxKeys: 10,
       showLess: null,
       activeDatasetColumns: {},
@@ -82,15 +82,17 @@ export default {
     this.labelCategories = I18n.t("gobierto_data.projects.categories")
     this.labelshowAll = I18n.t("gobierto_data.projects.showAll")
     this.labelshowLess = I18n.t("gobierto_data.projects.showLess")
-    //TODO Datasets should be order in filter mixin
+    // TODO Datasets should be order in filter mixin
     this.sortedItems = this.items.sort(({ attributes: { name: a } = {} }, { attributes: { name: b } = {} }) => a.localeCompare(b));
-    this.selectCurrentDataset()
+
+    let { id } = this.$route.params
+    this.selectCurrentDataset(id)
   },
   watch: {
-    currentDatasetIndex: function(value) {
+    currentDatasetSlug: function(newSlug) {
       this.showLess = true;
-      if(this.listDatasets.length) {
-        this.activeDatasetColumns = this.listDatasets[value].attributes.columns || {}
+      if(this.sortedItems.length) {
+        this.activeDatasetColumns = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === newSlug).attributes.columns || {}
         this.showToggle = Object.keys(this.activeDatasetColumns).length > this.showMaxKeys
       }
     }
@@ -108,21 +110,19 @@ export default {
     }
   },
   methods: {
-    selectCurrentDataset() {
-      // Get slug from route params, we need this when user click in any dataset
-      let { id } = this.$route.params
-      let selectedDatasetIndex = 0
-      if(id !== undefined) {
-        selectedDatasetIndex = this.sortedItems.findIndex(({ attributes: { slug } = {} }) => slug === id)
+    selectCurrentDataset(selectedDatasetSlug) {
+      if(selectedDatasetSlug === undefined && this.sortedItems.length) {
+        selectedDatasetSlug = this.sortedItems[0].attributes.slug
       }
-
-      let selectedDataset = this.sortedItems[selectedDatasetIndex]
-      let filteredArray = this.sortedItems.filter(({ attributes: { slug } = {} }) => slug !== selectedDataset.attributes.slug)
-      this.listDatasets = [selectedDataset].concat(filteredArray)
-      this.currentDatasetIndex = 0
+      if(selectedDatasetSlug !== undefined) {
+        let selectedDataset = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === selectedDatasetSlug)
+        let filteredArray = this.sortedItems.filter(({ attributes: { slug } = {} }) => slug !== selectedDatasetSlug)
+        this.listDatasets = [selectedDataset].concat(filteredArray)
+        this.currentDatasetSlug = selectedDatasetSlug
+      }
     },
-    handleToggle(index) {
-      this.currentDatasetIndex = index;
+    handleToggle(slug) {
+      this.currentDatasetSlug = slug
     }
   },
   filters: {

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -14,8 +14,8 @@
 
         <router-link
           :to="`/datos/${slug}`"
-         class="gobierto-data-sidebar-datasets-name"
-         @click.native="selectCurrentDataset(slug)"
+          class="gobierto-data-sidebar-datasets-name"
+          @click.native="selectCurrentDataset(slug)"
         >
           {{ name }}
         </router-link>
@@ -29,19 +29,21 @@
               :key="`${column}-${type}`"
               class="gobierto-data-sidebar-datasets-links-columns"
             >
-              {{ column }}: {{type | translateType}}
+              {{ column }}: {{ type | translateType }}
             </span>
           </template>
           <div v-if="showToggle">
-            <span v-if="showLess"
-              class="gobierto-data-sidebar-datasets-links-columns-see-more"
-              @click="showLess = false"
+            <span
+              v-if="showLess"
+                class="gobierto-data-sidebar-datasets-links-columns-see-more"
+                @click="showLess = false"
             >
               {{ labelshowAll }}
             </span>
-            <span v-else
-              class="gobierto-data-sidebar-datasets-links-columns-see-more"
-              @click="showLess = true"
+            <span
+              v-else
+                class="gobierto-data-sidebar-datasets-links-columns-see-more"
+                @click="showLess = true"
             >
               {{ labelshowLess }}
             </span>
@@ -91,7 +93,7 @@ export default {
   watch: {
     currentDatasetSlug: function(newSlug) {
       this.showLess = true;
-      if(this.sortedItems.length) {
+      if (this.sortedItems.length) {
         this.activeDatasetColumns = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === newSlug).attributes.columns || {}
         this.showToggle = Object.keys(this.activeDatasetColumns).length > this.showMaxKeys
       }
@@ -99,7 +101,7 @@ export default {
   },
   computed: {
     activeDatasetVisibleColumns() {
-      if(this.showLess && Object.keys(this.activeDatasetColumns).length) {
+      if (this.showLess && Object.keys(this.activeDatasetColumns).length) {
        return Object.keys(this.activeDatasetColumns).slice(0, this.showMaxKeys).reduce((result, key) => {
           result[key] = this.activeDatasetColumns[key];
           return result;
@@ -111,10 +113,10 @@ export default {
   },
   methods: {
     selectCurrentDataset(selectedDatasetSlug) {
-      if(!selectedDatasetSlug && this.sortedItems.length) {
+      if (!selectedDatasetSlug && this.sortedItems.length) {
         selectedDatasetSlug = this.sortedItems[0].attributes.slug
       }
-      if(selectedDatasetSlug) {
+      if (selectedDatasetSlug) {
         const selectedDataset = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === selectedDatasetSlug)
         const filteredArray = this.sortedItems.filter(({ attributes: { slug } = {} }) => slug !== selectedDatasetSlug)
         this.listDatasets = [selectedDataset].concat(filteredArray)

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -111,12 +111,12 @@ export default {
   },
   methods: {
     selectCurrentDataset(selectedDatasetSlug) {
-      if(selectedDatasetSlug === undefined && this.sortedItems.length) {
+      if(!selectedDatasetSlug && this.sortedItems.length) {
         selectedDatasetSlug = this.sortedItems[0].attributes.slug
       }
-      if(selectedDatasetSlug !== undefined) {
-        let selectedDataset = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === selectedDatasetSlug)
-        let filteredArray = this.sortedItems.filter(({ attributes: { slug } = {} }) => slug !== selectedDatasetSlug)
+      if(selectedDatasetSlug) {
+        const selectedDataset = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === selectedDatasetSlug)
+        const filteredArray = this.sortedItems.filter(({ attributes: { slug } = {} }) => slug !== selectedDatasetSlug)
         this.listDatasets = [selectedDataset].concat(filteredArray)
         this.currentDatasetSlug = selectedDatasetSlug
       }

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -35,6 +35,7 @@ ignore_missing:
   - 'gobierto_common.visualizations.cards.*'
   - 'gobierto_common.visualizations.frequency.dailt'
   - 'gobierto_admin.gobierto_plans.projects.moderation_visibility_action.*'
+  - 'gobierto_data.data_type.*'
 
 ignore_unused:
   - 'number.*'
@@ -116,6 +117,7 @@ ignore_unused:
   - 'gobierto_plans.plan_types.show.read_more'
   - 'gobierto_admin.layouts.application.modules.*'
   - 'gobierto_admin.layouts.application.global'
+  - 'gobierto_data.data_type.*'
 
 translation:
   api_key: ''

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -2,14 +2,18 @@
 ca:
   gobierto_data:
     data_type:
-      boolean: bolea
+      boolean: boolean
       date: data
+      datetime: data i hora
       decimal: decimal
-      integer: senser
+      hstore: hstore
+      integer: enter
+      jsonb: jsonb
+      string: cadena
       text: text
       time: temps
-      timestamp: temps
-      timestampz: temps
+      timestamp: data i hora
+      timestampz: data i hora
     events:
       gobierto_data_dataset_dataset_created: Conjunt de dades creat
       gobierto_data_dataset_dataset_updated: Conjunt de dades actualitzat

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -1,6 +1,15 @@
 ---
 ca:
   gobierto_data:
+    data_type:
+      boolean: bolea
+      date: data
+      decimal: decimal
+      integer: senser
+      text: text
+      time: temps
+      timestamp: temps
+      timestampz: temps
     events:
       gobierto_data_dataset_dataset_created: Conjunt de dades creat
       gobierto_data_dataset_dataset_updated: Conjunt de dades actualitzat

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -2,11 +2,15 @@
 en:
   gobierto_data:
     data_type:
-      boolean: boleaan
+      boolean: boolean
       date: date
+      datetime: datetime
       decimal: decimal
+      hstore: hstore
       integer: integer
-      text: texto
+      jsonb: jsonb
+      string: string
+      text: text
       time: time
       timestamp: time
       timestampz: time

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -1,6 +1,15 @@
 ---
 en:
   gobierto_data:
+    data_type:
+      boolean: boleaan
+      date: date
+      decimal: decimal
+      integer: integer
+      text: texto
+      time: time
+      timestamp: time
+      timestampz: time
     events:
       gobierto_data_dataset_dataset_created: Dataset created
       gobierto_data_dataset_dataset_updated: Dataset updated

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -2,10 +2,14 @@
 es:
   gobierto_data:
     data_type:
+      boolean: logico
       date: fecha
       decimal: decimal
       integer: entero
       text: texto
+      time: tiempo
+      timestamp: tiempo
+      timestampz: tiempo
     events:
       gobierto_data_dataset_dataset_created: Conjunto de datos creado
       gobierto_data_dataset_dataset_updated: Conjunto de datos actualizado

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -2,14 +2,18 @@
 es:
   gobierto_data:
     data_type:
-      boolean: logico
+      boolean: boolean
       date: fecha
+      datetime: fecha y hora
       decimal: decimal
+      hstore: hstore
       integer: entero
+      jsonb: jsonb
+      string: cadena
       text: texto
       time: tiempo
-      timestamp: tiempo
-      timestampz: tiempo
+      timestamp: fecha y hora
+      timestampz: fecha y hora
     events:
       gobierto_data_dataset_dataset_created: Conjunto de datos creado
       gobierto_data_dataset_dataset_updated: Conjunto de datos actualizado

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -1,6 +1,11 @@
 ---
 es:
   gobierto_data:
+    data_type:
+      date: fecha
+      decimal: decimal
+      integer: entero
+      text: texto
     events:
       gobierto_data_dataset_dataset_created: Conjunto de datos creado
       gobierto_data_dataset_dataset_updated: Conjunto de datos actualizado


### PR DESCRIPTION
 :v: What does this PR do?

This PR adds the column types to dataset sidebar description, to make it easier to create queries. Maybe the design can be improved a bit

It also refactors the component to follow Vue principles specially in `watch` and `computed` properties. I'll add some comments in the code.

## :mag: How should this be manually tested?

In the datasets sidebar, you should be able to see the column types of a dataset

## :eyes: Screenshots

### Before this PR

![Screen Shot 2020-04-22 at 07 05 54](https://user-images.githubusercontent.com/17616/79942730-c9c74880-8467-11ea-9f7d-624926f68041.png)

### After this PR

![Screen Shot 2020-04-22 at 07 13 09](https://user-images.githubusercontent.com/17616/79943264-be285180-8468-11ea-8409-8c76767e4c42.png)


