### PR TITLE
Reset query and viz

### DIFF
--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -652,10 +652,18 @@
     margin-left: .5em;
   }
 
-  &-sql-editor-modified-label {
+  &-sql-editor-modified-label,
+  &-sql-editor-modified-event {
     font-size: 14px;
     color: #666;
     opacity: .5;
+  }
+
+  &-sql-editor-modified-event {
+    text-transform: lowercase;
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0 .25rem;
   }
 
   &-sql-editor-footer-records,

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -469,7 +469,7 @@
   &-sql-editor-container {
     display: inline-block;
     position: relative;
-    margin-right: .5em;
+    margin-right: .25rem;
   }
 
   &-sql-editor-recent-queries {
@@ -616,7 +616,7 @@
       }
     }
 
-    .btn-sql-editor-cancel {
+    .btn-sql-editor-revert {
       margin-left: .5em;
     }
   }
@@ -649,7 +649,7 @@
   &-sql-editor-modified-label-container {
     display: inline-flex;
     align-items: center;
-    margin-left: .5em;
+    margin: 0 .5rem 0 .25rem;
   }
 
   &-sql-editor-modified-label,

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -335,7 +335,7 @@
       .gobierto-data-btn-download-data-modal {
         height: auto;
         display: block;
-        z-index: 1;
+        z-index: 3;
         min-width: 200px;
 
         &::after,

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -377,6 +377,8 @@
     }
 
     &.modal-right {
+      float: right;
+
       .gobierto-data-btn-download-data-modal {
         width: inherit;
         max-width: 125px;
@@ -547,6 +549,7 @@
       font-weight: 600;
       font-size: 14px;
       margin: 0;
+      vertical-align: top;
 
       &.isDisabled {
         opacity: .4;

--- a/app/javascript/gobierto_data/lib/router.js
+++ b/app/javascript/gobierto_data/lib/router.js
@@ -27,7 +27,7 @@ export const router = new VueRouter({
       }, {
         path: ":id/q/:queryId?",
         component: Dataset,
-        name: 'Dataset',
+        name: 'Query',
         props: { activeDatasetTab: 1 }
       }]
     }],

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -157,6 +157,10 @@ export default {
       if (to.path !== from.path) {
         this.setDefaultQuery()
       }
+
+      if (to.name === 'Query') {
+        this.runCurrentQuery()
+      }
     },
   },
   async created() {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -176,8 +176,15 @@ export default {
     }
   },
   beforeRouteEnter (to, from, next) {
+    const {
+      params: { tab }
+    } = to;
     next(vm => {
-     vm.showRevertQuery = true
+      if (!tab) {
+        vm.showRevertQuery = true
+      } else {
+        vm.showRevertQuery = false
+      }
     })
   },
   async created() {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -353,8 +353,6 @@ export default {
         } = {}
       } = getSavedQuery
 
-      //QueryDefault: users can reset to the initial Query
-      this.queryDefault = `SELECT * FROM ${this.tableName} LIMIT 50`;
       //QueryRevert: if the user loads a saved query, there can reset to the initial query or reset to the saved query.
       this.queryRevert = queryRevert
     },
@@ -493,6 +491,7 @@ export default {
         this.queryDuration = new Date().getTime() - startTime;
         this.isQueryRunning = false;
         this.getColumnsQuery(this.items)
+        this.queryError = null
       } catch (error) {
         const {
           response: {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -53,6 +53,9 @@
       :query-duration="queryDuration"
       :query-error="queryError"
       :query-default="queryDefault"
+      :query-revert="queryRevert"
+      :reset-query-default="resetQueryDefault"
+      :revert-query-saved="revertQuerySaved"
     />
 
     <QueriesTab
@@ -129,9 +132,12 @@ export default {
       arrayColumnsQuery: [],
       currentQuery: null,
       queryDefault: null,
+      queryRevert: null,
       items: '',
       isQueryRunning: false,
       isQueryModified: false,
+      resetQueryDefault: false,
+      revertQuerySaved: false,
       queryName: null,
       queryDuration: 0,
       queryError: null
@@ -161,7 +167,7 @@ export default {
       if (to.name === 'Query') {
         this.runCurrentQuery()
       }
-    },
+    }
   },
   async created() {
     const {
@@ -243,6 +249,12 @@ export default {
     this.$root.$on("storeCurrentQuery", this.storeCurrentQuery);
     // save the visualization in database
     this.$root.$on("storeCurrentVisualization", this.storeCurrentVisualization);
+    // hide when user click on cancel
+    this.$root.$on("hideLabelQueryModified", this.hideLabelQueryModified);
+
+    this.$root.$on('resetQuery', this.resetQuery)
+
+    this.$root.$on('revertSavedQuery', this.revertSavedQuery)
   },
   deactivated() {
     this.$root.$off("deleteSavedQuery");
@@ -250,6 +262,9 @@ export default {
     this.$root.$off("runCurrentQuery");
     this.$root.$off("storeCurrentQuery");
     this.$root.$off("storeCurrentVisualization");
+    this.$root.$off("hideLabelQueryModified");
+    this.$root.$off("resetQuery");
+    this.$root.$off("revertSavedQuery");
   },
   methods: {
     parseUrl({ queryId, sql }) {
@@ -275,15 +290,10 @@ export default {
       }
     },
     setDefaultQuery() {
-      const {
-        query: { sql },
-      } = this.$route;
-
-      if (sql) {
-        this.queryDefault = sql
-      } else {
-        this.queryDefault = this.currentQuery
-      }
+      //QueryDefault: users can reset to the initial Query
+      this.queryDefault = `SELECT * FROM ${this.tableName} LIMIT 50`;
+      //QueryRevert: if the user loads a saved query, there can reset to the initial query or reset to the saved query.
+      this.queryRevert = this.currentQuery
     },
     ensureUserIsLogged() {
       if (getUserId() === "")
@@ -464,6 +474,15 @@ export default {
 
       const columns = lines[0].split(",");
       this.arrayColumnsQuery = columns
+    },
+    hideLabelQueryModified(value) {
+      this.isQueryModified = value;
+    },
+    resetQuery(value) {
+      this.resetQueryDefault = value
+    },
+    revertSavedQuery(value) {
+      this.revertQuerySaved = value
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -56,6 +56,7 @@
       :query-revert="queryRevert"
       :reset-query-default="resetQueryDefault"
       :revert-query-saved="revertQuerySaved"
+      :enabled-saved-button="enabledSavedButton"
     />
 
     <QueriesTab
@@ -138,6 +139,7 @@ export default {
       isQueryModified: false,
       resetQueryDefault: false,
       revertQuerySaved: false,
+      enabledSavedButton: false,
       queryName: null,
       queryDuration: 0,
       queryError: null
@@ -251,10 +253,12 @@ export default {
     this.$root.$on("storeCurrentVisualization", this.storeCurrentVisualization);
     // hide when user click on cancel
     this.$root.$on("hideLabelQueryModified", this.hideLabelQueryModified);
-
+    // Reset to the default query
     this.$root.$on('resetQuery', this.resetQuery)
-
+    //reset to the saved query
     this.$root.$on('revertSavedQuery', this.revertSavedQuery)
+
+    this.$root.$on('enableSavedButton', this.activatedSavedButton)
   },
   deactivated() {
     this.$root.$off("deleteSavedQuery");
@@ -265,6 +269,7 @@ export default {
     this.$root.$off("hideLabelQueryModified");
     this.$root.$off("resetQuery");
     this.$root.$off("revertSavedQuery");
+    this.$root.$off('enableSavedButton')
   },
   methods: {
     parseUrl({ queryId, sql }) {
@@ -483,6 +488,9 @@ export default {
     },
     revertSavedQuery(value) {
       this.revertQuerySaved = value
+    },
+    activatedSavedButton() {
+      this.enabledSavedButton = true
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -44,6 +44,7 @@
       :recent-queries="recentQueriesFiltered"
       :array-columns="arrayColumns"
       :array-formats="arrayFormats"
+      :array-columns-query="arrayColumnsQuery"
       :items="items"
       :is-query-running="isQueryRunning"
       :is-query-modified="isQueryModified"
@@ -124,6 +125,7 @@ export default {
       publicQueries: [],
       recentQueries: [],
       resourcesList: [],
+      arrayColumnsQuery: [],
       currentQuery: null,
       items: '',
       isQueryRunning: false,
@@ -152,17 +154,6 @@ export default {
     },
   },
   async created() {
-    // remove saved query
-    this.$root.$on("deleteSavedQuery", this.deleteSavedQuery);
-    // change the current query, triggering a new SQL execution
-    this.$root.$on("setCurrentQuery", this.setCurrentQuery);
-    // execute the current query
-    this.$root.$on("runCurrentQuery", this.runCurrentQuery);
-    // save the query in database
-    this.$root.$on("storeCurrentQuery", this.storeCurrentQuery);
-    // save the visualization in database
-    this.$root.$on("storeCurrentVisualization", this.storeCurrentVisualization);
-
     const {
       params: { id, queryId },
       query: { sql },
@@ -235,10 +226,8 @@ export default {
     // change the current query, triggering a new SQL execution
     this.$root.$on("setCurrentQuery", this.setCurrentQuery);
     // execute the current query
-    this.$root.$off("runCurrentQuery");
     this.$root.$on("runCurrentQuery", this.runCurrentQuery);
     // save the query in database
-    this.$root.$off("storeCurrentQuery");
     this.$root.$on("storeCurrentQuery", this.storeCurrentQuery);
     // save the visualization in database
     this.$root.$on("storeCurrentVisualization", this.storeCurrentVisualization);
@@ -399,6 +388,7 @@ export default {
         this.items = items;
         this.queryDuration = new Date().getTime() - startTime;
         this.isQueryRunning = false;
+        this.getColumnsQuery(this.items)
       } catch (error) {
         this.queryError = error;
       }
@@ -446,6 +436,12 @@ export default {
       // TODO: indicar algo con el status OK
       console.log("postVisualization", status);
     },
+    getColumnsQuery(csv) {
+      const lines = csv.split("\n");
+
+      const columns = lines[0].split(",");
+      this.arrayColumnsQuery = columns
+    }
   },
 };
 </script>

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -57,6 +57,7 @@
       :reset-query-default="resetQueryDefault"
       :revert-query-saved="revertQuerySaved"
       :enabled-saved-button="enabledSavedButton"
+      :show-revert-query="showRevertQuery"
     />
 
     <QueriesTab
@@ -140,6 +141,7 @@ export default {
       resetQueryDefault: false,
       revertQuerySaved: false,
       enabledSavedButton: false,
+      showRevertQuery: false,
       queryName: null,
       queryDuration: 0,
       queryError: null
@@ -170,6 +172,11 @@ export default {
         this.runCurrentQuery()
       }
     }
+  },
+  beforeRouteEnter (to, from, next) {
+    next(vm => {
+     vm.showRevertQuery = true
+    })
   },
   async created() {
     const {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -58,6 +58,7 @@
       :revert-query-saved="revertQuerySaved"
       :enabled-saved-button="enabledSavedButton"
       :show-revert-query="showRevertQuery"
+      :show-private="showPrivate"
     />
 
     <QueriesTab
@@ -135,9 +136,10 @@ export default {
       currentQuery: null,
       queryDefault: null,
       queryRevert: null,
-      items: '',
+      items: "",
       isQueryRunning: false,
       isQueryModified: false,
+      showPrivate: false,
       resetQueryDefault: false,
       revertQuerySaved: false,
       enabledSavedButton: false,
@@ -291,11 +293,13 @@ export default {
 
       if (item) {
         const {
-          attributes: { sql: itemSql, name, user_id },
+          attributes: { sql: itemSql, name, user_id, privacy_status },
         } = item;
 
         this.queryName = name;
         this.queryUserId = user_id;
+
+        this.showPrivate = privacy_status === 'closed' ? true : false
 
         // update the editor text content
         this.setCurrentQuery(itemSql);

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -52,6 +52,7 @@
       :query-name="queryName"
       :query-duration="queryDuration"
       :query-error="queryError"
+      :query-default="queryDefault"
     />
 
     <QueriesTab
@@ -213,6 +214,8 @@ export default {
       this.currentQuery = `SELECT * FROM ${this.tableName} LIMIT 50`;
     }
     this.runCurrentQuery();
+
+    this.queryDefault = `SELECT * FROM ${this.tableName} LIMIT 50`;
 
   },
   mounted() {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -167,7 +167,6 @@ export default {
       }
 
       if (to.path !== from.path) {
-        this.setDefaultQuery()
         this.disabledSavedButton()
         this.isQueryModified = false;
       }
@@ -264,7 +263,6 @@ export default {
     }
   },
   activated() {
-    this.setDefaultQuery();
     this.$root.$on("deleteSavedQuery", this.deleteSavedQuery);
     // change the current query, triggering a new SQL execution
     this.$root.$on("setCurrentQuery", this.setCurrentQuery);
@@ -329,10 +327,23 @@ export default {
       }
     },
     setDefaultQuery() {
+      const {
+        params: { queryId }
+      } = this.$route;
+
+      //We need to keep this query separate from the editor query
+      //When load a saved query we use the queryId to find inside privateQueries
+      let getSavedQuery = this.privateQueries.find(({ id }) => id === queryId)
+      const {
+        attributes: {
+          sql: queryRevert
+        }
+      } = getSavedQuery
+
       //QueryDefault: users can reset to the initial Query
       this.queryDefault = `SELECT * FROM ${this.tableName} LIMIT 50`;
       //QueryRevert: if the user loads a saved query, there can reset to the initial query or reset to the saved query.
-      this.queryRevert = this.currentQuery
+      this.queryRevert = queryRevert
     },
     ensureUserIsLogged() {
       if (getUserId() === "")
@@ -389,6 +400,7 @@ export default {
         data: { data: items },
       } = response;
       this.privateQueries = items;
+      this.setDefaultQuery()
     },
     async getPublicQueries() {
       // factory method
@@ -457,9 +469,6 @@ export default {
       this.storeRecentQuery();
 
       const params = { sql: this.currentQuery };
-
-      this.setDefaultQuery()
-
       //
       const startTime = new Date().getTime();
       // factory method

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -174,9 +174,12 @@ export default {
         this.isQueryModified = false;
       }
 
-      if (to.name === 'Query') {
+      //FIXME: Hugo, we need to talk about this hack
+      // https://stackoverflow.com/questions/50295985/how-to-tell-if-a-vue-component-is-active-or-not
+      if (to.name === 'Query' && this._inactive === false) {
         this.runCurrentQuery()
       }
+
     }
   },
   beforeRouteEnter (to, from, next) {
@@ -189,6 +192,7 @@ export default {
       } else {
         vm.showRevertQuery = false
       }
+
     })
   },
   async created() {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -48,6 +48,7 @@
       :items="items"
       :is-query-running="isQueryRunning"
       :is-query-modified="isQueryModified"
+      :is-query-saved="isQuerySaved"
       :query-stored="currentQuery"
       :query-name="queryName"
       :query-duration="queryDuration"
@@ -139,6 +140,7 @@ export default {
       items: "",
       isQueryRunning: false,
       isQueryModified: false,
+      isQuerySaved: false,
       showPrivate: false,
       resetQueryDefault: false,
       revertQuerySaved: false,
@@ -279,6 +281,8 @@ export default {
     this.$root.$on('resetToInitialState', this.resetToInitialState)
 
     this.$root.$on('disabledSavedButton', this.disabledSavedButton)
+    //Show a message for the user, your query is saved
+    this.$root.$on('disabledStringSavedQuery', this.disabledStringSavedQuery)
   },
   deactivated() {
     this.$root.$off("deleteSavedQuery");
@@ -291,6 +295,7 @@ export default {
     this.$root.$off('enableSavedButton')
     this.$root.$off('resetToInitialState')
     this.$root.$off('disabledSavedButton')
+    this.$root.$off('disabledStringSavedQuery')
   },
   methods: {
     parseUrl({ queryId, sql }) {
@@ -428,6 +433,8 @@ export default {
       // 200 OK (PUT) / 201 Created (POST)
       if ([200, 201].includes(status)) {
         this.isQueryModified = false;
+        //Show a message for the user, your query is saved
+        this.isQuerySaved = true;
 
         this.setPublicQueries(await this.getPublicQueries());
         this.setPrivateQueries(await this.getPrivateQueries());
@@ -541,6 +548,7 @@ export default {
         this.isQueryModified = false
         this.runCurrentQuery()
         this.disabledSavedButton()
+        this.disabledStringSavedQuery()
       }
     },
     revertSavedQuery(value) {
@@ -550,6 +558,7 @@ export default {
         this.isQueryModified = false
         this.runCurrentQuery()
         this.disabledSavedButton()
+        this.disabledStringSavedQuery()
       }
     },
     activatedSavedButton() {
@@ -569,6 +578,9 @@ export default {
     resetToInitialState() {
       this.showRevertQuery = false
       this.isQueryModified = false
+    },
+    disabledStringSavedQuery() {
+      this.isQuerySaved = false;
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -168,6 +168,8 @@ export default {
 
       if (to.path !== from.path) {
         this.setDefaultQuery()
+        this.disabledSavedButton()
+        this.isQueryModified = false;
       }
 
       if (to.name === 'Query') {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -132,7 +132,6 @@ export default {
       resourcesList: [],
       arrayColumnsQuery: [],
       currentQuery: null,
-      queryDefault: null,
       queryRevert: null,
       items: "",
       isQueryRunning: false,
@@ -186,12 +185,7 @@ export default {
       name: nameComponent
     } = to;
     next(vm => {
-      if (nameComponent === 'Query') {
-        vm.showRevertQuery = true
-      } else {
-        vm.showRevertQuery = false
-      }
-
+      vm.showRevertQuery = (nameComponent === 'Query')
     })
   },
   async created() {
@@ -342,16 +336,9 @@ export default {
         items = this.publicQueries
       }
 
-      //Find the query
-      const getSavedQuery = items.find(({ id }) => id === queryId) || {}
-
       //We need to keep this query separate from the editor query
       //When load a saved query we use the queryId to find inside privateQueries or publicQueries
-      const {
-        attributes: {
-          sql: queryRevert
-        } = {}
-      } = getSavedQuery
+      const { attributes: { sql: queryRevert } = {} } = items.find(({ id }) => id === queryId) || {}
 
       //QueryRevert: if the user loads a saved query, there can reset to the initial query or reset to the saved query.
       this.queryRevert = queryRevert

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -128,6 +128,7 @@ export default {
       resourcesList: [],
       arrayColumnsQuery: [],
       currentQuery: null,
+      queryDefault: null,
       items: '',
       isQueryRunning: false,
       isQueryModified: false,
@@ -143,7 +144,7 @@ export default {
     },
   },
   watch: {
-    $route(to) {
+    $route(to, from) {
       if (to) {
         const {
           params: { queryId },
@@ -151,6 +152,10 @@ export default {
         } = to;
 
         this.parseUrl({ queryId, sql });
+      }
+
+      if (to.path !== from.path) {
+        this.setDefaultQuery()
       }
     },
   },
@@ -213,9 +218,9 @@ export default {
       // update the editor text content by default
       this.currentQuery = `SELECT * FROM ${this.tableName} LIMIT 50`;
     }
-    this.runCurrentQuery();
 
-    this.queryDefault = `SELECT * FROM ${this.tableName} LIMIT 50`;
+    this.runCurrentQuery();
+    this.setDefaultQuery();
 
   },
   mounted() {
@@ -263,6 +268,17 @@ export default {
 
         // update the editor text content
         this.setCurrentQuery(itemSql);
+      }
+    },
+    setDefaultQuery() {
+      const {
+        query: { sql },
+      } = this.$route;
+
+      if (sql) {
+        this.queryDefault = sql
+      } else {
+        this.queryDefault = this.currentQuery
       }
     },
     ensureUserIsLogged() {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -169,6 +169,7 @@ export default {
       if (to.path !== from.path) {
         this.disabledSavedButton()
         this.isQueryModified = false;
+        this.setDefaultQuery()
       }
 
       //FIXME: Hugo, we need to talk about this hack
@@ -254,6 +255,7 @@ export default {
     }
 
     this.runCurrentQuery();
+    this.setDefaultQuery()
 
   },
   mounted() {
@@ -327,17 +329,28 @@ export default {
       }
     },
     setDefaultQuery() {
+      const userId = getUserId();
       const {
         params: { queryId }
       } = this.$route;
 
+      let items;
+      //Check if user is logged
+      if (userId) {
+        items = this.privateQueries
+      } else {
+        items = this.publicQueries
+      }
+
+      //Find the query
+      const getSavedQuery = items.find(({ id }) => id === queryId) || {}
+
       //We need to keep this query separate from the editor query
-      //When load a saved query we use the queryId to find inside privateQueries
-      let getSavedQuery = this.privateQueries.find(({ id }) => id === queryId)
+      //When load a saved query we use the queryId to find inside privateQueries or publicQueries
       const {
         attributes: {
           sql: queryRevert
-        }
+        } = {}
       } = getSavedQuery
 
       //QueryDefault: users can reset to the initial Query
@@ -400,7 +413,6 @@ export default {
         data: { data: items },
       } = response;
       this.privateQueries = items;
-      this.setDefaultQuery()
     },
     async getPublicQueries() {
       // factory method

--- a/app/javascript/gobierto_data/webapp/components/commons/Button.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Button.vue
@@ -9,7 +9,7 @@
       style="color: inherit;"
       class="fas"
     />
-    {{ text || '' }}
+    {{ text }}
     <slot />
   </button>
 </template>

--- a/app/javascript/gobierto_data/webapp/components/commons/Button.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Button.vue
@@ -9,7 +9,7 @@
       style="color: inherit;"
       class="fas"
     />
-    {{ text }}
+    {{ text || '' }}
     <slot />
   </button>
 </template>
@@ -20,7 +20,7 @@ export default {
   props: {
     text: {
       type: String,
-      required: true
+      default: ''
     },
     icon: {
       type: String,

--- a/app/javascript/gobierto_data/webapp/components/commons/Button.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Button.vue
@@ -6,7 +6,7 @@
     <i
       v-if="icon"
       :class="'fa-' + icon"
-      style="color: inherit;"
+      style="color: inherit; margin: 0;"
       class="fas"
     />
     {{ text }}

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -189,7 +189,7 @@ export default {
     onKeyDownTextHandler(event) {
       const { value } = event.target
       this.labelValue = value
-      this.isSavingPromptVisible = true
+      this.$root.$emit('enableSavedButton')
     },
     onInputCheckboxHandler(event) {
       const { checked } = event.target

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -6,7 +6,6 @@
         ref="inputText"
         v-model="labelValue"
         :placeholder="placeholder"
-        :disabled="disabledSavedButton"
         type="text"
         class="gobierto-data-sql-editor-container-save-text"
         @keydown.stop="onKeyDownTextHandler"
@@ -70,7 +69,7 @@
             ? 'color: #fff; background-color: var(--color-base)'
             : 'color: var(--color-base); background-color: rgb(255, 255, 255);'
         "
-        :disabled="disabledSavedButton"
+        :disabled="!enabledSavedButton"
         icon="save"
         color="var(--color-base)"
         background="#fff"
@@ -118,13 +117,16 @@ export default {
     isQueryModified: {
       type: Boolean,
       default: false
+    },
+    enabledSavedButton: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
       isPrivate: false,
       isSavingPromptVisible: false,
-      disabledSavedButton: true,
       labelValue: this.value,
       labelPrivate: I18n.t('gobierto_data.projects.private') || "",
       labelCancel: I18n.t('gobierto_data.projects.cancel') || "",
@@ -144,12 +146,6 @@ export default {
         this.isSavingPromptVisible = false
       }
     }
-  },
-  mounted() {
-    this.$root.$on('enableSavedButton', this.enableSavedButton)
-  },
-  beforeDestroy() {
-    this.$root.$off('enableSavedButton')
   },
   methods: {
     onClickSaveHandler() {
@@ -181,9 +177,6 @@ export default {
     onInputCheckboxHandler(event) {
       const { checked } = event.target
       this.isPrivate = checked
-    },
-    enableSavedButton() {
-      this.disabledSavedButton = false
     },
     revertQuery() {
       this.$emit('revertQuery')

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -40,7 +40,7 @@
     <!-- show edit button if there's no prompt but some name, otherwise, save button -->
     <template v-if="!isSavingPromptVisible && labelValue">
       <Button
-        :text="labelEdit"
+        :text="saveString"
         class="btn-sql-editor"
         icon="edit"
         color="var(--color-base)"
@@ -50,7 +50,7 @@
     </template>
     <template v-else>
       <Button
-        :text="labelSave"
+        :text="saveString"
         :style="
           isSavingPromptVisible
             ? 'color: #fff; background-color: var(--color-base)'
@@ -100,6 +100,10 @@ export default {
     saveCallback: {
       type: Function,
       default: () => {}
+    },
+    saveString: {
+      type: String,
+      default: ''
     }
   },
   data() {
@@ -107,7 +111,6 @@ export default {
       isPrivate: false,
       isSavingPromptVisible: false,
       labelValue: this.value,
-      labelSave: I18n.t("gobierto_data.projects.save") || "",
       labelPrivate: I18n.t('gobierto_data.projects.private') || "",
       labelCancel: I18n.t('gobierto_data.projects.cancel') || "",
       labelEdit: I18n.t("gobierto_data.projects.edit") || ""

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -112,10 +112,6 @@ export default {
     showPrivate: {
       type: Boolean,
       default: false
-    },
-    disabledInputSaved: {
-      type: Boolean,
-      default: false
     }
   },
   data() {
@@ -143,13 +139,6 @@ export default {
     },
     showPrivate(newValue) {
       this.isPrivate = newValue ? true : false
-    },
-    disabledInputSaved(newValue, oldValue) {
-      console.log("disabledInputSaved -> oldValue", oldValue)
-      console.log("disabledInputSaved -> newValue", newValue)
-      if (newValue !== oldValue) {
-        this.isSavingPromptVisible = false
-      }
     }
   },
   methods: {

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -40,7 +40,7 @@
     <!-- show edit button if there's no prompt but some name, otherwise, save button -->
     <template v-if="!isSavingPromptVisible && labelValue">
       <Button
-        :text="saveString"
+        :text="labelSave"
         class="btn-sql-editor"
         icon="edit"
         color="var(--color-base)"
@@ -50,7 +50,7 @@
     </template>
     <template v-else>
       <Button
-        :text="saveString"
+        :text="labelSave"
         :style="
           isSavingPromptVisible
             ? 'color: #fff; background-color: var(--color-base)'
@@ -101,7 +101,7 @@ export default {
       type: Function,
       default: () => {}
     },
-    saveString: {
+    labelSave: {
       type: String,
       default: ''
     }

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -37,10 +37,24 @@
       />
     </template>
 
+    <template v-if="isQueryModified">
+      <div class="gobierto-data-sql-editor-modified-label-container">
+        <span class="gobierto-data-sql-editor-modified-label">
+          {{ labelModifiedQuery }}
+        </span>
+        <a
+          class="gobierto-data-sql-editor-modified-event"
+          @click.prevent="revertQuery"
+        >
+          ( {{ labelRevert }} )
+        </a>
+      </div>
+    </template>
+
     <!-- show edit button if there's no prompt but some name, otherwise, save button -->
     <template v-if="!isSavingPromptVisible && labelValue">
       <Button
-        :text="labelSave"
+        :text="labelEdit"
         class="btn-sql-editor"
         icon="edit"
         color="var(--color-base)"
@@ -97,13 +111,13 @@ export default {
       type: String,
       default: ''
     },
-    saveCallback: {
-      type: Function,
-      default: () => {}
-    },
     labelSave: {
       type: String,
       default: ''
+    },
+    isQueryModified: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -114,7 +128,21 @@ export default {
       labelValue: this.value,
       labelPrivate: I18n.t('gobierto_data.projects.private') || "",
       labelCancel: I18n.t('gobierto_data.projects.cancel') || "",
-      labelEdit: I18n.t("gobierto_data.projects.edit") || ""
+      labelEdit: I18n.t("gobierto_data.projects.edit") || "",
+      labelRevert: I18n.t("gobierto_data.projects.revert") || "",
+      labelModifiedQuery: I18n.t("gobierto_data.projects.modifiedQuery") || ""
+    }
+  },
+  watch: {
+    value(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.labelValue = newValue
+      }
+    },
+    $route(to, from) {
+      if (to.path !== from.path) {
+        this.isSavingPromptVisible = false
+      }
     }
   },
   mounted() {
@@ -139,6 +167,8 @@ export default {
       this.labelValue = null
       this.isSavingPromptVisible = false
       this.$emit('resetButtonViz')
+      this.$emit('showLabelIcons')
+      this.$root.$emit("hideLabelQueryModified", false);
     },
     onClickEditHandler() {
       this.isSavingPromptVisible = true
@@ -154,6 +184,9 @@ export default {
     },
     enableSavedButton() {
       this.disabledSavedButton = false
+    },
+    revertQuery() {
+      this.$emit('revertQuery')
     }
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -42,6 +42,7 @@
           {{ labelModifiedQuery }}
         </span>
         <a
+          v-if="showRevertQuery"
           class="gobierto-data-sql-editor-modified-event"
           @click.prevent="revertQuery"
         >
@@ -119,6 +120,10 @@ export default {
       default: false
     },
     enabledSavedButton: {
+      type: Boolean,
+      default: false
+    },
+    showRevertQuery: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -6,7 +6,7 @@
         ref="inputText"
         v-model="labelValue"
         :placeholder="placeholder"
-        :disabled="!isSavingPromptVisible"
+        :disabled="disabledSavedButton"
         type="text"
         class="gobierto-data-sql-editor-container-save-text"
         @keydown.stop="onKeyDownTextHandler"
@@ -56,7 +56,7 @@
             ? 'color: #fff; background-color: var(--color-base)'
             : 'color: var(--color-base); background-color: rgb(255, 255, 255);'
         "
-        :disabled="isSavingPromptVisible && !labelValue"
+        :disabled="disabledSavedButton"
         icon="save"
         color="var(--color-base)"
         background="#fff"
@@ -110,11 +110,18 @@ export default {
     return {
       isPrivate: false,
       isSavingPromptVisible: false,
+      disabledSavedButton: true,
       labelValue: this.value,
       labelPrivate: I18n.t('gobierto_data.projects.private') || "",
       labelCancel: I18n.t('gobierto_data.projects.cancel') || "",
       labelEdit: I18n.t("gobierto_data.projects.edit") || ""
     }
+  },
+  mounted() {
+    this.$root.$on('enableSavedButton', this.enableSavedButton)
+  },
+  beforeDestroy() {
+    this.$root.$off('enableSavedButton')
   },
   methods: {
     onClickSaveHandler() {
@@ -145,6 +152,9 @@ export default {
       const { checked } = event.target
       this.isPrivate = checked
     },
+    enableSavedButton() {
+      this.disabledSavedButton = false
+    }
   }
 }
 </script>

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -131,6 +131,7 @@ export default {
     onClickCancelHandler() {
       this.labelValue = null
       this.isSavingPromptVisible = false
+      this.$emit('resetButtonViz')
     },
     onClickEditHandler() {
       this.isSavingPromptVisible = true

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -44,6 +44,14 @@
       </div>
     </template>
 
+    <template v-if="isQuerySaved">
+      <div class="gobierto-data-sql-editor-modified-label-container">
+        <span class="gobierto-data-sql-editor-modified-label">
+          Consulta guardada
+        </span>
+      </div>
+    </template>
+
     <!-- show edit button if there's no prompt but some name, otherwise, save button -->
     <Button
       :text="labelSave"
@@ -112,6 +120,10 @@ export default {
     showPrivate: {
       type: Boolean,
       default: false
+    },
+    isQuerySaved: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -143,6 +155,26 @@ export default {
   },
   methods: {
     onClickSaveHandler() {
+      const {
+        params: { queryId }
+      } = this.$route;
+
+      if (queryId) {
+        this.saveHandlerSavedQuery()
+      } else {
+        this.saveHandlerNewQuery()
+      }
+
+    },
+    saveHandlerSavedQuery() {
+      // the output is the content of the input plus the private flag
+      this.$emit('save', { name: this.labelValue, privacy: this.isPrivate })
+
+      this.isSavingPromptVisible = false
+      this.$root.$emit('disabledSavedButton')
+      this.$root.$emit("resetToInitialState");
+    },
+    saveHandlerNewQuery() {
       if (!this.isSavingPromptVisible) {
         this.isSavingPromptVisible = true
         this.$nextTick(() => this.$refs.inputText.focus());
@@ -150,12 +182,7 @@ export default {
         if (this.labelValue === null) {
           this.$nextTick(() => this.$refs.inputText.focus());
         } else {
-          // the output is the content of the input plus the private flag
-          this.$emit('save', { name: this.labelValue, privacy: this.isPrivate })
-
-          this.isSavingPromptVisible = false
-          this.$root.$emit('disabledSavedButton')
-          this.$root.$emit("resetToInitialState");
+          this.saveHandlerSavedQuery()
         }
       }
     },

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -41,53 +41,35 @@
         <span class="gobierto-data-sql-editor-modified-label">
           {{ labelModifiedQuery }}
         </span>
-        <a
-          v-if="showRevertQuery"
-          class="gobierto-data-sql-editor-modified-event"
-          @click.prevent="revertQuery"
-        >
-          ( {{ labelRevert }} )
-        </a>
       </div>
     </template>
 
     <!-- show edit button if there's no prompt but some name, otherwise, save button -->
-    <template v-if="!isSavingPromptVisible && labelValue">
-      <Button
-        :text="labelEdit"
-        class="btn-sql-editor"
-        icon="edit"
-        color="var(--color-base)"
-        background="#fff"
-        @click.native="onClickEditHandler"
-      />
-    </template>
-    <template v-else>
-      <Button
-        :text="labelSave"
-        :style="
-          isSavingPromptVisible
-            ? 'color: #fff; background-color: var(--color-base)'
-            : 'color: var(--color-base); background-color: rgb(255, 255, 255);'
-        "
-        :disabled="!enabledSavedButton"
-        icon="save"
-        color="var(--color-base)"
-        background="#fff"
-        class="btn-sql-editor"
-        @click.native="onClickSaveHandler"
-      />
-    </template>
+    <Button
+      :text="labelSave"
+      :style="
+        isSavingPromptVisible
+          ? 'color: #fff; background-color: var(--color-base)'
+          : 'color: var(--color-base); background-color: rgb(255, 255, 255);'
+      "
+      :disabled="!enabledSavedButton"
+      icon="save"
+      color="var(--color-base)"
+      background="#fff"
+      class="btn-sql-editor"
+      @click.native="onClickSaveHandler"
+    />
 
     <!-- only show cancel button on prompt visible -->
-    <template v-if="isSavingPromptVisible">
+    <template v-if="showRevertQuery">
       <Button
-        :text="labelCancel"
-        :icon="null"
-        class="btn-sql-editor btn-sql-editor-cancel"
+        :text="labelRevert"
+        :disabled="!enabledSavedButton"
+        icon="undo"
+        class="btn-sql-editor btn-sql-editor-revert"
         color="var(--color-base)"
         background="#fff"
-        @click.native="onClickCancelHandler"
+        @click.native="revertQuery"
       />
     </template>
   </div>
@@ -130,6 +112,10 @@ export default {
     showPrivate: {
       type: Boolean,
       default: false
+    },
+    disabledInputSaved: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -157,6 +143,13 @@ export default {
     },
     showPrivate(newValue) {
       this.isPrivate = newValue ? true : false
+    },
+    disabledInputSaved(newValue, oldValue) {
+      console.log("disabledInputSaved -> oldValue", oldValue)
+      console.log("disabledInputSaved -> newValue", newValue)
+      if (newValue !== oldValue) {
+        this.isSavingPromptVisible = false
+      }
     }
   },
   methods: {
@@ -169,31 +162,26 @@ export default {
         this.$emit('save', { name: this.labelValue, privacy: this.isPrivate })
 
         this.isSavingPromptVisible = false
+        this.$root.$emit('disabledSavedButton')
+        this.$root.$emit("resetToInitialState");
       }
-    },
-    onClickCancelHandler() {
-      this.labelValue = null
-      this.isSavingPromptVisible = false
-      this.$emit('resetButtonViz')
-      this.$emit('showLabelIcons')
-      this.$root.$emit("hideLabelQueryModified", false);
-    },
-    onClickEditHandler() {
-      this.isSavingPromptVisible = true
-      this.$nextTick(() => this.$refs.inputText.focus());
     },
     onKeyDownTextHandler(event) {
       const { value } = event.target
       this.labelValue = value
       this.isSavingPromptVisible = true
-      this.$root.$emit("hideLabelQueryModified", true);
     },
     onInputCheckboxHandler(event) {
       const { checked } = event.target
       this.isPrivate = checked
     },
     revertQuery() {
-      this.$emit('revertQuery')
+      this.$root.$emit('revertSavedQuery', true)
+      this.isSavingPromptVisible = false
+    },
+    disableSavingPrompt() {
+      this.isSavingPromptVisible = false
+      this.labelValue = null
     }
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -147,12 +147,16 @@ export default {
         this.isSavingPromptVisible = true
         this.$nextTick(() => this.$refs.inputText.focus());
       } else {
-        // the output is the content of the input plus the private flag
-        this.$emit('save', { name: this.labelValue, privacy: this.isPrivate })
+        if (this.labelValue === null) {
+          this.$nextTick(() => this.$refs.inputText.focus());
+        } else {
+          // the output is the content of the input plus the private flag
+          this.$emit('save', { name: this.labelValue, privacy: this.isPrivate })
 
-        this.isSavingPromptVisible = false
-        this.$root.$emit('disabledSavedButton')
-        this.$root.$emit("resetToInitialState");
+          this.isSavingPromptVisible = false
+          this.$root.$emit('disabledSavedButton')
+          this.$root.$emit("resetToInitialState");
+        }
       }
     },
     onKeyDownTextHandler(event) {

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -36,21 +36,32 @@
       />
     </template>
 
-    <template v-if="isQueryModified">
-      <div class="gobierto-data-sql-editor-modified-label-container">
-        <span class="gobierto-data-sql-editor-modified-label">
-          {{ labelModifiedQuery }}
-        </span>
-      </div>
-    </template>
+    <transition
+      name="fade"
+      mode="out-in"
+    >
+      <template v-if="isQueryModified">
+        <div class="gobierto-data-sql-editor-modified-label-container">
+          <span class="gobierto-data-sql-editor-modified-label">
+            {{ labelModifiedQuery }}
+          </span>
+        </div>
+      </template>
+    </transition>
 
-    <template v-if="isQuerySaved">
-      <div class="gobierto-data-sql-editor-modified-label-container">
-        <span class="gobierto-data-sql-editor-modified-label">
-          Consulta guardada
-        </span>
-      </div>
-    </template>
+    <transition
+      name="fade"
+      mode="out-in"
+    >
+      <template v-if="isQuerySaved">
+        <div class="gobierto-data-sql-editor-modified-label-container">
+          <span class="gobierto-data-sql-editor-modified-label">
+            {{ labelSavedQuery }}
+          </span>
+        </div>
+      </template>
+    </transition>
+
 
     <!-- show edit button if there's no prompt but some name, otherwise, save button -->
     <Button
@@ -77,7 +88,7 @@
         class="btn-sql-editor btn-sql-editor-revert"
         color="var(--color-base)"
         background="#fff"
-        @click.native="revertQuery"
+        @click.native="revertQueryHandler"
       />
     </template>
   </div>
@@ -109,6 +120,10 @@ export default {
       type: Boolean,
       default: false
     },
+    isSavingPromptVisible: {
+      type: Boolean,
+      default: false
+    },
     enabledSavedButton: {
       type: Boolean,
       default: false
@@ -129,13 +144,13 @@ export default {
   data() {
     return {
       isPrivate: false,
-      isSavingPromptVisible: false,
       labelValue: this.value,
       labelPrivate: I18n.t('gobierto_data.projects.private') || "",
       labelCancel: I18n.t('gobierto_data.projects.cancel') || "",
       labelEdit: I18n.t("gobierto_data.projects.edit") || "",
       labelRevert: I18n.t("gobierto_data.projects.revert") || "",
-      labelModifiedQuery: I18n.t("gobierto_data.projects.modifiedQuery") || ""
+      labelModifiedQuery: I18n.t("gobierto_data.projects.modifiedQuery") || "",
+      labelSavedQuery: I18n.t("gobierto_data.projects.savedQuery") || ""
     }
   },
   watch: {
@@ -144,13 +159,8 @@ export default {
         this.labelValue = newValue
       }
     },
-    $route(to, from) {
-      if (to.path !== from.path) {
-        this.isSavingPromptVisible = false
-      }
-    },
     showPrivate(newValue) {
-      this.isPrivate = newValue ? true : false
+      this.isPrivate = (newValue);
     }
   },
   methods: {
@@ -170,16 +180,16 @@ export default {
       // the output is the content of the input plus the private flag
       this.$emit('save', { name: this.labelValue, privacy: this.isPrivate })
 
-      this.isSavingPromptVisible = false
       this.$root.$emit('disabledSavedButton')
       this.$root.$emit("resetToInitialState");
+      this.$root.$emit("isSavingPromptVisible", false);
     },
     saveHandlerNewQuery() {
       if (!this.isSavingPromptVisible) {
-        this.isSavingPromptVisible = true
+        this.$root.$emit("isSavingPromptVisible", true);
         this.$nextTick(() => this.$refs.inputText.focus());
       } else {
-        if (this.labelValue === null) {
+        if (!this.labelValue) {
           this.$nextTick(() => this.$refs.inputText.focus());
         } else {
           this.saveHandlerSavedQuery()
@@ -195,13 +205,8 @@ export default {
       const { checked } = event.target
       this.isPrivate = checked
     },
-    revertQuery() {
+    revertQueryHandler() {
       this.$root.$emit('revertSavedQuery', true)
-      this.isSavingPromptVisible = false
-    },
-    disableSavingPrompt() {
-      this.isSavingPromptVisible = false
-      this.labelValue = null
     }
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/SavingDialog.vue
@@ -126,6 +126,10 @@ export default {
     showRevertQuery: {
       type: Boolean,
       default: false
+    },
+    showPrivate: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -150,6 +154,9 @@ export default {
       if (to.path !== from.path) {
         this.isSavingPromptVisible = false
       }
+    },
+    showPrivate(newValue) {
+      this.isPrivate = newValue ? true : false
     }
   },
   methods: {
@@ -178,6 +185,8 @@ export default {
     onKeyDownTextHandler(event) {
       const { value } = event.target
       this.labelValue = value
+      this.isSavingPromptVisible = true
+      this.$root.$emit("hideLabelQueryModified", true);
     },
     onInputCheckboxHandler(event) {
       const { checked } = event.target

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -37,7 +37,7 @@ export default {
     },
     arrayColumnsQuery(newValue, oldValue) {
       if (newValue !== oldValue) {
-        this.viewer.setAttribute('columns', this.arrayColumnsQuery)
+        this.viewer.setAttribute('columns', JSON.stringify(this.newValue))
       }
     }
   },
@@ -48,7 +48,6 @@ export default {
   methods: {
     initPerspective(data) {
       this.viewer.setAttribute('plugin', this.typeChart)
-      /*this.viewer.setAttribute('columns', this.arrayColumnsQuery)*/
       this.viewer.clear();
       const table = perspective.worker().table(data);
 

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -78,21 +78,12 @@ export default {
       const configButtonPerspective = shadowRootPerspective.getElementById('config_button')
       configButtonPerspective.style.display = "none"
       const selectVizPerspective = shadowRootPerspective.getElementById('vis_selector')
-      const showDialog = this.showSavingDialog
-      const sendSelectedValue = this.selectedValue
-      let selectedValue
 
-      selectVizPerspective.addEventListener('change', function() {
-        selectedValue = selectVizPerspective.options[selectVizPerspective.selectedIndex].value;
-        showDialog()
-        sendSelectedValue(selectedValue)
+      selectVizPerspective.addEventListener('change', () => {
+        const selectedValue = selectVizPerspective.options[selectVizPerspective.selectedIndex].value;
+        this.$emit("showSaving")
+        this.$emit("selectedChart", selectedValue)
       })
-    },
-    showSavingDialog() {
-      this.$emit("showSaving")
-    },
-    selectedValue(chart) {
-      this.$emit("selectedChart", chart)
     },
     setColumns() {
       this.viewer.setAttribute('columns', this.arrayColumnsQuery)

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -1,5 +1,8 @@
 <template>
-  <perspective-viewer v-if="items" ref="perspective-viewer" />
+  <perspective-viewer
+    v-if="items"
+    ref="perspective-viewer"
+  />
 </template>
 <script>
 import perspective from "@finos/perspective";
@@ -39,6 +42,7 @@ export default {
       if (newValue !== oldValue) {
         this.viewer.clear();
         this.viewer.setAttribute('columns', JSON.stringify(this.newValue))
+        this.initPerspective(this.items);
       }
     }
   },
@@ -78,7 +82,7 @@ export default {
       const sendSelectedValue = this.selectedValue
       let selectedValue
 
-      selectVizPerspective.addEventListener('change', function(e) {
+      selectVizPerspective.addEventListener('change', function() {
         selectedValue = selectVizPerspective.options[selectVizPerspective.selectedIndex].value;
         showDialog()
         sendSelectedValue(selectedValue)

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -41,7 +41,7 @@ export default {
     arrayColumnsQuery(newValue, oldValue) {
       if (newValue !== oldValue) {
         this.viewer.clear();
-        this.viewer.setAttribute('columns', JSON.stringify(this.newValue))
+        this.viewer.setAttribute('columns', JSON.stringify(newValue))
         this.initPerspective(this.items);
       }
     }

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -15,9 +15,9 @@ export default {
       type: String,
       default: ''
     },
-    config: {
-      type: Object,
-      default: () => {}
+    typeChart: {
+      type: String,
+      default: ''
     }
   },
   watch: {
@@ -25,18 +25,22 @@ export default {
       if (newValue !== oldValue) {
         this.initPerspective(newValue)
       }
+    },
+    typeChart(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        console.log("oldValue", oldValue);
+        console.log("newValue", newValue);
+        this.viewer.setAttribute('plugin', newValue)
+      }
     }
   },
   mounted() {
     this.viewer = this.$refs["perspective-viewer"];
-    this.initPerspective(this.items);
-    this.$root.$on('resetViz', this.resetViz)
-  },
-  beforeDestroy() {
-    this.$root.$off('resetViz')
+    this.initPerspective(this.items, this.typeChart);
   },
   methods: {
     initPerspective(data) {
+      this.viewer.setAttribute('plugin', this.typeChart)
       this.viewer.clear();
       const table = perspective.worker().table(data);
 

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -93,6 +93,9 @@ export default {
     },
     selectedValue(chart) {
       this.$emit("selectedChart", chart)
+    },
+    setColumns() {
+      this.viewer.setAttribute('columns', this.arrayColumnsQuery)
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -39,13 +39,13 @@ export default {
       if (newValue !== oldValue) {
         this.viewer.clear();
         this.viewer.setAttribute('columns', JSON.stringify(this.newValue))
-        this.initPerspective(this.items);
       }
     }
   },
   mounted() {
     this.viewer = this.$refs["perspective-viewer"];
     this.initPerspective(this.items);
+    this.listenerPerspective()
   },
   methods: {
     initPerspective(data) {
@@ -62,8 +62,33 @@ export default {
       // export the visualization configuration object
       return this.viewer.save()
     },
-    resetViz() {
-      this.viewer.delete();
+    enableDisabledPerspective(value) {
+      const shadowRootPerspective = document.querySelector('perspective-viewer').shadowRoot
+      const sidePanelPerspective = shadowRootPerspective.getElementById('side_panel')
+      const topPanelPerspective = shadowRootPerspective.getElementById('top_panel')
+      topPanelPerspective.style.display = value
+      sidePanelPerspective.style.display = value
+    },
+    listenerPerspective() {
+      const shadowRootPerspective = document.querySelector('perspective-viewer').shadowRoot
+      const configButtonPerspective = shadowRootPerspective.getElementById('config_button')
+      configButtonPerspective.style.display = "none"
+      const selectVizPerspective = shadowRootPerspective.getElementById('vis_selector')
+      const showDialog = this.showSavingDialog
+      const sendSelectedValue = this.selectedValue
+      let selectedValue
+
+      selectVizPerspective.addEventListener('change', function(e) {
+        selectedValue = selectVizPerspective.options[selectVizPerspective.selectedIndex].value;
+        showDialog()
+        sendSelectedValue(selectedValue)
+      })
+    },
+    showSavingDialog() {
+      this.$emit("showSaving")
+    },
+    selectedValue(chart) {
+      this.$emit("selectedChart", chart)
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -25,11 +25,16 @@ export default {
       if (newValue !== oldValue) {
         this.initPerspective(newValue)
       }
+    },
+    typeChart(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.viewer.setAttribute('plugin', newValue)
+      }
     }
   },
   mounted() {
     this.viewer = this.$refs["perspective-viewer"];
-    this.initPerspective(this.items, this.typeChart);
+    this.initPerspective(this.items);
   },
   methods: {
     initPerspective(data) {
@@ -45,6 +50,9 @@ export default {
     getConfig() {
       // export the visualization configuration object
       return this.viewer.save()
+    },
+    resetViz() {
+      this.viewer.delete();
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -37,7 +37,9 @@ export default {
     },
     arrayColumnsQuery(newValue, oldValue) {
       if (newValue !== oldValue) {
+        this.viewer.clear();
         this.viewer.setAttribute('columns', JSON.stringify(this.newValue))
+        this.initPerspective(this.items);
       }
     }
   },

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -25,13 +25,6 @@ export default {
       if (newValue !== oldValue) {
         this.initPerspective(newValue)
       }
-    },
-    typeChart(newValue, oldValue) {
-      if (newValue !== oldValue) {
-        console.log("oldValue", oldValue);
-        console.log("newValue", newValue);
-        this.viewer.setAttribute('plugin', newValue)
-      }
     }
   },
   mounted() {

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -18,7 +18,11 @@ export default {
     typeChart: {
       type: String,
       default: ''
-    }
+    },
+    arrayColumnsQuery: {
+      type: Array,
+      default: () => []
+    },
   },
   watch: {
     items(newValue, oldValue) {
@@ -30,6 +34,11 @@ export default {
       if (newValue !== oldValue) {
         this.viewer.setAttribute('plugin', newValue)
       }
+    },
+    arrayColumnsQuery(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.viewer.setAttribute('columns', this.arrayColumnsQuery)
+      }
     }
   },
   mounted() {
@@ -39,6 +48,7 @@ export default {
   methods: {
     initPerspective(data) {
       this.viewer.setAttribute('plugin', this.typeChart)
+      /*this.viewer.setAttribute('columns', this.arrayColumnsQuery)*/
       this.viewer.clear();
       const table = perspective.worker().table(data);
 

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -45,9 +45,6 @@ export default {
     getConfig() {
       // export the visualization configuration object
       return this.viewer.save()
-    },
-    resetViz() {
-      this.viewer.delete();
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -30,6 +30,10 @@ export default {
   mounted() {
     this.viewer = this.$refs["perspective-viewer"];
     this.initPerspective(this.items);
+    this.$root.$on('resetViz', this.resetViz)
+  },
+  beforeDestroy() {
+    this.$root.$off('resetViz')
   },
   methods: {
     initPerspective(data) {
@@ -44,6 +48,9 @@ export default {
     getConfig() {
       // export the visualization configuration object
       return this.viewer.save()
+    },
+    resetViz() {
+      this.viewer.delete();
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -7,6 +7,7 @@
         :recent-queries="recentQueries"
         :is-query-running="isQueryRunning"
         :is-query-modified="isQueryModified"
+        :is-query-saved="isQuerySaved"
         :query-name="queryName"
         :enabled-saved-button="enabledSavedButton"
         :show-revert-query="showRevertQuery"
@@ -122,6 +123,10 @@ export default {
       default: false
     },
     showPrivate: {
+      type: Boolean,
+      default: false
+    },
+    isQuerySaved: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -9,6 +9,7 @@
         :is-query-modified="isQueryModified"
         :query-name="queryName"
         :enabled-saved-button="enabledSavedButton"
+        :show-revert-query="showRevertQuery"
       />
       <SQLEditorCode
         :array-columns="arrayColumns"
@@ -115,6 +116,10 @@ export default {
       type: Boolean,
       default: false
     },
+    showRevertQuery: {
+      type: Boolean,
+      default: false
+    }
   }
 }
 

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -8,6 +8,7 @@
         :is-query-running="isQueryRunning"
         :is-query-modified="isQueryModified"
         :is-query-saved="isQuerySaved"
+        :is-saving-prompt-visible="isSavingPromptVisible"
         :query-name="queryName"
         :enabled-saved-button="enabledSavedButton"
         :show-revert-query="showRevertQuery"
@@ -16,12 +17,8 @@
       <SQLEditorCode
         :array-columns="arrayColumns"
         :query-stored="queryStored"
-        :query-default="queryDefault"
         :query-duration="queryDuration"
         :query-error="queryError"
-        :query-revert="queryRevert"
-        :reset-query-default="resetQueryDefault"
-        :revert-query-saved="revertQuerySaved"
       />
       <SQLEditorResults
         v-if="items.length"
@@ -82,15 +79,11 @@ export default {
       type: Boolean,
       default: false
     },
+    isSavingPromptVisible: {
+      type: Boolean,
+      default: false
+    },
     queryStored: {
-      type: String,
-      default: null
-    },
-    queryDefault: {
-      type: String,
-      default: null
-    },
-    queryRevert: {
       type: String,
       default: null
     },
@@ -105,14 +98,6 @@ export default {
     queryError: {
       type: String,
       default: null
-    },
-    resetQueryDefault: {
-      type: Boolean,
-      default: false
-    },
-    revertQuerySaved: {
-      type: Boolean,
-      default: false
     },
     enabledSavedButton: {
       type: Boolean,

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -18,6 +18,7 @@
       <SQLEditorResults
         v-if="items.length"
         :array-formats="arrayFormats"
+        :array-columns="arrayColumnsQuery"
         :items="items"
       />
     </div>
@@ -48,6 +49,10 @@ export default {
     arrayColumns: {
       type: Object,
       required: true
+    },
+    arrayColumnsQuery: {
+      type: Array,
+      default: () => []
     },
     publicQueries: {
       type: Array,

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -18,7 +18,7 @@
       <SQLEditorResults
         v-if="items.length"
         :array-formats="arrayFormats"
-        :array-columns="arrayColumnsQuery"
+        :array-columns-query="arrayColumnsQuery"
         :items="items"
       />
     </div>

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -12,6 +12,7 @@
       <SQLEditorCode
         :array-columns="arrayColumns"
         :query-stored="queryStored"
+        :query-default="queryDefault"
         :query-duration="queryDuration"
         :query-error="queryError"
       />
@@ -75,6 +76,10 @@ export default {
       default: false
     },
     queryStored: {
+      type: String,
+      default: null
+    },
+    queryDefault: {
       type: String,
       default: null
     },

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -15,6 +15,9 @@
         :query-default="queryDefault"
         :query-duration="queryDuration"
         :query-error="queryError"
+        :query-revert="queryRevert"
+        :reset-query-default="resetQueryDefault"
+        :revert-query-saved="revertQuerySaved"
       />
       <SQLEditorResults
         v-if="items.length"
@@ -83,6 +86,10 @@ export default {
       type: String,
       default: null
     },
+    queryRevert: {
+      type: String,
+      default: null
+    },
     queryName: {
       type: String,
       default: null
@@ -94,6 +101,14 @@ export default {
     queryError: {
       type: String,
       default: null
+    },
+    resetQueryDefault: {
+      type: Boolean,
+      default: false
+    },
+    revertQuerySaved: {
+      type: Boolean,
+      default: false
     },
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -10,6 +10,7 @@
         :query-name="queryName"
         :enabled-saved-button="enabledSavedButton"
         :show-revert-query="showRevertQuery"
+        :show-private="showPrivate"
       />
       <SQLEditorCode
         :array-columns="arrayColumns"
@@ -117,6 +118,10 @@ export default {
       default: false
     },
     showRevertQuery: {
+      type: Boolean,
+      default: false
+    },
+    showPrivate: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -8,6 +8,7 @@
         :is-query-running="isQueryRunning"
         :is-query-modified="isQueryModified"
         :query-name="queryName"
+        :enabled-saved-button="enabledSavedButton"
       />
       <SQLEditorCode
         :array-columns="arrayColumns"
@@ -107,6 +108,10 @@ export default {
       default: false
     },
     revertQuerySaved: {
+      type: Boolean,
+      default: false
+    },
+    enabledSavedButton: {
       type: Boolean,
       default: false
     },

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -43,6 +43,10 @@ export default {
       type: String,
       default: ""
     },
+    queryDefault: {
+      type: String,
+      default: ""
+    },
     queryDuration: {
       type: Number,
       default: 0
@@ -185,8 +189,8 @@ export default {
       };
     },
     resetEditor() {
-      const resetSql = ''
-      this.editor.setValue(resetSql)
+      //TODO: if we have clicked on a saved query that should be the default query.
+      this.editor.setValue(this.queryDefault)
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -43,14 +43,6 @@ export default {
       type: String,
       default: ""
     },
-    queryDefault: {
-      type: String,
-      default: ""
-    },
-    queryRevert: {
-      type: String,
-      default: ""
-    },
     queryDuration: {
       type: Number,
       default: 0
@@ -58,14 +50,6 @@ export default {
     queryError: {
       type: String,
       default: null
-    },
-    resetQueryDefault: {
-      type: Boolean,
-      default: false
-    },
-    revertQuerySaved: {
-      type: Boolean,
-      default: false
     }
   },
   data() {
@@ -87,18 +71,6 @@ export default {
     queryStored(newValue, oldValue) {
       if (newValue !== oldValue) {
         this.setEditorValue(newValue);
-      }
-    },
-    resetQueryDefault(newValue, oldValue) {
-      if (newValue !== oldValue) {
-        this.setEditorValue(this.queryDefault);
-        this.editor.focus()
-      }
-    },
-    revertQuerySaved(newValue, oldValue) {
-      if (newValue !== oldValue) {
-        this.setEditorValue(this.queryRevert);
-        this.editor.focus()
       }
     }
   },
@@ -151,9 +123,6 @@ export default {
         // update the query while typing
         this.$root.$emit("setCurrentQuery", value);
         this.$root.$emit('enableSavedButton')
-        this.$root.$emit("resetQuery", false);
-        this.$root.$emit("revertSavedQuery", false);
-        this.$root.$emit("disabledStringSavedQuery", false);
       }, 50);
     },
     mergeTables() {

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -47,6 +47,10 @@ export default {
       type: String,
       default: ""
     },
+    queryRevert: {
+      type: String,
+      default: ""
+    },
     queryDuration: {
       type: Number,
       default: 0
@@ -54,6 +58,14 @@ export default {
     queryError: {
       type: String,
       default: null
+    },
+    resetQueryDefault: {
+      type: Boolean,
+      default: false
+    },
+    revertQuerySaved: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -75,6 +87,18 @@ export default {
     queryStored(newValue, oldValue) {
       if (newValue !== oldValue) {
         this.setEditorValue(newValue);
+      }
+    },
+    resetQueryDefault(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.setEditorValue(this.queryDefault);
+        this.editor.focus()
+      }
+    },
+    revertQuerySaved(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.setEditorValue(this.queryRevert);
+        this.editor.focus()
       }
     }
   },
@@ -111,7 +135,6 @@ export default {
     // metaKey + keyUp doesn't work with MacOS
     // https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser
     this.editor.on("keydown", this.onKeyDown);
-    this.$root.$on('resetQuery', this.resetEditor)
   },
   methods: {
     onKeyDown(editor, e) {
@@ -127,8 +150,11 @@ export default {
 
         // update the query while typing
         this.$root.$emit("setCurrentQuery", value);
-        this.$root.$emit('enableSavedButton')
       }, 250);
+      this.$root.$emit('enableSavedButton')
+      this.$root.$emit("hideLabelQueryModified", true);
+      this.$root.$emit("resetQuery", false);
+      this.$root.$emit("revertSavedQuery", false);
     },
     mergeTables() {
       for (let i = 0; i < this.arrayColumns.length; i++) {
@@ -188,10 +214,6 @@ export default {
         from: CodeMirror.Pos(cur.line, token.start),
         to: CodeMirror.Pos(cur.line, token.end)
       };
-    },
-    resetEditor() {
-      //TODO: if we have clicked on a saved query that should be the default query.
-      this.editor.setValue(this.queryDefault)
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -152,7 +152,6 @@ export default {
         this.$root.$emit("setCurrentQuery", value);
       }, 250);
       this.$root.$emit('enableSavedButton')
-      this.$root.$emit("hideLabelQueryModified", true);
       this.$root.$emit("resetQuery", false);
       this.$root.$emit("revertSavedQuery", false);
     },

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -150,10 +150,11 @@ export default {
 
         // update the query while typing
         this.$root.$emit("setCurrentQuery", value);
-      }, 250);
-      this.$root.$emit('enableSavedButton')
-      this.$root.$emit("resetQuery", false);
-      this.$root.$emit("revertSavedQuery", false);
+        this.$root.$emit('enableSavedButton')
+        this.$root.$emit("resetQuery", false);
+        this.$root.$emit("revertSavedQuery", false);
+        this.$root.$emit("disabledStringSavedQuery", false);
+      }, 50);
     },
     mergeTables() {
       for (let i = 0; i < this.arrayColumns.length; i++) {

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -127,6 +127,7 @@ export default {
 
         // update the query while typing
         this.$root.$emit("setCurrentQuery", value);
+        this.$root.$emit('enableSavedButton')
       }, 250);
     },
     mergeTables() {

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -114,6 +114,7 @@ export default {
     // metaKey + keyUp doesn't work with MacOS
     // https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser
     this.editor.on("keydown", this.onKeyDown);
+    this.$root.$on('resetQuery', this.resetEditor)
   },
   methods: {
     onKeyDown(editor, e) {
@@ -189,6 +190,10 @@ export default {
         from: CodeMirror.Pos(cur.line, token.start),
         to: CodeMirror.Pos(cur.line, token.end)
       };
+    },
+    resetEditor() {
+      const resetSql = ''
+      this.editor.setValue(resetSql)
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -63,7 +63,7 @@
     <SavingDialog
       :placeholder="labelQueryName"
       :value="queryName"
-      :save-string="labelSave"
+      :label-save="labelSave"
       @save="onSaveEventHandler"
     />
 

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -174,6 +174,9 @@ export default {
     // it has to be the same event (keydown) as SQLEditorCode
     document.addEventListener("keydown", this.keyboardShortcutsListener);
   },
+  deactivated() {
+    this.$destroy()
+  },
   beforeDestroy() {
     this.removeKeyboardListener()
   },

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -67,6 +67,7 @@
       :is-query-modified="isQueryModified"
       :enabled-saved-button="enabledSavedButton"
       :show-revert-query="showRevertQuery"
+      :show-private="showPrivate"
       @save="onSaveEventHandler"
       @showLabelIcons="showHideLabelIcons(false)"
       @revertQuery="revertQuery"
@@ -134,6 +135,10 @@ export default {
       default: false
     },
     showRevertQuery: {
+      type: Boolean,
+      default: false
+    },
+    showPrivate: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -62,20 +62,15 @@
     </div>
 
     <SavingDialog
+      v-if="queryName"
       :placeholder="labelQueryName"
       :value="queryName"
       :label-save="labelSave"
+      :is-query-modified="isQueryModified"
       @save="onSaveEventHandler"
+      @showLabelIcons="showHideLabelIcons(false)"
+      @revertQuery="revertQuery"
     />
-
-    <div
-      v-if="isQueryModified"
-      class="gobierto-data-sql-editor-modified-label-container"
-    >
-      <span class="gobierto-data-sql-editor-modified-label">
-        {{ labelModifiedQuery }}
-      </span>
-    </div>
 
     <Button
       :text="labelRunQuery"
@@ -132,7 +127,7 @@ export default {
     },
     queryName: {
       type: String,
-      default: null,
+      default: '',
     },
   },
   data() {
@@ -143,7 +138,6 @@ export default {
       labelResetQuery: I18n.t("gobierto_data.projects.resetQuery") || "",
       labelSave: I18n.t("gobierto_data.projects.save") || "",
       labelQueryName: I18n.t("gobierto_data.projects.queryName") || "",
-      labelModifiedQuery: I18n.t("gobierto_data.projects.modifiedQuery") || "",
       labelButtonQueries: I18n.t("gobierto_data.projects.buttonQueries") || "",
       labelButtonRecentQueries:
         I18n.t("gobierto_data.projects.buttonRecentQueries") || "",
@@ -154,16 +148,26 @@ export default {
       isRecentModalActive: false,
     };
   },
+  watch: {
+    $route(to, from) {
+      if (to.path !== from.path) {
+        this.showHideLabelIcons(true)
+      }
+    },
+  },
   created() {
     // it has to be the same event (keydown) as SQLEditorCode
     document.addEventListener("keydown", this.keyboardShortcutsListener);
+
+    if (this.$route.name === 'Query') {
+      this.showHideLabelIcons(true)
+    }
   },
   deactivated() {
     this.removeKeyboardListener()
   },
   methods: {
     keyboardShortcutsListener(e) {
-      console.log("keyboardShortcutsListener -> e", e)
       if (e.keyCode == 67) {
         // key "c"
         this.isQueriesModalActive ? this.closeQueriesModal() : this.openQueriesModal();
@@ -211,7 +215,13 @@ export default {
       this.isQueriesModalActive = false;
     },
     resetQuery() {
-      this.$root.$emit('resetQuery')
+      this.$root.$emit('resetQuery', true)
+    },
+    revertQuery() {
+      this.$root.$emit('revertSavedQuery', true)
+    },
+    showHideLabelIcons(value) {
+      this.removeLabelBtn = value
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -2,6 +2,7 @@
   <div class="gobierto-data-sql-editor-toolbar">
     <div class="gobierto-data-sql-editor-container">
       <Button
+        v-if="isQueryModified"
         :title="labelResetQuery"
         class="btn-sql-editor"
         icon="home"
@@ -195,7 +196,6 @@ export default {
     },
     clickRunQueryHandler() {
       this.$root.$emit("runCurrentQuery");
-      this.resetPerspective()
     },
     openRecentModal() {
       this.isRecentModalActive = true;
@@ -211,10 +211,7 @@ export default {
     },
     resetQuery() {
       this.$root.$emit('resetQuery')
-    },
-    resetPerspective() {
-      this.$root.$emit('resetPerspective')
-    },
+    }
   },
 };
 </script>

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -66,6 +66,7 @@
       :label-save="labelSave"
       :is-query-modified="isQueryModified"
       :enabled-saved-button="enabledSavedButton"
+      :show-revert-query="showRevertQuery"
       @save="onSaveEventHandler"
       @showLabelIcons="showHideLabelIcons(false)"
       @revertQuery="revertQuery"
@@ -132,6 +133,10 @@ export default {
       type: Boolean,
       default: false
     },
+    showRevertQuery: {
+      type: Boolean,
+      default: false
+    }
   },
   data() {
     return {

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -2,7 +2,7 @@
   <div class="gobierto-data-sql-editor-toolbar">
     <div class="gobierto-data-sql-editor-container">
       <Button
-        :title="labelButtonRecentQueries"
+        :title="labelResetQuery"
         class="btn-sql-editor"
         icon="home"
         color="var(--color-base)"
@@ -139,6 +139,7 @@ export default {
       labelRecents: I18n.t("gobierto_data.projects.recents") || "",
       labelQueries: I18n.t("gobierto_data.projects.queries") || "",
       labelRunQuery: I18n.t("gobierto_data.projects.runQuery") || "",
+      labelResetQuery: I18n.t("gobierto_data.projects.resetQuery") || "",
       labelSave: I18n.t("gobierto_data.projects.save") || "",
       labelQueryName: I18n.t("gobierto_data.projects.queryName") || "",
       labelModifiedQuery: I18n.t("gobierto_data.projects.modifiedQuery") || "",

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -195,6 +195,7 @@ export default {
     },
     clickRunQueryHandler() {
       this.$root.$emit("runCurrentQuery");
+      this.resetPerspective()
     },
     openRecentModal() {
       this.isRecentModalActive = true;
@@ -210,6 +211,9 @@ export default {
     },
     resetQuery() {
       this.$root.$emit('resetQuery')
+    },
+    resetPerspective() {
+      this.$root.$emit('resetPerspective')
     },
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -60,13 +60,12 @@
         />
       </transition>
     </div>
-
     <SavingDialog
-      v-if="queryName"
       :placeholder="labelQueryName"
       :value="queryName"
       :label-save="labelSave"
       :is-query-modified="isQueryModified"
+      :enabled-saved-button="enabledSavedButton"
       @save="onSaveEventHandler"
       @showLabelIcons="showHideLabelIcons(false)"
       @revertQuery="revertQuery"
@@ -128,6 +127,10 @@ export default {
     queryName: {
       type: String,
       default: '',
+    },
+    enabledSavedButton: {
+      type: Boolean,
+      default: false
     },
   },
   data() {
@@ -216,9 +219,11 @@ export default {
     },
     resetQuery() {
       this.$root.$emit('resetQuery', true)
+      this.$root.$emit("hideLabelQueryModified", false);
     },
     revertQuery() {
       this.$root.$emit('revertSavedQuery', true)
+      this.$root.$emit("hideLabelQueryModified", false);
     },
     showHideLabelIcons(value) {
       this.removeLabelBtn = value

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -7,7 +7,7 @@
         icon="home"
         color="var(--color-base)"
         background="#fff"
-        @click.native="resetQuery"
+        @click.native="resetQueryHandler"
       />
     </div>
     <div class="gobierto-data-sql-editor-container">
@@ -66,6 +66,7 @@
       :label-save="labelSave"
       :is-query-modified="isQueryModified"
       :is-query-saved="isQuerySaved"
+      :is-saving-prompt-visible="isSavingPromptVisible"
       :enabled-saved-button="enabledSavedButton"
       :show-revert-query="showRevertQuery"
       :show-private="showPrivate"
@@ -122,6 +123,10 @@ export default {
       type: Boolean,
       default: false
     },
+    isSavingPromptVisible: {
+      type: Boolean,
+      default: false
+    },
     isQueryModified: {
       type: Boolean,
       default: false
@@ -169,7 +174,7 @@ export default {
     // it has to be the same event (keydown) as SQLEditorCode
     document.addEventListener("keydown", this.keyboardShortcutsListener);
   },
-  deactivated() {
+  beforeDestroy() {
     this.removeKeyboardListener()
   },
   methods: {
@@ -220,11 +225,11 @@ export default {
     closeQueriesModal() {
       this.isQueriesModalActive = false;
     },
-    resetQuery() {
-      this.$refs.savingDialog.disableSavingPrompt();
+    resetQueryHandler() {
       this.$root.$emit('resetQuery', true)
       this.$router.push(
         `/datos/${this.$route.params.id}/${tabs[1]}`
+      //Avoid errors when user goes to the same route
       // eslint-disable-next-line no-unused-vars
       ).catch(err => {})
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -2,7 +2,6 @@
   <div class="gobierto-data-sql-editor-toolbar">
     <div class="gobierto-data-sql-editor-container">
       <Button
-        v-if="isQueryModified"
         :title="labelResetQuery"
         class="btn-sql-editor"
         icon="home"
@@ -10,9 +9,10 @@
         background="#fff"
         @click.native="resetQuery"
       />
+    </div>
+    <div class="gobierto-data-sql-editor-container">
       <Button
         v-clickoutside="closeRecentModal"
-        :text="labelRecents"
         :class="{ 'remove-label' : removeLabelBtn }"
         :title="labelButtonRecentQueries"
         class="btn-sql-editor"
@@ -38,7 +38,6 @@
     <div class="gobierto-data-sql-editor-container">
       <Button
         v-clickoutside="closeQueriesModal"
-        :text="labelQueries"
         :class="{ 'remove-label' : removeLabelBtn }"
         :title="labelButtonQueries"
         class="btn-sql-editor"
@@ -61,6 +60,7 @@
       </transition>
     </div>
     <SavingDialog
+      ref="savingDialog"
       :placeholder="labelQueryName"
       :value="queryName"
       :label-save="labelSave"
@@ -69,8 +69,6 @@
       :show-revert-query="showRevertQuery"
       :show-private="showPrivate"
       @save="onSaveEventHandler"
-      @showLabelIcons="showHideLabelIcons(false)"
-      @revertQuery="revertQuery"
     />
 
     <Button
@@ -88,6 +86,7 @@
 </template>
 <script>
 import { CommonsMixin, closableMixin } from "./../../../../lib/commons.js";
+import { tabs } from '../../../../lib/router';
 
 import Button from "./../../commons/Button.vue";
 import Queries from "./../../commons/Queries.vue";
@@ -158,23 +157,12 @@ export default {
         I18n.t("gobierto_data.projects.buttonRunQuery") || "",
       removeLabelBtn: false,
       isQueriesModalActive: false,
-      isRecentModalActive: false,
+      isRecentModalActive: false
     };
-  },
-  watch: {
-    $route(to, from) {
-      if (to.path !== from.path) {
-        this.showHideLabelIcons(true)
-      }
-    },
   },
   created() {
     // it has to be the same event (keydown) as SQLEditorCode
     document.addEventListener("keydown", this.keyboardShortcutsListener);
-
-    if (this.$route.name === 'Query') {
-      this.showHideLabelIcons(true)
-    }
   },
   deactivated() {
     this.removeKeyboardListener()
@@ -228,15 +216,12 @@ export default {
       this.isQueriesModalActive = false;
     },
     resetQuery() {
+      this.$refs.savingDialog.disableSavingPrompt();
       this.$root.$emit('resetQuery', true)
-      this.$root.$emit("hideLabelQueryModified", false);
-    },
-    revertQuery() {
-      this.$root.$emit('revertSavedQuery', true)
-      this.$root.$emit("hideLabelQueryModified", false);
-    },
-    showHideLabelIcons(value) {
-      this.removeLabelBtn = value
+      this.$router.push(
+        `/datos/${this.$route.params.id}/${tabs[1]}`
+      // eslint-disable-next-line no-unused-vars
+      ).catch(err => {})
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -158,11 +158,12 @@ export default {
     // it has to be the same event (keydown) as SQLEditorCode
     document.addEventListener("keydown", this.keyboardShortcutsListener);
   },
-  beforeDestroy() {
+  deactivated() {
     this.removeKeyboardListener()
   },
   methods: {
     keyboardShortcutsListener(e) {
+      console.log("keyboardShortcutsListener -> e", e)
       if (e.keyCode == 67) {
         // key "c"
         this.isQueriesModalActive ? this.closeQueriesModal() : this.openQueriesModal();

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -2,6 +2,13 @@
   <div class="gobierto-data-sql-editor-toolbar">
     <div class="gobierto-data-sql-editor-container">
       <Button
+        class="btn-sql-editor"
+        icon="home"
+        color="var(--color-base)"
+        background="#fff"
+        @click.native="resetQuery"
+      />
+      <Button
         v-clickoutside="closeRecentModal"
         :text="labelRecents"
         :class="{ 'remove-label' : removeLabelBtn }"
@@ -193,6 +200,9 @@ export default {
     },
     closeQueriesModal() {
       this.isQueriesModalActive = false;
+    },
+    resetQuery() {
+      this.$root.$emit('resetQuery')
     },
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -65,6 +65,7 @@
       :value="queryName"
       :label-save="labelSave"
       :is-query-modified="isQueryModified"
+      :is-query-saved="isQuerySaved"
       :enabled-saved-button="enabledSavedButton"
       :show-revert-query="showRevertQuery"
       :show-private="showPrivate"
@@ -138,6 +139,10 @@ export default {
       default: false
     },
     showPrivate: {
+      type: Boolean,
+      default: false
+    },
+    isQuerySaved: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -2,6 +2,7 @@
   <div class="gobierto-data-sql-editor-toolbar">
     <div class="gobierto-data-sql-editor-container">
       <Button
+        :title="labelButtonRecentQueries"
         class="btn-sql-editor"
         icon="home"
         color="var(--color-base)"
@@ -62,6 +63,7 @@
     <SavingDialog
       :placeholder="labelQueryName"
       :value="queryName"
+      :save-string="labelSave"
       @save="onSaveEventHandler"
     />
 
@@ -137,6 +139,7 @@ export default {
       labelRecents: I18n.t("gobierto_data.projects.recents") || "",
       labelQueries: I18n.t("gobierto_data.projects.queries") || "",
       labelRunQuery: I18n.t("gobierto_data.projects.runQuery") || "",
+      labelSave: I18n.t("gobierto_data.projects.save") || "",
       labelQueryName: I18n.t("gobierto_data.projects.queryName") || "",
       labelModifiedQuery: I18n.t("gobierto_data.projects.modifiedQuery") || "",
       labelButtonQueries: I18n.t("gobierto_data.projects.buttonQueries") || "",

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -60,7 +60,7 @@
         :type-chart="typeChart"
         :array-columns-query="arrayColumnsQuery"
         @showSaving="showSavingDialog"
-        @selectedChart="changeChart"
+        @selectedChart="typeChart = $event"
       />
     </div>
   </div>
@@ -142,9 +142,6 @@ export default {
       this.showVisualize = false
       this.showResetViz = true
       this.isVisualizationModified = true
-    },
-    changeChart(chart) {
-      this.typeChart = chart
     },
     resetButtonViz() {
       this.removeLabelBtn = false

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -116,6 +116,7 @@ export default {
       this.typeChart = 'hypergrid'
       const hidePerspective = "none"
       this.$refs.viewer.enableDisabledPerspective(hidePerspective);
+      this.$refs.viewer.setColumns();
     },
     showChart() {
       this.showVisualization = true

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -7,6 +7,7 @@
       >
         <Button
           v-if="showVisualization"
+          :title="labelResetViz"
           class="btn-sql-editor"
           icon="home"
           color="var(--color-base)"
@@ -81,6 +82,7 @@ export default {
       labelVisName: I18n.t('gobierto_data.projects.visName') || "",
       labelSaveViz: I18n.t('gobierto_data.projects.saveViz') || "",
       labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
+      labelResetViz: I18n.t('gobierto_data.projects.resetViz') || "",
       showVisualization: false,
       removeLabelBtn: false,
       typeChart: 'hypergrid'

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -6,14 +6,6 @@
         style="margin-bottom: 1rem"
       >
         <Button
-          :text="'Visualizar'"
-          class="btn-sql-editor"
-          icon="chart-area"
-          color="var(--color-base)"
-          background="#fff"
-          @click.native="showChart"
-        />
-        <Button
           v-if="showVisualization"
           class="btn-sql-editor"
           icon="home"
@@ -21,10 +13,19 @@
           background="#fff"
           @click.native="resetViz"
         />
+        <Button
+          :text="'Visualizar'"
+          :class="{ 'remove-label' : removeLabelBtn }"
+          class="btn-sql-editor"
+          icon="chart-area"
+          color="var(--color-base)"
+          background="#fff"
+          @click.native="showChart"
+        />
         <SavingDialog
           v-if="showVisualization"
           :placeholder="labelVisName"
-          :save-string="labelSaveViz"
+          :label-save="labelSaveViz"
           @save="onSaveEventHandler"
         />
 
@@ -46,6 +47,7 @@
         v-if="items"
         ref="viewer"
         :items="items"
+        :type-chart="typeChart"
       />
     </div>
   </div>
@@ -78,8 +80,17 @@ export default {
     return {
       labelVisName: I18n.t('gobierto_data.projects.visName') || "",
       labelSaveViz: I18n.t('gobierto_data.projects.saveViz') || "",
-      showVisualization: false
+      showVisualization: false,
+      removeLabelBtn: false,
+      typeChart: 'hypergrid'
     };
+  },
+  watch: {
+    typeChart(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.typeChart = newValue
+      }
+    }
   },
   methods: {
     onSaveEventHandler(opts) {
@@ -87,12 +98,14 @@ export default {
       const config = this.$refs.viewer.getConfig()
 
       this.$root.$emit("storeCurrentVisualization", config, opts);
+      this.removeLabelBtn = true
     },
     resetViz() {
-      this.$root.$emit('resetViz')
+      this.typeChart = 'hypergrid'
     },
-    visualization() {
-      plugin="xy_scatter"
+    showChart() {
+      this.showVisualization = true
+      this.typeChart = 'y_line'
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -6,7 +6,7 @@
         style="margin-bottom: 1rem"
       >
         <Button
-          v-if="showVisualization"
+          v-if="showResetViz"
           :title="labelResetViz"
           class="btn-sql-editor"
           icon="home"
@@ -91,6 +91,7 @@ export default {
       labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
       labelResetViz: I18n.t('gobierto_data.projects.resetViz') || "",
       showVisualization: false,
+      showResetViz: false,
       showVisualize: true,
       removeLabelBtn: false,
       perspectiveChanged: false,
@@ -124,6 +125,7 @@ export default {
     showSavingDialog() {
       this.perspectiveChanged = true
       this.showVisualize = false
+      this.showResetViz = true
     },
     changeChart(chart) {
       this.typeChart = chart

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -31,6 +31,14 @@
           @save="onSaveEventHandler"
           @resetButtonViz="resetButtonViz"
         />
+        <div
+          v-if="isVisualizationModified"
+          class="gobierto-data-sql-editor-modified-label-container"
+        >
+          <span class="gobierto-data-sql-editor-modified-label">
+            {{ labelModifiedVizualition }}
+          </span>
+        </div>
       </div>
       <div
         class="pure-u-1 pure-u-lg-1-4"
@@ -91,7 +99,9 @@ export default {
       labelSaveViz: I18n.t('gobierto_data.projects.saveViz') || "",
       labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
       labelResetViz: I18n.t('gobierto_data.projects.resetViz') || "",
+      labelModifiedVizualition: I18n.t("gobierto_data.projects.modifiedVisualization") || "",
       showVisualization: false,
+      isVisualizationModified: false,
       showResetViz: false,
       showVisualize: true,
       removeLabelBtn: false,
@@ -106,6 +116,7 @@ export default {
 
       this.$root.$emit("storeCurrentVisualization", config, opts);
       this.removeLabelBtn = true
+      this.isVisualizationModified = false
     },
     resetViz() {
       const hidePerspective = "none"
@@ -115,6 +126,7 @@ export default {
       this.removeLabelBtn = false
       this.showResetViz = false
       this.typeChart = 'hypergrid'
+      this.isVisualizationModified = false
 
       this.$refs.viewer.enableDisabledPerspective(hidePerspective);
       this.$refs.viewer.setColumns();
@@ -129,6 +141,7 @@ export default {
       this.perspectiveChanged = true
       this.showVisualize = false
       this.showResetViz = true
+      this.isVisualizationModified = true
     },
     changeChart(chart) {
       this.typeChart = chart

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -1,20 +1,38 @@
 <template>
   <div class="gobierto-data-sql-editor-tabs">
     <div class="pure-g">
-      <Button
-        class="btn-sql-editor"
-        icon="home"
-        color="var(--color-base)"
-        background="#fff"
-      />
       <div
-        class="pure-u-1"
-        style="text-align: right; margin-bottom: 1rem"
+        class="pure-u-1 pure-u-lg-3-4"
+        style="margin-bottom: 1rem"
       >
+        <Button
+          :text="'Visualizar'"
+          class="btn-sql-editor"
+          icon="chart-area"
+          color="var(--color-base)"
+          background="#fff"
+          @click.native="showChart"
+        />
+        <Button
+          v-if="showVisualization"
+          class="btn-sql-editor"
+          icon="home"
+          color="var(--color-base)"
+          background="#fff"
+          @click.native="resetViz"
+        />
         <SavingDialog
+          v-if="showVisualization"
           :placeholder="labelVisName"
+          :save-string="labelSaveViz"
           @save="onSaveEventHandler"
         />
+
+      </div>
+      <div
+        class="pure-u-1 pure-u-lg-1-4"
+        style="margin-bottom: 1rem"
+      >
         <DownloadButton
           :editor="true"
           :array-formats="arrayFormats"
@@ -59,6 +77,8 @@ export default {
   data() {
     return {
       labelVisName: I18n.t('gobierto_data.projects.visName') || "",
+      labelSaveViz: I18n.t('gobierto_data.projects.saveViz') || "",
+      showVisualization: false
     };
   },
   methods: {
@@ -67,6 +87,12 @@ export default {
       const config = this.$refs.viewer.getConfig()
 
       this.$root.$emit("storeCurrentVisualization", config, opts);
+    },
+    resetViz() {
+      this.$root.$emit('resetViz')
+    },
+    visualization() {
+      plugin="xy_scatter"
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -49,7 +49,7 @@
         ref="viewer"
         :items="items"
         :type-chart="typeChart"
-        :array-columns="arrayColumnsQuery"
+        :array-columns-query="arrayColumnsQuery"
       />
     </div>
   </div>

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -29,6 +29,7 @@
           :placeholder="labelVisName"
           :label-save="labelSaveViz"
           @save="onSaveEventHandler"
+          @resetButtonViz="resetButtonViz"
         />
       </div>
       <div
@@ -98,12 +99,6 @@ export default {
       typeChart: 'hypergrid'
     };
   },
-  created() {
-    this.$root.$on('resetPerspective', this.resetVizColumns)
-  },
-  beforeDestroy() {
-    this.$root.$off('resetPerspective')
-  },
   methods: {
     onSaveEventHandler(opts) {
       // get children configuration
@@ -113,14 +108,21 @@ export default {
       this.removeLabelBtn = true
     },
     resetViz() {
-      this.typeChart = 'hypergrid'
       const hidePerspective = "none"
+
+      this.showVisualize = true
+      this.perspectiveChanged = false
+      this.removeLabelBtn = false
+      this.showResetViz = false
+      this.typeChart = 'hypergrid'
+
       this.$refs.viewer.enableDisabledPerspective(hidePerspective);
       this.$refs.viewer.setColumns();
     },
     showChart() {
-      this.showVisualization = true
       const showPerspective = "flex"
+
+      this.showVisualization = true
       this.$refs.viewer.enableDisabledPerspective(showPerspective);
     },
     showSavingDialog() {
@@ -131,6 +133,10 @@ export default {
     changeChart(chart) {
       this.typeChart = chart
     },
+    resetButtonViz() {
+      this.removeLabelBtn = false
+      this.showResetViz = true
+    }
   },
 };
 </script>

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -14,7 +14,7 @@
           @click.native="resetViz"
         />
         <Button
-          :text="'Visualizar'"
+          :text="labelVisualize"
           :class="{ 'remove-label' : removeLabelBtn }"
           class="btn-sql-editor"
           icon="chart-area"
@@ -80,6 +80,7 @@ export default {
     return {
       labelVisName: I18n.t('gobierto_data.projects.visName') || "",
       labelSaveViz: I18n.t('gobierto_data.projects.saveViz') || "",
+      labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
       showVisualization: false,
       removeLabelBtn: false,
       typeChart: 'hypergrid'

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -94,7 +94,7 @@ export default {
     };
   },
   created() {
-    this.$root.$on('resetPerspective', this.resetViz)
+    this.$root.$on('resetPerspective', this.resetVizColumns)
   },
   beforeDestroy() {
     this.$root.$off('resetPerspective')

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -15,6 +15,7 @@
           @click.native="resetViz"
         />
         <Button
+          v-if="showVisualize"
           :text="labelVisualize"
           :class="{ 'remove-label' : removeLabelBtn }"
           class="btn-sql-editor"
@@ -24,12 +25,11 @@
           @click.native="showChart"
         />
         <SavingDialog
-          v-if="showVisualization"
+          v-if="perspectiveChanged"
           :placeholder="labelVisName"
           :label-save="labelSaveViz"
           @save="onSaveEventHandler"
         />
-
       </div>
       <div
         class="pure-u-1 pure-u-lg-1-4"
@@ -50,6 +50,8 @@
         :items="items"
         :type-chart="typeChart"
         :array-columns-query="arrayColumnsQuery"
+        @showSaving="showSavingDialog"
+        @selectedChart="changeChart"
       />
     </div>
   </div>
@@ -89,7 +91,9 @@ export default {
       labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
       labelResetViz: I18n.t('gobierto_data.projects.resetViz') || "",
       showVisualization: false,
+      showVisualize: true,
       removeLabelBtn: false,
+      perspectiveChanged: false,
       typeChart: 'hypergrid'
     };
   },
@@ -109,12 +113,21 @@ export default {
     },
     resetViz() {
       this.typeChart = 'hypergrid'
+      const hidePerspective = "none"
+      this.$refs.viewer.enableDisabledPerspective(hidePerspective);
     },
     showChart() {
       this.showVisualization = true
-      //Charts Perspective: y_line, hypegrid, xy_scatter, y_scatter, y_area, x_bar, y_bar, heatmap, sunburst, treemap, ohlc, candlestick
-      this.typeChart = 'y_line'
-    }
+      const showPerspective = "flex"
+      this.$refs.viewer.enableDisabledPerspective(showPerspective);
+    },
+    showSavingDialog() {
+      this.perspectiveChanged = true
+      this.showVisualize = false
+    },
+    changeChart(chart) {
+      this.typeChart = chart
+    },
   },
 };
 </script>

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="gobierto-data-sql-editor-tabs">
     <div class="pure-g">
+      <Button
+        class="btn-sql-editor"
+        icon="home"
+        color="var(--color-base)"
+        background="#fff"
+      />
       <div
         class="pure-u-1"
         style="text-align: right; margin-bottom: 1rem"
@@ -26,6 +32,7 @@
   </div>
 </template>
 <script>
+import Button from "./../../commons/Button.vue";
 import DownloadButton from "./../../commons/DownloadButton.vue";
 import SavingDialog from "./../../commons/SavingDialog.vue";
 import Visualizations from "./../../commons/Visualizations.vue";
@@ -35,6 +42,7 @@ export default {
   components: {
     Visualizations,
     DownloadButton,
+    Button,
     SavingDialog
   },
   props: {

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -88,13 +88,6 @@ export default {
       typeChart: 'hypergrid'
     };
   },
-  watch: {
-    typeChart(newValue, oldValue) {
-      if (newValue !== oldValue) {
-        this.typeChart = newValue
-      }
-    }
-  },
   methods: {
     onSaveEventHandler(opts) {
       // get children configuration
@@ -108,6 +101,7 @@ export default {
     },
     showChart() {
       this.showVisualization = true
+      //Charts Perspective: y_line, hypegrid, xy_scatter, y_scatter, y_area, x_bar, y_bar, heatmap, sunburst, treemap, ohlc, candlestick
       this.typeChart = 'y_line'
     }
   },

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -49,6 +49,7 @@
         ref="viewer"
         :items="items"
         :type-chart="typeChart"
+        :array-columns="arrayColumnsQuery"
       />
     </div>
   </div>
@@ -72,6 +73,10 @@ export default {
       type: Object,
       required: true
     },
+    arrayColumnsQuery: {
+      type: Array,
+      default: () => []
+    },
     items: {
       type: String,
       default: ''
@@ -87,6 +92,12 @@ export default {
       removeLabelBtn: false,
       typeChart: 'hypergrid'
     };
+  },
+  created() {
+    this.$root.$on('resetPerspective', this.resetViz)
+  },
+  beforeDestroy() {
+    this.$root.$off('resetPerspective')
   },
   methods: {
     onSaveEventHandler(opts) {

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -69,11 +69,6 @@ export default {
   },
   data() {
     return {
-      labelSets: "",
-      labelQueries: "",
-      labelCategories: "",
-      labelshowAll: "",
-      labelshowLess: "",
       sortedItems: [],
       listDatasets: [],
       currentDatasetSlug: null,
@@ -81,6 +76,11 @@ export default {
       showLess: null,
       activeDatasetColumns: {},
       showToggle: null,
+      labelSets: I18n.t("gobierto_data.projects.sets"),
+      labelQueries: I18n.t("gobierto_data.projects.queries"),
+      labelCategories: I18n.t("gobierto_data.projects.categories"),
+      labelshowAll: I18n.t("gobierto_data.projects.showAll"),
+      labelshowLess: I18n.t("gobierto_data.projects.showLess")
     }
   },
   computed: {
@@ -96,20 +96,15 @@ export default {
     }
   },
   watch: {
-    currentDatasetSlug: function(newSlug) {
+    currentDatasetSlug (newSlug) {
       this.showLess = true;
-      if (this.sortedItems.length && newSlug !== '') {
+      if (this.sortedItems.length && newSlug) {
         this.activeDatasetColumns = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === newSlug).attributes.columns || {}
         this.showToggle = Object.keys(this.activeDatasetColumns).length > this.showMaxKeys
       }
     }
   },
   created() {
-    this.labelSets = I18n.t("gobierto_data.projects.sets")
-    this.labelQueries = I18n.t("gobierto_data.projects.queries")
-    this.labelCategories = I18n.t("gobierto_data.projects.categories")
-    this.labelshowAll = I18n.t("gobierto_data.projects.showAll")
-    this.labelshowLess = I18n.t("gobierto_data.projects.showLess")
     // TODO Datasets should be order in filter mixin
     this.sortedItems = this.items.sort(({ attributes: { name: a } = {} }, { attributes: { name: b } = {} }) => a.localeCompare(b));
 

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarDatasets.vue
@@ -35,15 +35,15 @@
           <div v-if="showToggle">
             <span
               v-if="showLess"
-                class="gobierto-data-sidebar-datasets-links-columns-see-more"
-                @click="showLess = false"
+              class="gobierto-data-sidebar-datasets-links-columns-see-more"
+              @click="showLess = false"
             >
               {{ labelshowAll }}
             </span>
             <span
               v-else
-                class="gobierto-data-sidebar-datasets-links-columns-see-more"
-                @click="showLess = true"
+              class="gobierto-data-sidebar-datasets-links-columns-see-more"
+              @click="showLess = true"
             >
               {{ labelshowLess }}
             </span>
@@ -56,6 +56,11 @@
 <script>
 export default {
   name: "SidebarDatasets",
+  filters: {
+    translateType: function(type) {
+      return I18n.t(`gobierto_data.data_type.${type}`)
+    }
+  },
   props: {
     items: {
       type: Array,
@@ -78,27 +83,6 @@ export default {
       showToggle: null,
     }
   },
-  created() {
-    this.labelSets = I18n.t("gobierto_data.projects.sets")
-    this.labelQueries = I18n.t("gobierto_data.projects.queries")
-    this.labelCategories = I18n.t("gobierto_data.projects.categories")
-    this.labelshowAll = I18n.t("gobierto_data.projects.showAll")
-    this.labelshowLess = I18n.t("gobierto_data.projects.showLess")
-    // TODO Datasets should be order in filter mixin
-    this.sortedItems = this.items.sort(({ attributes: { name: a } = {} }, { attributes: { name: b } = {} }) => a.localeCompare(b));
-
-    let { id } = this.$route.params
-    this.selectCurrentDataset(id)
-  },
-  watch: {
-    currentDatasetSlug: function(newSlug) {
-      this.showLess = true;
-      if (this.sortedItems.length) {
-        this.activeDatasetColumns = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === newSlug).attributes.columns || {}
-        this.showToggle = Object.keys(this.activeDatasetColumns).length > this.showMaxKeys
-      }
-    }
-  },
   computed: {
     activeDatasetVisibleColumns() {
       if (this.showLess && Object.keys(this.activeDatasetColumns).length) {
@@ -110,6 +94,27 @@ export default {
         return this.activeDatasetColumns;
       }
     }
+  },
+  watch: {
+    currentDatasetSlug: function(newSlug) {
+      this.showLess = true;
+      if (this.sortedItems.length && newSlug !== '') {
+        this.activeDatasetColumns = this.sortedItems.find(({ attributes: { slug } = {} }) => slug === newSlug).attributes.columns || {}
+        this.showToggle = Object.keys(this.activeDatasetColumns).length > this.showMaxKeys
+      }
+    }
+  },
+  created() {
+    this.labelSets = I18n.t("gobierto_data.projects.sets")
+    this.labelQueries = I18n.t("gobierto_data.projects.queries")
+    this.labelCategories = I18n.t("gobierto_data.projects.categories")
+    this.labelshowAll = I18n.t("gobierto_data.projects.showAll")
+    this.labelshowLess = I18n.t("gobierto_data.projects.showLess")
+    // TODO Datasets should be order in filter mixin
+    this.sortedItems = this.items.sort(({ attributes: { name: a } = {} }, { attributes: { name: b } = {} }) => a.localeCompare(b));
+
+    let { id } = this.$route.params
+    this.selectCurrentDataset(id)
   },
   methods: {
     selectCurrentDataset(selectedDatasetSlug) {
@@ -127,13 +132,8 @@ export default {
       if (slug !== this.currentDatasetSlug) {
         this.currentDatasetSlug = slug
       } else {
-        this.currentDatasetSlug = null
+        this.currentDatasetSlug = ''
       }
-    }
-  },
-  filters: {
-    translateType: function(type) {
-      return I18n.t(`gobierto_data.data_type.${type}`)
     }
   }
 };

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -51,13 +51,14 @@ ca:
       queryName: Nom consulta
       recents: Recents
       records: Registres
-      resetQuery: Restableix la consulta
-      resetViz: Restableix la Visualització
+      resetQuery: Restablir la consulta
+      resetViz: Restablir la Visualització
       resources: Recursos
       revert: Revertir
       runQuery: Executeu consulta
       save: Deseu
       saveViz: Deseu Visualització
+      savedQuery: Consulta desada
       sets: Conjunts
       showAll: Vegeu-ho tot
       showLess: Vegeu-ne menys

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -37,9 +37,9 @@ ca:
       queryName: Nom consulta
       recents: Recents
       records: Registres
-      resources: Recursos
       resetQuery: Restableix la consulta
       resetViz: Restableix la Visualització
+      resources: Recursos
       runQuery: Executeu consulta
       save: Deseu
       saveViz: Deseu Visualització
@@ -54,4 +54,5 @@ ca:
       visPrivate: Les teves visualitzacions
       visPublic: Totes
       visualizations: Visualitzacions
+      visualize: Visualitzar
       yourQueries: Les teves consultes

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -38,8 +38,11 @@ ca:
       recents: Recents
       records: Registres
       resources: Recursos
+      resetQuery: Restableix la consulta
+      resetViz: Restableix la Visualització
       runQuery: Executeu consulta
       save: Deseu
+      saveViz: Deseu Visualització
       sets: Conjunts
       showAll: Vegeu-ho tot
       showLess: Vegeu-ne menys

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -54,6 +54,7 @@ ca:
       resetQuery: Restableix la consulta
       resetViz: Restableix la Visualització
       resources: Recursos
+      revert: Revertir
       runQuery: Executeu consulta
       save: Deseu
       saveViz: Deseu Visualització

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -43,6 +43,7 @@ ca:
       guide: Guia per utilitzar l'editor SQL
       info: Informació
       modifiedQuery: Consulta modificada
+      modifiedVisualization: Visualització modificada
       news: Notícies
       private: Privat
       queries: Consultes

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -38,8 +38,11 @@ en:
       recents: Recents
       records: Records
       resources: Resources
+      resetQuery: Reset Query
+      resetViz: Reset Visualization
       runQuery: Run query
       save: Save
+      saveViz: Save Visualization
       sets: Sets
       showAll: Show all
       showLess: Show less

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -54,6 +54,7 @@ en:
       resetQuery: Reset Query
       resetViz: Reset Visualization
       resources: Resources
+      revert: Revert
       runQuery: Run query
       save: Save
       saveViz: Save Visualization

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -43,6 +43,7 @@ en:
       guide: Guide to using the SQL editor
       info: Information
       modifiedQuery: Modified Query
+      modifiedVisualization: Modified Visualization
       news: News
       private: Private
       queries: Queries

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -58,6 +58,7 @@ en:
       runQuery: Run query
       save: Save
       saveViz: Save Visualization
+      savedQuery: Saved query
       sets: Sets
       showAll: Show all
       showLess: Show less

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -37,9 +37,9 @@ en:
       queryName: Query name
       recents: Recents
       records: Records
-      resources: Resources
       resetQuery: Reset Query
       resetViz: Reset Visualization
+      resources: Resources
       runQuery: Run query
       save: Save
       saveViz: Save Visualization
@@ -54,4 +54,5 @@ en:
       visPrivate: Your visualizations
       visPublic: All
       visualizations: Visualizations
+      visualize: Visualize
       yourQueries: Your queries

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -38,6 +38,7 @@ es:
       recents: Recientes
       records: Registros
       resetQuery: Restablecer consulta
+      resetViz: Restablecer Visualización
       resources: Recursos
       runQuery: Ejecutar consulta
       save: Guardar

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -58,6 +58,7 @@ es:
       runQuery: Ejecutar consulta
       save: Guardar
       saveViz: Guardar Visualización
+      savedQuery: Consulta guardada
       sets: Conjuntos
       showAll: Ver todo
       showLess: Ver menos

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -54,6 +54,7 @@ es:
       resetQuery: Restablecer consulta
       resetViz: Restablecer Visualización
       resources: Recursos
+      revert: Revertir
       runQuery: Ejecutar consulta
       save: Guardar
       saveViz: Guardar Visualización

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -37,8 +37,8 @@ es:
       queryName: Nombre consulta
       recents: Recientes
       records: Registros
-      resources: Recursos
       resetQuery: Restablecer consulta
+      resources: Recursos
       runQuery: Ejecutar consulta
       save: Guardar
       saveViz: Guardar Visualización
@@ -53,4 +53,5 @@ es:
       visPrivate: Tus visualizaciones
       visPublic: Todas
       visualizations: Visualizaciones
+      visualize: Visualizar
       yourQueries: Tus consultas

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -43,6 +43,7 @@ es:
       guide: Guía para usar el editor SQL
       info: Información
       modifiedQuery: Consulta modificada
+      modifiedVisualization: Visualización modificada
       news: Noticias
       private: Privada
       queries: Consultas

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -38,8 +38,10 @@ es:
       recents: Recientes
       records: Registros
       resources: Recursos
+      resetQuery: Restablecer consulta
       runQuery: Ejecutar consulta
       save: Guardar
+      saveViz: Guardar Visualización
       sets: Conjuntos
       showAll: Ver todo
       showLess: Ver menos


### PR DESCRIPTION
Closes #2916 #2970


## :v: What does this PR do?

Include button for reset query from editor.
Include button for reset Visualization.

## :mag: How should this be manually tested?
Staging

Steps to reset query:

1. Edit the query on editor.
2. Click on the reset query button.
3. The default query will appear in the editor

Steps to reset saved query:

1. Load a saved query.
2. Edit the saved query on editor.
3. Click on the reset query button.
4. The saved query will appear in the editor.

Steps to reset Visualization:

1. Click on Visualize/Visualizar
2. Select a new type of Visuzaliton.
3. Saved Visualization and reset visualization buttons will appear, the Visualize button will disappear.
4. Click on the reset visualization button.
5. Perspective visualization changes to Grid, and Perspective menus shouldn't be seen.