### PR TITLE
2930 datasets performance response

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -165,7 +165,7 @@ module GobiertoData
 
         def cached_item_json
           Rails.cache.fetch("#{@item.cache_key}/show.json") do
-            query_result = execute_query @item.rails_model.all
+            query_result = execute_query @item.rails_model.all, include_stats: true
             {
               data: query_result.delete(:result),
               meta: query_result,
@@ -176,19 +176,19 @@ module GobiertoData
 
         def cached_item_download_json
           Rails.cache.fetch("#{@item.cache_key}/download.json") do
-            execute_query(@item.rails_model.all).fetch(:result, "").to_json
+            execute_query(@item.rails_model.all).to_json
           end
         end
 
         def cached_item_csv
           Rails.cache.fetch("#{@item.cache_key}/show.csv?#{csv_options_params.to_json}") do
-            csv_from_query_result(execute_query(@item.rails_model.all).fetch(:result, ""), csv_options_params)
+            csv_from_query_result(execute_query(@item.rails_model.all), csv_options_params)
           end
         end
 
         def cached_item_xlsx
           Rails.cache.fetch("#{@item.cache_key}/show.xlsx") do
-            xlsx_from_query_result(execute_query(@item.rails_model.all).fetch(:result, ""), name: @item.name).read
+            xlsx_from_query_result(execute_query(@item.rails_model.all), name: @item.name).read
           end
         end
 
@@ -200,8 +200,8 @@ module GobiertoData
           @item = base_relation.find_by!(slug: params[:slug])
         end
 
-        def execute_query(relation)
-          GobiertoData::Connection.execute_query(current_site, relation.to_sql, include_draft: valid_preview_token?)
+        def execute_query(relation, include_stats: false)
+          GobiertoData::Connection.execute_query(current_site, relation.to_sql, include_draft: valid_preview_token?, include_stats: include_stats)
         end
 
         def links(self_key = nil)

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -34,7 +34,7 @@ module GobiertoData
         # GET /api/v1/data/queries/1.xlsx
         def show
           find_item
-          query_result = @item.result(include_draft: valid_preview_token?)
+          query_result = @item.result(include_draft: valid_preview_token?, include_stats: request.format.json?)
           respond_to do |format|
             format.json do
               render(
@@ -49,11 +49,11 @@ module GobiertoData
             end
 
             format.csv do
-              render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+              render_csv(csv_from_query_result(query_result, csv_options_params))
             end
 
             format.xlsx do
-              send_data xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, filename: "#{@item.id}.xlsx"
+              send_data xlsx_from_query_result(query_result, name: @item.name).read, filename: "#{@item.id}.xlsx"
             end
           end
         end
@@ -67,15 +67,15 @@ module GobiertoData
           basename = @item.file_basename
           respond_to do |format|
             format.json do
-              send_download(query_result.fetch(:result, ""), :json, basename)
+              send_download(query_result, :json, basename)
             end
 
             format.csv do
-              send_download(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params), :csv, basename)
+              send_download(csv_from_query_result(query_result, csv_options_params), :csv, basename)
             end
 
             format.xlsx do
-              send_download(xlsx_from_query_result(query_result.fetch(:result, ""), name: @item.name).read, :xlsx, basename)
+              send_download(xlsx_from_query_result(query_result, name: @item.name).read, :xlsx, basename)
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -10,7 +10,7 @@ module GobiertoData
         # GET /api/v1/data.csv?sql=SELECT%20%2A%20FROM%20table_name
         # GET /api/v1/data.xlsx?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          query_result = execute_query(params[:sql] || {})
+          query_result = execute_query(params[:sql] || {}, include_stats: request.format.json? )
 
           if query_result.is_a?(Hash) && query_result.has_key?(:errors)
             render json: query_result, status: :bad_request, adapter: :json_api
@@ -21,11 +21,11 @@ module GobiertoData
               end
 
               format.csv do
-                render_csv(csv_from_query_result(query_result.fetch(:result, ""), csv_options_params))
+                render_csv(csv_from_query_result(query_result, csv_options_params))
               end
 
               format.xlsx do
-                send_data xlsx_from_query_result(query_result.fetch(:result, "")).read, filename: "data.xlsx"
+                send_data xlsx_from_query_result(query_result).read, filename: "data.xlsx"
               end
             end
           end
@@ -33,8 +33,8 @@ module GobiertoData
 
         private
 
-        def execute_query(sql)
-          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql), include_draft: valid_preview_token?)
+        def execute_query(sql, include_stats: false)
+          GobiertoData::Connection.execute_query(current_site, Arel.sql(sql), include_stats: include_stats, include_draft: valid_preview_token?)
         end
 
       end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -10,7 +10,7 @@ module GobiertoData
         # GET /api/v1/data.csv?sql=SELECT%20%2A%20FROM%20table_name
         # GET /api/v1/data.xlsx?sql=SELECT%20%2A%20FROM%20table_name
         def index
-          query_result = execute_query(params[:sql] || {}, include_stats: request.format.json? )
+          query_result = execute_query(params[:sql] || {}, include_stats: request.format.json?)
 
           if query_result.is_a?(Hash) && query_result.has_key?(:errors)
             render json: query_result, status: :bad_request, adapter: :json_api

--- a/app/forms/concerns/gobierto_data/has_sql_attribute.rb
+++ b/app/forms/concerns/gobierto_data/has_sql_attribute.rb
@@ -13,8 +13,8 @@ module GobiertoData
     def sql_validation
       return if site.blank? || sql.blank?
 
-      query_test = Connection.execute_query(site, "explain #{sql}", include_stats: false)
-      if query_test.has_key? :errors
+      query_test = Connection.execute_query(site, "explain #{sql}")
+      if query_test.is_a?(Hash) && query_test.has_key?(:errors)
         errors.add(:sql, query_test[:errors].map { |error| error[:sql] }.join("\n"))
       end
     end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -8,7 +8,7 @@ module GobiertoData
 
     class << self
 
-      def execute_query(site, query, include_stats: true, write: false, include_draft: false)
+      def execute_query(site, query, include_stats: false, write: false, include_draft: false)
         with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(write, include_draft)) do
           connection.execute("CREATE SCHEMA IF NOT EXISTS draft") if write
           connection.execute("SET search_path TO draft, public") if write || include_draft
@@ -23,6 +23,8 @@ module GobiertoData
           end
 
           execution = connection.execute(query) || null_query
+
+          return execution unless include_stats
 
           {
             result: execution,

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -78,14 +78,11 @@ module GobiertoData
       private
 
       def with_connection(db_conf, fallback: nil, connection_key: :read_db_config)
-        base_connection_config = connection_config
         return fallback if db_conf.nil?
 
         db_conf = db_conf[connection_key] if db_conf.has_key?(connection_key)
         establish_connection(db_conf)
         yield
-      ensure
-        establish_connection(base_connection_config)
       end
 
       def connection_key_from_options(write, include_draft)

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -101,7 +101,7 @@ module GobiertoData
 
     def table_schema
       table_columns = Connection.execute_query(site, "SELECT column_name, data_type FROM information_schema.COLUMNS WHERE table_name='#{table_name}'", write: true)
-      table_columns[:result].inject({}) do |schema, column|
+      table_columns.inject({}) do |schema, column|
         schema.update(column["column_name"] => { "original_name" => column["column_name"], "type" => column["data_type"] })
       end
     end

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -17,8 +17,8 @@ module GobiertoData
 
     delegate :site, :visibility_level, to: :dataset
 
-    def result(include_draft: false)
-      Connection.execute_query(site, sql, include_draft: include_draft)
+    def result(include_draft: false, include_stats: false)
+      Connection.execute_query(site, sql, include_draft: include_draft, include_stats: include_stats)
     end
 
     def file_basename

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -36,8 +36,9 @@ module GobiertoData
       {
         number_of_rows: ::GobiertoData::Connection.execute_query(
           object.site,
-          Arel.sql("SELECT COUNT(*) FROM #{object.table_name} LIMIT 1"), include_draft: true
-        ).dig(:result)&.first&.dig("count")
+          Arel.sql("SELECT COUNT(*) FROM #{object.table_name} LIMIT 1"),
+          include_draft: true
+        )&.first&.dig("count")
       }
     end
 

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -91,7 +91,7 @@ module GobiertoData
               assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
             end
 
-            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
             assert_equal 4, query_result[:rows]
             query_result[:result].first.each_value do |value|
               assert value.is_a? String
@@ -119,7 +119,7 @@ module GobiertoData
               assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
             end
 
-            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
             assert_equal 4, query_result[:rows]
 
             query_result[:result].first.each_key do |column_name|
@@ -157,7 +157,7 @@ module GobiertoData
               assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
             end
 
-            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
             assert_equal 1, query_result[:rows]
             query_result[:result].first.each_value do |value|
               assert value.is_a? String
@@ -194,7 +194,7 @@ module GobiertoData
               assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
             end
 
-            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
             assert_equal 5, query_result[:rows]
             query_result[:result].first.each_value do |value|
               assert value.is_a? String
@@ -233,7 +233,7 @@ module GobiertoData
               assert_equal multipart_form_params[:dataset][attribute], attributes[attribute]
             end
 
-            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset")
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
             assert_equal 5, query_result[:rows]
 
             schema = Dataset.find_by_slug(slug).send(:table_schema)

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -22,6 +22,13 @@ module GobiertoData
 
     def test_execute_query_with_module_enabled
       result = Connection.execute_query(site, "SELECT COUNT(*) AS test_count FROM users")
+      result = JSON.parse(result.to_json)
+
+      assert_equal [{ "test_count" => 7 }], result
+    end
+
+    def test_execute_query_including_stats
+      result = Connection.execute_query(site, "SELECT COUNT(*) AS test_count FROM users", include_stats: true)
       hash_result = JSON.parse(result.to_json)
 
       assert hash_result.has_key?("result")


### PR DESCRIPTION
Closes #2930


## :v: What does this PR do?

Make some changes to improve data response. The controller by default gets the result of the required queries using directly the connection pool.

The times generating csv from a remote server are better and improve as the number of csv rows is greater. For the query in https://github.com/PopulateTools/issues/issues/1008#issuecomment-621899116 these are the improvements 

| Limit | % of time saved for each csv generation (remote server) |
| ----- | ----- |
| 10 | 14.3% |
| 100 | 7.4% |
| 1000 | 17.5% |
| 10000 | 40.4% |

However for small queries the improvement is poor.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
