### PR TITLE
Download a query result and hide legends if user is not logged in

### DIFF
--- a/app/javascript/gobierto_data/lib/factories/download.js
+++ b/app/javascript/gobierto_data/lib/factories/download.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+// Data-endpoint factory to get/post/put/delete API data
+export const DownloadFilesFactoryMixin = {
+  methods: {
+    getFiles(url, name) {
+      return axios
+        .get(url, { responseType: 'blob' })
+        .then(response => {
+          const blob = new Blob([response.data], { type: 'text/plain' });
+          const link = document.createElement('a');
+          link.href = URL.createObjectURL(blob);
+          link.download = name;
+          link.click();
+          URL.revokeObjectURL(link.href);
+        })
+        .catch(console.error);
+    }
+  }
+};

--- a/app/javascript/gobierto_data/lib/factories/download.js
+++ b/app/javascript/gobierto_data/lib/factories/download.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-// Data-endpoint factory to get/post/put/delete API data
+// Factor to force download files in multiple formats
 export const DownloadFilesFactoryMixin = {
   methods: {
     getFiles(url, name) {

--- a/app/javascript/gobierto_data/lib/factories/download.js
+++ b/app/javascript/gobierto_data/lib/factories/download.js
@@ -7,11 +7,13 @@ const endPoint = `${baseUrl}/data.`;
 export const DownloadFilesFactoryMixin = {
   methods: {
     createObjectFormatsQuery(sql) {
-
       //Get the formats from API
       const keyFormats = Object.keys(this.arrayFormats)
-      //Convert all linebreaks from any SO(Windows: \r\n Linux: \n Older Macs: \r) to spaces.
-      const formatSQL = sql.replace(/[\r\n]+/gm, " ");
+
+      //Create an object to parse query, is the same method which use to run a query. If we don't do this we've to use regex and replace to encode URL with too hacks https://stackoverflow.com/a/32882427
+      const objectSql = { sql: sql }
+      let queryUrl = new URLSearchParams(objectSql);
+
       let datetime = new Date();
       const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
 
@@ -26,7 +28,7 @@ export const DownloadFilesFactoryMixin = {
       for (let i = 0; i < keyFormats.length; i++) {
         this.arrayFormatsQuery[i] = {
           label: keyFormats[i],
-          url: `${endPoint}${keyFormats[i]}?sql=${formatSQL}`,
+          url: `${endPoint}${keyFormats[i]}?${queryUrl.toString()}`,
           name: `${titleFile}_${date}.${keyFormats[i]}`
         };
       }

--- a/app/javascript/gobierto_data/lib/factories/download.js
+++ b/app/javascript/gobierto_data/lib/factories/download.js
@@ -1,8 +1,37 @@
+import { baseUrl } from '../commons.js';
 import axios from 'axios';
+
+const endPoint = `${baseUrl}/data.`;
 
 // Factor to force download files in multiple formats
 export const DownloadFilesFactoryMixin = {
   methods: {
+    createObjectFormatsQuery(sql) {
+
+      //Get the formats from API
+      const keyFormats = Object.keys(this.arrayFormats)
+      //Convert all linebreaks from any SO(Windows: \r\n Linux: \n Older Macs: \r) to spaces.
+      const formatSQL = sql.replace(/[\r\n]+/gm, " ");
+      let datetime = new Date();
+      const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
+
+      const {
+        params: {
+          id: titleFile
+        }
+      } = this.$route
+
+      this.titleFile = titleFile
+
+      for (let i = 0; i < keyFormats.length; i++) {
+        this.arrayFormatsQuery[i] = {
+          label: keyFormats[i],
+          url: `${endPoint}${keyFormats[i]}?sql=${formatSQL}`,
+          name: `${titleFile}_${date}.${keyFormats[i]}`
+        };
+      }
+
+    },
     getFiles(url, name) {
       return axios
         .get(url, { responseType: 'blob' })

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -233,8 +233,6 @@ export default {
       queriesPromises.push(this.getPrivateQueries(userId));
     }
 
-      console.log("created -> !userId", !userId)
-      console.log("created -> userId.length", userId.length)
     if (!userId || userId.length === 0) {
       this.isUserLogged = false
     } else {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -35,6 +35,7 @@
       :array-formats="arrayFormats"
       :resources-list="resourcesList"
       :dataset-attributes="attributes"
+      :user-is-not-logged="userIsNotLogged"
     />
 
     <DataTab
@@ -57,17 +58,20 @@
       :enabled-saved-button="enabledSavedButton"
       :show-revert-query="showRevertQuery"
       :show-private="showPrivate"
+      :user-is-not-logged="userIsNotLogged"
     />
 
     <QueriesTab
       v-else-if="activeDatasetTab === 2"
       :private-queries="privateQueries"
       :public-queries="publicQueries"
+      :user-is-not-logged="userIsNotLogged"
     />
 
     <VisualizationsTab
       v-else-if="activeDatasetTab === 3"
       :dataset-id="datasetId"
+      :user-is-not-logged="userIsNotLogged"
     />
 
     <DownloadsTab
@@ -145,7 +149,8 @@ export default {
       showRevertQuery: false,
       queryName: null,
       queryDuration: 0,
-      queryError: null
+      queryError: null,
+      userIsNotLogged: false
     };
   },
   computed: {
@@ -226,6 +231,8 @@ export default {
     if (userId) {
       // Do not request private queries if the user is not logged
       queriesPromises.push(this.getPrivateQueries(userId));
+    } else {
+      this.userIsNotLogged = true
     }
 
     // In order to update from the url, we need both public and private queries

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -233,6 +233,8 @@ export default {
       queriesPromises.push(this.getPrivateQueries(userId));
     }
 
+      console.log("created -> !userId", !userId)
+      console.log("created -> userId.length", userId.length)
     if (!userId || userId.length === 0) {
       this.isUserLogged = false
     } else {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -35,7 +35,7 @@
       :array-formats="arrayFormats"
       :resources-list="resourcesList"
       :dataset-attributes="attributes"
-      :user-is-not-logged="userIsNotLogged"
+      :is-user-logged="isUserLogged"
     />
 
     <DataTab
@@ -58,20 +58,20 @@
       :enabled-saved-button="enabledSavedButton"
       :show-revert-query="showRevertQuery"
       :show-private="showPrivate"
-      :user-is-not-logged="userIsNotLogged"
+      :is-user-logged="isUserLogged"
     />
 
     <QueriesTab
       v-else-if="activeDatasetTab === 2"
       :private-queries="privateQueries"
       :public-queries="publicQueries"
-      :user-is-not-logged="userIsNotLogged"
+      :is-user-logged="isUserLogged"
     />
 
     <VisualizationsTab
       v-else-if="activeDatasetTab === 3"
       :dataset-id="datasetId"
-      :user-is-not-logged="userIsNotLogged"
+      :is-user-logged="isUserLogged"
     />
 
     <DownloadsTab
@@ -150,7 +150,7 @@ export default {
       queryName: null,
       queryDuration: 0,
       queryError: null,
-      userIsNotLogged: false
+      isUserLogged: false
     };
   },
   computed: {
@@ -231,8 +231,12 @@ export default {
     if (userId) {
       // Do not request private queries if the user is not logged
       queriesPromises.push(this.getPrivateQueries(userId));
+    }
+
+    if (!userId || userId.length === 0) {
+      this.isUserLogged = false
     } else {
-      this.userIsNotLogged = true
+      this.isUserLogged = true
     }
 
     // In order to update from the url, we need both public and private queries

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -235,11 +235,7 @@ export default {
       queriesPromises.push(this.getPrivateQueries(userId));
     }
 
-    if (!userId || userId.length === 0) {
-      this.isUserLogged = false
-    } else {
-      this.isUserLogged = true
-    }
+    this.isUserLogged = !!(userId && userId.length)
 
     // In order to update from the url, we need both public and private queries
     const [publicResponse, privateResponse] = await Promise.all(

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -102,12 +102,13 @@ export default {
       this.isHidden = true
     },
     createObjectFormatsQuery(sql) {
+      //Convert all linebreaks from any SO(Windows: \r\n Linux: \n Older Macs: \r) to spaces.
+      const formatSQL = sql.replace(/[\r\n]+/gm, " ");
       let datetime = new Date();
       const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
-      const queryCode = new URLSearchParams(sql)
-      const endPointCSV = `${baseUrl}/data.csv?sql=${queryCode.toString()}&csv_separator=semicolon`
-      const endPointJSON = `${baseUrl}/data.json?sql=${queryCode.toString()}`
-      const endPointXLSX = `${baseUrl}/data.xlsx?sql=${queryCode.toString()}`
+      const endPointCSV = `${baseUrl}/data.csv?sql=${formatSQL}&csv_separator=semicolon`
+      const endPointJSON = `${baseUrl}/data.json?sql=${formatSQL}`
+      const endPointXLSX = `${baseUrl}/data.xlsx?sql=${formatSQL}`
 
       const {
         params: {

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -42,10 +42,8 @@
             >
               <a
                 :key="index"
-                :href="url"
-                :download="name"
                 class="gobierto-data-btn-download-data-modal-element"
-                target="_blank"
+                @click.prevent="getFiles(url, name)"
               >
                 {{ label }}
               </a>
@@ -59,12 +57,14 @@
 <script>
 import Button from "./Button.vue";
 import { baseUrl, CommonsMixin } from "./../../../lib/commons.js";
+import { DownloadFilesFactoryMixin } from "./../../../lib/factories/download";
+
 export default {
   name: 'DownloadButton',
   components: {
     Button
   },
-  mixins: [CommonsMixin],
+  mixins: [CommonsMixin, DownloadFilesFactoryMixin],
   props: {
     editor: {
       type: Boolean,
@@ -131,7 +131,7 @@ export default {
         {
           label: 'XLSX',
           url: endPointXLSX,
-          name: 'prueban_xls'
+          name: `${titleFile}_${date}.xls`
         }
       ]
     }

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -56,7 +56,7 @@
 </template>
 <script>
 import Button from "./Button.vue";
-import { baseUrl, CommonsMixin } from "./../../../lib/commons.js";
+import { CommonsMixin } from "./../../../lib/commons.js";
 import { DownloadFilesFactoryMixin } from "./../../../lib/factories/download";
 
 export default {

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -22,7 +22,7 @@
               v-for="(item, key, index) in arrayFormats"
             >
               <a
-                :key="index"
+                :key="key"
                 :href="item"
                 :download="titleFile"
                 class="gobierto-data-btn-download-data-modal-element"
@@ -41,7 +41,7 @@
               v-for="({ url, name, label }, index) in arrayFormatsQuery"
             >
               <a
-                :key="index"
+                :key="key"
                 class="gobierto-data-btn-download-data-modal-element"
                 @click.prevent="getFiles(url, name)"
               >

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -102,10 +102,12 @@ export default {
       this.isHidden = true
     },
     createObjectFormatsQuery(sql) {
-      const queryTrim = sql.trim()
-      const endPointCSV = `${baseUrl}/data.csv?sql=${queryTrim}&csv_separator=semicolon`
-      const endPointJSON = `${baseUrl}/data.json?sql=${queryTrim}`
-      const endPointXLSX = `${baseUrl}/data.xlsx?sql=${queryTrim}`
+      let datetime = new Date();
+      const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
+      const queryCode = new URLSearchParams(sql)
+      const endPointCSV = `${baseUrl}/data.csv?sql=${queryCode.toString()}&csv_separator=semicolon`
+      const endPointJSON = `${baseUrl}/data.json?sql=${queryCode.toString()}`
+      const endPointXLSX = `${baseUrl}/data.xlsx?sql=${queryCode.toString()}`
 
       const {
         params: {
@@ -119,17 +121,17 @@ export default {
         {
           label: 'CSV',
           url: endPointCSV,
-          name: `${titleFile}.csv`
+          name: `${titleFile}_${date}.csv`
         },
         {
           label: 'JSON',
           url: endPointJSON,
-          name: `${titleFile}.json`
+          name: `${titleFile}_${date}.json`
         },
         {
           label: 'XLSX',
           url: endPointXLSX,
-          name: `${titleFile}.xlsx`
+          name: 'prueban_xls'
         }
       ]
     }

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -13,24 +13,45 @@
         name="fade"
         mode="out-in"
       >
-        <div
-          v-show="!isHidden"
-          class="gobierto-data-btn-download-data-modal"
-        >
-          <template
-            v-for="(item, key, index) in arrayFormats"
+        <template v-if="!editor">
+          <div
+            v-show="!isHidden"
+            class="gobierto-data-btn-download-data-modal"
           >
-            <a
-              :key="index"
-              :item="item"
-              :href="editor ? sqlfileCSV : item"
-              :download="titleDataset"
-              class="gobierto-data-btn-download-data-modal-element"
+            <template
+              v-for="(item, key, index) in arrayFormats"
             >
-              {{ key }}
-            </a>
-          </template>
-        </div>
+              <a
+                :key="index"
+                :href="item"
+                :download="titleFile"
+                class="gobierto-data-btn-download-data-modal-element"
+              >
+                {{ key }}
+              </a>
+            </template>
+          </div>
+        </template>
+        <template v-else>
+          <div
+            v-show="!isHidden"
+            class="gobierto-data-btn-download-data-modal"
+          >
+            <template
+              v-for="({ url, name, label }, index) in arrayFormatsQuery"
+            >
+              <a
+                :key="index"
+                :href="url"
+                :download="name"
+                class="gobierto-data-btn-download-data-modal-element"
+                target="_blank"
+              >
+                {{ label }}
+              </a>
+            </template>
+          </div>
+        </template>
       </transition>
     </Button>
   </div>
@@ -52,32 +73,65 @@ export default {
     arrayFormats: {
       type: Object,
       required: true
-    }
+    },
+    queryStored: {
+      type: String,
+      default: ""
+    },
   },
   data() {
     return {
-      labelDownloadData: "",
+      labelDownloadData: I18n.t("gobierto_data.projects.downloadData") || "",
       isHidden: true,
-      sqlfileCSV: '',
-      sqlfileXLSX: '',
-      sqlfileJSON: '',
-      titleDataset: ''
+      arrayFormatsQuery: {},
+      titleFile: ''
+    }
+  },
+  watch: {
+    queryStored(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.createObjectFormatsQuery(newValue)
+      }
     }
   },
   created() {
-    this.labelDownloadData = I18n.t("gobierto_data.projects.downloadData")
+    this.createObjectFormatsQuery(this.queryStored)
   },
   methods: {
     closeMenu() {
       this.isHidden = true
     },
-    updateCode(sqlQuery) {
-      // TODO: this method do nothing
-      const code = sqlQuery
-      const endPointSQL = `${baseUrl}/data.csv?sql=`
-      this.sqlfileCSV = `${endPointSQL}${code}&csv_separator=semicolon`
-      this.sqlfileXLSX = `${endPointSQL}${code}`
-      this.sqlfileJSON = `${endPointSQL}${code}`
+    createObjectFormatsQuery(sql) {
+      const queryTrim = sql.trim()
+      const endPointCSV = `${baseUrl}/data.csv?sql=${queryTrim}&csv_separator=semicolon`
+      const endPointJSON = `${baseUrl}/data.json?sql=${queryTrim}`
+      const endPointXLSX = `${baseUrl}/data.xlsx?sql=${queryTrim}`
+
+      const {
+        params: {
+          id: titleFile
+        }
+      } = this.$route
+
+      this.titleFile = titleFile
+
+      this.arrayFormatsQuery = [
+        {
+          label: 'CSV',
+          url: endPointCSV,
+          name: `${titleFile}.csv`
+        },
+        {
+          label: 'JSON',
+          url: endPointJSON,
+          name: `${titleFile}.json`
+        },
+        {
+          label: 'XLSX',
+          url: endPointXLSX,
+          name: `${titleFile}.xlsx`
+        }
+      ]
     }
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -100,31 +100,6 @@ export default {
   methods: {
     closeMenu() {
       this.isHidden = true
-    },
-    createObjectFormatsQuery(sql) {
-
-      //Get the formats from API
-      const keyFomarts = Object.keys(this.arrayFormats)
-      //Convert all linebreaks from any SO(Windows: \r\n Linux: \n Older Macs: \r) to spaces.
-      const formatSQL = sql.replace(/[\r\n]+/gm, " ");
-      let datetime = new Date();
-      const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
-
-      const {
-        params: {
-          id: titleFile
-        }
-      } = this.$route
-
-      this.titleFile = titleFile
-
-      for (let i = 0; i < keyFomarts.length; i++) {
-        this.arrayFormatsQuery[i] = {
-          label: keyFomarts[i],
-          url: `${baseUrl}/data.${keyFomarts[i]}?sql=${formatSQL}`,
-          name: `${titleFile}_${date}.${keyFomarts[i]}`
-        };
-      }
     }
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -19,7 +19,7 @@
             class="gobierto-data-btn-download-data-modal"
           >
             <template
-              v-for="(item, key, index) in arrayFormats"
+              v-for="(item, key) in arrayFormats"
             >
               <a
                 :key="key"
@@ -38,7 +38,7 @@
             class="gobierto-data-btn-download-data-modal"
           >
             <template
-              v-for="({ url, name, label }, index) in arrayFormatsQuery"
+              v-for="({ url, name, label }, key) in arrayFormatsQuery"
             >
               <a
                 :key="key"
@@ -102,13 +102,13 @@ export default {
       this.isHidden = true
     },
     createObjectFormatsQuery(sql) {
+
+      //Get the formats from API
+      const keyFomarts = Object.keys(this.arrayFormats)
       //Convert all linebreaks from any SO(Windows: \r\n Linux: \n Older Macs: \r) to spaces.
       const formatSQL = sql.replace(/[\r\n]+/gm, " ");
       let datetime = new Date();
       const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
-      const endPointCSV = `${baseUrl}/data.csv?sql=${formatSQL}&csv_separator=semicolon`
-      const endPointJSON = `${baseUrl}/data.json?sql=${formatSQL}`
-      const endPointXLSX = `${baseUrl}/data.xlsx?sql=${formatSQL}`
 
       const {
         params: {
@@ -118,23 +118,13 @@ export default {
 
       this.titleFile = titleFile
 
-      this.arrayFormatsQuery = [
-        {
-          label: 'CSV',
-          url: endPointCSV,
-          name: `${titleFile}_${date}.csv`
-        },
-        {
-          label: 'JSON',
-          url: endPointJSON,
-          name: `${titleFile}_${date}.json`
-        },
-        {
-          label: 'XLSX',
-          url: endPointXLSX,
-          name: `${titleFile}_${date}.xls`
-        }
-      ]
+      for (let i = 0; i < keyFomarts.length; i++) {
+        this.arrayFormatsQuery[i] = {
+          label: keyFomarts[i],
+          url: `${baseUrl}/data.${keyFomarts[i]}?sql=${formatSQL}`,
+          name: `${titleFile}_${date}.${keyFomarts[i]}`
+        };
+      }
     }
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -57,61 +57,6 @@
             <!-- TODO: Favorite Queries -->
             <div />
           </Dropdown>
-          <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
-            <template v-slot:trigger>
-              <h3 class="gobierto-data-summary-queries-panel-title">
-                <Caret :rotate="showPrivateQueries" />
-
-                {{ labelYourQueries }} ({{ privateQueries.length }})
-              </h3>
-            </template>
-
-            <div>
-              <transition-group name="fade">
-                <div
-                  v-for="{ id, attributes: { sql, name, privacy_status }} in privateQueries"
-                  :key="id"
-                  class="gobierto-data-summary-queries-container"
-                  @mouseover="showSQLCode(sql)"
-                  @mouseleave="removeSQLCode()"
-                >
-                  <router-link
-                    :to="`/datos/${$route.params.id}/q/${id}`"
-                    class="gobierto-data-summary-queries-container-name"
-                  >
-                    {{ name }}
-                  </router-link>
-
-                  <div class="gobierto-data-summary-queries-container-icon">
-                    <i
-                      class="fas fa-trash-alt icons-your-queries"
-                      style="color: var(--color-base);"
-                      @click.stop="clickDeleteQueryHandler(id)"
-                    />
-
-                    <PrivateIcon
-                      :is-closed="privacy_status === 'closed'"
-                      class="icons-your-queries"
-                    />
-                  </div>
-                </div>
-              </transition-group>
-            </div>
-          </Dropdown>
-
-          <Dropdown @is-content-visible="showFavQueries = !showFavQueries">
-            <template v-slot:trigger>
-              <h3 class="gobierto-data-summary-queries-panel-title">
-                <Caret :rotate="showFavQueries" />
-
-                <!-- TODO: Favorite Queries -->
-                {{ labelFavs }} ({{ 0 }})
-              </h3>
-            </template>
-
-            <!-- TODO: Favorite Queries -->
-            <div />
-          </Dropdown>
         </template>
 
         <Dropdown @is-content-visible="showPublicQueries = !showPublicQueries">

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -2,61 +2,119 @@
   <div class="gobierto-data-summary-queries">
     <div class="gobierto-data-summary-queries-panel pure-g">
       <div class="pure-u-1-2 gobierto-data-summary-queries-panel-dropdown">
-        <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
-          <template v-slot:trigger>
-            <h3 class="gobierto-data-summary-queries-panel-title">
-              <Caret :rotate="showPrivateQueries" />
+        <template v-if="userIsNotLogged">
+          <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
+            <template v-slot:trigger>
+              <h3 class="gobierto-data-summary-queries-panel-title">
+                <Caret :rotate="showPrivateQueries" />
 
-              {{ labelYourQueries }} ({{ privateQueries.length }})
-            </h3>
-          </template>
+                {{ labelYourQueries }} ({{ privateQueries.length }})
+              </h3>
+            </template>
 
-          <div>
-            <transition-group name="fade">
-              <div
-                v-for="{ id, attributes: { sql, name, privacy_status }} in privateQueries"
-                :key="id"
-                class="gobierto-data-summary-queries-container"
-                @mouseover="showSQLCode(sql)"
-                @mouseleave="removeSQLCode()"
-              >
-                <router-link
-                  :to="`/datos/${$route.params.id}/q/${id}`"
-                  class="gobierto-data-summary-queries-container-name"
+            <div>
+              <transition-group name="fade">
+                <div
+                  v-for="{ id, attributes: { sql, name, privacy_status }} in privateQueries"
+                  :key="id"
+                  class="gobierto-data-summary-queries-container"
+                  @mouseover="showSQLCode(sql)"
+                  @mouseleave="removeSQLCode()"
                 >
-                  {{ name }}
-                </router-link>
+                  <router-link
+                    :to="`/datos/${$route.params.id}/q/${id}`"
+                    class="gobierto-data-summary-queries-container-name"
+                  >
+                    {{ name }}
+                  </router-link>
 
-                <div class="gobierto-data-summary-queries-container-icon">
-                  <i
-                    class="fas fa-trash-alt icons-your-queries"
-                    style="color: var(--color-base);"
-                    @click.stop="clickDeleteQueryHandler(id)"
-                  />
+                  <div class="gobierto-data-summary-queries-container-icon">
+                    <i
+                      class="fas fa-trash-alt icons-your-queries"
+                      style="color: var(--color-base);"
+                      @click.stop="clickDeleteQueryHandler(id)"
+                    />
 
-                  <PrivateIcon
-                    :is-closed="privacy_status === 'closed'"
-                    class="icons-your-queries"
-                  />
+                    <PrivateIcon
+                      :is-closed="privacy_status === 'closed'"
+                      class="icons-your-queries"
+                    />
+                  </div>
                 </div>
-              </div>
-            </transition-group>
-          </div>
-        </Dropdown>
+              </transition-group>
+            </div>
+          </Dropdown>
 
-        <Dropdown @is-content-visible="showFavQueries = !showFavQueries">
-          <template v-slot:trigger>
-            <h3 class="gobierto-data-summary-queries-panel-title">
-              <Caret :rotate="showFavQueries" />
+          <Dropdown @is-content-visible="showFavQueries = !showFavQueries">
+            <template v-slot:trigger>
+              <h3 class="gobierto-data-summary-queries-panel-title">
+                <Caret :rotate="showFavQueries" />
 
-              <!-- TODO: Favorite Queries -->
-              {{ labelFavs }} ({{ 0 }})
-            </h3>
-          </template>
+                <!-- TODO: Favorite Queries -->
+                {{ labelFavs }} ({{ 0 }})
+              </h3>
+            </template>
 
-          <!-- TODO: Favorite Queries -->
-          <div />
-        </Dropdown>
+            <!-- TODO: Favorite Queries -->
+            <div />
+          </Dropdown>
+
+            <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
+            <template v-slot:trigger>
+              <h3 class="gobierto-data-summary-queries-panel-title">
+                <Caret :rotate="showPrivateQueries" />
+
+                {{ labelYourQueries }} ({{ privateQueries.length }})
+              </h3>
+            </template>
+
+            <div>
+              <transition-group name="fade">
+                <div
+                  v-for="{ id, attributes: { sql, name, privacy_status }} in privateQueries"
+                  :key="id"
+                  class="gobierto-data-summary-queries-container"
+                  @mouseover="showSQLCode(sql)"
+                  @mouseleave="removeSQLCode()"
+                >
+                  <router-link
+                    :to="`/datos/${$route.params.id}/q/${id}`"
+                    class="gobierto-data-summary-queries-container-name"
+                  >
+                    {{ name }}
+                  </router-link>
+
+                  <div class="gobierto-data-summary-queries-container-icon">
+                    <i
+                      class="fas fa-trash-alt icons-your-queries"
+                      style="color: var(--color-base);"
+                      @click.stop="clickDeleteQueryHandler(id)"
+                    />
+
+                    <PrivateIcon
+                      :is-closed="privacy_status === 'closed'"
+                      class="icons-your-queries"
+                    />
+                  </div>
+                </div>
+              </transition-group>
+            </div>
+          </Dropdown>
+
+          <Dropdown @is-content-visible="showFavQueries = !showFavQueries">
+            <template v-slot:trigger>
+              <h3 class="gobierto-data-summary-queries-panel-title">
+                <Caret :rotate="showFavQueries" />
+
+                <!-- TODO: Favorite Queries -->
+                {{ labelFavs }} ({{ 0 }})
+              </h3>
+            </template>
+
+            <!-- TODO: Favorite Queries -->
+            <div />
+          </Dropdown>
+        </template>
 
         <Dropdown @is-content-visible="showPublicQueries = !showPublicQueries">
           <template v-slot:trigger>
@@ -116,6 +174,10 @@ export default {
     publicQueries: {
       type: Array,
       required: true
+    },
+    userIsNotLogged: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -2,12 +2,11 @@
   <div class="gobierto-data-summary-queries">
     <div class="gobierto-data-summary-queries-panel pure-g">
       <div class="pure-u-1-2 gobierto-data-summary-queries-panel-dropdown">
-        <template v-if="userIsNotLogged">
+        <template v-if="isUserLogged">
           <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
             <template v-slot:trigger>
               <h3 class="gobierto-data-summary-queries-panel-title">
                 <Caret :rotate="showPrivateQueries" />
-
                 {{ labelYourQueries }} ({{ privateQueries.length }})
               </h3>
             </template>
@@ -58,8 +57,7 @@
             <!-- TODO: Favorite Queries -->
             <div />
           </Dropdown>
-
-            <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
+          <Dropdown @is-content-visible="showPrivateQueries = !showPrivateQueries">
             <template v-slot:trigger>
               <h3 class="gobierto-data-summary-queries-panel-title">
                 <Caret :rotate="showPrivateQueries" />
@@ -175,7 +173,7 @@ export default {
       type: Array,
       required: true
     },
-    userIsNotLogged: {
+    isUserLogged: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -13,7 +13,7 @@
         :enabled-saved-button="enabledSavedButton"
         :show-revert-query="showRevertQuery"
         :show-private="showPrivate"
-        :user-is-not-logged="userIsNotLogged"
+        :is-user-logged="isUserLogged"
       />
       <SQLEditorCode
         :array-columns="arrayColumns"
@@ -114,6 +114,10 @@ export default {
       default: false
     },
     isQuerySaved: {
+      type: Boolean,
+      default: false
+    },
+    isUserLogged: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -24,6 +24,7 @@
         v-if="items.length"
         :array-formats="arrayFormats"
         :array-columns-query="arrayColumnsQuery"
+        :query-stored="queryStored"
         :items="items"
       />
     </div>

--- a/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/DataTab.vue
@@ -13,6 +13,7 @@
         :enabled-saved-button="enabledSavedButton"
         :show-revert-query="showRevertQuery"
         :show-private="showPrivate"
+        :user-is-not-logged="userIsNotLogged"
       />
       <SQLEditorCode
         :array-columns="arrayColumns"

--- a/app/javascript/gobierto_data/webapp/components/sets/QueriesTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/QueriesTab.vue
@@ -3,6 +3,7 @@
     <Queries
       :private-queries="privateQueries"
       :public-queries="publicQueries"
+      :is-user-logged="isUserLogged"
     />
   </div>
 </template>
@@ -23,6 +24,10 @@ export default {
       type: Array,
       required: true
     },
+    isUserLogged: {
+      type: Boolean,
+      default: false
+    }
   }
 }
 </script>

--- a/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
@@ -17,7 +17,7 @@
     <Queries
       :private-queries="privateQueries"
       :public-queries="publicQueries"
-      :user-is-not-logged="userIsNotLogged"
+      :is-user-logged="isUserLogged"
     />
   </div>
 </template>
@@ -62,7 +62,7 @@ export default {
       required: true,
       default: () => [],
     },
-    userIsNotLogged: {
+    isUserLogged: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
@@ -17,6 +17,7 @@
     <Queries
       :private-queries="privateQueries"
       :public-queries="publicQueries"
+      :user-is-not-logged="userIsNotLogged"
     />
   </div>
 </template>
@@ -61,6 +62,10 @@ export default {
       required: true,
       default: () => [],
     },
+    userIsNotLogged: {
+      type: Boolean,
+      default: false
+    }
   },
   data() {
     return {

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="gobierto-data-sets-nav--tab-container">
-    <template v-if="isUserLoggged">
+    <template v-if="isUserLogged">
       <Dropdown @is-content-visible="showPrivateVis = !showPrivateVis">
         <template v-slot:trigger>
           <h3 class="gobierto-data-visualization--h3">
@@ -129,6 +129,10 @@ export default {
     datasetId: {
       type: Number,
       required: true
+    },
+    isUserLogged: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -138,7 +142,6 @@ export default {
       labelVisPublic: I18n.t("gobierto_data.projects.visPublic") || "",
       publicVisualizations: [],
       privateVisualizations: [],
-      isUserLoggged: false,
       isPrivateLoading: false,
       isPublicLoading: false,
       showPrivateVis: true,
@@ -147,7 +150,6 @@ export default {
   },
   created() {
     this.userId = getUserId();
-    this.isUserLoggged = !!this.userId;
 
     // Get all visualizations
     this.getPrivateVisualizations();

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -50,6 +50,10 @@ export default {
     queryError: {
       type: String,
       default: null
+    },
+    tableName: {
+      type: String,
+      default: ''
     }
   },
   data() {
@@ -59,7 +63,8 @@ export default {
       labelRecords: I18n.t("gobierto_data.projects.records") || "",
       sqlAutocomplete: sqlKeywords,
       arrayMutated: [],
-      autoCompleteKeys: []
+      autoCompleteKeys: [],
+      tableNameAutocomplete: []
     };
   },
   computed: {
@@ -75,8 +80,6 @@ export default {
     }
   },
   mounted() {
-    this.mergeTables();
-
     const cmOption = {
       tabSize: 2,
       styleActiveLine: false,
@@ -107,32 +110,55 @@ export default {
     // metaKey + keyUp doesn't work with MacOS
     // https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser
     this.editor.on("keydown", this.onKeyDown);
+    // This event detects any changes in the editor
+    this.editor.on("change", this.onChange);
+    // We need this event to enable autocomplete(hint)
+    this.editor.on("keyup", this.onKeyUp);
   },
   methods: {
+    onKeyUp(editor, e) {
+      const {
+        state: {
+          completionActive: isEditorActive
+        }
+      } = editor
+
+      // Show autocomplete only when a letter key is pressed
+      if (!isEditorActive && e.keyCode > 64 && e.keyCode < 91) {
+        editor.showHint({ completeSingle: false })
+      }
+
+      this.$root.$emit('enableSavedButton')
+      this.$root.$emit('enabledForkPrompt')
+    },
+    onChange(editor) {
+      this.mergeTables();
+      const value = editor.getValue();
+      this.$root.$emit("setCurrentQuery", value);
+    },
     onKeyDown(editor, e) {
+      this.mergeTables();
       // keyUp event to stop "c|r" open modals, but allow ctrl+enter (or cmd+enter) to run query
       if (!((e.keyCode == 10 || e.keyCode == 13) && (e.ctrlKey || e.metaKey))) {
         e.stopPropagation();
       }
-
-      // keydown needs to wait a little to update the value
-      setTimeout(() => {
-        editor.showHint();
-        const value = editor.getValue();
-
-        // update the query while typing
-        this.$root.$emit("setCurrentQuery", value);
-        this.$root.$emit('enableSavedButton')
-      }, 50);
     },
     mergeTables() {
-      for (let i = 0; i < this.arrayColumns.length; i++) {
+      const sizeArrayColumns = Object.keys(this.arrayColumns);
+
+      for (let i = 0; i < sizeArrayColumns.length; i++) {
         this.arrayMutated[i] = {
           className: "table",
-          text: this.arrayColumns[i]
+          text: sizeArrayColumns[i]
         };
       }
-      this.autoCompleteKeys = [...this.arrayMutated, ...this.sqlAutocomplete];
+      this.autoCompleteKeys = [
+        ...this.arrayMutated,
+        ...this.sqlAutocomplete,
+        {
+          className: "dataset",
+          text: this.tableName
+      }];
     },
     setEditorValue(newCode) {
       const pos = this.editor.getCursor();

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -128,6 +128,7 @@ export default {
         editor.showHint({ completeSingle: false })
       }
 
+      // Enabled saved and fork button while typping on editor
       this.$root.$emit('enableSavedButton')
       this.$root.$emit('enabledForkPrompt')
     },

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -55,6 +55,7 @@
           v-if="isQueriesModalActive"
           :private-queries="privateQueries"
           :public-queries="publicQueries"
+
           class="gobierto-data-sets-nav--tab-container gobierto-data-sql-editor-your-queries-container arrow-top"
         />
       </transition>
@@ -148,6 +149,10 @@ export default {
       default: false
     },
     isQuerySaved: {
+      type: Boolean,
+      default: false
+    },
+    userIsNotLogged: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorHeader.vue
@@ -55,7 +55,7 @@
           v-if="isQueriesModalActive"
           :private-queries="privateQueries"
           :public-queries="publicQueries"
-
+          :is-user-logged="isUserLogged"
           class="gobierto-data-sets-nav--tab-container gobierto-data-sql-editor-your-queries-container arrow-top"
         />
       </transition>
@@ -152,7 +152,7 @@ export default {
       type: Boolean,
       default: false
     },
-    userIsNotLogged: {
+    isUserLogged: {
       type: Boolean,
       default: false
     }

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -46,6 +46,7 @@
       >
         <DownloadButton
           :editor="true"
+          :query-stored="queryStored"
           :array-formats="arrayFormats"
           class="arrow-top modal-right"
         />
@@ -91,6 +92,10 @@ export default {
     items: {
       type: String,
       default: ''
+    },
+    queryStored: {
+      type: String,
+      default: ""
     }
   },
   data() {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1015
https://github.com/PopulateTools/issues/issues/959


## :v: What does this PR do?

Now you can download a file for any query in format CSV, JSON and XLSX.
Hide legends(your queries, favorites, your visualizations) if the user is not logged in.


## :mag: How should this be manually tested?

Staging


**Download files:**
![download 2020-05-07 17_05_56](https://user-images.githubusercontent.com/2649175/81311409-a61a1a00-9085-11ea-918c-5c98067202a6.gif)

**Hide legends:**
![hide-legends 2020-05-07 17_09_45](https://user-images.githubusercontent.com/2649175/81311396-a31f2980-9085-11ea-9df4-1515a0d882f3.gif)

