### PR TITLE
Upgrade rake version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,8 @@ gem "font-awesome-sass", "~> 5.6"
 gem "webpacker", "~> 5.0"
 
 # Elasticsearch
-gem "elasticsearch"
-gem "elasticsearch-extensions"
+gem "elasticsearch", "~> 6.0", ">= 6.0.2"
+gem "elasticsearch-extensions", "~> 0.0.27"
 
 # Background processing
 gem "sidekiq", "~> 5.2.7"

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "sidekiq", "~> 5.2.7"
 gem "sidekiq-monitor-stats"
 
 # AWS SDK client
-gem "aws-sdk", "~> 2.6", require: false
+gem "aws-sdk-s3", "~> 1"
 
 # AWS SES client
 gem "aws-ses", "~> 0.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "ruby_px"
 gem "before_renders"
 gem "bootsnap"
 gem "truncate_html"
+gem "rake", "~> 13.0"
 
 # Frontend
 gem "bourbon", "~> 7.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 970d544dba508108a4c84b7991993c35c906613e
+  revision: 6292904905333bd36d4597e6b50bf2c617cfa5ac
   specs:
     gobierto_data (0.1.0)
-      actionpack (>= 5.0.0.1)
-      activesupport (>= 5.0.0)
-      aws-sdk (~> 2.11, >= 2.11.45)
+      actionpack
+      activesupport
+      aws-sdk-s3
       elasticsearch (~> 6.0, >= 6.0.2)
       elasticsearch-extensions (~> 0.0.27)
       ine-places (~> 0.3.0)
-      oj (~> 3.5, >= 3.5.0)
-      rake (~> 12.3.2)
+      oj (~> 3.6)
+      rake (~> 13.0)
 
 GEM
   remote: https://rubygems.org/
@@ -78,13 +78,19 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.1.0)
-    aws-sdk (2.11.495)
-      aws-sdk-resources (= 2.11.495)
-    aws-sdk-core (2.11.495)
-      aws-sigv4 (~> 1.0)
+    aws-partitions (1.312.0)
+    aws-sdk-core (3.95.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.495)
-      aws-sdk-core (= 2.11.495)
+    aws-sdk-kms (1.31.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.64.0)
+      aws-sdk-core (~> 3, >= 3.83.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
     aws-ses (0.6.0)
       builder
       mail (> 2.2.5)
@@ -301,7 +307,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     ntlm-http (0.1.1)
-    oj (3.9.2)
+    oj (3.10.6)
     os (1.1.0)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
@@ -356,7 +362,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.3)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -502,7 +508,7 @@ DEPENDENCIES
   actionpack-action_caching
   active_model_serializers
   algoliasearch-rails (~> 1.17)
-  aws-sdk (~> 2.6)
+  aws-sdk-s3 (~> 1)
   aws-ses (~> 0.6.0)
   bcrypt (~> 3.1.0)
   before_renders
@@ -555,6 +561,7 @@ DEPENDENCIES
   rails (~> 5.2.4)
   rails-html-sanitizer
   rails_performance
+  rake (~> 13.0)
   rb-readline
   redcarpet
   redis (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,8 +523,8 @@ DEPENDENCIES
   cookies_eu
   d3-rails (~> 4.8)
   dalli
-  elasticsearch
-  elasticsearch-extensions
+  elasticsearch (~> 6.0, >= 6.0.2)
+  elasticsearch-extensions (~> 0.0.27)
   exchanger
   flight-for-rails
   font-awesome-sass (~> 5.6)

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "aws-sdk"
+require "aws-sdk-s3"
 
 module FileUploader
   class S3

--- a/test/integration/gobierto_admin/site_update_test.rb
+++ b/test/integration/gobierto_admin/site_update_test.rb
@@ -198,7 +198,15 @@ YAML
         visit admin_root_path
 
         click_link "Customize site"
-        click_button "Update"
+
+        within "form.edit_site" do
+          # Force the site to be published to avoid a flaky test issue
+          within ".widget_save" do
+            choose "Published"
+          end
+
+          click_button "Update"
+        end
 
         assert has_content? "Site was successfully updated"
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -122,7 +122,7 @@ class ActionDispatch::IntegrationTest
   Capybara.configure do |config|
     config.javascript_driver = (ENV["INTEGRATION_TEST_DRIVER"] || :headless_chrome).to_sym
     config.default_host = "http://gobierto.test"
-    config.default_max_wait_time = 3
+    config.default_max_wait_time = 10
   end
 
   self.use_transactional_tests = true


### PR DESCRIPTION
## :v: What does this PR do?

- Upgrades rake version to 13.x which removes all the warnings from Ruby 2.7

- Uses the new modularization of aws-sdk gem, which allows you to load the services you are going to use (s3 in our case) and reduce the size of the loaded dependencies

- Freezes elasticsearch client gem versions, because version 7 seems to be incompatible

- Fixes #3042 and Fixes #3036 

## :mag: How should this be manually tested?

Tests should pass and you shouldn't see rake warnings if you open a console.
