### PR TITLE
3004 table custom fields from csv

### DIFF
--- a/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
@@ -3,7 +3,7 @@
 module GobiertoAdmin
   module GobiertoPlans
     class PlanTableCustomFieldsForm < BaseForm
-      REQUIRED_COLUMNS = %w(Node.Title external_id custom_field).freeze
+      REQUIRED_COLUMNS = %w(external_id custom_field).freeze
       TRANSFORMATIONS = {
         text: ->(data) { data.to_s },
         integer: ->(data) { data. to_i },
@@ -53,7 +53,7 @@ module GobiertoAdmin
         errors.add(:base, :file_not_found) unless csv_file.present?
         errors.add(:base, :invalid_format) unless csv_file_content
 
-        unless !csv_file_content || (REQUIRED_COLUMNS - csv_file_content.headers).blank? && csv_file_content.headers.any? { |header| /col_\d+/.match?(header) }
+        if !csv_file_content || (REQUIRED_COLUMNS - csv_file_content.headers).present? || csv_file_content.headers.none? { |header| /col_\d+/.match?(header) }
           errors.add(:base, :invalid_columns)
         end
       end

--- a/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoPlans
+    class PlanTableCustomFieldsForm < BaseForm
+      REQUIRED_COLUMNS = %w(Node.Title external_id custom_field).freeze
+      TRANSFORMATIONS = {
+        text: ->(data) { data.to_s },
+        integer: ->(data) { data. to_i },
+        float: ->(data) { data.to_f },
+        date: ->(data) { Date.parse(data) }
+      }.with_indifferent_access.freeze
+
+      attr_accessor(
+        :plan,
+        :csv_file
+      )
+
+      validates :plan, :csv_file, presence: true
+      validate :csv_file_format
+
+      def initialize(options = {})
+        super(options)
+
+        tables_definitions
+      end
+
+      def save
+        save_table_custom_fields_data if valid?
+      end
+
+      private
+
+      def tables_definitions
+        @tables_definitions ||=
+          ::GobiertoCommon::CustomFieldRecordsForm.new(instance: plan, item: plan.nodes.new).available_custom_fields.plugin.inject({}) do |definitions, custom_field|
+            next definitions unless custom_field.configuration.plugin_type == "table"
+
+            definitions.update(
+              custom_field.uid => custom_field.configuration["plugin_configuration"]["columns"]
+            )
+          end
+      end
+
+      def save_table_custom_fields_data
+        ActiveRecord::Base.transaction do
+          import_table_custom_fields
+          @plan.touch
+        end
+      end
+
+      def csv_file_format
+        errors.add(:base, :file_not_found) unless csv_file.present?
+        errors.add(:base, :invalid_format) unless csv_file_content
+
+        unless !csv_file_content || (REQUIRED_COLUMNS - csv_file_content.headers).blank? && csv_file_content.headers.any? { |header| /col_\d+/.match?(header) }
+          errors.add(:base, :invalid_columns)
+        end
+      end
+
+      def import_table_custom_fields
+        nodes_data = csv_file_content.inject({}) do |hash, row|
+          hash.update(row["external_id"] => (hash[row["external_id"]] || []) << row)
+        end
+
+        nodes_data.each_pair do |external_id, rows|
+          next unless (node = plan.nodes.find_by_external_id external_id).present?
+
+          custom_field_records_values = {}
+
+          rows.each do |row|
+            uid = row["custom_field"].parameterize.tr("_", "-")
+            next unless (transformed_row = transform_row(row, uid)).present?
+
+            (custom_field_records_values[uid] ||= []) << transformed_row
+          end
+
+          custom_fields_form = ::GobiertoCommon::CustomFieldRecordsForm.new(
+            site_id: @plan.site.id,
+            item: node,
+            instance: @plan,
+            with_version: true,
+            version_index: 0
+          )
+          custom_fields_form.custom_field_records = custom_field_records_values
+          if custom_fields_form.changed?
+            custom_fields_form.force_new_version = true
+            node.touch
+            publish_if_required node
+          end
+          custom_fields_form.save
+        end
+      end
+
+      def transform_row(row, uid)
+        return unless (config = tables_definitions[uid]).present?
+
+        col_names = config.map { |col| col.fetch("id") }
+        transformations = config.map { |col| TRANSFORMATIONS[col.fetch("type")] }
+        raw_values = row.to_h.select { |header, _| /col_\d+/.match?(header) }.values
+        transformed_values = transformations.zip(raw_values).map { |(function, value)| value.presence && function.call(value) }
+        col_names.zip(transformed_values).to_h
+      end
+
+      def save_custom_fields(row_decorator)
+        node = row_decorator.node
+
+        custom_fields_form = ::GobiertoCommon::CustomFieldRecordsForm.new(
+          site_id: @plan.site.id,
+          item: node,
+          instance: @plan,
+          with_version: true,
+          version_index: 0
+        )
+
+        custom_fields_form.custom_field_records = row_decorator.custom_field_records_values
+        if custom_fields_form.changed?
+          custom_fields_form.force_new_version = true
+          node.touch
+        end
+
+        custom_fields_form.save
+      end
+
+      def col_sep
+        separators = [",", ";"]
+        first_line = csv_file.open.first
+        separators.max do |a, b|
+          first_line.split(a).count <=> first_line.split(b).count
+        end
+      end
+
+      def csv_file_content
+        @csv_file_content ||= begin
+                                ::CSV.read(csv_file.open, headers: true, col_sep: col_sep)
+                              rescue ArgumentError, CSV::MalformedCSVError
+                                false
+                              end
+      end
+
+      def publish_if_required(node)
+        return unless @plan.publish_last_version_automatically?
+
+        node.published!
+        node.update_attribute(:published_version, node.versions.count)
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
@@ -7,7 +7,7 @@ module GobiertoAdmin
       TRANSFORMATIONS = {
         text: ->(data) { data.to_s },
         integer: ->(data) { data. to_i },
-        float: ->(data) { data.to_f },
+        float: ->(data) { ::GobiertoCommon::CustomFieldValue::Numeric.parse_float(data) },
         date: ->(data) { Date.parse(data) }
       }.with_indifferent_access.freeze
 

--- a/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
@@ -97,7 +97,7 @@ module GobiertoAdmin
 
         col_names = config.map { |col| col.fetch("id") }
         transformations = config.map { |col| TRANSFORMATIONS[col.fetch("type")] }
-        raw_values = row.to_h.select { |header, _| /col_\d+/.match?(header) }.values
+        raw_values = row.to_h.select { |header, _| /col_\d+/i.match?(header) }.values
         transformed_values = transformations.zip(raw_values).map { |(function, value)| value.presence && function.call(value) }
         col_names.zip(transformed_values).to_h
       end

--- a/app/models/gobierto_common/custom_field_value/numeric.rb
+++ b/app/models/gobierto_common/custom_field_value/numeric.rb
@@ -4,12 +4,18 @@ module GobiertoCommon::CustomFieldValue
   class Numeric < Base
     def value=(value)
       if custom_field
-        record.payload = { custom_field.uid => value.blank? ? nil : value.to_f }
+        record.payload = { custom_field.uid => value.blank? ? nil : self.class.parse_float(value) }
       end
     end
 
     def value_string
       raw_value.to_s
+    end
+
+    def self.parse_float(value)
+      return value.to_f if value.is_a? ::Numeric
+
+      value.to_s.tr(",", value.count(".") > 0 || value.count(",") > 1 ? "" : ".").to_f
     end
   end
 end

--- a/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
@@ -1,4 +1,5 @@
 <%= render "gobierto_admin/shared/validation_errors", resource: @plan_data_form %>
+<%= render "gobierto_admin/shared/validation_errors", resource: @plan_table_custom_fields_form %>
 
 <%= form_for(@plan_data_form, as: :plan, url: admin_plans_plan_import_data_path(@plan), method: :patch, html: { multipart: true }) do |f| %>
   <div class="pure-g">

--- a/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/_import_csv_form.html.erb
@@ -12,12 +12,27 @@
         <p><%= t(".more_info_html", url: "https://gobierto.readme.io/docs/planes#section-importar-datos-de-un-plan") %></p>
       <% else %>
         <p><%= t(".more_info_html", url: "https://gobierto.readme.io/docs/planes#section-importar-datos-de-un-plan") %></p>
+
+        <h3> <%= t(".plan_content") %></h3>
         <div class="form_item file_field">
           <%= f.label :csv_file %>
           <%= f.file_field :csv_file %>
         </div>
         <%= f.submit t(".submit"), class: "button", data: { disable_with: t(".disable_with"), confirm: t(".confirm_import") } %>
       <% end %>
+    </div>
+  </div>
+<% end %>
+<div class="separator"></div>
+<%= form_for(@plan_table_custom_fields_form, as: :file, url: admin_plans_plan_import_table_custom_fields_path(@plan), method: :patch, html: { multipart: true }) do |f| %>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-md-16-24">
+      <h3> <%= t(".custom_fields_table_plugin") %></h3>
+      <div class="form_item file_field">
+        <%= f.label :csv_file %>
+        <%= f.file_field :csv_file %>
+      </div>
+      <%= f.submit t(".submit"), class: "button", data: { disable_with: t(".disable_with"), confirm: t(".confirm_import") } %>
     </div>
   </div>
 <% end %>

--- a/config/locales/gobierto_admin/gobierto_plans/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/ca.yml
@@ -45,3 +45,9 @@ ca:
                 vocabulari '%{vocabulary}' usat per la columna 'Node.%{uid}'
               used_resource: El vocabulari empra termes que s'usen en altres parts
                 de l'aplicació
+        gobierto_admin/gobierto_plans/plan_table_custom_fields_form:
+          attributes:
+            base:
+              file_not_found: Fitxer no trobat
+              invalid_columns: No estan totes les columnes necessàries
+              invalid_format: Format de fitxer invàlid

--- a/config/locales/gobierto_admin/gobierto_plans/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/en.yml
@@ -45,3 +45,9 @@ en:
                 '%{vocabulary}' used by the column 'Node.%{uid}'
               used_resource: The vocabulary contains terms used in other parts of
                 the application
+        gobierto_admin/gobierto_plans/plan_table_custom_fields_form:
+          attributes:
+            base:
+              file_not_found: File not found
+              invalid_columns: Required columns are missing
+              invalid_format: Invalid file format

--- a/config/locales/gobierto_admin/gobierto_plans/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/es.yml
@@ -46,3 +46,9 @@ es:
                 el vocabulario '%{vocabulary}' usado por la columna 'Node.%{uid}'
               used_resource: El vocabulario emplea términos que se usan en otras partes
                 de la aplicación
+        gobierto_admin/gobierto_plans/plan_table_custom_fields_form:
+          attributes:
+            base:
+              file_not_found: Fichero no encontrado
+              invalid_columns: No están todas las columnas necesarias
+              invalid_format: Formato de fichero inválido

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -58,9 +58,11 @@ ca:
           title: Importa CSV
         import_csv_form:
           confirm_import: Estàs segur?
+          custom_fields_table_plugin: Camps personalitzats (plugin de taula)
           disable_with: Carregant...
           more_info_html: Per obtenir més informació visita la documentació <a href="%{url}"
             target="_blank">Importar datos de un plan</a>.
+          plan_content: Contingut del pla
           submit: Importa des de fitxer CSV
           vocabulary_used_by_other_plans: El vocabulari configurat per aquest pla
             ja està configurat per a algun altre. Si us plau, crea un vocabulari nou

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -56,9 +56,11 @@ en:
           title: Import CSV
         import_csv_form:
           confirm_import: Are you sure?
+          custom_fields_table_plugin: Custom fields (table plugin)
           disable_with: Loading...
           more_info_html: For more information, visit the documentation <a href="%{url}"
             target="_blank">Importar datos de un plan</a>.
+          plan_content: Plan content
           submit: Import from CSV file
           vocabulary_used_by_other_plans: The vocabulary configured for this plan
             is already configured for someone else. Please create a new vocabulary

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -58,9 +58,11 @@ es:
           title: Importar CSV
         import_csv_form:
           confirm_import: "¿Estás seguro?"
+          custom_fields_table_plugin: Campos personalizados (plugin de tabla)
           disable_with: Cargando...
           more_info_html: Para obtener más información visita la documentación de
             cómo <a href="%{url}" target="_blank">Importar datos de un plan</a>.
+          plan_content: Contenido del plan
           submit: Importar desde fichero CSV
           vocabulary_used_by_other_plans: El vocabulario configurado para este plan
             ya está configurado para algún otro. Por favor, crea un vocabulario nuevo

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -23,7 +23,8 @@ ca:
           contracts: Contracts
           summary: Resum
           tenders: Licitacions
-        permalink: Consulteu aquest contracte a la Plataforma de Contractació del Sector Públic
+        permalink: Consulteu aquest contracte a la Plataforma de Contractació del
+          Sector Públic
         process_type: Tipus de procés
         status: Estat
         submission_date: Data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,7 @@ Rails.application.routes.draw do
           delete :delete_contents
           put :recover
           patch :import_data
+          patch :import_table_custom_fields
         end
         resources :plan_types, except: [:show], path: :plan_types do
           put :recover

--- a/test/fixtures/files/gobierto_plans/table_custom_fields.csv
+++ b/test/fixtures/files/gobierto_plans/table_custom_fields.csv
@@ -1,0 +1,8 @@
+Node.Title,external_id,custom_field,col_1,col_2,col_3,col_4
+Basic needs of District Center families,2,indicators-table,,45,23,2020
+Scholarships for families in the Central District,1,indicators-table,,45,23,2020
+Scholarships for families in the Central District,1,directory,Miguel Pérez,999999999,miguel@example.org,1980-01-01
+Scholarships for families in the Central District,1,directory,,222222222,marina@example.org,1980-06-01
+Basic needs of District Center families,2,directory,Alberto Díaz,,alberto@example.org,1977-10-01
+Basic needs of District Center families,2,directory,María González,666666666,maria@example.org,1994-04-04
+Basic needs of District Center families,2,directory,Felipe López,111111111,felipe@example.org,1995-05-11

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -159,7 +159,7 @@ political_agendas_indicators_table_custom_field_record:
   item: political_agendas (GobiertoPlans::Node)
   custom_field: madrid_custom_field_indicators_table_plugin
   payload: <%= {
-    indicators_table: [
+    "indicators-table" => [
       {
         indicator: ActiveRecord::FixtureSet.identify(:indicators_raw_savings),
         objective: 100,

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -387,7 +387,7 @@ madrid_custom_field_indicators_table_plugin:
   position: 9
   name_translations: <%= { en: "Indicator (table)", es: "Indicador (tabla)" }.to_json %>
   field_type: <%= GobiertoCommon::CustomField.field_types[:plugin] %>
-  uid: indicators_table
+  uid: indicators-table
   options: <%= {
     configuration: {
       plugin_type: "table",

--- a/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
@@ -25,6 +25,18 @@ module GobiertoAdmin
         @site ||= sites(:madrid)
       end
 
+      def node
+        @node ||= gobierto_plans_nodes(:scholarships_kindergartens)
+      end
+
+      def table_custom_field_indicators
+        @table_custom_field_indicators ||= gobierto_common_custom_fields(:madrid_custom_field_indicators_table_plugin)
+      end
+
+      def table_custom_field_directory
+        @table_custom_field_directory ||= gobierto_common_custom_fields(:madrid_custom_field_table_plugin)
+      end
+
       def vocabulary_used_in_other_context
         @vocabulary_used_in_other_context ||= gobierto_common_vocabularies(:issues_vocabulary)
       end
@@ -40,7 +52,7 @@ module GobiertoAdmin
 
             click_link "Import from CSV"
 
-            within "form" do
+            within "form.new_plan" do
               click_button "Import from CSV file"
             end
 
@@ -57,7 +69,7 @@ module GobiertoAdmin
           click_link "Import from CSV"
 
           attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan2.csv")
-          within "form" do
+          within "form.new_plan" do
             with_stubbed_s3_file_upload do
               click_button "Import from CSV file"
             end
@@ -87,7 +99,7 @@ module GobiertoAdmin
           click_link "Import from CSV"
 
           attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan2.csv")
-          within "form" do
+          within "form.new_plan" do
             with_stubbed_s3_file_upload do
               click_button "Import from CSV file"
             end
@@ -131,7 +143,7 @@ module GobiertoAdmin
             click_link "Import from CSV"
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan2.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -154,7 +166,7 @@ module GobiertoAdmin
             click_link "Import from CSV"
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan2.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -177,7 +189,7 @@ module GobiertoAdmin
             click_link "Import from CSV"
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan_blank_statuses.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -187,6 +199,38 @@ module GobiertoAdmin
               assert has_content? "Data imported successfully"
             end
           end
+        end
+      end
+
+      def test_import_csv_table_custom_fields
+        with(site: site, admin: admin) do
+          visit path
+
+          click_link "Import from CSV"
+
+          attach_file "file_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/table_custom_fields.csv")
+          within "form.new_file" do
+            with_stubbed_s3_file_upload do
+              click_button "Import from CSV file"
+            end
+          end
+
+          within ".flash-message", match: :first do
+            assert has_content? "Data imported successfully"
+          end
+
+          imported_directory = node.custom_field_records.find_by(custom_field: table_custom_field_directory).value
+
+          assert_equal 2, imported_directory.count
+          assert_equal "miguel@example.org", imported_directory.first["email"]
+          assert_equal 999_999_999, imported_directory.first["phone_number"]
+
+          imported_indicators = node.custom_field_records.find_by(custom_field: table_custom_field_indicators).value
+
+          assert_equal 1, imported_indicators.count
+          assert_equal 45.0, imported_indicators.first["objective"]
+          assert_equal 23.0, imported_indicators.first["value_reached"]
+          assert_equal "2020", imported_indicators.first["date"]
         end
       end
 
@@ -201,7 +245,7 @@ module GobiertoAdmin
             click_link "Import from CSV"
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -249,8 +293,10 @@ module GobiertoAdmin
 
             click_link "Import from CSV"
 
-            assert has_content? "The vocabulary configured for this plan is already configured for someone else"
-            assert has_no_button? "Import from CSV file"
+            within "form.new_plan" do
+              assert has_content? "The vocabulary configured for this plan is already configured for someone else"
+              assert has_no_button? "Import from CSV file"
+            end
           end
         end
       end
@@ -265,7 +311,7 @@ module GobiertoAdmin
             click_link "Import from CSV"
 
             attach_file("plan_csv_file", "test/fixtures/files/gobierto_plans/plan.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -287,7 +333,7 @@ module GobiertoAdmin
             click_link "Import from CSV"
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -302,7 +348,7 @@ module GobiertoAdmin
             assert_equal 1, node.published_version
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end
@@ -317,7 +363,7 @@ module GobiertoAdmin
             assert_equal 1, node.published_version
 
             attach_file "plan_csv_file", Rails.root.join("test/fixtures/files/gobierto_plans/plan_updated.csv")
-            within "form" do
+            within "form.new_plan" do
               with_stubbed_s3_file_upload do
                 click_button "Import from CSV file"
               end

--- a/test/models/gobierto_common/custom_field_value/numeric_test.rb
+++ b/test/models/gobierto_common/custom_field_value/numeric_test.rb
@@ -40,5 +40,41 @@ module GobiertoCommon::CustomFieldValue
       assert_equal 0.0, record.value
     end
 
+    def test_value_assign_string_with_only_a_comma
+      record.value = "1,56"
+      record.save
+
+      record.reload
+
+      assert_equal 1.56, record.value
+    end
+
+    def test_value_assign_string_with_more_than_a_comma
+      record.value = "1,000,000"
+      record.save
+
+      record.reload
+
+      assert_equal 1000000.0, record.value
+    end
+
+    def test_value_assign_string_with_comma_and_dot
+      record.value = "1,000.78"
+      record.save
+
+      record.reload
+
+      assert_equal 1000.78, record.value
+    end
+
+    def test_value_assign_integer
+      record.value = 25
+      record.save
+
+      record.reload
+
+      assert_equal 25.0, record.value
+    end
+
   end
 end


### PR DESCRIPTION
Closes #3004


## :v: What does this PR do?

Allows admins to upload custom field from a CSV according to description of the related issue

## :mag: How should this be manually tested?

The CSV of the example in the issue has been uploaded after creating a custom field of type table with `campo-indicadores` uid and configuration:

```json
{
  "columns": [
    {
      "id": "name",
      "type": "text",
      "name_translations": {
        "ca": "Nom",
        "en": "Name",
        "es": "Nombre"
      }
    },
    {
      "id": "value",
      "type": "text",
      "name_translations": {
        "ca": "Valor",
        "en": "Value",
        "es": "Valor"
      }
    },
    {
      "id": "description",
      "type": "text",
      "name_translations": {
        "ca": "Descripció",
        "en": "Description",
        "es": "Descripción"
      }
    },
    {
      "id": "other",
      "type": "text",
      "name_translations": {
        "ca": "Otro texto",
        "en": "Other text",
        "es": "Otro texto"
      }
    }
  ]
}
```

The value field can be configured as type float, but some values as `0,5` would be converted to 0 and `10%` to 10

## :eyes: Screenshots

### Before this PR

🚫 

### After this PR

![3004_after](https://user-images.githubusercontent.com/446459/81851214-65287680-9559-11ea-8e2b-6ec7ae1c7d8f.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Pending
