### PR TITLE
Horizontal bars in dashboards summary page

### DIFF
--- a/app/assets/stylesheets/module-dashboards.scss
+++ b/app/assets/stylesheets/module-dashboards.scss
@@ -178,10 +178,6 @@
         }
       }
 
-      &:not(:first-child) {
-        white-space: nowrap;
-      }
-
       &:not(:first-child):not(:last-child) > *::first-letter {
         text-transform: uppercase;
       }

--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -4,6 +4,7 @@ import crossfilter from 'crossfilter2'
 import moment from 'moment'
 import { d3locale } from 'lib/shared'
 import 'jsgrid'
+import { AmountDistributionBars } from "lib/visualizations/modules/amount_distribution_bars.js";
 
 window.GobiertoBudgets.InvoicesController = (function() {
 

--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -4,7 +4,7 @@ import crossfilter from 'crossfilter2'
 import moment from 'moment'
 import { d3locale } from 'lib/shared'
 import 'jsgrid'
-import { AmountDistributionBars } from "lib/visualizations/modules/amount_distribution_bars.js";
+import { AmountDistributionBars } from "lib/visualizations";
 
 window.GobiertoBudgets.InvoicesController = (function() {
 

--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -444,121 +444,18 @@ window.GobiertoBudgets.InvoicesController = (function() {
   }
 
   function _renderByAmountsChart() {
-    // Declaration
-    var hbars2 = dc.rowChart("#hbars2", "group");
+    const amounts = ndx.dimension(contract => contract.range);
 
-    // Dimensions
-    var amounts = ndx.dimension(function(d) {
-        return d.range
-      }),
-      amountByInvoices = amounts.group().reduceCount();
+    const renderOptions = {
+      containerSelector: "#hbars2",
+      dimension: amounts,
+      range: _r,
+      labelMore: I18n.t('gobierto_budgets.invoices.show.more'),
+      labelFromTo: I18n.t('gobierto_budgets.invoices.show.fromto'),
+      onFilteredFunction: (chart) => this._refreshFromCharts(amounts.top(Infinity))
+    }
 
-    // Styling
-    var _count = amountByInvoices.size(),
-      _gap = 10,
-      _barHeight = 18,
-      _labelOffset = 195;
-
-    const node = hbars2.root().node() || document.createElement("div")
-
-    hbars2
-      .width((node.parentNode || node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
-      .height(hbars2.margins().top + hbars2.margins().bottom + (_count * _barHeight) + ((_count + 1) * _gap)) // Margins top/bottom + bars + gaps (space between)
-      .fixedBarHeight(_barHeight)
-      .x(d3.scaleThreshold())
-      .dimension(amounts)
-      .group(amountByInvoices)
-      .ordering(function(d) {
-        return d.key
-      })
-      .labelOffsetX(-_labelOffset)
-      .gap(_gap)
-      .elasticX(true)
-      .title(function(d) { return d.value })
-      .on('pretransition', function(chart){
-        // Apply rounded corners AFTER render, otherwise they don't exist
-        chart.selectAll('rect').attr("rx", 4).attr("ry", 4);
-
-        // edit labels positions
-        chart.selectAll('text.row')
-          .text('')
-          .selectAll('tspan')
-          .data(d => {
-            // helper
-            function intervalFormat(d) {
-              var n = Number(_r.domain[d.key])
-              var _s = Number(_r.domain[d.key - 1]) || 1;
-
-              // Last value is not a range
-              if (d.key === _r.domain.length) {
-                return [I18n.t('gobierto_budgets.invoices.show.more') + " " + (_s - 1).toLocaleString(I18n.locale, {
-                  style: 'currency',
-                  currency: 'EUR',
-                  minimumFractionDigits: 0
-                })]
-              }
-
-              var _l = Number(n - 1);
-
-              return [_s, _l].map(n => n.toLocaleString(I18n.locale, {
-                style: 'currency',
-                currency: 'EUR',
-                minimumFractionDigits: 0
-              }))
-            }
-
-            return intervalFormat(d)
-          })
-          .enter()
-          .append('tspan')
-          .text(d => d)
-          .attr('x', (d, i) => i === 0 ? -_labelOffset : -_labelOffset / 2)
-
-        chart.select('g.axis')
-          .attr('transform', 'translate(0,0)')
-          .append('text')
-          .attr('class', 'axis-title')
-          .attr('y', -9) // Default
-          .selectAll('text')
-          .data(() => {
-            // helper
-            function titleFormat(str) {
-              str = str.split(' ')
-              if (str.length !== 4) throw new Error()
-
-              var last = [str[2], str[3]].join(' ')
-              return [str[0], str[1], last]
-            }
-
-            return titleFormat(I18n.t('gobierto_budgets.invoices.show.fromto'));
-          })
-          .enter()
-          .append('tspan')
-          .text(d => d)
-          .attr('x', (d, i) => (i === 0) ? -_labelOffset : (i === 1) ? -_labelOffset / 2 : 0)
-          .attr('text-anchor', (d, i) => (i === 2) ? 'middle' : '')
-
-        chart.selectAll('g.axis line.grid-line').attr("y2", function() {
-          return Math.abs(+d3.select(this).attr("y2")) + (chart.margins().top / 2)
-        });
-      })
-      .on('filtered', function(){
-        _refreshFromCharts(amounts.top(Infinity));
-      });
-
-    // Customize
-    hbars2.xAxis(d3.axisTop().ticks(5))
-    hbars2.xAxis().tickFormat(
-      function(tick, pos) {
-        if (pos === 0) return null
-        return tick
-      });
-    hbars2.margins().top = 20;
-    hbars2.margins().left = _labelOffset + 5;
-    hbars2.margins().right = 0;
-
-    // Render
-    hbars2.render();
+    new AmountDistributionBars(renderOptions);
   }
 
   function _renderTableFilter() {

--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -453,7 +453,7 @@ window.GobiertoBudgets.InvoicesController = (function() {
       range: _r,
       labelMore: I18n.t('gobierto_budgets.invoices.show.more'),
       labelFromTo: I18n.t('gobierto_budgets.invoices.show.fromto'),
-      onFilteredFunction: (chart) => this._refreshFromCharts(amounts.top(Infinity))
+      onFilteredFunction: (chart) => _refreshFromCharts(amounts.top(Infinity))
     }
 
     new AmountDistributionBars(renderOptions);

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -32,9 +32,7 @@ export class ContractsController {
     if (entryPoint) {
       const htmlRouterBlock = `
         <keep-alive>
-          <transition name="fade" mode="out-in">
-            <router-view :key="$route.fullPath"></router-view>
-          </transition>
+          <router-view :key="$route.fullPath"></router-view>
         </keep-alive>
       `;
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -194,7 +194,8 @@ export class ContractsController {
     document.getElementById("median-contracts").innerText = money(medianContracts);
 
     document.getElementById("mean-savings").innerText = meanSavings.toLocaleString(I18n.locale, {
-      style: 'percent'
+      style: 'percent',
+      minimumFractionDigits: 2
     });
     document.getElementById("less-than-1000-pct").innerText = lessThan1000Pct.toLocaleString(I18n.locale, {
       style: 'percent'

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -9,10 +9,10 @@ import crossfilter from 'crossfilter2'
 
 import { getRemoteData } from '../webapp/lib/get_remote_data'
 import { EventBus } from '../webapp/mixins/event_bus'
-import { money } from 'lib/shared/modules/vue-filters'
+import { money } from 'lib/shared'
 
-import { AmountDistributionBars } from "lib/visualizations/modules/amount_distribution_bars.js";
-import { GroupPctDistributionBars } from "lib/visualizations/modules/group_pct_distribution_bars.js";
+import { AmountDistributionBars } from "lib/visualizations";
+import { GroupPctDistributionBars } from "lib/visualizations";
 
 Vue.use(VueRouter);
 Vue.config.productionTip = false;

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -1,7 +1,8 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
 
-import { scaleThreshold, sum, mean, median, max } from 'd3';
+import { sum, mean, median, max } from 'd3-array';
+import { scaleThreshold } from 'd3-scale';
 const d3 = { scaleThreshold, sum, mean, median, max }
 
 import crossfilter from 'crossfilter2'
@@ -9,9 +10,6 @@ import crossfilter from 'crossfilter2'
 import { getRemoteData } from '../webapp/lib/get_remote_data'
 import { EventBus } from '../webapp/mixins/event_bus'
 import { money } from 'lib/shared/modules/vue-filters'
-import { sum, mean, median, max } from 'd3-array';
-
-const d3 = { sum, mean, median, max }
 
 import { AmountDistributionBars } from "lib/visualizations/modules/amount_distribution_bars.js";
 import { GroupPctDistributionBars } from "lib/visualizations/modules/group_pct_distribution_bars.js";

--- a/app/javascript/gobierto_dashboards/webapp/components/Table.vue
+++ b/app/javascript/gobierto_dashboards/webapp/components/Table.vue
@@ -9,19 +9,13 @@
           <div>{{ translation }}</div>
         </th>
       </thead>
-      <transition-group
-        name="fade"
-        tag="tbody"
-        mode="out-in"
-      >
-        <TableRow
-          v-for="item in items"
-          :key="item.id"
-          :item="item"
-          :routing-member="routingMember"
-          :columns="columns"
-        />
-      </transition-group>
+      <TableRow
+        v-for="item in items"
+        :key="item.id"
+        :item="item"
+        :routing-member="routingMember"
+        :columns="columns"
+      />
     </table>
   </div>
   <div v-else>

--- a/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
@@ -14,6 +14,8 @@
 </template>
 
 <script>
+import { money, truncate } from 'lib/shared/modules/vue-filters'
+
 export default {
   name: "TableRow",
   data(){
@@ -42,12 +44,11 @@ export default {
     initFormattedItem(){
       this.columns.forEach(({format, field}) => {
         if (format === 'currency') {
-          this.formattedItem[field] = parseFloat(this.item[field]).toLocaleString(I18n.locale, {
-            style: 'currency',
-            currency: 'EUR'
-          });
+          this.formattedItem[field] = money(this.item[field]);
+        } else if(format == 'truncated'){
+          this.formattedItem[field] = truncate(this.item[field], {length: 60});
         } else {
-          this.formattedItem[field] = this.item[field]
+          this.formattedItem[field] = this.item[field];
         }
       });
     }

--- a/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { money, truncate } from 'lib/shared/modules/vue-filters'
+import { money, truncate } from 'lib/shared'
 
 export default {
   name: "TableRow",

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsIndex.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsIndex.vue
@@ -1,11 +1,10 @@
 <template>
-  <div>
-    <Table
-      :items="items"
-      :routing-member="'contracts_show'"
-      :columns="columns"
-    />
-  </div>
+  <Table
+    :items="items"
+    :routing-member="'contracts_show'"
+    :columns="columns"
+  >
+  </Table>
 </template>
 
 <script>

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
@@ -81,6 +81,7 @@ export default {
       assignee,
       document_number,
       final_amount,
+      initial_amount,
       status,
       process_type
     } = contract

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -9,7 +9,9 @@
           @active-tab="setActiveTab"
         ></Nav>
         <main class="dashboards-home-main">
-          <router-view></router-view>
+          <keep-alive include="Summary">
+            <router-view :key="$route.fullPath"></router-view>
+          </keep-alive>
         </main>
       </div>
     </div>

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -72,6 +72,28 @@
         <p class="decorator" v-html="labelHalfSpendingsContracts"></p>
       </div>
     </div>
+
+    <div class="pure-g block">
+      <div class="pure-u-1 pure-u-lg-1-2 p_h_r_3">
+        <div class="m_b_3">
+          <h3 class="mt1 graph-title">{{ labelContractType }}</h3>
+          <div id="contract-type-bars"></div>
+        </div>
+
+        <div>
+          <h3 class="mt1 graph-title">{{ labelProcessType }}</h3>
+          <div id="process-type-bars"></div>
+        </div>
+      </div>
+
+      <div class="pure-u-1 pure-u-lg-1-2 header_block_inline">
+        <div>
+          <h3 class="mt1 graph-title">{{ labelAmountDistribution }}</h3>
+          <div id="amount-distribution-bars"></div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </template>
 
@@ -91,10 +113,11 @@ export default {
       labelMeanSavings: I18n.t('gobierto_dashboards.dashboards.contracts.summary.mean_savings'),
       labelLessThan1000: I18n.t('gobierto_dashboards.dashboards.contracts.summary.label_less_than_1000'),
       labelLargerContractAmount: I18n.t('gobierto_dashboards.dashboards.contracts.summary.label_larger_contract_amount'),
-      labelHalfSpendingsContracts: I18n.t('gobierto_dashboards.dashboards.contracts.summary.label_half_spendings_contracts')
+      labelHalfSpendingsContracts: I18n.t('gobierto_dashboards.dashboards.contracts.summary.label_half_spendings_contracts'),
+      labelContractType: I18n.t('gobierto_dashboards.dashboards.contracts.contract_type'),
+      labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
+      labelAmountDistribution: I18n.t('gobierto_dashboards.dashboards.contracts.amount_distribution')
     }
-  },
-  created() {
   },
   mounted() {
     EventBus.$emit("summary_ready");

--- a/app/javascript/gobierto_dashboards/webapp/containers/tender/TendersIndex.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/tender/TendersIndex.vue
@@ -1,11 +1,10 @@
 <template>
-  <div>
-    <Table
-      :items="items"
-      :routing-member="'tenders_show'"
-      :columns="columns"
-    />
-  </div>
+  <Table
+    :items="items"
+    :routing-member="'tenders_show'"
+    :columns="columns"
+  >
+  </Table>
 </template>
 
 <script>

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -1,6 +1,6 @@
 export const contractsColumns = [
   {field: 'assignee', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null},
-  {field: 'contractor', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: null},
+  {field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: null},
   {field: 'final_amount', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
   {field: 'end_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.end_date'), format: null},
 ];

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -1,6 +1,6 @@
 export const contractsColumns = [
   {field: 'assignee', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null},
-  {field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: null},
+  {field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: 'truncated'},
   {field: 'final_amount', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
   {field: 'end_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.end_date'), format: null},
 ];

--- a/app/javascript/lib/shared/index.js
+++ b/app/javascript/lib/shared/index.js
@@ -25,7 +25,8 @@ import {
   VueFiltersMixin,
   translate,
   money,
-  date
+  date,
+  truncate
 } from "./modules/vue-filters.js";
 import { Middleware } from "./modules/middleware.js";
 
@@ -45,5 +46,6 @@ export {
   Middleware,
   translate,
   money,
-  date
+  date,
+  truncate
 };

--- a/app/javascript/lib/shared/modules/vue-filters.js
+++ b/app/javascript/lib/shared/modules/vue-filters.js
@@ -27,8 +27,6 @@ export const date = (value, opts = {}) => {
 }
 
 export const truncate = (value, opts = {}) => {
-  debugger
-
   const omission = opts['omission'] || '...';
   const length = opts['length'] || 30;
 

--- a/app/javascript/lib/shared/modules/vue-filters.js
+++ b/app/javascript/lib/shared/modules/vue-filters.js
@@ -26,15 +26,26 @@ export const date = (value, opts = {}) => {
   return value instanceof Date ? value.toLocaleDateString(lang, opts) : new Date(value).toLocaleDateString(lang, opts);
 }
 
+export const truncate = (value, opts = {}) => {
+  debugger
+
+  const omission = opts['omission'] || '...';
+  const length = opts['length'] || 30;
+
+  return `${value.substring(0, length)}${omission}`
+}
+
 export const VueFiltersMixin = {
   methods: {
     translate,
     money,
-    date
+    date,
+    truncate
   },
   filters: {
     translate,
     money,
-    date
+    date,
+    truncate
   }
 };

--- a/app/javascript/lib/visualizations/index.js
+++ b/app/javascript/lib/visualizations/index.js
@@ -22,6 +22,8 @@ import { VisUnemploymentAge } from './modules/unemployment_age.js'
 import { VisUnemploymentRate } from './modules/unemployment_rate.js'
 import { VisUnemploymentSex } from './modules/unemployment_sex.js'
 import { Areachart } from './modules/areachart'
+import { AmountDistributionBars } from './modules/amount_distribution_bars'
+import { GroupPctDistributionBars } from './modules/group_pct_distribution_bars'
 
 export {
   Areachart,
@@ -47,5 +49,7 @@ export {
   VisTreemap,
   VisUnemploymentAge,
   VisUnemploymentRate,
-  VisUnemploymentSex
+  VisUnemploymentSex,
+  AmountDistributionBars,
+  GroupPctDistributionBars
 }

--- a/app/javascript/lib/visualizations/modules/amount_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/amount_distribution_bars.js
@@ -1,0 +1,121 @@
+import { scaleThreshold, axisTop, select } from 'd3';
+import { rowChart } from 'dc';
+
+const d3 = { scaleThreshold, axisTop, select }
+const dc = { rowChart }
+
+export class AmountDistributionBars {
+  constructor(options) {
+    // Declaration
+    const { containerSelector, dimension, onFilteredFunction, range, labelMore, labelFromTo } = options
+    const container = dc.rowChart(containerSelector, "group");
+
+    // Dimensions
+    const amountByGroupingField = dimension.group().reduceCount();
+
+    // Styling
+    const _count = amountByGroupingField.size(),
+          _gap = 10,
+          _barHeight = 18,
+          _labelOffset = 195;
+
+    const node = container.root().node() || document.createElement("div")
+
+    // Construction
+    container
+      .width((node.parentNode || node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
+      .height(container.margins().top + container.margins().bottom + (_count * _barHeight) + ((_count + 1) * _gap)) // Margins top/bottom + bars + gaps (space between)
+      .fixedBarHeight(_barHeight)
+      .x(d3.scaleThreshold())
+      .dimension(dimension)
+      .group(amountByGroupingField)
+      .ordering(d => d.key)
+      .labelOffsetX(-_labelOffset)
+      .gap(_gap)
+      .elasticX(true)
+      .title(d => d.value)
+      .on('pretransition', function(chart){
+        // Apply rounded corners AFTER render, otherwise they don't exist
+        chart.selectAll('rect').attr("rx", 4).attr("ry", 4);
+
+        // edit labels positions
+        chart.selectAll('text.row')
+          .text('')
+          .selectAll('tspan')
+          .data(d => {
+            // helper
+            function intervalFormat(d) {
+              var n = Number(range.domain[d.key])
+              var _s = Number(range.domain[d.key - 1]) || 1;
+
+              // Last value is not a range
+              if (d.key === range.domain.length) {
+                return [labelMore + " " + (_s - 1).toLocaleString(I18n.locale, {
+                  style: 'currency',
+                  currency: 'EUR',
+                  minimumFractionDigits: 0
+                })]
+              }
+
+              var _l = Number(n - 1);
+
+              return [_s, _l].map(n => n.toLocaleString(I18n.locale, {
+                style: 'currency',
+                currency: 'EUR',
+                minimumFractionDigits: 0
+              }))
+            }
+
+            return intervalFormat(d)
+          })
+          .enter()
+          .append('tspan')
+          .text(d => d)
+          .attr('x', (d, i) => i === 0 ? -_labelOffset : -_labelOffset / 2)
+
+        chart.select('g.axis')
+          .attr('transform', 'translate(0,0)')
+          .append('text')
+          .attr('class', 'axis-title')
+          .attr('y', -9) // Default
+          .selectAll('text')
+          .data(() => {
+            // helper
+            function titleFormat(str) {
+              str = str.split(' ')
+              if (str.length !== 4) throw new Error()
+
+              var last = [str[2], str[3]].join(' ')
+              return [str[0], str[1], last]
+            }
+
+            return titleFormat(labelFromTo);
+          })
+          .enter()
+          .append('tspan')
+          .text(d => d)
+          .attr('x', (d, i) => (i === 0) ? -_labelOffset : (i === 1) ? -_labelOffset / 2 : 0)
+          .attr('text-anchor', (d, i) => (i === 2) ? 'middle' : '')
+
+        chart.selectAll('g.axis line.grid-line').attr("y2", function() {
+          return Math.abs(+d3.select(this).attr("y2")) + (chart.margins().top / 2)
+        });
+      })
+      .on('filtered', () => onFilteredFunction());
+
+    // Customization
+    container.xAxis(d3.axisTop().ticks(5))
+    container.xAxis().tickFormat(
+      function(tick, pos) {
+        if (pos === 0) return null
+        return tick
+      });
+    container.margins().top = 20;
+    container.margins().left = _labelOffset + 5;
+    container.margins().right = 0;
+
+    // Rendering
+    container.render();
+
+  }
+}

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -1,0 +1,84 @@
+import { scaleThreshold, axisTop, select } from 'd3';
+import { rowChart } from 'dc';
+
+const d3 = { scaleThreshold, axisTop, select }
+const dc = { rowChart }
+
+export class GroupPctDistributionBars {
+  constructor(options) {
+    // Declaration
+    const { containerSelector, dimension, onFilteredFunction } = options
+    const container = dc.rowChart(containerSelector, "group");
+
+    // Dimensions
+    const groupedDimension = dimension.group().reduceCount(),
+          all = dimension.groupAll();
+
+    // Styling
+    const _count = groupedDimension.size(),
+          _gap = 10,
+          _barHeight = 18,
+          _initialLabelOffset = 250,
+          _pctLabelOffset = 70;
+
+    const node = container.root().node() || document.createElement("div")
+
+    // Construction
+    container
+      .width((node.parentNode || node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
+      .height(container.margins().top + container.margins().bottom + (_count * _barHeight) + ((_count + 1) * _gap)) // Margins top/bottom + bars + gaps (space between)
+      .fixedBarHeight(_barHeight)
+      .x(d3.scaleThreshold())
+      .dimension(dimension)
+      .group(groupedDimension)
+      .ordering(d => d.key)
+      .labelOffsetX(-_initialLabelOffset)
+      .gap(_gap)
+      .elasticX(true)
+      .title(function(d) { return d.value })
+      .valueAccessor(d =>  parseFloat(d.value / all.value()) )
+
+    container
+      .on('pretransition', function(chart){
+        // Apply rounded corners AFTER render, otherwise they don't exist
+        chart.selectAll('rect').attr("rx", 4).attr("ry", 4);
+
+        // Custom labels
+        chart.selectAll('text.row')
+          .text('')
+          .selectAll('tspan')
+          .data(d => {
+            let label = d.key, pct;
+
+            if (container.hasFilter() && !container.hasFilter(d.key)){
+              pct = 0.0;
+            } else if (container.hasFilter() && container.hasFilter(d.key)){
+              pct = parseFloat(d.value / dimension.top(Infinity).length);
+            } else{
+              pct = parseFloat(d.value / all.value());
+            }
+
+            pct = pct.toLocaleString(I18n.locale, {
+                    style: 'percent',
+                    minimumFractionDigits: 1
+                  });
+
+            return [label, pct]
+          })
+          .enter()
+          .append('tspan')
+          .text(d => d)
+          .attr('x', (d, i) => i === 0 ? -_initialLabelOffset : -_pctLabelOffset)
+      })
+
+    container.on('filtered', () => onFilteredFunction());
+
+    // Customization
+    container.xAxis(d3.axisTop().ticks(0))
+    container.margins().left = _initialLabelOffset + 5;
+    container.margins().right = 0;
+
+    // Rendering
+    container.render();
+  }
+}

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -13,6 +13,8 @@ ca:
         empty_table: No hi ha dades disponibles
         end_date: Data
         final_amount: Quantitat
+        fromto: De a Nº Contr.
+        more: Més de
         nav:
           contracts: Contracts
           summary: Resum

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -3,8 +3,10 @@ ca:
   gobierto_dashboards:
     dashboards:
       contracts:
+        amount_distribution: Distribució per imports
         assignee: Adjudicatari
         contract_amount: Imp. adjudicació
+        contract_type: Tipus de contracte
         contractor: Contractor
         description: Visualització i anàlisi dels contractes adjudicats i les licitacions
           del %{entity_name}
@@ -15,7 +17,7 @@ ca:
           contracts: Contracts
           summary: Resum
           tenders: Licitacions
-        process_type: Tipus
+        process_type: Tipus de procés
         status: Procediment
         submission_date: Data
         summary:

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -13,6 +13,8 @@ en:
         empty_table: There is no available data
         end_date: Date
         final_amount: Amount
+        fromto: From To No Contr.
+        more: More than
         nav:
           contracts: Contracts
           summary: Summary

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -3,8 +3,10 @@ en:
   gobierto_dashboards:
     dashboards:
       contracts:
+        amount_distribution: Amount distribution
         assignee: Assignee
         contract_amount: Contract Amount
+        contract_type: Type of contract
         contractor: Contractor
         description: Visualizations and analisys for the awarded contracts and tenders
           to %{entity_name}
@@ -15,7 +17,7 @@ en:
           contracts: Contracts
           summary: Summary
           tenders: Tenders
-        process_type: Type
+        process_type: Type of process
         status: Status
         submission_date: Date
         summary:

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -3,8 +3,10 @@ es:
   gobierto_dashboards:
     dashboards:
       contracts:
+        amount_distribution: Distribución por importes
         assignee: Adjudicatario
         contract_amount: Imp. adjudicación
+        contract_type: Tipo de contrato
         contractor: Contrato
         description: Visualización y análisis de los contratos adjudicados y las licitaciones
           del %{entity_name}
@@ -15,7 +17,7 @@ es:
           contracts: Contratos
           summary: Resumen
           tenders: Licitaciones
-        process_type: Tipo
+        process_type: Tipo de proceso
         status: Procedicimiento
         submission_date: Fecha
         summary:

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -13,6 +13,8 @@ es:
         empty_table: No hay datos disponibles
         end_date: Fecha
         final_amount: Importe
+        fromto: Desde A Nº. Contr.
+        more: Más de
         nav:
           contracts: Contratos
           summary: Resumen

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -103,8 +103,8 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       # Assignee
       assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
 
-      # Contractor
-      assert first_contract.has_content?('Consejero Delegado del Consejo de Administración de Limpieza y Medio Ambiente de Getafe')
+      # Contract
+      assert first_contract.has_content?('Suministro, de forma sucesiva y por precio unitario, y por lotes de equipos de protección individual ')
 
       # Amount
       assert first_contract.has_content?('€28,600.53')

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -76,7 +76,7 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert page.has_content?("Importe medio\n297.879,16 €")
       assert page.has_content?("Importe mediano\n28.357,56 €")
 
-      assert page.has_content?("Ahorro medio de licitación a adjudicación\n49 %")
+      assert page.has_content?("Ahorro medio de licitación a adjudicación\n49,06 %")
 
       ## Headlines
       assert page.has_content?("El 12 % de los contratos son menores de 1.000 €")
@@ -112,7 +112,7 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
 
       # Contract
-      assert first_contract.has_content?('Suministro, de forma sucesiva y por precio unitario, y por lotes de equipos de protección individual ')
+      assert first_contract.has_content?('Suministro, de forma sucesiva y por precio unitario, y por l...')
 
       # Amount
       assert first_contract.has_content?('€28,600.53')

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -59,7 +59,7 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
     with(site: site, js: true) do
       visit @summary_path
 
-      # Active tab is Summary
+      ## Active tab is Summary
       assert find(".dashboards-home-nav--tab.is-active").text, 'RESUMEN'
 
       # Box
@@ -78,10 +78,18 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
 
       assert page.has_content?("Ahorro medio de licitación a adjudicación\n49 %")
 
-      # Headlines
-      assert page.has_content?("El 10 % de los contratos son menores de 1.000 €")
+      ## Headlines
+      assert page.has_content?("El 12 % de los contratos son menores de 1.000 €")
       assert page.has_content?("El mayor contrato supone un 18 % de todo el gasto en contratos")
       assert page.has_content?("El 2 % de contratos concentran el 50% de todo el gasto")
+
+      ## Charts
+      # Contract type
+      assert page.has_content?(/Gestión de servicios públicos\d*1,6 %/)
+      assert page.has_content?(/Servicios\d*56,3 %/)
+      # Process type
+      assert page.has_content?(/Abierto simplificado\d*29,8 %/)
+      assert page.has_content?(/Negociado con publicidad\d*0,4 %/)
     end
   end
 


### PR DESCRIPTION
Closes #3045 

## :v: What does this PR do?

It adds the horizontal bars with  for amount distribution, contract type and process type in the Summary page for the Dashboard module.

It also changes some code from the invoices part. Since the amount distribution chart we add for dashboards is the same as the one present in invoices, both of them now use a generic chart placed in `lib/visualizations/modules/amount_distribution_bars.js`.

## :mag: How should this be manually tested?

It's deployed to Staging: https://burjassot.gobify.net/dashboards/contratos/resumen

Try different combinations within the bars filters to check whether the data and percentages are correct.

The mentioned amount distribution chart in Invoices should still work. You can test it here https://mataro.gobify.net/presupuestos/proveedores-facturas

:eyes: Screenshots

![Kapture 2020-05-14 at 17 29 14](https://user-images.githubusercontent.com/545235/81953950-8d22e300-9608-11ea-9206-1626ba91ca58.gif)

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
