### PR TITLE
Optimize fetch last activity date query

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_calendars/calendar_configuration_controller.rb
@@ -71,8 +71,10 @@ module GobiertoAdmin
       def set_last_sync
         @last_sync = if collection_container = @calendar_configuration_form.try(:collection_container)
                        current_site.activities.where(action: 'admin_gobierto_calendars.calendars_synchronized', subject: collection_container)
-                         .order(created_at: :asc)
-                         .last.try(:created_at)
+                         .order(created_at: :desc)
+                         .limit(1)
+                         .pluck(:created_at)
+                         .first
                      end
       end
 

--- a/app/models/gobierto_budgets/site_stats.rb
+++ b/app/models/gobierto_budgets/site_stats.rb
@@ -29,17 +29,19 @@ module GobiertoBudgets
     end
 
     def budgets_data_updated_at
-      @site.activities.where("action ~* ?", "gobierto_budgets.budgets_updated")
-           .order(created_at: :asc)
-           .pluck(:created_at)
-           .last
+      @site.activities.where(action: "gobierto_budgets.budgets_updated")
+        .order(created_at: :desc)
+        .limit(1)
+        .pluck(:created_at)
+        .first
     end
 
     def providers_data_updated_at
-      @site.activities.where("action ~* ?", "gobierto_budgets.providers_updated")
-           .order(created_at: :asc)
-           .pluck(:created_at)
-           .last
+      @site.activities.where(action: "gobierto_budgets.providers_updated")
+        .order(created_at: :desc)
+        .limit(1)
+        .pluck(:created_at)
+        .first
     end
 
     def has_data?(variable, year)

--- a/app/models/gobierto_indicators/site_stats.rb
+++ b/app/models/gobierto_indicators/site_stats.rb
@@ -9,9 +9,10 @@ module GobiertoIndicators
 
     def indicator_updated_at
       activity_updated_at = @site.activities.where(subject: @indicator)
-                                 .order(created_at: :asc)
+                                 .order(created_at: :desc)
+                                 .limit(1)
                                  .pluck(:created_at)
-                                 .last
+                                 .first
 
       if activity_updated_at
         [@indicator.updated_at, activity_updated_at].max.to_date

--- a/app/models/gobierto_plans/site_stats.rb
+++ b/app/models/gobierto_plans/site_stats.rb
@@ -9,9 +9,10 @@ module GobiertoPlans
 
     def plan_updated_at
       activity_updated_at = @site.activities.where(subject: @plan)
-                                 .order(created_at: :asc)
+                                 .order(created_at: :desc)
+                                 .limit(1)
                                  .pluck(:created_at)
-                                 .last
+                                 .first
 
       if activity_updated_at
         [@plan.updated_at, activity_updated_at].max.to_date

--- a/db/migrate/20200515093807_add_index_activities_action.rb
+++ b/db/migrate/20200515093807_add_index_activities_action.rb
@@ -1,0 +1,6 @@
+class AddIndexActivitiesAction < ActiveRecord::Migration[5.2]
+  def change
+    add_index :activities, :action
+    add_index :activities, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_142619) do
+ActiveRecord::Schema.define(version: 2020_05_15_093807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -29,8 +29,10 @@ ActiveRecord::Schema.define(version: 2020_04_23_142619) do
     t.boolean "admin_activity", null: false
     t.integer "site_id"
     t.datetime "created_at", null: false
+    t.index ["action"], name: "index_activities_on_action"
     t.index ["admin_activity"], name: "index_activities_on_admin_activity"
     t.index ["author_type", "author_id"], name: "index_activities_on_author_type_and_author_id"
+    t.index ["created_at"], name: "index_activities_on_created_at"
     t.index ["recipient_type", "recipient_id"], name: "index_activities_on_recipient_type_and_recipient_id"
     t.index ["site_id"], name: "index_activities_on_site_id"
     t.index ["subject_id", "subject_type"], name: "index_activities_on_subject_id_and_subject_type"


### PR DESCRIPTION
Today arrived a notifiication from AppSignal with this query, which is totally wrong, because doesn't use a `LIMIT`:

```
MESSAGE
PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
: SELECT "activities"."created_at" FROM "activities" WHERE "activities"."site_id" = $1 AND (action ~* 'gobierto_budgets.budgets_updated') ORDER BY "activities"."created_at" ASC
```

Activity table has 280k records. For some sites, this query returns more than 1000 records, when we just need one.

The table also lacks of two basic indexes: created_at and action.

## :v: What does this PR do?

- Fixes all the wrong queries I've found in budgets, plans, indicators.

- Adds the missing index. You can see the sort key index and the filter index:

```
                                                   QUERY PLAN
----------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.28..1.28 rows=1 width=8) (actual time=0.082..0.082 rows=1 loops=1)
   ->  Sort  (cost=1.28..1.28 rows=1 width=8) (actual time=0.081..0.081 rows=1 loops=1)
         Sort Key: created_at DESC
         Sort Method: top-N heapsort  Memory: 25kB
         ->  Seq Scan on activities  (cost=0.00..1.27 rows=1 width=8) (actual time=0.033..0.035 rows=5 loops=1)
               Filter: ((site_id = 1009469985) AND ((action)::text = 'gobierto_budgets.budgets_updated'::text))
               Rows Removed by Filter: 13
 Planning Time: 9.518 ms
 Execution Time: 0.141 ms
```

## :mag: How should this be manually tested?

- Updated dates in indicators, budgets and plans shouldn't change
