### PR TITLE
Contracts dashboards: assignees ranking

### DIFF
--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -190,7 +190,7 @@ export class ContractsController {
     const amountsArray = _contractsData.map(({final_amount = 0}) => parseFloat(final_amount) );
     const sortedAmountsArray = amountsArray.sort((a, b) => b - a);
     const savingsArray = _contractsData.map(({initial_amount = 0, final_amount = 0}) =>
-      1 - parseFloat(final_amount) / parseFloat(initial_amount)
+      1 - (parseFloat(final_amount) / parseFloat(initial_amount))
     );
 
     // Calculations box items
@@ -286,4 +286,3 @@ export class ContractsController {
     )
   }
 }
-

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -169,7 +169,7 @@ export class ContractsController {
     const _tendersData = this._currentDataSource().tendersData
 
     // Calculations
-    const amountsArray = _tendersData.map(({initial_amount = 0}) => initial_amount === '' ? 0.0 : parseFloat(initial_amount) );
+    const amountsArray = _tendersData.map(({initial_amount = 0}) => parseFloat(initial_amount) );
 
     const numberTenders = _tendersData.length;
     const sumTenders = d3.sum(amountsArray);
@@ -186,7 +186,7 @@ export class ContractsController {
   _renderContractsMetricsBox(){
     const _contractsData = this._currentDataSource().contractsData
     // Calculations
-    const amountsArray = _contractsData.map(({final_amount = 0}) => final_amount === '' ? 0.0 : parseFloat(final_amount) );
+    const amountsArray = _contractsData.map(({final_amount = 0}) => parseFloat(final_amount) );
     const sortedAmountsArray = amountsArray.sort((a, b) => b - a);
     const savingsArray = _contractsData.map(({initial_amount = 0, final_amount = 0}) =>{
       initial_amount = initial_amount === '' ? 0.0 : initial_amount;

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -15,9 +15,6 @@ import { money } from 'lib/shared'
 import { AmountDistributionBars } from "lib/visualizations";
 import { GroupPctDistributionBars } from "lib/visualizations";
 
-import { AmountDistributionBars } from "lib/visualizations/modules/amount_distribution_bars.js";
-import { GroupPctDistributionBars } from "lib/visualizations/modules/group_pct_distribution_bars.js";
-
 Vue.use(VueRouter);
 Vue.config.productionTip = false;
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -135,9 +135,11 @@ export class ContractsController {
 
     for(let i = 0; i < contractsData.length; i++){
       const contract = contractsData[i],
-            final_amount = (contract.final_amount === '' || contract.final_amount === undefined) ? 0.0 : parseFloat(contract.final_amount);
+            final_amount = (contract.final_amount === '' || contract.final_amount === undefined) ? 0.0 : parseFloat(contract.final_amount),
+            initial_amount = (contract.initial_amount === '' || contract.initial_amount === undefined) ? 0.0 : parseFloat(contract.initial_amount);
 
       contract.final_amount = final_amount;
+      contract.initial_amount = initial_amount;
       contract.range = rangeFormat(+final_amount);
     }
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -130,9 +130,9 @@ export class ContractsController {
     var rangeFormat = d3.scaleThreshold().domain(_r.domain).range(_r.range);
 
     for(let i = 0; i < contractsData.length; i++){
-      const contract = contractsData[i],
-            final_amount = (contract.final_amount === '' || contract.final_amount === undefined) ? 0.0 : parseFloat(contract.final_amount),
-            initial_amount = (contract.initial_amount === '' || contract.initial_amount === undefined) ? 0.0 : parseFloat(contract.initial_amount);
+      const contract = contractsData[i];
+      const final_amount = (contract.final_amount === '' || contract.final_amount === undefined) ? 0.0 : parseFloat(contract.final_amount);
+      const initial_amount = (contract.initial_amount === '' || contract.initial_amount === undefined) ? 0.0 : parseFloat(contract.initial_amount);
 
       contract.final_amount = final_amount;
       contract.initial_amount = initial_amount;

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -3,6 +3,7 @@ import VueRouter from "vue-router";
 
 import { sum, mean, median, max } from 'd3-array';
 import { scaleThreshold } from 'd3-scale';
+
 const d3 = { scaleThreshold, sum, mean, median, max }
 
 import crossfilter from 'crossfilter2'
@@ -13,6 +14,9 @@ import { money } from 'lib/shared'
 
 import { AmountDistributionBars } from "lib/visualizations";
 import { GroupPctDistributionBars } from "lib/visualizations";
+
+import { AmountDistributionBars } from "lib/visualizations/modules/amount_distribution_bars.js";
+import { GroupPctDistributionBars } from "lib/visualizations/modules/group_pct_distribution_bars.js";
 
 Vue.use(VueRouter);
 Vue.config.productionTip = false;

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -281,8 +281,8 @@ export class ContractsController {
   }
 
   _formalizedContracts(){
-    return this._currentDataSource().contractsData.filter((contract) =>
-      contract.status == 'Formalizado' || contract.status == 'Adjudicado'
+    return this._currentDataSource().contractsData.filter(({status}) =>
+      status === 'Formalizado' || status === 'Adjudicado'
     )
   }
 }

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -148,7 +148,7 @@ export class ContractsController {
   }
 
   _renderSummary(){
-    ndx = crossfilter(data.contractsData);
+    ndx = crossfilter(this._formalizedContracts());
 
     this._renderTendersMetricsBox();
     this._renderContractsMetricsBox();
@@ -188,16 +188,14 @@ export class ContractsController {
   }
 
   _renderContractsMetricsBox(){
-    const _contractsData = this._currentDataSource().contractsData
+    const _contractsData = this._formalizedContracts();
+
     // Calculations
     const amountsArray = _contractsData.map(({final_amount = 0}) => parseFloat(final_amount) );
     const sortedAmountsArray = amountsArray.sort((a, b) => b - a);
-    const savingsArray = _contractsData.map(({initial_amount = 0, final_amount = 0}) =>{
-      initial_amount = initial_amount === '' ? 0.0 : initial_amount;
-      final_amount = final_amount === '' ? 0.0 : final_amount;
-
-      return (1 - parseFloat(final_amount) / parseFloat(initial_amount))
-    });
+    const savingsArray = _contractsData.map(({initial_amount = 0, final_amount = 0}) =>
+      1 - parseFloat(final_amount) / parseFloat(initial_amount)
+    );
 
     // Calculations box items
     const numberContracts = _contractsData.length;
@@ -283,7 +281,7 @@ export class ContractsController {
   }
 
   _renderAssigneesTable(){
-    const _contractsData = this._currentDataSource().contractsData,
+    const _contractsData = this._formalizedContracts(),
           table = document.getElementById("assignees-table"),
           cellClass = "dashboards-home-main--td",
           groupedByAssignee = {};
@@ -334,6 +332,12 @@ export class ContractsController {
 
   _currentDataSource(){
     return reduced || data
+  }
+
+  _formalizedContracts(){
+    return this._currentDataSource().contractsData.filter((contract) =>
+      contract.status == 'Formalizado' || contract.status == 'Adjudicado'
+    )
   }
 }
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -117,9 +117,9 @@ export class ContractsController {
         }
 
         if ( aDate < bDate ){
-          return -1;
-        } else if ( aDate > bDate ){
           return 1;
+        } else if ( aDate > bDate ){
+          return -1;
         } else {
           return 0;
         }

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -8,7 +8,7 @@ const d3 = { scaleThreshold, sum, mean, median, max }
 
 import crossfilter from 'crossfilter2'
 
-import { getRemoteData } from '../webapp/lib/get_remote_data'
+import { getRemoteData } from '../webapp/lib/utils'
 import { EventBus } from '../webapp/mixins/event_bus'
 import { money } from 'lib/shared'
 
@@ -154,17 +154,15 @@ export class ContractsController {
     this._renderByAmountsChart();
     this._renderContractTypeChart();
     this._renderProcessTypeChart();
-
-    this._renderAssigneesTable();
   }
 
   _refreshData(reducedContractsData){
     reduced = {tendersData: data.tendersData, contractsData: reducedContractsData};
 
     vueApp.contractsData = reducedContractsData;
+    EventBus.$emit('refresh_summary_data');
 
     this._renderContractsMetricsBox();
-    this._renderAssigneesTable();
   }
 
   _renderTendersMetricsBox(){
@@ -276,56 +274,6 @@ export class ContractsController {
     }
 
     new GroupPctDistributionBars(renderOptions);
-  }
-
-  _renderAssigneesTable(){
-    const _contractsData = this._formalizedContracts(),
-          table = document.getElementById("assignees-table"),
-          cellClass = "dashboards-home-main--td",
-          groupedByAssignee = {};
-
-    // Group contracts by assignee
-    _contractsData.forEach((contract) => {
-      if (contract.assignee === '' || contract.assignee === undefined) {
-        return;
-      }
-
-      groupedByAssignee[contract.assignee] = groupedByAssignee[contract.assignee] || {name: contract.assignee}
-
-      groupedByAssignee[contract.assignee].sum = groupedByAssignee[contract.assignee].sum || 0
-      groupedByAssignee[contract.assignee].sum += parseFloat(contract.final_amount)
-
-      groupedByAssignee[contract.assignee].count = groupedByAssignee[contract.assignee].count || 0
-      groupedByAssignee[contract.assignee].count++;
-    });
-
-
-    // Sort grouped elements by number of contracts
-    const sortedAndGrouped = Object.values(groupedByAssignee).sort((a, b) => { return a.count > b.count ? 1 : -1 });
-
-    // If the table already has content we remove it
-    if (table.rows.length > 0) {
-      for (var i = table.rows.length - 1; i >= 0; i--) {
-        table.deleteRow(i);
-      }
-    }
-
-    // Build the table
-    sortedAndGrouped.forEach((groupedItem) => {
-      const row = table.insertRow(0);
-
-      const cellAssignee = row.insertCell(0);
-      const cellContracts = row.insertCell(1);
-      const cellAmountSum = row.insertCell(2);
-
-      cellAssignee.classList.add(cellClass);
-      cellContracts.classList.add(cellClass);
-      cellAmountSum.classList.add(cellClass);
-
-      cellAssignee.innerHTML = groupedItem.name;
-      cellContracts.innerHTML = groupedItem.count;
-      cellAmountSum.innerHTML = money(groupedItem.sum);
-    })
   }
 
   _currentDataSource(){

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -29,11 +29,7 @@ export class ContractsController {
     const entryPoint = document.getElementById(selector);
 
     if (entryPoint) {
-      const htmlRouterBlock = `
-        <keep-alive>
-          <router-view :key="$route.fullPath"></router-view>
-        </keep-alive>
-      `;
+      const htmlRouterBlock = `<router-view></router-view>`;
 
       entryPoint.innerHTML = htmlRouterBlock;
 

--- a/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
@@ -5,8 +5,9 @@
     class="dashboards-home-main--tr"
   >
     <td
-      v-for="{ field } in columns"
+      v-for="{ field, format } in columns"
       class="dashboards-home-main--td"
+      :class="{ 'right': format === 'quantity' }"
     >
       <div>{{ formattedItem[field] }}</div>
     </td>

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
@@ -35,6 +35,11 @@
             <th class="left">{{ labelProcessType }}</th>
             <td>{{ process_type }}</td>
           </tr>
+          <tr>
+            <th class="left">
+              <a :href="permalink" target='blank'>{{ labelPermalink }}</a>
+            </th>
+          </tr>
         </table>
 
       </div>
@@ -61,39 +66,45 @@ export default {
       initial_amount: '',
       status: '',
       process_type: '',
+      permalink: '',
       labelAsignee: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'),
       labelTenderAmount: I18n.t('gobierto_dashboards.dashboards.contracts.tender_amount'),
       labelContractAmount: I18n.t('gobierto_dashboards.dashboards.contracts.contract_amount'),
       labelStatus: I18n.t('gobierto_dashboards.dashboards.contracts.status'),
-      labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type')
+      labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
+      labelPermalink: I18n.t('gobierto_dashboards.dashboards.contracts.permalink')
     }
   },
   created() {
     const itemId = this.$route.params.id;
 
-    const contract = this.contractsData.find((contract) => {
-      return contract.id === itemId
+    const contract = this.contractsData.find((data) => {
+      return data.id === itemId
     });
 
-    const {
-      title,
-      description,
-      assignee,
-      document_number,
-      final_amount,
-      initial_amount,
-      status,
-      process_type
-    } = contract
+    if (contract) {
+      const {
+        title,
+        description,
+        assignee,
+        document_number,
+        final_amount,
+        initial_amount,
+        status,
+        process_type,
+        permalink
+      } = contract
 
-    this.title = title
-    this.description = description
-    this.assignee = assignee
-    this.document_number = document_number
-    this.final_amount = final_amount
-    this.initial_amount = initial_amount
-    this.status = status
-    this.process_type = process_type
+      this.title = title
+      this.description = description
+      this.assignee = assignee
+      this.document_number = document_number
+      this.final_amount = final_amount
+      this.initial_amount = initial_amount
+      this.status = status
+      this.process_type = process_type
+      this.permalink = permalink
+    }
   }
 }
 </script>

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
@@ -77,10 +77,7 @@ export default {
   },
   created() {
     const itemId = this.$route.params.id;
-
-    const contract = this.contractsData.find((data) => {
-      return data.id === itemId
-    });
+    const contract = this.contractsData.find(({ id }) => id === itemId );
 
     if (contract) {
       const {

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
@@ -77,7 +77,7 @@ export default {
   },
   created() {
     const itemId = this.$route.params.id;
-    const contract = this.contractsData.find(({ id }) => id === itemId );
+    const contract = this.contractsData.find(({ id }) => id === itemId ) || {};
 
     if (contract) {
       const {

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Nav.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Nav.vue
@@ -6,6 +6,7 @@
         :class="{ 'is-active': activeTab === 0 }"
         tag="li"
         class="dashboards-home-nav--tab"
+        @click.native="markTabAsActive(0)"
       >
         <i class="fas fa-chart-bar" />
         <i class="far fa-chart-bar" />
@@ -16,6 +17,7 @@
         :class="{ 'is-active': activeTab === 1 }"
         tag="li"
         class="dashboards-home-nav--tab"
+        @click.native="markTabAsActive(1)"
       >
         <i class="fas fa-clone" />
         <i class="far fa-clone" />
@@ -26,6 +28,7 @@
         :class="{ 'is-active': activeTab === 2 }"
         tag="li"
         class="dashboards-home-nav--tab"
+        @click.native="markTabAsActive(2)"
       >
         <i class="fas fa-clone" />
         <i class="far fa-clone" />

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -94,6 +94,18 @@
       </div>
     </div>
 
+    <div class="m_t_4">
+      <h3 class="mt1 graph-title">{{ labelMainAssignees }}</h3>
+      <table id="assignees-table" class="dashboards-home-main--table">
+        <thead>
+          <th class="dashboards-home-main--th"><div>{{ labelTableThAssignee }}</div></th>
+          <th class="dashboards-home-main--th"><div>{{ labelTableThContracts }}</div></th>
+          <th class="dashboards-home-main--th"><div>{{ labelTableThAMount }}</div></th>
+        </thead>
+        <tbody id="assignees-table-body"></tbody>
+      </table>
+    </div>
+
   </div>
 </template>
 
@@ -116,7 +128,11 @@ export default {
       labelHalfSpendingsContracts: I18n.t('gobierto_dashboards.dashboards.contracts.summary.label_half_spendings_contracts'),
       labelContractType: I18n.t('gobierto_dashboards.dashboards.contracts.contract_type'),
       labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
-      labelAmountDistribution: I18n.t('gobierto_dashboards.dashboards.contracts.amount_distribution')
+      labelAmountDistribution: I18n.t('gobierto_dashboards.dashboards.contracts.amount_distribution'),
+      labelMainAssignees: I18n.t('gobierto_dashboards.dashboards.contracts.main_assignees'),
+      labelTableThAssignee: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'),
+      labelTableThContracts: I18n.t('gobierto_dashboards.dashboards.contracts.contracts'),
+      labelTableThAMount: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'),
     }
   },
   mounted() {

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -160,21 +160,22 @@ export default {
     buildItems() {
       const groupedByAssignee = {}
       // Group contracts by assignee
-      this.contractsData.forEach((contract) => {
-        if (contract.assignee === '' || contract.assignee === undefined) {
+      this.contractsData.forEach(({assignee, final_amount}) => {
+        if (assignee === '' || assignee === undefined) {
           return;
         }
 
-        groupedByAssignee[contract.assignee] = groupedByAssignee[contract.assignee] || {name: contract.assignee}
+        if (groupedByAssignee[assignee] === undefined) {
+          groupedByAssignee[assignee] = {
+            name: assignee,
+            id: uuid(),
+            sum: 0,
+            count: 0
+          }
+        }
 
-        // vue wouldn't update the table rows if there is no id attribute
-        groupedByAssignee[contract.assignee].id = groupedByAssignee[contract.assignee].id || uuid()
-
-        groupedByAssignee[contract.assignee].sum = groupedByAssignee[contract.assignee].sum || 0
-        groupedByAssignee[contract.assignee].sum += parseFloat(contract.final_amount)
-
-        groupedByAssignee[contract.assignee].count = groupedByAssignee[contract.assignee].count || 0
-        groupedByAssignee[contract.assignee].count++;
+        groupedByAssignee[assignee].sum += parseFloat(final_amount)
+        groupedByAssignee[assignee].count++;
       });
 
       // Sort grouped elements by number of contracts

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -151,6 +151,9 @@ export default {
     this.items = this.buildItems();
     this.columns = assigneesColumns;
   },
+  beforeDestroy(){
+    EventBus.$off('refresh_summary_data');
+  },
   methods: {
     refreshSummaryData(){
       this.contractsData = this.$root.$data.contractsData;

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -110,7 +110,6 @@
 import Table from "../../components/Table.vue";
 import { EventBus } from "../../mixins/event_bus";
 import { assigneesColumns } from "../../lib/config.js";
-import { uuid } from '../../lib/utils.js'
 
 export default {
   name: 'Summary',
@@ -168,7 +167,6 @@ export default {
         if (groupedByAssignee[assignee] === undefined) {
           groupedByAssignee[assignee] = {
             name: assignee,
-            id: uuid(),
             sum: 0,
             count: 0
           }
@@ -178,8 +176,12 @@ export default {
         groupedByAssignee[assignee].count++;
       });
 
+
       // Sort grouped elements by number of contracts
       const sortedAndGrouped = Object.values(groupedByAssignee).sort((a, b) => { return a.count < b.count ? 1 : -1 });
+
+      // The id must be unique so when data changes vue knows how to refresh the table accordingly.
+      sortedAndGrouped.forEach(contract => contract.id = `${contract.name}-${contract.count}`)
 
       return sortedAndGrouped;
     }

--- a/app/javascript/gobierto_dashboards/webapp/containers/tender/TendersShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/tender/TendersShow.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <h1>{{ tender.title }}</h1>
+    <h1>{{ title }}</h1>
 
-    <p v-if="tender.description">
-      {{ tender.description }}
+    <p v-if="description">
+      {{ description }}
     </p>
 
     <div class="pure-g p_2 bg-gray">
@@ -14,15 +14,20 @@
         <table>
           <tr>
             <th class="left">{{ labelTenderAmount }}</th>
-            <td>{{ tender.initial_amount | money }}</td>
+            <td>{{ initial_amount | money }}</td>
           </tr>
           <tr>
             <th class="left">{{ labelStatus }}</th>
-            <td>{{ tender.status }}</td>
+            <td>{{ status }}</td>
           </tr>
           <tr>
             <th class="left">{{ labelProcessType }}</th>
-            <td>{{ tender.process_type }}</td>
+            <td>{{ process_type }}</td>
+          </tr>
+          <tr>
+            <th class="left">
+              <a :href="permalink" target='blank'>{{ labelPermalink }}</a>
+            </th>
           </tr>
         </table>
       </div>
@@ -40,19 +45,44 @@ export default {
   data() {
     return {
       tendersData: this.$root.$data.tendersData,
-      tender: null,
+      title : '',
+      description : '',
+      initial_amount : '',
+      status : '',
+      process_type : '',
+      permalink : '',
       labelTenderAmount: I18n.t('gobierto_dashboards.dashboards.contracts.tender_amount'),
       labelContractAmount: I18n.t('gobierto_dashboards.dashboards.contracts.contract_amount'),
       labelStatus: I18n.t('gobierto_dashboards.dashboards.contracts.status'),
-      labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type')
+      labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
+      labelPermalink: I18n.t('gobierto_dashboards.dashboards.contracts.permalink')
     }
   },
   created() {
     const itemId = this.$route.params.id;
 
-    this.tender = this.tendersData.find((tender) => {
-      return tender.id === itemId
+    const tender = this.tendersData.find((data) => {
+      return data.id === itemId
     });
+
+    if (tender) {
+      const {
+        title,
+        description,
+        initial_amount,
+        status,
+        process_type,
+        permalink
+      } = tender
+
+      this.title = title
+      this.description = description
+      this.initial_amount = initial_amount
+      this.status = status
+      this.process_type = process_type
+      this.permalink = permalink
+    }
+
   }
 }
 </script>

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -10,3 +10,9 @@ export const tendersColumns = [
   {field: 'status', translation: I18n.t('gobierto_dashboards.dashboards.contracts.status'), format: null},
   {field: 'submission_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.submission_date'), format: null},
 ];
+
+export const assigneesColumns = [
+  {field: 'name', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null},
+  {field: 'count', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contracts'), format: 'quantity'},
+  {field: 'sum', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
+];

--- a/app/javascript/gobierto_dashboards/webapp/lib/utils.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/utils.js
@@ -11,3 +11,12 @@ export function getRemoteData(endpoint) {
       });
   })
 }
+
+export function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = Math.random() * 16 | 0,
+          val = c == 'x' ? r : (r & 0x3 | 0x8);
+
+    return val.toString(16);
+  });
+}

--- a/app/javascript/gobierto_dashboards/webapp/lib/utils.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/utils.js
@@ -11,12 +11,3 @@ export function getRemoteData(endpoint) {
       });
   })
 }
-
-export function uuid() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = Math.random() * 16 | 0,
-          val = c == 'x' ? r : (r & 0x3 | 0x8);
-
-    return val.toString(16);
-  });
-}

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -31,7 +31,7 @@ export class GroupPctDistributionBars {
       .x(d3.scaleThreshold())
       .dimension(dimension)
       .group(groupedDimension)
-      .ordering(d => d.key)
+      .ordering(d => -d.value)
       .labelOffsetX(-_initialLabelOffset)
       .gap(_gap)
       .elasticX(true)

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -8,7 +8,7 @@ ca:
         contract_amount: Imp. adjudicació
         contract_type: Tipus de contracte
         contractor: Contractor
-        contracts: Contracts
+        contracts: Contractes
         description: Visualització i anàlisi dels contractes adjudicats i les licitacions
           del %{entity_name}
         empty_table: No hi ha dades disponibles
@@ -21,7 +21,7 @@ ca:
           contracts: Contracts
           summary: Resum
           tenders: Licitacions
-        permalink: enllaç a la web oficial
+        permalink: enllaç cap a la web oficial
         process_type: Tipus de procés
         status: Procediment
         submission_date: Data

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -21,6 +21,7 @@ ca:
           contracts: Contracts
           summary: Resum
           tenders: Licitacions
+        permalink: enllaç a la web oficial
         process_type: Tipus de procés
         status: Procediment
         submission_date: Data

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -8,12 +8,14 @@ ca:
         contract_amount: Imp. adjudicació
         contract_type: Tipus de contracte
         contractor: Contractor
+        contracts: Contracts
         description: Visualització i anàlisi dels contractes adjudicats i les licitacions
           del %{entity_name}
         empty_table: No hi ha dades disponibles
         end_date: Data
         final_amount: Quantitat
         fromto: De a Nº Contr.
+        main_assignees: Principals adjudicataris
         more: Més de
         nav:
           contracts: Contracts

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -8,12 +8,14 @@ en:
         contract_amount: Contract Amount
         contract_type: Type of contract
         contractor: Contractor
+        contracts: Contracts
         description: Visualizations and analisys for the awarded contracts and tenders
           to %{entity_name}
         empty_table: There is no available data
         end_date: Date
         final_amount: Amount
         fromto: From To No Contr.
+        main_assignees: Main assignees
         more: More than
         nav:
           contracts: Contracts

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -21,6 +21,7 @@ en:
           contracts: Contracts
           summary: Summary
           tenders: Tenders
+        permalink: link to the official website
         process_type: Type of process
         status: Status
         submission_date: Date

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -8,12 +8,14 @@ es:
         contract_amount: Imp. adjudicación
         contract_type: Tipo de contrato
         contractor: Contrato
+        contracts: Contratos
         description: Visualización y análisis de los contratos adjudicados y las licitaciones
           del %{entity_name}
         empty_table: No hay datos disponibles
         end_date: Fecha
         final_amount: Importe
         fromto: Desde A Nº. Contr.
+        main_assignees: Principales adjudicatarios
         more: Más de
         nav:
           contracts: Contratos

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -21,6 +21,7 @@ es:
           contracts: Contratos
           summary: Resumen
           tenders: Licitaciones
+        permalink: enlace a la web oficial
         process_type: Tipo de proceso
         status: Procedicimiento
         submission_date: Fecha

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -63,41 +63,48 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert find(".dashboards-home-nav--tab.is-active").text, 'RESUMEN'
 
       # Box
-      assert page.has_content?("Licitaciones\n252")
-      assert page.has_content?("licitaciones por importe de\n134.068.916,04 €")
-      assert page.has_content?("Importe medio\n532.019,51 €")
+      metrics_box = find(".metric_box", match: :first)
 
-      assert page.has_content?("Importe medio\n532.019,51 €")
-      assert page.has_content?("Importe mediano\n87.725,00 €")
+      assert metrics_box.has_content?("Licitaciones\n252")
+      assert metrics_box.has_content?("licitaciones por importe de\n134.068.916,04 €")
+      assert metrics_box.has_content?("Importe medio\n532.019,51 €")
 
-      assert page.has_content?("Contratos adjudicados\n245")
-      assert page.has_content?("contratos por importe de\n72.980.393,23 €")
+      assert metrics_box.has_content?("Importe medio\n532.019,51 €")
+      assert metrics_box.has_content?("Importe mediano\n87.725,00 €")
 
-      assert page.has_content?("Importe medio\n297.879,16 €")
-      assert page.has_content?("Importe mediano\n28.357,56 €")
+      assert metrics_box.has_content?("Contratos adjudicados\n223")
+      assert metrics_box.has_content?("contratos por importe de\n72.894.648,94 €")
 
-      assert page.has_content?("Ahorro medio de licitación a adjudicación\n49,06 %")
+      assert metrics_box.has_content?("Importe medio\n326.881,83 €")
+      assert metrics_box.has_content?("Importe mediano\n33.668,25 €")
+
+      assert metrics_box.has_content?("Ahorro medio de licitación a adjudicación\n44,44 %")
 
       ## Headlines
-      assert page.has_content?("El 12 % de los contratos son menores de 1.000 €")
+      assert page.has_content?("El 5 % de los contratos son menores de 1.000 €")
       assert page.has_content?("El mayor contrato supone un 18 % de todo el gasto en contratos")
       assert page.has_content?("El 2 % de contratos concentran el 50% de todo el gasto")
 
+
       ## Charts
       # Contract type
-      assert page.has_content?(/Gestión de servicios públicos\d*1,6 %/)
-      assert page.has_content?(/Servicios\d*56,3 %/)
+      contract_type_container = find("#contract-type-bars", match: :first)
+
+      assert contract_type_container.has_content?(/Gestión de servicios públicos\d*1,3 %/)
+      assert contract_type_container.has_content?(/Servicios\d*56,5 %/)
 
       # # Process type
-      assert page.has_content?(/Abierto simplificado\d*29,8 %/)
-      assert page.has_content?(/Negociado con publicidad\d*0,4 %/)
+      process_type_container = find("#process-type-bars", match: :first)
+
+      assert process_type_container.has_content?(/Abierto simplificado\d*30,0 %/)
+      assert process_type_container.has_content?(/Negociado con publicidad\d*0,4 %/)
 
       # Assignees table
       first_contract = find("#assignees-table-body tr", match: :first)
 
-      assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
+      assert first_contract.has_content?('CONTENUR, S.L.')
       assert first_contract.has_content?(' 4 ')
-      assert first_contract.has_content?('60.004,64 €')
+      assert first_contract.has_content?('412.324,00 €')
     end
   end
 
@@ -117,16 +124,16 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       first_contract = find(".dashboards-home-main--tr", match: :first)
 
       # Assignee
-      assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
+      assert first_contract.has_content?('Marc Gil Van Beveren')
 
       # Contract
-      assert first_contract.has_content?('Suministro, de forma sucesiva y por precio unitario, y por l...')
+      assert first_contract.has_content?('Servicios de asesoramiento jurídico, defensa y formación en ...')
 
       # Amount
-      assert first_contract.has_content?('€28,600.53')
+      assert first_contract.has_content?('€5,808.00')
 
       # Date
-      assert first_contract.has_content?('2017-04-18')
+      assert first_contract.has_content?('2055-12-31')
 
       # Contracts Show
       ################
@@ -136,22 +143,22 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert find(".dashboards-home-nav--tab.is-active").text, 'CONTRACTS'
 
       # Url is updated
-      assert_equal current_path, "/dashboards/contratos/contratos/56111"
+      assert_equal current_path, "/dashboards/contratos/contratos/807008"
 
       # Title
-      assert page.has_content?('Suministro, de forma sucesiva y por precio unitario, y por lotes de equipos de protección individual para el personal de Limpieza y Medio Ambiente de Getafe SAM')
+      assert page.has_content?('Servicios de asesoramiento jurídico, defensa y formación en materia de contratación pública')
 
       # Assignee
-      assert page.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
+      assert page.has_content?('Marc Gil Van Beveren')
 
       # Contract amount
-      assert page.has_content?('€28,600.53')
+      assert page.has_content?('€5,808.00')
 
       # Tender amount
-      assert page.has_content?('€123,015.86')
+      assert page.has_content?('€217,800.00')
 
       # Status
-      assert page.has_content?('Desierto')
+      assert page.has_content?('Formalizado')
 
       # Type
       assert page.has_content?('Abierto')
@@ -176,7 +183,7 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert first_tender.has_content?('Adjudicado provisionalmente')
 
       # Date
-      assert first_tender.has_content?('2014-03-24')
+      assert first_tender.has_content?('2020-05-13')
 
 
       # Tenders Show
@@ -187,19 +194,19 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert find(".dashboards-home-nav--tab.is-active").text, 'TENDERS'
 
       # Url is updated
-      assert_equal current_path, "/dashboards/contratos/licitaciones/174387"
+      assert_equal current_path, "/dashboards/contratos/licitaciones/990198"
 
       # Title
-      assert page.has_content?('suministro mediante sistema de renting de tres camiones contenedores de carga trasera')
+      assert page.has_content?('Servicio de formación para renovación del Certificado de Aptitud Profesional .')
 
       # Tender amount
-      assert page.has_content?('€604,000.00')
+      assert page.has_content?('€33,600.00')
 
       # Status
       assert page.has_content?('Adjudicado provisionalmente')
 
       # Type
-      assert page.has_content?('Abierto')
+      assert page.has_content?('Abierto simplificado')
     end
   end
 

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -100,11 +100,10 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert process_type_container.has_content?(/Negociado con publicidad\d*0,4 %/)
 
       # Assignees table
-      first_contract = find("#assignees-table-body tr", match: :first)
+      first_contract = find(".dashboards-home-main--tr", match: :first)
 
-      assert first_contract.has_content?('CONTENUR, S.L.')
-      assert first_contract.has_content?(' 4 ')
-      assert first_contract.has_content?('412.324,00 €')
+      assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
+      assert first_contract.has_content?('60.004,64 €')
     end
   end
 

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -87,9 +87,17 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       # Contract type
       assert page.has_content?(/Gestión de servicios públicos\d*1,6 %/)
       assert page.has_content?(/Servicios\d*56,3 %/)
-      # Process type
+
+      # # Process type
       assert page.has_content?(/Abierto simplificado\d*29,8 %/)
       assert page.has_content?(/Negociado con publicidad\d*0,4 %/)
+
+      # Assignees table
+      first_contract = find("#assignees-table-body tr", match: :first)
+
+      assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
+      assert first_contract.has_content?(' 4 ')
+      assert first_contract.has_content?('60.004,64 €')
     end
   end
 


### PR DESCRIPTION
Closes #3046

## :v: What does this PR do?

It mainly adds the assignees ranking to the Dashboards contracts summary page. It should refresh along with the bar charts filters.

Along with that, it also includes the following fixes and features:

- Now the charts will also use contracts with Formalizado or Adjudicado status.
- Default order in indexes will be "date DESC".
- Link to official site in tenders and cotnracts individual views.
- Some performance fixes regarding vue page cache.

## :mag: How should this be manually tested?

It can be tested from the main summary page. It's been deployed to staing https://burjassot.gobify.net/dashboards/contratos/resumen

## :eyes: Screenshots

![Kapture 2020-05-19 at 9 57 37](https://user-images.githubusercontent.com/545235/82300512-40982880-99b7-11ea-86af-7787a553fa1e.gif)

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
