### PR TITLE
Hide custom field records when not sent by the API

### DIFF
--- a/app/controllers/gobierto_plans/plan_types_controller.rb
+++ b/app/controllers/gobierto_plans/plan_types_controller.rb
@@ -58,6 +58,7 @@ module GobiertoPlans
       @sdgs = SdgDecorator.new(find_plan)
       @sdg = @sdgs.sdg_term(params[:sdg_slug])
       @projects = @sdgs.projects_by_sdg(@sdg)
+      @projects_term = @plan.level_key(2, @plan.levels + 1)
     end
 
     private

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -95,7 +95,7 @@ module GobiertoPlans
             status: node.at_current_version.status&.name_translations,
             options: node.at_current_version.options,
             plugins_data: node_plugins_data(plan, node),
-            custom_field_records: node_custom_field_records(node)
+            custom_field_records: front_node_custom_field_records(node)
           },
           children: [] }
       end
@@ -151,8 +151,8 @@ module GobiertoPlans
       {}
     end
 
-    def node_custom_field_records(node)
-      ::GobiertoPlans::Node.node_custom_field_records(plan, node).map do |record|
+    def front_node_custom_field_records(node)
+      ::GobiertoPlans::Node.front_node_custom_field_records(plan, node).map do |record|
         next if record.custom_field.field_type == "plugin"
 
         record = record.versions[node.version_index]&.reify if node.version_index.negative?

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -148,7 +148,7 @@ module GobiertoPlans
     private
 
     def hide_empty_fields?
-      @hide_empty_fields ||= !plan.configuration_data.fetch("show_empty_fields", false)
+      @hide_empty_fields ||= !plan.configuration_data&.fetch("show_empty_fields", false)
     end
 
     def node_plugins_data(_plan, _node)

--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -147,6 +147,10 @@ module GobiertoPlans
 
     private
 
+    def hide_empty_fields?
+      @hide_empty_fields ||= !plan.configuration_data.fetch("show_empty_fields", false)
+    end
+
     def node_plugins_data(_plan, _node)
       {}
     end
@@ -157,10 +161,10 @@ module GobiertoPlans
 
         record = record.versions[node.version_index]&.reify if node.version_index.negative?
 
-        next if record.blank?
+        next if record.blank? || hide_empty_fields? && (value_string = record.value_string).blank?
 
         {
-          value: record.value_string,
+          value: value_string,
           raw_value: record.raw_value,
           custom_field_name_translations: record.custom_field.name_translations,
           custom_field_field_type: record.custom_field.field_type

--- a/app/models/gobierto_common/custom_field_value/numeric.rb
+++ b/app/models/gobierto_common/custom_field_value/numeric.rb
@@ -4,7 +4,7 @@ module GobiertoCommon::CustomFieldValue
   class Numeric < Base
     def value=(value)
       if custom_field
-        record.payload = { custom_field.uid => value.to_f }
+        record.payload = { custom_field.uid => value.blank? ? nil : value.to_f }
       end
     end
 

--- a/app/models/gobierto_plans.rb
+++ b/app/models/gobierto_plans.rb
@@ -85,7 +85,9 @@ module GobiertoPlans
       },
       "level0_options": [],
       "show_table_header": false,
-      "open_node": false
+      "open_node": false,
+      "fields_to_not_show_in_front": [],
+      "show_empty_fields": false
     }
 JSON
   end

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -93,7 +93,7 @@ module GobiertoPlans
     end
 
     def self.front_node_custom_field_records(plan, node)
-      node_custom_field_records(plan, node).where.not(custom_fields: { uid: plan.configuration_data.fetch("fields_to_not_show_in_front", []) })
+      node_custom_field_records(plan, node).where.not(custom_fields: { uid: plan.configuration_data&.fetch("fields_to_not_show_in_front", []) })
     end
 
     def global_custom_field_records

--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -92,6 +92,10 @@ module GobiertoPlans
       end
     end
 
+    def self.front_node_custom_field_records(plan, node)
+      node_custom_field_records(plan, node).where.not(custom_fields: { uid: plan.configuration_data.fetch("fields_to_not_show_in_front", []) })
+    end
+
     def global_custom_field_records
       ::GobiertoCommon::CustomFieldRecord.where(item: self).sorted
     end

--- a/app/views/gobierto_plans/plan_types/_planification-content.html.erb
+++ b/app/views/gobierto_plans/plan_types/_planification-content.html.erb
@@ -161,7 +161,7 @@
         <template v-if="Object.keys(customFields).length">
           <!-- Paragraph template  -->
           <template v-for="item in customFields.paragraphs">
-            <div class="project-description">
+            <div class="project-description" v-if="item.value">
               <div class="description-title" :class="{ 'mb1': item.value.length < 200 }">
                 <span v-if="item.custom_field_name_translations">{{ item.custom_field_name_translations | translate }}</span>
                 <span v-else><%= t("gobierto_plans.plan_types.show.desc") %></span>

--- a/app/views/gobierto_plans/plan_types/_x-templates.html.erb
+++ b/app/views/gobierto_plans/plan_types/_x-templates.html.erb
@@ -30,7 +30,7 @@
 <script type="text/x-template" id="table-view-template">
   <table>
     <thead v-if="header">
-      <th><%= t("gobierto_plans.plan_types.show.projects") %></th>
+      <th><%= @plan.level_key(2, @levels + 1) %></th>
       <th><%= t("gobierto_plans.plan_types.show.starts") %></th>
       <th><%= t("gobierto_plans.plan_types.show.status") %></th>
       <th><%= t("gobierto_plans.plan_types.show.progress") %></th>

--- a/app/views/gobierto_plans/plan_types/sdg.html.erb
+++ b/app/views/gobierto_plans/plan_types/sdg.html.erb
@@ -7,6 +7,6 @@
       </div>
     </div>
 
-    <%= render partial: "gobierto_plans/plan_types/sdg/projects", locals: { sdg: @sdg, projects: @projects } %>
+    <%= render partial: "gobierto_plans/plan_types/sdg/projects", locals: { sdg: @sdg, projects: @projects, projects_term: @projects_term } %>
   </div>
 </div>

--- a/app/views/gobierto_plans/plan_types/sdg/_projects.html.erb
+++ b/app/views/gobierto_plans/plan_types/sdg/_projects.html.erb
@@ -3,11 +3,11 @@
 </div>
 
 <% if projects.blank? %>
-  <%= t(".sdg_projects_empty") %>
+  <%= t(".sdg_projects_empty", projects_term: projects_term) %>
 <% else %>
   <div class="pure-g m_b_1">
     <div class="pure-u-1 pure-u-md-1-3 m_b_2 sdg_projects_title">
-      <%= t(".sdg_projects_title") %>:
+      <%= t(".sdg_projects_title", projects_term: projects_term).capitalize %>:
     </div>
 
     <div class="pure-u-1 pure-u-md-2-3">

--- a/config/locales/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_plans/views/ca.yml
@@ -35,7 +35,6 @@ ca:
         loading: Carregant...
         percentage_progress: "% progrés"
         progress: Progrés
-        projects: Projectes
         read_less: Llegiu menys
         read_more: Llegiu més
         see_all: Veure tot en

--- a/config/locales/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_plans/views/ca.yml
@@ -24,9 +24,9 @@ ca:
             d'Actuació Municipal connecta amb els ODS.
           sdgs_title: Objectius de Desenvolupament Sostenible
         projects:
-          sdg_projects_empty: No hi ha projectes de el pla relacionats amb aquest
-            ODS
-          sdg_projects_title: Projectes de el pla relacionats amb aquest ODS
+          sdg_projects_empty: No hi ha %{projects_term} de el pla relacionats amb
+            aquest ODS
+          sdg_projects_title: "%{projects_term} de el pla relacionats amb aquest ODS"
       show:
         desc: Descripció
         ends: Fi

--- a/config/locales/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_plans/views/en.yml
@@ -33,7 +33,6 @@ en:
         loading: Loading...
         percentage_progress: "% progress"
         progress: Progress
-        projects: Projects
         read_less: Read more
         read_more: Read less
         see_all: See all in

--- a/config/locales/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_plans/views/en.yml
@@ -23,8 +23,8 @@ en:
             with the SDGs.
           sdgs_title: Sustainable Development Goals
         projects:
-          sdg_projects_empty: There are no plan projects related to this Goal
-          sdg_projects_title: Plan projects related to this Goal
+          sdg_projects_empty: There are no plan %{projects_term} related to this Goal
+          sdg_projects_title: Plan %{projects_term} related to this Goal
       show:
         desc: Description
         ends: End

--- a/config/locales/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_plans/views/es.yml
@@ -34,7 +34,6 @@ es:
         loading: Cargando...
         percentage_progress: "% progreso"
         progress: Progreso
-        projects: Proyectos
         read_less: Leer menos
         read_more: Leer más
         see_all: Ver todo en

--- a/config/locales/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_plans/views/es.yml
@@ -24,8 +24,9 @@ es:
             Plan de Actuación Municipal conecta con los ODS.
           sdgs_title: Objetivos de Desarrollo Sostenible
         projects:
-          sdg_projects_empty: No hay proyectos del plan relacionados con este ODS
-          sdg_projects_title: Proyectos del plan relacionados con este ODS
+          sdg_projects_empty: No hay %{projects_term} del plan relacionados con este
+            ODS
+          sdg_projects_title: "%{projects_term} del plan relacionados con este ODS"
       show:
         desc: Descripción
         ends: Fin

--- a/test/models/gobierto_plans/node_test.rb
+++ b/test/models/gobierto_plans/node_test.rb
@@ -25,6 +25,10 @@ module GobiertoPlans
       ::GobiertoPlans::Node.node_custom_field_records(@plan, @node)
     end
 
+    def front_node_custom_field_records
+      ::GobiertoPlans::Node.front_node_custom_field_records(@plan, @node)
+    end
+
     def test_valid
       assert @node.valid?
     end
@@ -64,6 +68,30 @@ module GobiertoPlans
       record = ::GobiertoCommon::CustomFieldRecord.create!(@instance_custom_field_record.attributes)
 
       assert_equal [record], node_custom_field_records
+    end
+
+    def test_front_node_custom_field_records
+      ::GobiertoCommon::CustomFieldRecord.destroy_all
+      ::GobiertoCommon::CustomField.destroy_all
+
+      # when empty
+      assert front_node_custom_field_records.empty?
+
+      # when only global records
+      ::GobiertoCommon::CustomField.create!(@global_custom_field.attributes)
+      record = ::GobiertoCommon::CustomFieldRecord.create!(@global_custom_field_record.attributes)
+
+      assert_equal [record], front_node_custom_field_records
+      @plan.update_attribute(:configuration_data, { "fields_to_not_show_in_front" => [@global_custom_field.attributes["uid"]] }.to_json)
+      assert_equal [], front_node_custom_field_records
+
+      # when global and instance-level records
+      ::GobiertoCommon::CustomField.create!(@instance_custom_field.attributes)
+      record = ::GobiertoCommon::CustomFieldRecord.create!(@instance_custom_field_record.attributes)
+
+      assert_equal [record], front_node_custom_field_records
+      @plan.update_attribute(:configuration_data, { "fields_to_not_show_in_front" => [@instance_custom_field.attributes["uid"]] }.to_json)
+      assert_equal [], front_node_custom_field_records
     end
 
   end

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/app/decorators/gobierto_plans/project_decorator_progress_attachment.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/app/decorators/gobierto_plans/project_decorator_progress_attachment.rb
@@ -10,7 +10,7 @@ module GobiertoPlans
     def node_plugins_attributes
       super_result = super
 
-      calculation_plugin = ::GobiertoPlans::Node.node_custom_field_records(plan, object).where(custom_field: site.custom_fields.with_plugin_type(:progress)).find_by(item: object)
+      calculation_plugin = ::GobiertoPlans::Node.front_node_custom_field_records(plan, object).where(custom_field: site.custom_fields.with_plugin_type(:progress)).find_by(item: object)
       if calculation_plugin.present?
         super_result[:progress] = calculation_plugin.functions(version: published_version).progress&.*(100)
       end


### PR DESCRIPTION
Closes #3080
Closes PopulateTools/issues#1032
Closes PopulateTools/issues#1033


## :v: What does this PR do?

* Avoids errors trying to display custom field contents not provided by the API. When a custom field is not provided by the API the field is hidden in the front
* Allows to remove the value of a numeric custom field record in admin and set the custom field value to nil
* Adds 2 new configuration params on plans:
  * `fields_to_not_show_in_front`: specify a list of field UIDs which we should not expose in the API (the client wants to store the info but not show it on the front). Default: `[]`
  * `show_empty_fields`: be able to decide if fields with no value should be shown. Default: `false`

## :mag: How should this be manually tested?

Visit a project without records for a custom field of type text (this can be achieved by creating a new custom field of type paragraph and not entering to edit the projects from admin) 

## :eyes: Screenshots

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Sent suggestion to document configuration params
