### PR TITLE
Enable 5 runners for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
   tests:
     <<: *defaults
-    parallelism: 4
+    parallelism: 5
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
## :v: What does this PR do?

Sets 5 runners in CircleCI instead of four. Let's see the improvement
