### PR TITLE
Add a report with slower tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,7 +64,10 @@ Minitest::Retry.on_failure do |klass, test_name|
   Capybara.reset_session!
 end
 
-Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
+Minitest::Reporters.use! [
+  Minitest::Reporters::DefaultReporter.new(color: true),
+  Minitest::Reporters::MeanTimeReporter.new(color: true)
+]
 
 WebMock.disable_net_connect!(
   allow_localhost: true,


### PR DESCRIPTION
## :v: What does this PR do?

Activates the slow tests report, at the end of the tests execution:

![Screenshot 2020-05-20 at 22 49 08](https://user-images.githubusercontent.com/17616/82495891-201dba80-9aec-11ea-80a3-ea58094bc51c.png)

