### PR TITLE
Dashboards Contracts sidebar filters

### DIFF
--- a/app/assets/stylesheets/comp-block-header.scss
+++ b/app/assets/stylesheets/comp-block-header.scss
@@ -5,6 +5,7 @@
   font-size: .75rem;
   line-height: 14px;
   padding-top: 1em;
+  width: 100%;
 }
 
 .gobierto-block-header--title {

--- a/app/assets/stylesheets/module-dashboards.scss
+++ b/app/assets/stylesheets/module-dashboards.scss
@@ -1,5 +1,8 @@
 @import "css-conf";
 @import "mixins";
+@import "comp-block-checkbox";
+@import "comp-block-header";
+@import "comp-vue-dropdown";
 
 .dashboards {
   @include min-screen(768) {

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -6,7 +6,6 @@ import { scaleThreshold } from 'd3-scale';
 
 const d3 = { scaleThreshold, sum, mean, median, max }
 
-import * as dc from 'dc'
 import crossfilter from 'crossfilter2'
 
 import { getRemoteData } from '../webapp/lib/utils'

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -327,7 +327,7 @@ export class ContractsController {
 
   _formalizedContractsData(contractsData){
     return contractsData.filter(({status}) =>
-      status == 'Formalizado' || status == 'Adjudicado'
+      status === 'Formalizado' || status === 'Adjudicado'
     )
   }
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -96,6 +96,11 @@ export class ContractsController {
           this._updateChartsFromFilter(options);
         });
 
+        // - dc charts are drawn even if the summary page is not the page where the user lands for the first time
+        //   i.e.: they could first land on a contract page, but still this page would need to render for the filters to work
+        // - dc charts sizes are calculated automatically, but if the page is not visible it won't calculate sizes properly
+        // - Given all that: when we go from a page that is not summary to summary for the first time, the sizes must
+        //   be calculated and the charts redrawn. This is why this event only needs to be listened once.
         EventBus.$once('moved_to_summary', () => {
           this._redrawCharts();
         });

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -200,16 +200,12 @@ export class ContractsController {
     // Calculations
     const amountsArray = _contractsData.map(({final_amount = 0}) => parseFloat(final_amount) );
     const sortedAmountsArray = amountsArray.sort((a, b) => b - a);
-    const savingsArray = _contractsData.map(({initial_amount = 0, final_amount = 0}) =>
-      1 - (parseFloat(final_amount) / parseFloat(initial_amount))
-    );
 
     // Calculations box items
     const numberContracts = _contractsData.length;
     const sumContracts = d3.sum(amountsArray);
     const meanContracts = d3.mean(amountsArray);
     const medianContracts = d3.median(amountsArray);
-    const meanSavings = d3.mean(savingsArray);
 
     // Calculations headlines
     const lessThan1000Total = _contractsData.filter(({final_amount = 0}) => parseFloat(final_amount) < 1000).length;
@@ -233,10 +229,6 @@ export class ContractsController {
     document.getElementById("mean-contracts").innerText = money(meanContracts);
     document.getElementById("median-contracts").innerText = money(medianContracts);
 
-    document.getElementById("mean-savings").innerText = meanSavings.toLocaleString(I18n.locale, {
-      style: 'percent',
-      minimumFractionDigits: 2
-    });
     document.getElementById("less-than-1000-pct").innerText = lessThan1000Pct.toLocaleString(I18n.locale, {
       style: 'percent'
     });

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -6,6 +6,7 @@ import { scaleThreshold } from 'd3-scale';
 
 const d3 = { scaleThreshold, sum, mean, median, max }
 
+import * as dc from 'dc'
 import crossfilter from 'crossfilter2'
 
 import { getRemoteData } from '../webapp/lib/utils'
@@ -19,7 +20,7 @@ Vue.use(VueRouter);
 Vue.config.productionTip = false;
 
 // Global variables
-let data, reduced, ndx, _r, vueApp;
+let data, reduced, ndx, _amountRange, vueApp, charts = {};
 
 export class ContractsController {
   constructor(options) {
@@ -40,48 +41,48 @@ export class ContractsController {
       const TendersIndex = () => import("../webapp/containers/tender/TendersIndex.vue");
       const TendersShow = () => import("../webapp/containers/tender/TendersShow.vue");
 
-      const router = new VueRouter({
-        mode: "history",
-        routes: [
-          { path: "/dashboards/contratos", component: Home,
-            children: [
-              { path: "resumen", name: "summary", component: Summary },
-              { path: "contratos", name: "contracts_index", component: ContractsIndex },
-              { path: "contratos/:id", name: "contracts_show", component: ContractsShow },
-              { path: "licitaciones", name: "tenders_index", component: TendersIndex },
-              { path: "licitaciones/:id", name: "tenders_show", component: TendersShow },
-            ]
-          }
-
-        ],
-        scrollBehavior() {
-          const element = document.getElementById(selector);
-          window.scrollTo({ top: element.offsetTop, behavior: "smooth" });
-        }
-      });
-
-      const baseTitle = document.title;
-      router.afterEach(to => {
-        // Wait 2 ticks
-        Vue.nextTick(() =>
-          Vue.nextTick(() => {
-            let title = baseTitle;
-
-            if (to.name === "contracts_show" || to.name === "tenders_show") {
-              const { item: { title: itemTitle } = {} } = to.params;
-
-              if (itemTitle) {
-                title = `${itemTitle}${baseTitle}`;
-              }
-            }
-
-            document.title = title;
-          })
-        );
-      });
-
       Promise.all([getRemoteData(options.contractsEndpoint), getRemoteData(options.tendersEndpoint)]).then((rawData) => {
         this.setGlobalVariables(rawData)
+
+        const router = new VueRouter({
+          mode: "history",
+          routes: [
+            { path: "/dashboards/contratos", component: Home,
+              children: [
+                { path: "resumen", name: "summary", component: Summary},
+                { path: "contratos", name: "contracts_index", component: ContractsIndex },
+                { path: "contratos/:id", name: "contracts_show", component: ContractsShow },
+                { path: "licitaciones", name: "tenders_index", component: TendersIndex },
+                { path: "licitaciones/:id", name: "tenders_show", component: TendersShow },
+              ]
+            }
+
+          ],
+          scrollBehavior() {
+            const element = document.getElementById(selector);
+            window.scrollTo({ top: element.offsetTop, behavior: "smooth" });
+          }
+        });
+
+        const baseTitle = document.title;
+        router.afterEach(to => {
+          // Wait 2 ticks
+          Vue.nextTick(() =>
+            Vue.nextTick(() => {
+              let title = baseTitle;
+
+              if (to.name === "contracts_show" || to.name === "tenders_show") {
+                const { item: { title: itemTitle } = {} } = to.params;
+
+                if (itemTitle) {
+                  title = `${itemTitle}${baseTitle}`;
+                }
+              }
+
+              document.title = title;
+            })
+          );
+        });
 
         vueApp = new Vue({
           router,
@@ -90,6 +91,14 @@ export class ContractsController {
 
         EventBus.$on('summary_ready', () => {
           this._renderSummary();
+        });
+
+        EventBus.$on('filter_changed', (options) => {
+          this._updateChartsFromFilter(options);
+        });
+
+        EventBus.$once('moved_to_summary', () => {
+          this._redrawCharts();
         });
       });
     }
@@ -122,12 +131,12 @@ export class ContractsController {
       }
     }
 
-    // Contracts precalculations
-    _r = {
+    // Contracts precalculations and normalizations
+    _amountRange = {
       domain: [501, 1001, 5001, 10001, 15001],
       range: [0, 1, 2, 3, 4, 5]
     };
-    var rangeFormat = d3.scaleThreshold().domain(_r.domain).range(_r.range);
+    var rangeFormat = d3.scaleThreshold().domain(_amountRange.domain).range(_amountRange.range);
 
     for(let i = 0; i < contractsData.length; i++){
       const contract = contractsData[i];
@@ -137,16 +146,17 @@ export class ContractsController {
       contract.final_amount = final_amount;
       contract.initial_amount = initial_amount;
       contract.range = rangeFormat(+final_amount);
+      contract.start_date_year = contract.start_date != undefined && contract.start_date != '' ? (new Date(contract.start_date).getFullYear()) : contract.start_date;
     }
 
     data = {
-      contractsData: contractsData.sort(sortByField('end_date')),
+      contractsData: this._formalizedContractsData(contractsData).sort(sortByField('start_date')),
       tendersData: tendersData.sort(sortByField('submission_date')),
     }
   }
 
   _renderSummary(){
-    ndx = crossfilter(this._formalizedContracts());
+    ndx = crossfilter(this._currentDataSource().contractsData);
 
     this._renderTendersMetricsBox();
     this._renderContractsMetricsBox();
@@ -154,6 +164,7 @@ export class ContractsController {
     this._renderByAmountsChart();
     this._renderContractTypeChart();
     this._renderProcessTypeChart();
+    this._renderDateChart();
   }
 
   _refreshData(reducedContractsData){
@@ -184,7 +195,7 @@ export class ContractsController {
   }
 
   _renderContractsMetricsBox(){
-    const _contractsData = this._formalizedContracts();
+    const _contractsData = this._currentDataSource().contractsData;
 
     // Calculations
     const amountsArray = _contractsData.map(({final_amount = 0}) => parseFloat(final_amount) );
@@ -243,13 +254,15 @@ export class ContractsController {
     const renderOptions = {
       containerSelector: "#amount-distribution-bars",
       dimension: dimension,
-      range: _r,
+      range: _amountRange,
       labelMore: I18n.t('gobierto_dashboards.dashboards.contracts.more'),
       labelFromTo: I18n.t('gobierto_dashboards.dashboards.contracts.fromto'),
-      onFilteredFunction: () => this._refreshData(dimension.top(Infinity))
+      onFilteredFunction: (chart, filter) => {
+        this._refreshData(dimension.top(Infinity))
+      }
     }
 
-    new AmountDistributionBars(renderOptions);
+    charts['amount_distribution'] = new AmountDistributionBars(renderOptions);
   }
 
   _renderContractTypeChart(){
@@ -258,10 +271,13 @@ export class ContractsController {
     const renderOptions = {
       containerSelector: "#contract-type-bars",
       dimension: dimension,
-      onFilteredFunction: () => this._refreshData(dimension.top(Infinity))
+      onFilteredFunction: (chart, filter) => {
+        this._refreshData(dimension.top(Infinity))
+        EventBus.$emit('dc_filter_selected', {title: filter, id: 'contract_types'})
+      }
     }
 
-    new GroupPctDistributionBars(renderOptions);
+    charts['contract_types'] = new GroupPctDistributionBars(renderOptions);
   }
 
   _renderProcessTypeChart(){
@@ -270,19 +286,58 @@ export class ContractsController {
     const renderOptions = {
       containerSelector: "#process-type-bars",
       dimension: dimension,
-      onFilteredFunction: () => this._refreshData(dimension.top(Infinity))
+      onFilteredFunction: (chart, filter) => {
+        this._refreshData(dimension.top(Infinity))
+        EventBus.$emit('dc_filter_selected', {title: filter, id: 'process_types'})
+      }
     }
 
-    new GroupPctDistributionBars(renderOptions);
+    charts['process_types'] = new GroupPctDistributionBars(renderOptions);
+  }
+
+  _renderDateChart(){
+    const dimension = ndx.dimension(contract => contract.start_date_year)
+
+    const renderOptions = {
+      containerSelector: "#date-bars",
+      dimension: dimension,
+      onFilteredFunction: (chart, filter) => {
+        this._refreshData(dimension.top(Infinity))
+        EventBus.$emit('dc_filter_selected', {title: filter, id: 'dates'})
+      }
+    }
+
+    charts['dates'] = new GroupPctDistributionBars(renderOptions);
+  }
+
+  _updateChartsFromFilter(options){
+    const container = charts[options.id].container;
+
+    if (options.all) {
+      container.filter(null);
+      container.filter([options.titles]);
+    } else {
+      container.filter(options.title);
+    }
+
+    Object.values(charts).forEach((chart) => chart.container.redraw());
+  }
+
+  _redrawCharts(){
+    Object.values(charts).forEach((chart) => {
+      chart.setContainerSize();
+      chart.container.redraw();
+    });
   }
 
   _currentDataSource(){
     return reduced || data
   }
 
-  _formalizedContracts(){
-    return this._currentDataSource().contractsData.filter(({status}) =>
-      status === 'Formalizado' || status === 'Adjudicado'
+  _formalizedContractsData(contractsData){
+    return contractsData.filter(({status}) =>
+      status == 'Formalizado' || status == 'Adjudicado'
     )
   }
+
 }

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -146,7 +146,7 @@ export class ContractsController {
       contract.final_amount = final_amount;
       contract.initial_amount = initial_amount;
       contract.range = rangeFormat(+final_amount);
-      contract.start_date_year = contract.start_date != undefined && contract.start_date != '' ? (new Date(contract.start_date).getFullYear()) : contract.start_date;
+      contract.start_date_year = contract.start_date ? (new Date(contract.start_date).getFullYear()) : contract.start_date;
     }
 
     data = {

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsIndex.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsIndex.vue
@@ -9,6 +9,7 @@
 
 <script>
 import Table from "../../components/Table.vue";
+import { EventBus } from "../../mixins/event_bus";
 import { contractsColumns } from "../../lib/config.js";
 
 export default {
@@ -23,6 +24,11 @@ export default {
     }
   },
   created() {
+    EventBus.$on('refresh_summary_data', () => {
+      this.contractsData = this.$root.$data.contractsData
+      this.items = this.contractsData.slice(0, 50);
+    });
+
     this.items = this.contractsData.slice(0, 50);
     this.columns = contractsColumns;
   }

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -58,7 +58,7 @@ export default {
     }
   },
   created(){
-    this.initDateFilterOptions();
+    this.initFilterOptions();
     this.updateCounters(true);
 
     EventBus.$on('dc_filter_selected', ({title, id}) => {
@@ -77,26 +77,52 @@ export default {
     }
   },
   methods: {
-    initDateFilterOptions(){
-      const options = [];
-      let years = new Set( this.contractsData.map(({start_date_year}) => start_date_year) );
+    initFilterOptions(){
+      const contractTypesOptions = [], processTypesOptions = [], dateOptions = [];
+      const years = new Set( this.contractsData.map(({start_date_year}) => start_date_year) );
+      const contractTypes = new Set( this.contractsData.map(({contract_type}) => contract_type) );
+      const processTypes = new Set( this.contractsData.map(({process_type}) => process_type) );
 
+
+      // Contract Types
+      [...contractTypes]
+        .forEach((contractType, index) => {
+          if (contractType) {
+            contractTypesOptions.push({id: index, title: contractType, counter: 0, isOptionChecked: false })
+          }
+        });
+
+      // Process Types
+      [...processTypes]
+        .forEach((processType, index) => {
+          if (processType) {
+            processTypesOptions.push({id: index, title: processType, counter: 0, isOptionChecked: false })
+          }
+        });
+
+      // Dates
       [...years]
         .sort((a, b) => a < b ? 1 : -1)
         .forEach(year => {
-        if (year != '') {
-          options.push({id: year, title: year.toString(), counter: 0, isOptionChecked: false })
-        }
-      });
+          if (year) {
+            dateOptions.push({id: year, title: year.toString(), counter: 0, isOptionChecked: false })
+          }
+        });
 
       this.filters.forEach((filter) => {
-        if (filter.id == 'dates') {
-          filter.options = options;
+        if (filter.id === 'dates') {
+          filter.options = dateOptions;
+        } else if (filter.id === 'contract_types') {
+          filter.options = contractTypesOptions;
+        } else if (filter.id === 'process_types') {
+          filter.options = processTypesOptions;
         }
       })
     },
     updateCounters(firstUpdate=false) {
       const counter = {process_types: {}, contract_types: {}, dates: {}};
+
+      debugger
 
       this.contractsData.forEach(({process_type, contract_type, start_date_year}) => {
         counter.process_types[process_type] = counter.process_types[process_type] || 0

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -78,7 +78,9 @@ export default {
   },
   methods: {
     initFilterOptions(){
-      const contractTypesOptions = [], processTypesOptions = [], dateOptions = [];
+      const contractTypesOptions = [];
+      const processTypesOptions = [];
+      const dateOptions = [];
       const years = new Set( this.contractsData.map(({start_date_year}) => start_date_year) );
       const contractTypes = new Set( this.contractsData.map(({contract_type}) => contract_type) );
       const processTypes = new Set( this.contractsData.map(({process_type}) => process_type) );

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -6,7 +6,7 @@
         :key="filter.id"
         class="dashboards-home-aside--block"
       >
-        <Dropdown @is-content-visible="filter.isToggle = !filter.isToggle">
+        <Dropdown @is-content-visible="toggle(filter)">
           <template v-slot:trigger>
             <BlockHeader
               :title="filter.title"
@@ -48,18 +48,18 @@ export default {
   },
   data() {
     return {
-      contractsData: this.$root.$data.contractsData,
       filters: filtersConfig
+    }
+  },
+  props: {
+    contractsData: {
+      type: Array,
+      default: {}
     }
   },
   created(){
     this.initDateFilterOptions();
     this.updateCounters(true);
-
-    EventBus.$on('refresh_summary_data', () => {
-      this.contractsData = this.$root.$data.contractsData;
-      this.updateCounters();
-    });
 
     EventBus.$on('dc_filter_selected', ({title, id}) => {
       const filter = this.filters.find(filter => filter.id === id)
@@ -70,6 +70,11 @@ export default {
         }
       })
     });
+  },
+  watch: {
+    contractsData: function (newContractsData, oldContractsData) {
+      this.updateCounters();
+    }
   },
   methods: {
     initDateFilterOptions(){

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -62,9 +62,9 @@ export default {
     this.updateCounters(true);
 
     EventBus.$on('dc_filter_selected', ({title, id}) => {
-      const filter = this.filters.find(filter => filter.id === id)
+      const { options = [] } = this.filters.find(( { id: i } ) => id === i) || {};
 
-      filter.options.forEach(option => {
+      options.forEach(option => {
         if (option.title === title) {
           option.isOptionChecked = !option.isOptionChecked;
         }

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -122,8 +122,9 @@ export default {
     updateCounters(firstUpdate=false) {
       const counter = {process_types: {}, contract_types: {}, dates: {}};
 
-      debugger
-
+      // It iterates over the contracts to get the number of items for each year, process type and contract type
+      // In the end, it populates counter with something like:
+      // {process_types: {'Abierto': 12, 'Abierto Simplificado': 43,...}, dates: {2020: '12'...}}
       this.contractsData.forEach(({process_type, contract_type, start_date_year}) => {
         counter.process_types[process_type] = counter.process_types[process_type] || 0
         counter.process_types[process_type]++
@@ -135,6 +136,7 @@ export default {
         counter.dates[start_date_year]++
       })
 
+      // This loop fills the filters data attribute with the counter result we populated in the previous loop
       this.filters.forEach((filter) => {
         const { id } = filter;
         for (let i = 0; i < filter.options.length; i++) {

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -98,15 +98,15 @@ export default {
     updateCounters(firstUpdate=false) {
       const counter = {process_types: {}, contract_types: {}, dates: {}};
 
-      this.contractsData.forEach((contract) => {
-        counter.process_types[contract.process_type] = counter.process_types[contract.process_type] || 0
-        counter.process_types[contract.process_type]++
+      this.contractsData.forEach(({process_type, contract_type, start_date_year}) => {
+        counter.process_types[process_type] = counter.process_types[process_type] || 0
+        counter.process_types[process_type]++
 
-        counter.contract_types[contract.contract_type] = counter.contract_types[contract.contract_type] || 0
-        counter.contract_types[contract.contract_type]++
+        counter.contract_types[contract_type] = counter.contract_types[contract_type] || 0
+        counter.contract_types[contract_type]++
 
-        counter.dates[contract.start_date_year] = counter.dates[contract.start_date_year] || 0
-        counter.dates[contract.start_date_year]++
+        counter.dates[start_date_year] = counter.dates[start_date_year] || 0
+        counter.dates[start_date_year]++
       })
 
       this.filters.forEach((filter) => {

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -1,14 +1,124 @@
 <template>
   <div class="pure-u-1 pure-u-lg-1-4">
     <aside class="dashboards-home-aside--gap">
-      wip filtros
+      <div
+        v-for="filter in filters"
+        :key="filter.id"
+        class="dashboards-home-aside--block"
+      >
+        <BlockHeader
+          :title="filter.title"
+          class="dashboards-home-aside--block-header"
+          see-link
+          @select-all="e => handleIsEverythingChecked({ ...e, filter })"
+        />
+        <Checkbox
+          v-for="option in filter.options"
+          :id="option.id"
+          :key="option.id"
+          :title="option.title"
+          :checked="option.isOptionChecked"
+          :counter="option.counter"
+          class="dashboards-home-aside--checkbox"
+          @checkbox-change="e => handleCheckboxStatus({ ...e, filter })"
+        />
+      </div>
     </aside>
   </div>
 </template>
 
 <script>
+import { BlockHeader, Checkbox } from "lib/vue-components";
+import { EventBus } from "../../mixins/event_bus";
+import { filtersConfig } from "../../lib/config.js";
+
 export default {
   name: 'Aside',
-  data() { return {} }
+  components: {
+    BlockHeader,
+    Checkbox,
+  },
+  data() {
+    return {
+      contractsData: this.$root.$data.contractsData,
+      filters: filtersConfig
+    }
+  },
+  created(){
+    this.initDateFilterOptions();
+    this.updateCounters(true);
+
+    EventBus.$on('refresh_summary_data', () => {
+      this.contractsData = this.$root.$data.contractsData;
+      this.updateCounters();
+    });
+
+    EventBus.$on('dc_filter_selected', ({title, id}) => {
+      const filter = this.filters.find(filter => filter.id === id)
+
+      filter.options.forEach(option => {
+        if (option.title === title) {
+          option.isOptionChecked = !option.isOptionChecked;
+        }
+      })
+    });
+  },
+  methods: {
+    initDateFilterOptions(){
+      const options = [];
+      let years = new Set( this.contractsData.map(({start_date_year}) => start_date_year) );
+
+      [...years]
+        .sort((a, b) => a < b ? 1 : -1)
+        .forEach(year => {
+        if (year != '') {
+          options.push({id: year, title: year.toString(), counter: 0, isOptionChecked: false })
+        }
+      });
+
+      this.filters.forEach((filter) => {
+        if (filter.id == 'dates') {
+          filter.options = options;
+        }
+      })
+    },
+    updateCounters(firstUpdate=false) {
+      const counter = {process_types: {}, contract_types: {}, dates: {}};
+
+      this.contractsData.forEach((contract) => {
+        counter.process_types[contract.process_type] = counter.process_types[contract.process_type] || 0
+        counter.process_types[contract.process_type]++
+
+        counter.contract_types[contract.contract_type] = counter.contract_types[contract.contract_type] || 0
+        counter.contract_types[contract.contract_type]++
+
+        counter.dates[contract.start_date_year] = counter.dates[contract.start_date_year] || 0
+        counter.dates[contract.start_date_year]++
+      })
+
+      this.filters.forEach((filter) => {
+        const { id } = filter;
+        for (let i = 0; i < filter.options.length; i++) {
+          filter.options[i].counter = counter[id][filter.options[i].title];
+        }
+
+        if (firstUpdate && filter.id != 'dates') {
+          // Sorting from highest to lowest, just like the chart bars.
+          filter.options = filter.options.sort((a, b) => a.counter > b.counter ? -1 : 1)
+        }
+      })
+
+    },
+    handleIsEverythingChecked({ filter }) {
+      const titles = filter.options.map(option => option.title);
+      filter.options.forEach(option => option.isOptionChecked = true)
+
+      EventBus.$emit('filter_changed', {all: true, titles: titles, id: filter.id});
+    },
+    handleCheckboxStatus({ id, value, filter }) {
+      const option = filter.options.find(option => option.id === id)
+      EventBus.$emit('filter_changed', {all: false, title: option.title, id: filter.id});
+    },
+  }
 }
 </script>

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -161,7 +161,7 @@ export default {
     },
     toggle(filter){
       this.filters.forEach(_filter => {
-        if (_filter.id == filter.id) {
+        if (_filter.id === filter.id) {
           _filter.isToggle = !_filter.isToggle;
         }
       })

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -6,35 +6,43 @@
         :key="filter.id"
         class="dashboards-home-aside--block"
       >
-        <BlockHeader
-          :title="filter.title"
-          class="dashboards-home-aside--block-header"
-          see-link
-          @select-all="e => handleIsEverythingChecked({ ...e, filter })"
-        />
-        <Checkbox
-          v-for="option in filter.options"
-          :id="option.id"
-          :key="option.id"
-          :title="option.title"
-          :checked="option.isOptionChecked"
-          :counter="option.counter"
-          class="dashboards-home-aside--checkbox"
-          @checkbox-change="e => handleCheckboxStatus({ ...e, filter })"
-        />
+        <Dropdown @is-content-visible="filter.isToggle = !filter.isToggle">
+          <template v-slot:trigger>
+            <BlockHeader
+              :title="filter.title"
+              class="dashboards-home-aside--block-header"
+              see-link
+              @select-all="e => handleIsEverythingChecked({ ...e, filter })"
+              @toggle="toggle(filter)"
+            />
+          </template>
+          <div>
+            <Checkbox
+              v-for="option in filter.options"
+              :id="option.id"
+              :key="option.id"
+              :title="option.title"
+              :checked="option.isOptionChecked"
+              :counter="option.counter"
+              class="dashboards-home-aside--checkbox"
+              @checkbox-change="e => handleCheckboxStatus({ ...e, filter })"
+            />
+          </div>
+        </Dropdown>
       </div>
     </aside>
   </div>
 </template>
 
 <script>
-import { BlockHeader, Checkbox } from "lib/vue-components";
+import { BlockHeader, Checkbox, Dropdown } from "lib/vue-components";
 import { EventBus } from "../../mixins/event_bus";
 import { filtersConfig } from "../../lib/config.js";
 
 export default {
   name: 'Aside',
   components: {
+    Dropdown,
     BlockHeader,
     Checkbox,
   },
@@ -107,7 +115,6 @@ export default {
           filter.options = filter.options.sort((a, b) => a.counter > b.counter ? -1 : 1)
         }
       })
-
     },
     handleIsEverythingChecked({ filter }) {
       const titles = filter.options.map(option => option.title);
@@ -119,6 +126,13 @@ export default {
       const option = filter.options.find(option => option.id === id)
       EventBus.$emit('filter_changed', {all: false, title: option.title, id: filter.id});
     },
+    toggle(filter){
+      this.filters.forEach(_filter => {
+        if (_filter.id == filter.id) {
+          _filter.isToggle = !_filter.isToggle;
+        }
+      })
+    }
   }
 }
 </script>

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -52,11 +52,11 @@ export default {
     }
   },
   computed: {
-    isSummary: function() { return this.$route.name === 'summary' },
-    isContractsIndex: function() { return this.$route.name === 'contracts_index' },
-    isContractsShow: function() { return this.$route.name === 'contracts_show' },
-    isTendersIndex: function() { return this.$route.name === 'tenders_index' },
-    isTendersShow: function() { return this.$route.name === 'tenders_show' },
+    isSummary() { return this.$route.name === 'summary' },
+    isContractsIndex() { return this.$route.name === 'contracts_index' },
+    isContractsShow() { return this.$route.name === 'contracts_show' },
+    isTendersIndex() { return this.$route.name === 'tenders_index' },
+    isTendersShow() { return this.$route.name === 'tenders_show' },
   },
   created(){
     EventBus.$on('refresh_summary_data', () => {

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -11,11 +11,11 @@
           @active-tab="setActiveTab"
         ></Nav>
         <main class="dashboards-home-main">
-          <Summary v-show="isCurrentPath('summary')"/>
-          <ContractsIndex v-show="isCurrentPath('contracts_index')"/>
-          <ContractsShow v-if="isCurrentPath('contracts_show')"/>
-          <TendersIndex v-show="isCurrentPath('tenders_index')"/>
-          <TendersShow v-if="isCurrentPath('tenders_show')"/>
+          <Summary v-show="isSummary"/>
+          <ContractsIndex v-show="isContractsIndex"/>
+          <ContractsShow v-if="isContractsShow"/>
+          <TendersIndex v-show="isTendersIndex"/>
+          <TendersShow v-if="isTendersShow"/>
         </main>
       </div>
     </div>
@@ -51,6 +51,13 @@ export default {
       contractsData: this.$root.$data.contractsData,
     }
   },
+  computed: {
+    isSummary: function() { return this.$route.name === 'summary' },
+    isContractsIndex: function() { return this.$route.name === 'contracts_index' },
+    isContractsShow: function() { return this.$route.name === 'contracts_show' },
+    isTendersIndex: function() { return this.$route.name === 'tenders_index' },
+    isTendersShow: function() { return this.$route.name === 'tenders_show' },
+  },
   created(){
     EventBus.$on('refresh_summary_data', () => {
       this.contractsData = this.$root.$data.contractsData;
@@ -64,9 +71,6 @@ export default {
       if (this.isSummaryPage(tabIndex)) {
         EventBus.$emit("moved_to_summary");
       }
-    },
-    isCurrentPath(componentPathName){
-      return this.$route.name === componentPathName
     },
     isSummaryPage(tabIndex){
       return tabIndex === 0

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
     <div class="pure-g gutters m_b_4">
-      <Aside></Aside>
+      <Aside />
 
       <div class="pure-u-1 pure-u-lg-3-4">
         <Nav
@@ -9,9 +9,11 @@
           @active-tab="setActiveTab"
         ></Nav>
         <main class="dashboards-home-main">
-          <keep-alive include="Summary">
-            <router-view :key="$route.fullPath"></router-view>
-          </keep-alive>
+          <Summary v-show="isCurrentPath('summary')"/>
+          <ContractsIndex v-show="isCurrentPath('contracts_index')"/>
+          <ContractsShow v-if="isCurrentPath('contracts_show')"/>
+          <TendersIndex v-show="isCurrentPath('tenders_index')"/>
+          <TendersShow v-if="isCurrentPath('tenders_show')"/>
         </main>
       </div>
     </div>
@@ -21,14 +23,25 @@
 <script>
 import Nav from "./Nav.vue";
 import Aside from "./Aside.vue";
+import Summary from "./../summary/Summary.vue";
+import ContractsIndex from "./../contract/ContractsIndex.vue";
+import ContractsShow from "./../contract/ContractsShow.vue";
+import TendersIndex from "./../tender/TendersIndex.vue";
+import TendersShow from "./../tender/TendersShow.vue";
 
+import { EventBus } from "../../mixins/event_bus";
 import { store } from "../../mixins/store";
 
 export default {
   name: 'Home',
   components: {
     Aside,
-    Nav
+    Nav,
+    Summary,
+    ContractsIndex,
+    ContractsShow,
+    TendersIndex,
+    TendersShow
   },
   data() {
     return {
@@ -36,10 +49,20 @@ export default {
     }
   },
   methods: {
-    setActiveTab(value) {
-      this.activeTabIndex = value;
-      store.addCurrentTab(value);
+    setActiveTab(tabIndex) {
+      this.activeTabIndex = tabIndex;
+      store.addCurrentTab(tabIndex);
+
+      if (this.isSummaryPage(tabIndex)) {
+        EventBus.$emit("moved_to_summary");
+      }
     },
+    isCurrentPath(componentPathName){
+      return this.$route.name === componentPathName
+    },
+    isSummaryPage(tabIndex){
+      return tabIndex === 0
+    }
   }
 
 }

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -1,7 +1,9 @@
 <template>
   <main>
     <div class="pure-g gutters m_b_4">
-      <Aside />
+      <Aside
+        :contracts-data="contractsData"
+      />
 
       <div class="pure-u-1 pure-u-lg-3-4">
         <Nav
@@ -46,7 +48,13 @@ export default {
   data() {
     return {
       activeTabIndex: store.state.currentTab || 0,
+      contractsData: this.$root.$data.contractsData,
     }
+  },
+  created(){
+    EventBus.$on('refresh_summary_data', () => {
+      this.contractsData = this.$root.$data.contractsData;
+    });
   },
   methods: {
     setActiveTab(tabIndex) {

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -46,11 +46,6 @@
                     </div>
                   </div>
                 </div>
-
-                <div class="pure-u-1-2">
-                  <p class="m_t_0">{{ labelMeanSavings }}</p>
-                  <div class="metric m_b_1"><small><span id="mean-savings"></span></small></div>
-                </div>
               </div>
             </div> <!-- contracts -->
 

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -59,7 +59,7 @@
       </div> <!-- metric_box -->
     </div> <!-- metrix_boxes -->
 
-    <div class="pure-g block m_b_3">
+    <div class="pure-g block m_b_3" id="dccharts">
       <div class="pure-u-1 pure-u-lg-1-3 p_h_r_3 header_block_inline">
         <p class="decorator" v-html="labelLessThan1000"></p>
       </div>
@@ -90,6 +90,9 @@
         <div>
           <h3 class="mt1 graph-title">{{ labelAmountDistribution }}</h3>
           <div id="amount-distribution-bars"></div>
+        </div>
+        <div>
+          <div id="date-bars" class="hidden"></div>
         </div>
       </div>
     </div>
@@ -141,11 +144,11 @@ export default {
   },
 
   mounted() {
-    EventBus.$emit("summary_ready");
-
     EventBus.$on('refresh_summary_data', () => {
       this.refreshSummaryData();
     });
+
+    EventBus.$emit("summary_ready");
   },
   created() {
     this.items = this.buildItems();

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -21,11 +21,13 @@ export const filtersConfig = [
   {
     id: 'dates',
     title: I18n.t('gobierto_dashboards.dashboards.contracts.dates'),
+    isToggle: true,
     options: []
   },
   {
     id: 'contract_types',
     title: I18n.t('gobierto_dashboards.dashboards.contracts.contract_type'),
+    isToggle: true,
     options: [
       {id: 0, title: 'Gestión de servicios públicos', counter: 0, isOptionChecked: false},
       {id: 1, title: 'Obras', counter: 0, isOptionChecked: false},
@@ -36,6 +38,7 @@ export const filtersConfig = [
   {
     id: 'process_types',
     title: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
+    isToggle: true,
     options: [
         {id: 0, title: 'Abierto', counter: 0, isOptionChecked: false},
         {id: 1, title: 'Abierto simplificado', counter: 0, isOptionChecked: false},

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -28,23 +28,12 @@ export const filtersConfig = [
     id: 'contract_types',
     title: I18n.t('gobierto_dashboards.dashboards.contracts.contract_type'),
     isToggle: true,
-    options: [
-      {id: 0, title: 'Gestión de servicios públicos', counter: 0, isOptionChecked: false},
-      {id: 1, title: 'Obras', counter: 0, isOptionChecked: false},
-      {id: 2, title: 'Servicios', counter: 0, isOptionChecked: false},
-      {id: 3, title: 'Suministros', counter: 0, isOptionChecked: false},
-    ]
+    options: []
   },
   {
     id: 'process_types',
     title: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
     isToggle: true,
-    options: [
-        {id: 0, title: 'Abierto', counter: 0, isOptionChecked: false},
-        {id: 1, title: 'Abierto simplificado', counter: 0, isOptionChecked: false},
-        {id: 2, title: 'Basado en Acuerdo Marco', counter: 0, isOptionChecked: false},
-        {id: 3, title: 'Negociado con publicidad', counter: 0, isOptionChecked: false},
-        {id: 4, title: 'Negociado sin publicidad', counter: 0, isOptionChecked: false}
-      ]
+    options: []
   }
 ]

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -2,7 +2,7 @@ export const contractsColumns = [
   {field: 'assignee', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null},
   {field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: 'truncated'},
   {field: 'final_amount', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
-  {field: 'end_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.end_date'), format: null},
+  {field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null},
 ];
 
 export const tendersColumns = [
@@ -16,3 +16,32 @@ export const assigneesColumns = [
   {field: 'count', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contracts'), format: 'quantity'},
   {field: 'sum', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
 ];
+
+export const filtersConfig = [
+  {
+    id: 'dates',
+    title: I18n.t('gobierto_dashboards.dashboards.contracts.dates'),
+    options: []
+  },
+  {
+    id: 'contract_types',
+    title: I18n.t('gobierto_dashboards.dashboards.contracts.contract_type'),
+    options: [
+      {id: 0, title: 'Gestión de servicios públicos', counter: 0, isOptionChecked: false},
+      {id: 1, title: 'Obras', counter: 0, isOptionChecked: false},
+      {id: 2, title: 'Servicios', counter: 0, isOptionChecked: false},
+      {id: 3, title: 'Suministros', counter: 0, isOptionChecked: false},
+    ]
+  },
+  {
+    id: 'process_types',
+    title: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
+    options: [
+        {id: 0, title: 'Abierto', counter: 0, isOptionChecked: false},
+        {id: 1, title: 'Abierto simplificado', counter: 0, isOptionChecked: false},
+        {id: 2, title: 'Basado en Acuerdo Marco', counter: 0, isOptionChecked: false},
+        {id: 3, title: 'Negociado con publicidad', counter: 0, isOptionChecked: false},
+        {id: 4, title: 'Negociado sin publicidad', counter: 0, isOptionChecked: false}
+      ]
+  }
+]

--- a/app/javascript/lib/visualizations/modules/amount_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/amount_distribution_bars.js
@@ -8,30 +8,30 @@ export class AmountDistributionBars {
   constructor(options) {
     // Declaration
     const { containerSelector, dimension, onFilteredFunction, range, labelMore, labelFromTo } = options
-    const container = dc.rowChart(containerSelector, "group");
+    this.container = dc.rowChart(containerSelector, "group");
 
     // Dimensions
     const amountByGroupingField = dimension.group().reduceCount();
 
     // Styling
-    const _count = amountByGroupingField.size(),
-          _gap = 10,
-          _barHeight = 18,
-          _labelOffset = 195;
+    this._count = amountByGroupingField.size(),
+    this._gap = 10
+    this._barHeight = 18
 
-    const node = container.root().node() || document.createElement("div")
+    const _labelOffset = 195;
+
+    this.node = this.container.root().node() || document.createElement("div")
+
+    this.setContainerSize();
 
     // Construction
-    container
-      .width((node.parentNode || node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
-      .height(container.margins().top + container.margins().bottom + (_count * _barHeight) + ((_count + 1) * _gap)) // Margins top/bottom + bars + gaps (space between)
-      .fixedBarHeight(_barHeight)
+    this.container
       .x(d3.scaleThreshold())
       .dimension(dimension)
       .group(amountByGroupingField)
       .ordering(d => d.key)
       .labelOffsetX(-_labelOffset)
-      .gap(_gap)
+      .gap(this._gap)
       .elasticX(true)
       .title(d => d.value)
       .on('pretransition', function(chart){
@@ -101,21 +101,27 @@ export class AmountDistributionBars {
           return Math.abs(+d3.select(this).attr("y2")) + (chart.margins().top / 2)
         });
       })
-      .on('filtered', () => onFilteredFunction());
+      .on('filtered', (chart, filter) => onFilteredFunction(chart, filter));
 
     // Customization
-    container.xAxis(d3.axisTop().ticks(5))
-    container.xAxis().tickFormat(
+    this.container.xAxis(d3.axisTop().ticks(5))
+    this.container.xAxis().tickFormat(
       function(tick, pos) {
         if (pos === 0) return null
         return tick
       });
-    container.margins().top = 20;
-    container.margins().left = _labelOffset + 5;
-    container.margins().right = 0;
+    this.container.margins().top = 20;
+    this.container.margins().left = _labelOffset + 5;
+    this.container.margins().right = 0;
 
     // Rendering
-    container.render();
+    this.container.render();
+  }
 
+  setContainerSize(){
+    this.container
+      .width((this.node.parentNode || this.node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
+      .height(this.container.margins().top + this.container.margins().bottom + (this._count * this._barHeight) + ((this._count + 1) * this._gap)) // Margins top/bottom + bars + gaps (space between)
+      .fixedBarHeight(this._barHeight)
   }
 }

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -8,37 +8,37 @@ export class GroupPctDistributionBars {
   constructor(options) {
     // Declaration
     const { containerSelector, dimension, onFilteredFunction } = options
-    const container = dc.rowChart(containerSelector, "group");
+    this.container = dc.rowChart(containerSelector, "group");
 
     // Dimensions
     const groupedDimension = dimension.group().reduceCount(),
           all = dimension.groupAll();
 
     // Styling
-    const _count = groupedDimension.size(),
-          _gap = 10,
-          _barHeight = 18,
-          _initialLabelOffset = 250,
+    this._count = groupedDimension.size()
+    this._gap = 10
+    this._barHeight = 18
+
+    const _initialLabelOffset = 250,
           _pctLabelOffset = 70;
 
-    const node = container.root().node() || document.createElement("div")
+    this.node = this.container.root().node() || document.createElement("div")
+
+    this.setContainerSize();
 
     // Construction
-    container
-      .width((node.parentNode || node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
-      .height(container.margins().top + container.margins().bottom + (_count * _barHeight) + ((_count + 1) * _gap)) // Margins top/bottom + bars + gaps (space between)
-      .fixedBarHeight(_barHeight)
+    this.container
       .x(d3.scaleThreshold())
       .dimension(dimension)
       .group(groupedDimension)
       .ordering(d => -d.value)
       .labelOffsetX(-_initialLabelOffset)
-      .gap(_gap)
+      .gap(this._gap)
       .elasticX(true)
       .title(function(d) { return d.value })
       .valueAccessor(d =>  parseFloat(d.value / all.value()) )
 
-    container
+    this.container
       .on('pretransition', function(chart){
         // Apply rounded corners AFTER render, otherwise they don't exist
         chart.selectAll('rect').attr("rx", 4).attr("ry", 4);
@@ -50,9 +50,9 @@ export class GroupPctDistributionBars {
           .data(d => {
             let label = d.key, pct;
 
-            if (container.hasFilter() && !container.hasFilter(d.key)){
+            if (this.hasFilter() && !this.hasFilter(d.key)){
               pct = 0.0;
-            } else if (container.hasFilter() && container.hasFilter(d.key)){
+            } else if (this.hasFilter() && this.hasFilter(d.key)){
               pct = parseFloat(d.value / dimension.top(Infinity).length);
             } else{
               pct = parseFloat(d.value / all.value());
@@ -71,14 +71,21 @@ export class GroupPctDistributionBars {
           .attr('x', (d, i) => i === 0 ? -_initialLabelOffset : -_pctLabelOffset)
       })
 
-    container.on('filtered', () => onFilteredFunction());
+    this.container.on('filtered', (chart, filter) => onFilteredFunction(chart, filter));
 
     // Customization
-    container.xAxis(d3.axisTop().ticks(0))
-    container.margins().left = _initialLabelOffset + 5;
-    container.margins().right = 0;
+    this.container.xAxis(d3.axisTop().ticks(0))
+    this.container.margins().left = _initialLabelOffset + 5;
+    this.container.margins().right = 0;
 
     // Rendering
-    container.render();
+    this.container.render();
+  }
+
+  setContainerSize(){
+    this.container
+      .width((this.node.parentNode || this.node).getBoundingClientRect().width) // webkit doesn't recalculate dynamic width. it has to be set by parentNode
+      .height(this.container.margins().top + this.container.margins().bottom + (this._count * this._barHeight) + ((this._count + 1) * this._gap)) // Margins top/bottom + bars + gaps (space between)
+      .fixedBarHeight(this._barHeight)
   }
 }

--- a/app/javascript/lib/vue-components/modules/BlockHeader.vue
+++ b/app/javascript/lib/vue-components/modules/BlockHeader.vue
@@ -10,7 +10,7 @@
     <a
       v-if="seeLink"
       class="gobierto-block-header--link"
-      @click="selectAll"
+      @click.stop="selectAll"
     >{{
       labelAlt ? labelNone : labelAll
     }}</a>

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -9,10 +9,11 @@ ca:
         contract_type: Tipus de contracte
         contractor: Contractor
         contracts: Contractes
+        date: Data
+        dates: Dates
         description: Visualització i anàlisi dels contractes adjudicats i les licitacions
           del %{entity_name}
         empty_table: No hi ha dades disponibles
-        end_date: Data
         final_amount: Quantitat
         fromto: De a Nº Contr.
         main_assignees: Principals adjudicataris

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -9,10 +9,11 @@ en:
         contract_type: Type of contract
         contractor: Contractor
         contracts: Contracts
+        date: Date
+        dates: Dates
         description: Visualizations and analisys for the awarded contracts and tenders
           to %{entity_name}
         empty_table: There is no available data
-        end_date: Date
         final_amount: Amount
         fromto: From To No Contr.
         main_assignees: Main assignees

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -9,10 +9,11 @@ es:
         contract_type: Tipo de contrato
         contractor: Contrato
         contracts: Contratos
+        date: Fecha
+        dates: Fechas
         description: Visualización y análisis de los contratos adjudicados y las licitaciones
           del %{entity_name}
         empty_table: No hay datos disponibles
-        end_date: Fecha
         final_amount: Importe
         fromto: Desde A Nº. Contr.
         main_assignees: Principales adjudicatarios

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -100,8 +100,8 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       # Assignees table
       first_contract = find(".dashboards-home-main--tr", match: :first)
 
-      assert first_contract.has_content?('IMPORTACIONES INDUSTRIALES, S.A.')
-      assert first_contract.has_content?('60.004,64 €')
+      assert first_contract.has_content?('LIDER SYSTEM, S.L.')
+      assert first_contract.has_content?('43.671,37 €')
     end
   end
 
@@ -121,16 +121,16 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       first_contract = find(".dashboards-home-main--tr", match: :first)
 
       # Assignee
-      assert first_contract.has_content?('Marc Gil Van Beveren')
+      assert first_contract.has_content?('Grupo Conforsa Análisis, Desarrollo y Formación , S.A.')
 
       # Contract
-      assert first_contract.has_content?('Servicios de asesoramiento jurídico, defensa y formación en ...')
+      assert first_contract.has_content?('Prestación del servicio de plataforma de formación online "E...')
 
       # Amount
-      assert first_contract.has_content?('€5,808.00')
+      assert first_contract.has_content?('€34,364.00')
 
       # Date
-      assert first_contract.has_content?('2055-12-31')
+      assert first_contract.has_content?('2020-07-01')
 
       # Contracts Show
       ################
@@ -140,25 +140,25 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert find(".dashboards-home-nav--tab.is-active").text, 'CONTRACTS'
 
       # Url is updated
-      assert_equal current_path, "/dashboards/contratos/contratos/807008"
+      assert_equal current_path, "/dashboards/contratos/contratos/807094"
 
       # Title
-      assert page.has_content?('Servicios de asesoramiento jurídico, defensa y formación en materia de contratación pública')
+      assert page.has_content?('Prestación del servicio de plataforma de formación online "Escuela Virtual Formalef Getafe".')
 
       # Assignee
-      assert page.has_content?('Marc Gil Van Beveren')
+      assert page.has_content?('Grupo Conforsa Análisis, Desarrollo y Formación , S.A.')
 
       # Contract amount
-      assert page.has_content?('€5,808.00')
+      assert page.has_content?('€34,364.00')
 
       # Tender amount
-      assert page.has_content?('€217,800.00')
+      assert page.has_content?('€48,400.00')
 
       # Status
       assert page.has_content?('Formalizado')
 
       # Type
-      assert page.has_content?('Abierto')
+      assert page.has_content?('Abierto simplificado')
     end
   end
 

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -78,8 +78,6 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert metrics_box.has_content?("Importe medio\n326.881,83 €")
       assert metrics_box.has_content?("Importe mediano\n33.668,25 €")
 
-      assert metrics_box.has_content?("Ahorro medio de licitación a adjudicación\n44,44 %")
-
       ## Headlines
       assert page.has_content?("El 5 % de los contratos son menores de 1.000 €")
       assert page.has_content?("El mayor contrato supone un 18 % de todo el gasto en contratos")


### PR DESCRIPTION
Closes #3047

## :v: What does this PR do?

It adds the sidebar filters to Dashboards Contracts.

@Crashillo I think this was the first time that Dropdown and Blockheader are being used together, and there were a couple of bugs. The first is a matter of styling, I added a new rule `widht: 100%` in `app/assets/stylesheets/comp-block-header.scss`. Otherwise the "All" link and the blockheader title would stay together (even with the flex and justify-between rules). The other bug was that when clicking "All" would also work as a toggle and collapse. The fix, which @jorgeatgu figured out, was adding the event modifier `stop` (as in `@click.stop="selectAll"`). Now it works.

What's still pending to do is using the Caret component in Blockheader and make it rotate accordingly.

### Some implementation details

I'd like to share some details so you can better understand the reasons behind some parts of the code. 

The most important thing you need to know is that all the filtering in the sidebars is actually made by the dc charts, so there's no filtering logic in the vue components.

To make this work, the dc charts have to be initialized no matter the page you are or start at. So, for instance, if you enter `/dashboards/contratos/contratos` the dc charts (which are not in that component) have to be created because you could filter from the sidebar there. 

Another issue that arised is that, since they could be created without the component being shown, when going to Summary the charts didn't have the proper size (the size is calculated when creating the chart using the size of the target element). So there's an event called `moved_to_summary` that will be listened just once to redraw the charts when going to Summary from others . 

Last, there's a sidebar filter for dates. To make this work, there's a hidden dc chart for dates that does all the filtering with the other charts.

## :mag: How should this be manually tested?

Head to https://getafe.gobify.net/dashboards/contratos/resumen and play with the sidebar filters. Case scenarios:

- Clicking on any sidebar filter will update the current filters. It should also update the chart bars if the filter has a char version.
- When filtering with the chart bar, the sidebar filter should update if it applies.
- If there's a version of the filter as a chart, the chart filter should be updated too.
- If you're using the sidebar filter from any index (contracts or tenders), listing should be updated

## :eyes: Screenshots

![Captura de pantalla 2020-05-21 a las 10 51 40](https://user-images.githubusercontent.com/545235/82541646-18443180-9b51-11ea-870f-d5e917b68b54.png)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

No