### PR TITLE
Dashboard open data link

### DIFF
--- a/app/assets/stylesheets/module-dashboards.scss
+++ b/app/assets/stylesheets/module-dashboards.scss
@@ -208,4 +208,28 @@
       border-top-color: transparent;
     }
   }
+
+  &-home-aside {
+    &--download-open-data {
+      padding: 2em 0;
+      font-size: 1em;
+
+      a {
+        color: var(--color-base);
+        width: 75%;
+        display: inline-block;
+        vertical-align: top;
+        line-height: 1.4em;
+      }
+
+      a:hover {
+        color: rgba(var(--color-base-string), 0.8);
+      }
+
+      .fas {
+        color: var(--color-base);
+        margin: 0 0.6em;
+      }
+    }
+  }
 }

--- a/app/javascript/gobierto_dashboards/index.js
+++ b/app/javascript/gobierto_dashboards/index.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     logoUrl: appNode.dataset.logoUrl,
     homeUrl: appNode.dataset.homeUrl,
     contractsEndpoint: appNode.dataset.contractsEndpoint,
-    tendersEndpoint: appNode.dataset.tendersEndpoint
+    tendersEndpoint: appNode.dataset.tendersEndpoint,
+    dataDownloadEndpoint: appNode.dataset.dataDownloadEndpoint,
   });
 });

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -46,7 +46,7 @@ export class ContractsController {
         const router = new VueRouter({
           mode: "history",
           routes: [
-            { path: "/dashboards/contratos", component: Home,
+            { path: "/dashboards/contratos", component: Home, props: {dataDownloadEndpoint: options.dataDownloadEndpoint},
               children: [
                 { path: "resumen", name: "summary", component: Summary},
                 { path: "contratos", name: "contracts_index", component: ContractsIndex },

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -150,6 +150,7 @@ export default {
           filter.options = filter.options.sort((a, b) => a.counter > b.counter ? -1 : 1)
         }
       })
+
     },
     handleIsEverythingChecked({ filter }) {
       const titles = filter.options.map(option => option.title);

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -30,6 +30,17 @@
           </div>
         </Dropdown>
       </div>
+
+      <div
+        v-if="showDownloadDataLink()"
+        class="dashboards-home-aside--download-open-data"
+      >
+        <i class="fas fa-table"></i>
+        <a :href="dataDownloadEndpoint" target="blank">
+          {{ labelDownloadData }}
+        </a>
+      </div>
+
     </aside>
   </div>
 </template>
@@ -48,6 +59,8 @@ export default {
   },
   data() {
     return {
+      labelDownloadData: I18n.t('gobierto_dashboards.dashboards.contracts.download_data'),
+      contractsData: this.$root.$data.contractsData,
       filters: filtersConfig
     }
   },
@@ -55,6 +68,10 @@ export default {
     contractsData: {
       type: Array,
       default: {}
+    },
+    dataDownloadEndpoint: {
+      type: String,
+      default: ''
     }
   },
   created(){
@@ -168,6 +185,9 @@ export default {
           _filter.isToggle = !_filter.isToggle;
         }
       })
+    },
+    showDownloadDataLink(){
+      return(this.dataDownloadEndpoint != '' && this.dataDownloadEndpoint != undefined)
     }
   }
 }

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -32,7 +32,7 @@
       </div>
 
       <div
-        v-if="showDownloadDataLink()"
+        v-if="isShowDownloadDatalinkShown"
         class="dashboards-home-aside--download-open-data"
       >
         <i class="fas fa-table"></i>
@@ -60,7 +60,6 @@ export default {
   data() {
     return {
       labelDownloadData: I18n.t('gobierto_dashboards.dashboards.contracts.download_data'),
-      contractsData: this.$root.$data.contractsData,
       filters: filtersConfig
     }
   },
@@ -77,6 +76,8 @@ export default {
   created(){
     this.initFilterOptions();
     this.updateCounters(true);
+
+    this.isShowDownloadDatalinkShown = !!this.dataDownloadEndpoint
 
     EventBus.$on('dc_filter_selected', ({title, id}) => {
       const { options = [] } = this.filters.find(( { id: i } ) => id === i) || {};
@@ -185,9 +186,6 @@ export default {
           _filter.isToggle = !_filter.isToggle;
         }
       })
-    },
-    showDownloadDataLink(){
-      return !!this.dataDownloadEndpoint
     }
   }
 }

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Aside.vue
@@ -36,7 +36,7 @@
         class="dashboards-home-aside--download-open-data"
       >
         <i class="fas fa-table"></i>
-        <a :href="dataDownloadEndpoint" target="blank">
+        <a :href="dataDownloadEndpoint" target="_blank">
           {{ labelDownloadData }}
         </a>
       </div>
@@ -187,7 +187,7 @@ export default {
       })
     },
     showDownloadDataLink(){
-      return(this.dataDownloadEndpoint != '' && this.dataDownloadEndpoint != undefined)
+      return !!this.dataDownloadEndpoint
     }
   }
 }

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -3,6 +3,7 @@
     <div class="pure-g gutters m_b_4">
       <Aside
         :contracts-data="contractsData"
+        :dataDownloadEndpoint="dataDownloadEndpoint"
       />
 
       <div class="pure-u-1 pure-u-lg-3-4">
@@ -62,6 +63,12 @@ export default {
     EventBus.$on('refresh_summary_data', () => {
       this.contractsData = this.$root.$data.contractsData;
     });
+  },
+  props: {
+    dataDownloadEndpoint: {
+      type: String,
+      default: null
+    }
   },
   methods: {
     setActiveTab(tabIndex) {

--- a/app/views/gobierto_dashboards/dashboards/contracts.html.erb
+++ b/app/views/gobierto_dashboards/dashboards/contracts.html.erb
@@ -17,7 +17,9 @@
        data-logo-url="<%= @site.configuration.logo_with_fallback %>"
        data-home-url="<%= gobierto_dashboards_contracts_url %>"
        data-contracts-endpoint="<%= @dashboards_config.dig('data_urls', 'contracts') %>"
-       data-tenders-endpoint="<%= @dashboards_config.dig('data_urls', 'tenders') %>" >
+       data-tenders-endpoint="<%= @dashboards_config.dig('data_urls', 'tenders') %>"
+       data-data-download-endpoint="<%= @dashboards_config['data_download_source'] %>"
+  >
   </div>
 
 </div>

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -13,6 +13,7 @@ ca:
         dates: Dates
         description: Visualització i anàlisi dels contractes adjudicats i les licitacions
           del %{entity_name}
+        download_data: Descarregueu les dades en format reutilitzable
         empty_table: No hi ha dades disponibles
         final_amount: Quantitat
         fromto: De a Nº Contr.

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -13,6 +13,7 @@ en:
         dates: Dates
         description: Visualizations and analisys for the awarded contracts and tenders
           to %{entity_name}
+        download_data: Download the full dataset in a reusable format
         empty_table: There is no available data
         final_amount: Amount
         fromto: From To No Contr.

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -13,6 +13,7 @@ es:
         dates: Fechas
         description: Visualización y análisis de los contratos adjudicados y las licitaciones
           del %{entity_name}
+        download_data: Descarga los datos completos en formatos reutilizables
         empty_table: No hay datos disponibles
         final_amount: Importe
         fromto: Desde A Nº. Contr.

--- a/test/integration/gobierto_dashboards/dashboards_contracts_download_data_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_download_data_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GobiertoDashboards::DashboardsContractsDownloadDataTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @summary_path = gobierto_dashboards_contracts_path(locale: 'es')
+  end
+
+  def site
+    @site ||= sites(:madrid)
+  end
+
+  def data_download_source
+    "http://fake.url/"
+  end
+
+  def with_download_data_settings
+    {
+      "dashboards_config" => {
+        "dashboards" => {
+          "contracts" => {
+            "enabled" => true,
+            "data_urls" => {},
+            "data_download_source" => data_download_source
+          }
+        }
+      }
+    }
+  end
+
+  def without_download_data_settings
+    {
+      "dashboards_config" => {
+        "dashboards" => {
+          "contracts" => {
+            "enabled" => true,
+            "data_urls" => {}
+          }
+        }
+      }
+    }
+  end
+
+  def test_download_data_filled
+    ::GobiertoModuleSettings.create!({
+      site_id: site.id,
+      module_name: "GobiertoDashboards",
+      settings: with_download_data_settings
+    })
+
+    with(site: site, js: true) do
+      visit @summary_path
+      assert page.has_content?("Descarga los datos completos")
+
+      link = find(".dashboards-home-aside--download-open-data a", match: :first)
+      assert_equal link[:href], data_download_source
+    end
+  end
+
+  def test_download_data_missing
+    ::GobiertoModuleSettings.create!({
+      site_id: site.id,
+      module_name: "GobiertoDashboards",
+      settings: without_download_data_settings
+    })
+
+    with(site: site, js: true) do
+      visit @summary_path
+      refute page.has_content?("Descarga los datos completos")
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #3077

## :v: What does this PR do?

Enables the option to define a data source in the settings like:

```json 
    {
      "dashboards_config": {
        "dashboards": {
          "contracts": {
            "enabled": true,
            "data_urls": {},
            "data_download_source": "http://data.source.url"
          }
        }
      }
    }
```

If added, a download button will appear (see screenshot).

## :mag: How should this be manually tested?

I added the option in Staging, you can check it in the summary page: 

https://getafe.gobify.net/dashboards/contratos/resumen

If removed, it shouldn't appear.

## :eyes: Screenshots

![Captura de pantalla 2020-05-21 a las 15 20 20](https://user-images.githubusercontent.com/545235/82563043-9ff06700-9b76-11ea-9870-39f42e585b90.png)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No