### PR TITLE
Order by site name in the admin dropdown and menu CSS adjustment

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -109,7 +109,7 @@ class Site < ApplicationRecord
   translates :name, :title
 
   def self.alphabetically_sorted
-    all.sort_by(&:title).reverse
+    all.sort_by(&:name)
   end
 
   def self.find_by_allowed_domain(domain)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -109,7 +109,7 @@ class Site < ApplicationRecord
   translates :name, :title
 
   def self.alphabetically_sorted
-    all.sort_by(&:name)
+    all.sort_by{ |site| site.try(:name) || "" }
   end
 
   def self.find_by_allowed_domain(domain)

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -34,7 +34,7 @@
           <%= link_to "#", id: "menuLink1", class: "pure-menu-link" do %>
             <%= t(".site_network") %>
           <% end %>
-          <ul id="managed-sites-list" class="pure-menu-children" style="max-height: 80vh;" >
+          <ul id="managed-sites-list" class="pure-menu-children" style="max-height: 80vh; overflow-y: scroll" >
             <% managed_sites.alphabetically_sorted.each do |site| %>
               <li class="pure-menu-item" style="display: block; height: 35px;" >
                 <%= link_to(

--- a/app/views/gobierto_admin/layouts/application.html.erb
+++ b/app/views/gobierto_admin/layouts/application.html.erb
@@ -34,11 +34,11 @@
           <%= link_to "#", id: "menuLink1", class: "pure-menu-link" do %>
             <%= t(".site_network") %>
           <% end %>
-          <ul id="managed-sites-list" class="pure-menu-children">
+          <ul id="managed-sites-list" class="pure-menu-children" style="max-height: 80vh;" >
             <% managed_sites.alphabetically_sorted.each do |site| %>
-              <li class="pure-menu-item">
+              <li class="pure-menu-item" style="display: block; height: 35px;" >
                 <%= link_to(
-                  site.name,
+                  site.name + " - " + site.title,
                   admin_root_url(host: site.domain),
                   class: "pure-menu-link") %>
               </li>


### PR DESCRIPTION
Closes unexpected

## :v: What does this PR do?

- Order the site list in the admin dropdown by site name (the org), and adds the site title
- Enables scroll if the dropdown list height is greater than the viewport, and a max-height for the container
- It adds inline styles, which may come as an abobination, but since I'm becoming a fan of Tailwind and the likes, and this is only going to be used here, it makes sense to me ;)


## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
