### PR TITLE
Update tenders summary too when filtering

### DIFF
--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -182,7 +182,9 @@ export class ContractsController {
   }
 
   _refreshData(reducedContractsData, filters, tendersAttribute){
-    this._refreshTendersDataFromFilters(filters, tendersAttribute);
+    if (filters) {
+      this._refreshTendersDataFromFilters(filters, tendersAttribute);
+    }
     reduced = {tendersData: data.tendersData, contractsData: reducedContractsData};
 
     vueApp.contractsData = reducedContractsData;

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -52,8 +52,6 @@ export class ContractsController {
                 { path: "resumen", name: "summary", component: Summary},
                 { path: "contratos", name: "contracts_index", component: ContractsIndex },
                 { path: "contratos/:id", name: "contracts_show", component: ContractsShow },
-                { path: "licitaciones", name: "tenders_index", component: TendersIndex },
-                { path: "licitaciones/:id", name: "tenders_show", component: TendersShow },
               ]
             }
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -158,7 +158,7 @@ export class ContractsController {
 
       tender.initial_amount = initial_amount;
       tender.submission_date_year = tender.submission_date != undefined && tender.submission_date != '' ? (new Date(tender.submission_date).getFullYear()) : tender.submission_date;
-      tender.submission_date_year = tender.submission_date_year.toString()
+      if(tender.submission_date_year) { tender.submission_date_year = tender.submission_date_year.toString() }
     }
 
     unfilteredTendersData = tendersData.sort(sortByField('submission_date'));

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -337,8 +337,6 @@ export class ContractsController {
     tendersFilters[tendersAttribute] = filters;
     let filteredTendersData = [...unfilteredTendersData]
 
-    debugger
-
     Object.keys(tendersFilters).forEach((key) => {
       if (tendersFilters[key].length > 0) {
         filteredTendersData = filteredTendersData.filter(tender => tendersFilters[key].includes(tender[key]) )

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -15,8 +15,6 @@
           <Summary v-show="isSummary"/>
           <ContractsIndex v-show="isContractsIndex"/>
           <ContractsShow v-if="isContractsShow"/>
-          <TendersIndex v-show="isTendersIndex"/>
-          <TendersShow v-if="isTendersShow"/>
         </main>
       </div>
     </div>
@@ -43,8 +41,6 @@ export default {
     Summary,
     ContractsIndex,
     ContractsShow,
-    TendersIndex,
-    TendersShow
   },
   data() {
     return {
@@ -56,8 +52,6 @@ export default {
     isSummary() { return this.$route.name === 'summary' },
     isContractsIndex() { return this.$route.name === 'contracts_index' },
     isContractsShow() { return this.$route.name === 'contracts_show' },
-    isTendersIndex() { return this.$route.name === 'tenders_index' },
-    isTendersShow() { return this.$route.name === 'tenders_show' },
   },
   created(){
     EventBus.$on('refresh_summary_data', () => {

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Nav.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Nav.vue
@@ -23,17 +23,6 @@
         <i class="far fa-clone" />
         <span>{{ labelContracts }}</span>
       </router-link>
-      <router-link
-        :to="{ name: 'tenders_index' }"
-        :class="{ 'is-active': activeTab === 2 }"
-        tag="li"
-        class="dashboards-home-nav--tab"
-        @click.native="markTabAsActive(2)"
-      >
-        <i class="fas fa-clone" />
-        <i class="far fa-clone" />
-        <span>{{ labelTenders }}</span>
-      </router-link>
     </ul>
   </nav>
 </template>

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -162,49 +162,4 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
     end
   end
 
-  def test_tenders
-    with(site: site, js: true) do
-      # Tenders Index
-      ###############
-      visit @tenders_path
-
-      # Active tab is Tenders
-      assert find(".dashboards-home-nav--tab.is-active").text, 'TENDERS'
-
-      first_tender = find(".dashboards-home-main--tr", match: :first)
-
-      # Contractor
-      assert first_tender.has_content?('Consejero Delegado del Consejo de Administración de Limpieza y Medio Ambiente de Getafe, Sociedad Anónima Municipal')
-
-      # Status
-      assert first_tender.has_content?('Adjudicado provisionalmente')
-
-      # Date
-      assert first_tender.has_content?('2020-05-13')
-
-
-      # Tenders Show
-      ##############
-      first_tender.click
-
-      # Active tab is still Tenders
-      assert find(".dashboards-home-nav--tab.is-active").text, 'TENDERS'
-
-      # Url is updated
-      assert_equal current_path, "/dashboards/contratos/licitaciones/990198"
-
-      # Title
-      assert page.has_content?('Servicio de formación para renovación del Certificado de Aptitud Profesional .')
-
-      # Tender amount
-      assert page.has_content?('€33,600.00')
-
-      # Status
-      assert page.has_content?('Adjudicado provisionalmente')
-
-      # Type
-      assert page.has_content?('Abierto simplificado')
-    end
-  end
-
 end


### PR DESCRIPTION
Closes PopulateTools/issues#1040  

## :v: What does this PR do?

There are two changes in this PR:

1. Now, when filtering (from sidebar or from the charts), the calculations for Tenders in the metrics box from the Summary page will be updated too. This calculation is not done by dc charts (although it uses the filters from the charts).

2. Remove tenders tab from the navigation. Components will not render either. 

## :mag: How should this be manually tested?

Filtering data from the sidebar should update the numbers in the summary page.

https://burjassot.gobify.net/dashboards/contratos/resumen

## :eyes: Screenshots

![Kapture 2020-05-22 at 8 25 43](https://user-images.githubusercontent.com/545235/82637932-21430a80-9c06-11ea-8fd2-89f75aadbff5.gif)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No