### PR TITLE
Dashboards / Quantities without taxes, new amount ranges

### DIFF
--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -143,8 +143,8 @@ export class ContractsController {
 
     for(let i = 0; i < contractsData.length; i++){
       const contract = contractsData[i];
-      const final_amount_no_taxes = (contract.final_amount_no_taxes === '' || contract.final_amount_no_taxes === undefined) ? 0.0 : parseFloat(contract.final_amount_no_taxes);
-      const initial_amount_no_taxes = (contract.initial_amount_no_taxes === '' || contract.initial_amount_no_taxes === undefined) ? 0.0 : parseFloat(contract.initial_amount_no_taxes);
+      const final_amount_no_taxes = contract.final_amount_no_taxes ? parseFloat(contract.final_amount_no_taxes) : 0.0;
+      const initial_amount_no_taxes = contract.initial_amount_no_taxes ? parseFloat(contract.initial_amount_no_taxes) : 0.0 ;
 
       contract.final_amount_no_taxes = final_amount_no_taxes;
       contract.initial_amount_no_taxes = initial_amount_no_taxes;
@@ -154,10 +154,11 @@ export class ContractsController {
 
     for(let i = 0; i < tendersData.length; i++){
       const tender = tendersData[i];
-      const initial_amount_no_taxes = (tender.initial_amount_no_taxes === '' || tender.initial_amount_no_taxes === undefined) ? 0.0 : parseFloat(tender.initial_amount_no_taxes);
+      const initial_amount_no_taxes = tender.initial_amount_no_taxes ? parseFloat(tender.initial_amount_no_taxes) : 0.0;
 
       tender.initial_amount_no_taxes = initial_amount_no_taxes;
-      tender.submission_date_year = tender.submission_date != undefined && tender.submission_date != '' ? (new Date(tender.submission_date).getFullYear()) : tender.submission_date;
+      tender.submission_date_year = tender.submission_date ? (new Date(tender.submission_date).getFullYear()) : tender.submission_date;
+
       if(tender.submission_date_year) { tender.submission_date_year = tender.submission_date_year.toString() }
     }
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -136,8 +136,8 @@ export class ContractsController {
 
     // Contracts precalculations and normalizations
     _amountRange = {
-      domain: [501, 1001, 5001, 10001, 15001],
-      range: [0, 1, 2, 3, 4, 5]
+      domain: [1001, 10001, 50001, 100001],
+      range: [0, 1, 2, 3, 4]
     };
     var rangeFormat = d3.scaleThreshold().domain(_amountRange.domain).range(_amountRange.range);
 

--- a/app/javascript/gobierto_dashboards/modules/contracts_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/contracts_controller.js
@@ -143,20 +143,20 @@ export class ContractsController {
 
     for(let i = 0; i < contractsData.length; i++){
       const contract = contractsData[i];
-      const final_amount = (contract.final_amount === '' || contract.final_amount === undefined) ? 0.0 : parseFloat(contract.final_amount);
-      const initial_amount = (contract.initial_amount === '' || contract.initial_amount === undefined) ? 0.0 : parseFloat(contract.initial_amount);
+      const final_amount_no_taxes = (contract.final_amount_no_taxes === '' || contract.final_amount_no_taxes === undefined) ? 0.0 : parseFloat(contract.final_amount_no_taxes);
+      const initial_amount_no_taxes = (contract.initial_amount_no_taxes === '' || contract.initial_amount_no_taxes === undefined) ? 0.0 : parseFloat(contract.initial_amount_no_taxes);
 
-      contract.final_amount = final_amount;
-      contract.initial_amount = initial_amount;
-      contract.range = rangeFormat(+final_amount);
+      contract.final_amount_no_taxes = final_amount_no_taxes;
+      contract.initial_amount_no_taxes = initial_amount_no_taxes;
+      contract.range = rangeFormat(+final_amount_no_taxes);
       contract.start_date_year = contract.start_date ? (new Date(contract.start_date).getFullYear()) : contract.start_date;
     }
 
     for(let i = 0; i < tendersData.length; i++){
       const tender = tendersData[i];
-      const initial_amount = (tender.initial_amount === '' || tender.initial_amount === undefined) ? 0.0 : parseFloat(tender.initial_amount);
+      const initial_amount_no_taxes = (tender.initial_amount_no_taxes === '' || tender.initial_amount_no_taxes === undefined) ? 0.0 : parseFloat(tender.initial_amount_no_taxes);
 
-      tender.initial_amount = initial_amount;
+      tender.initial_amount_no_taxes = initial_amount_no_taxes;
       tender.submission_date_year = tender.submission_date != undefined && tender.submission_date != '' ? (new Date(tender.submission_date).getFullYear()) : tender.submission_date;
       if(tender.submission_date_year) { tender.submission_date_year = tender.submission_date_year.toString() }
     }
@@ -198,7 +198,7 @@ export class ContractsController {
     const _tendersData = this._currentDataSource().tendersData
 
     // Calculations
-    const amountsArray = _tendersData.map(({initial_amount = 0}) => parseFloat(initial_amount) );
+    const amountsArray = _tendersData.map(({initial_amount_no_taxes = 0}) => parseFloat(initial_amount_no_taxes) );
 
     const numberTenders = _tendersData.length;
     const sumTenders = d3.sum(amountsArray);
@@ -216,7 +216,7 @@ export class ContractsController {
     const _contractsData = this._currentDataSource().contractsData;
 
     // Calculations
-    const amountsArray = _contractsData.map(({final_amount = 0}) => parseFloat(final_amount) );
+    const amountsArray = _contractsData.map(({final_amount_no_taxes = 0}) => parseFloat(final_amount_no_taxes) );
     const sortedAmountsArray = amountsArray.sort((a, b) => b - a);
 
     // Calculations box items
@@ -226,10 +226,10 @@ export class ContractsController {
     const medianContracts = d3.median(amountsArray);
 
     // Calculations headlines
-    const lessThan1000Total = _contractsData.filter(({final_amount = 0}) => parseFloat(final_amount) < 1000).length;
+    const lessThan1000Total = _contractsData.filter(({final_amount_no_taxes = 0}) => parseFloat(final_amount_no_taxes) < 1000).length;
     const lessThan1000Pct = lessThan1000Total/numberContracts;
 
-    const largerContractAmount = d3.max(_contractsData, ({final_amount = 0}) => parseFloat(final_amount));
+    const largerContractAmount = d3.max(_contractsData, ({final_amount_no_taxes = 0}) => parseFloat(final_amount_no_taxes));
     const largerContractAmountPct = largerContractAmount / sumContracts;
 
     let iteratorAmountsSum = 0, numberContractsHalfSpendings = 0;

--- a/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/contract/ContractsShow.vue
@@ -21,11 +21,11 @@
         <table>
           <tr>
             <th class="left">{{ labelContractAmount }}</th>
-            <td>{{ final_amount | money }}</td>
+            <td>{{ final_amount_no_taxes | money }}</td>
           </tr>
           <tr>
             <th class="left">{{ labelTenderAmount }}</th>
-            <td>{{ initial_amount | money }}</td>
+            <td>{{ initial_amount_no_taxes | money }}</td>
           </tr>
           <tr>
             <th class="left">{{ labelStatus }}</th>
@@ -62,8 +62,8 @@ export default {
       description: '',
       assignee: '',
       document_number: '',
-      final_amount: '',
-      initial_amount: '',
+      final_amount_no_taxes: '',
+      initial_amount_no_taxes: '',
       status: '',
       process_type: '',
       permalink: '',
@@ -85,8 +85,8 @@ export default {
         description,
         assignee,
         document_number,
-        final_amount,
-        initial_amount,
+        final_amount_no_taxes,
+        initial_amount_no_taxes,
         status,
         process_type,
         permalink
@@ -96,8 +96,8 @@ export default {
       this.description = description
       this.assignee = assignee
       this.document_number = document_number
-      this.final_amount = final_amount
-      this.initial_amount = initial_amount
+      this.final_amount_no_taxes = final_amount_no_taxes
+      this.initial_amount_no_taxes = initial_amount_no_taxes
       this.status = status
       this.process_type = process_type
       this.permalink = permalink

--- a/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/shared/Home.vue
@@ -27,8 +27,6 @@ import Aside from "./Aside.vue";
 import Summary from "./../summary/Summary.vue";
 import ContractsIndex from "./../contract/ContractsIndex.vue";
 import ContractsShow from "./../contract/ContractsShow.vue";
-import TendersIndex from "./../tender/TendersIndex.vue";
-import TendersShow from "./../tender/TendersShow.vue";
 
 import { EventBus } from "../../mixins/event_bus";
 import { store } from "../../mixins/store";

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -157,18 +157,18 @@ export default {
     buildItems() {
       const groupedByAssignee = {}
       // Group contracts by assignee
-      this.contractsData.forEach(({assignee, final_amount}) => {
+      this.contractsData.forEach(({assignee, final_amount_no_taxes}) => {
         if (assignee === '' || assignee === undefined) {
           return;
         }
 
-        groupedByAssignee[contract.assignee] = groupedByAssignee[contract.assignee] || {name: contract.assignee}
-
-        // vue wouldn't update the table rows if there is no id attribute
-        groupedByAssignee[contract.assignee].id = groupedByAssignee[contract.assignee].id || uuid()
-
-        groupedByAssignee[contract.assignee].sum = groupedByAssignee[contract.assignee].sum || 0
-        groupedByAssignee[contract.assignee].sum += parseFloat(contract.final_amount_no_taxes)
+        if (groupedByAssignee[assignee] === undefined) {
+          groupedByAssignee[assignee] = {
+            name: assignee,
+            sum: 0,
+            count: 0
+          }
+        }
 
         groupedByAssignee[assignee].sum += parseFloat(final_amount_no_taxes)
         groupedByAssignee[assignee].count++;

--- a/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/summary/Summary.vue
@@ -132,9 +132,6 @@ export default {
       labelProcessType: I18n.t('gobierto_dashboards.dashboards.contracts.process_type'),
       labelAmountDistribution: I18n.t('gobierto_dashboards.dashboards.contracts.amount_distribution'),
       labelMainAssignees: I18n.t('gobierto_dashboards.dashboards.contracts.main_assignees'),
-      labelTableThAssignee: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'),
-      labelTableThContracts: I18n.t('gobierto_dashboards.dashboards.contracts.contracts'),
-      labelTableThAMount: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'),
     }
   },
 
@@ -165,15 +162,15 @@ export default {
           return;
         }
 
-        if (groupedByAssignee[assignee] === undefined) {
-          groupedByAssignee[assignee] = {
-            name: assignee,
-            sum: 0,
-            count: 0
-          }
-        }
+        groupedByAssignee[contract.assignee] = groupedByAssignee[contract.assignee] || {name: contract.assignee}
 
-        groupedByAssignee[assignee].sum += parseFloat(final_amount)
+        // vue wouldn't update the table rows if there is no id attribute
+        groupedByAssignee[contract.assignee].id = groupedByAssignee[contract.assignee].id || uuid()
+
+        groupedByAssignee[contract.assignee].sum = groupedByAssignee[contract.assignee].sum || 0
+        groupedByAssignee[contract.assignee].sum += parseFloat(contract.final_amount_no_taxes)
+
+        groupedByAssignee[assignee].sum += parseFloat(final_amount_no_taxes)
         groupedByAssignee[assignee].count++;
       });
 

--- a/app/javascript/gobierto_dashboards/webapp/containers/tender/TendersShow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/tender/TendersShow.vue
@@ -14,7 +14,7 @@
         <table>
           <tr>
             <th class="left">{{ labelTenderAmount }}</th>
-            <td>{{ initial_amount | money }}</td>
+            <td>{{ initial_amount_no_taxes | money }}</td>
           </tr>
           <tr>
             <th class="left">{{ labelStatus }}</th>
@@ -47,7 +47,7 @@ export default {
       tendersData: this.$root.$data.tendersData,
       title : '',
       description : '',
-      initial_amount : '',
+      initial_amount_no_taxes : '',
       status : '',
       process_type : '',
       permalink : '',
@@ -69,7 +69,7 @@ export default {
       const {
         title,
         description,
-        initial_amount,
+        initial_amount_no_taxes,
         status,
         process_type,
         permalink
@@ -77,7 +77,7 @@ export default {
 
       this.title = title
       this.description = description
-      this.initial_amount = initial_amount
+      this.initial_amount_no_taxes = initial_amount_no_taxes
       this.status = status
       this.process_type = process_type
       this.permalink = permalink

--- a/app/javascript/gobierto_dashboards/webapp/lib/config.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config.js
@@ -1,7 +1,7 @@
 export const contractsColumns = [
   {field: 'assignee', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null},
   {field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: 'truncated'},
-  {field: 'final_amount', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
+  {field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency'},
   {field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null},
 ];
 
@@ -14,7 +14,7 @@ export const tendersColumns = [
 export const assigneesColumns = [
   {field: 'name', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null},
   {field: 'count', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contracts'), format: 'quantity'},
-  {field: 'sum', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount'), format: 'currency'},
+  {field: 'sum', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency'},
 ];
 
 export const filtersConfig = [

--- a/config/locales/gobierto_dashboards/views/ca.yml
+++ b/config/locales/gobierto_dashboards/views/ca.yml
@@ -15,7 +15,7 @@ ca:
           del %{entity_name}
         download_data: Descarregueu les dades en format reutilitzable
         empty_table: No hi ha dades disponibles
-        final_amount: Quantitat
+        final_amount_no_taxes: Quantitat
         fromto: De a Nº Contr.
         main_assignees: Principals adjudicataris
         more: Més de

--- a/config/locales/gobierto_dashboards/views/en.yml
+++ b/config/locales/gobierto_dashboards/views/en.yml
@@ -15,7 +15,7 @@ en:
           to %{entity_name}
         download_data: Download the full dataset in a reusable format
         empty_table: There is no available data
-        final_amount: Amount
+        final_amount_no_taxes: Amount
         fromto: From To No Contr.
         main_assignees: Main assignees
         more: More than

--- a/config/locales/gobierto_dashboards/views/es.yml
+++ b/config/locales/gobierto_dashboards/views/es.yml
@@ -15,7 +15,7 @@ es:
           del %{entity_name}
         download_data: Descarga los datos completos en formatos reutilizables
         empty_table: No hay datos disponibles
-        final_amount: Importe
+        final_amount_no_taxes: Importe
         fromto: Desde A Nº. Contr.
         main_assignees: Principales adjudicatarios
         more: Más de

--- a/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
+++ b/test/integration/gobierto_dashboards/dashboards_contracts_test.rb
@@ -66,23 +66,21 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       metrics_box = find(".metric_box", match: :first)
 
       assert metrics_box.has_content?("Licitaciones\n252")
-      assert metrics_box.has_content?("licitaciones por importe de\n134.068.916,04 €")
-      assert metrics_box.has_content?("Importe medio\n532.019,51 €")
+      assert metrics_box.has_content?("licitaciones por importe de\n113.122.855,23 €")
 
-      assert metrics_box.has_content?("Importe medio\n532.019,51 €")
-      assert metrics_box.has_content?("Importe mediano\n87.725,00 €")
+      assert metrics_box.has_content?("Importe medio\n448.900,22 €")
+      assert metrics_box.has_content?("Importe mediano\n72.500,00 €")
 
       assert metrics_box.has_content?("Contratos adjudicados\n223")
-      assert metrics_box.has_content?("contratos por importe de\n72.894.648,94 €")
+      assert metrics_box.has_content?("contratos por importe de\n61.990.830,68 €")
 
-      assert metrics_box.has_content?("Importe medio\n326.881,83 €")
-      assert metrics_box.has_content?("Importe mediano\n33.668,25 €")
+      assert metrics_box.has_content?("Importe medio\n277.985,79 €")
+      assert metrics_box.has_content?("Importe mediano\n28.400,00 €")
 
       ## Headlines
       assert page.has_content?("El 5 % de los contratos son menores de 1.000 €")
-      assert page.has_content?("El mayor contrato supone un 18 % de todo el gasto en contratos")
+      assert page.has_content?("El mayor contrato supone un 20 % de todo el gasto en contratos")
       assert page.has_content?("El 2 % de contratos concentran el 50% de todo el gasto")
-
 
       ## Charts
       # Contract type
@@ -101,7 +99,7 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       first_contract = find(".dashboards-home-main--tr", match: :first)
 
       assert first_contract.has_content?('LIDER SYSTEM, S.L.')
-      assert first_contract.has_content?('43.671,37 €')
+      assert first_contract.has_content?('40.261,50 €')
     end
   end
 
@@ -127,7 +125,7 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert first_contract.has_content?('Prestación del servicio de plataforma de formación online "E...')
 
       # Amount
-      assert first_contract.has_content?('€34,364.00')
+      assert first_contract.has_content?('€28,400.00')
 
       # Date
       assert first_contract.has_content?('2020-07-01')
@@ -149,10 +147,10 @@ class GobiertoDashboards::DashboardsContractsTest < ActionDispatch::IntegrationT
       assert page.has_content?('Grupo Conforsa Análisis, Desarrollo y Formación , S.A.')
 
       # Contract amount
-      assert page.has_content?('€34,364.00')
+      assert page.has_content?('€28,400.00')
 
       # Tender amount
-      assert page.has_content?('€48,400.00')
+      assert page.has_content?('€40,000.00')
 
       # Status
       assert page.has_content?('Formalizado')


### PR DESCRIPTION
Closes #3078 
Closes PopulateTools/issues#1038

## :v: What does this PR do?

- Amounts are now the ones without taxes
- Differente ranges in amount distribution

## :eyes: Screenshots

![Captura de pantalla 2020-05-22 a las 11 24 58](https://user-images.githubusercontent.com/545235/82653050-ea2d2300-9c1e-11ea-81bb-b050dd639017.png)

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

No