### PR TITLE
Avoid exceptions calling INE::Places::Place.find with blank argument

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -175,7 +175,7 @@ class Site < ApplicationRecord
   # If the organization_id corresponds to a municipality ID,
   # this method will return an instance of INE::Places::Place
   def place
-    @place ||= if self.organization_id
+    @place ||= if self.organization_id.present?
                  INE::Places::Place.find(self.organization_id)
                end
   end


### PR DESCRIPTION
Closes #3100


## :v: What does this PR do?

* Avoids exceptions calling INE::Places::Place.find with blank argument

*Note*: Merging in staging is pending. Currently there are conflicts trying to merge into staging

## :mag: How should this be manually tested?

There are multiple parts where this exception can occur. One of them is visiting a plan front on a site where the organization id is blank. The plan can't be loaded and the spinner freezes

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No