### PR TITLE
3016 3107 performance optimizations

### DIFF
--- a/app/controllers/gobierto_budgets/application_controller.rb
+++ b/app/controllers/gobierto_budgets/application_controller.rb
@@ -1,6 +1,8 @@
 class GobiertoBudgets::ApplicationController < ApplicationController
   include User::SessionHelper
 
+  helper_method :cache_path
+
   rescue_from GobiertoBudgets::BudgetLine::RecordNotFound, with: :render_404
   rescue_from GobiertoBudgets::BudgetLine::InvalidSearchConditions do |exception|
     head :bad_request

--- a/app/controllers/gobierto_budgets/application_controller.rb
+++ b/app/controllers/gobierto_budgets/application_controller.rb
@@ -13,4 +13,10 @@ class GobiertoBudgets::ApplicationController < ApplicationController
   def set_current_site
     @site = SiteDecorator.new(current_site)
   end
+
+  private
+
+  def cache_path
+    "#{current_site.cache_key}/#{current_module}/#{self.controller_name}/#{self.action_name}/#{I18n.locale}"
+  end
 end

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -2,6 +2,13 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
   before_action :load_params
   before_action :check_elaboration, only: [:show]
 
+  caches_action(
+    :show,
+    :index,
+    cache_path: -> { cache_path },
+    unless: -> { user_signed_in? }
+  )
+
   def index
     @place_budget_lines = updated_forecast(level: @level)
     @sample_budget_lines = GobiertoBudgets::TopBudgetLine.limit(20).where(site: current_site, year: @year, kind: @kind).all.sample(3)
@@ -76,6 +83,10 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     else
       []
     end
+  end
+
+  def cache_path
+    "#{super}/#{ [@code, @year, @area_name, @kind, @level].compact.join("/") }"
   end
 
 end

--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -2,6 +2,12 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
   before_action :load_year, except: [:guide]
   before_action :overrided_root_redirect, only: [:index]
 
+  caches_action(
+    :index,
+    cache_path: -> { cache_path },
+    unless: -> { user_signed_in? }
+  )
+
   def index
     @kind = GobiertoBudgets::BudgetLine::INCOME
     @area_name = GobiertoBudgets::EconomicArea.area_name
@@ -32,6 +38,10 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
   end
 
   private
+
+  def cache_path
+    "#{super}/#{@year}"
+  end
 
   def load_year
     if params[:year].nil?

--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -25,7 +25,7 @@ class MetaWelcomeController < ApplicationController
         @section_item = ::GobiertoCms::SectionItem.find_by!(item: page, section: @section)
       else
         @collection = page.collection
-        @pages = current_site.pages.where(id: @collection.pages_in_collection).active
+        @pages = current_site.pages.where(id: @collection.pages_in_collection).active.includes(:collection, :sections)
       end
 
       @page = GobiertoCms::PageDecorator.new(page)

--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -30,7 +30,7 @@ class MetaWelcomeController < ApplicationController
 
       @page = GobiertoCms::PageDecorator.new(page)
 
-      render "gobierto_cms/pages/show", layout: GobiertoCms::ApplicationController::DEFAULT_LAYOUT
+      render "gobierto_cms/pages/meta_welcome", layout: GobiertoCms::ApplicationController::DEFAULT_LAYOUT
     end
   end
 end

--- a/app/helpers/gobierto_cms/page_helper.rb
+++ b/app/helpers/gobierto_cms/page_helper.rb
@@ -21,8 +21,9 @@ module GobiertoCms
     def gobierto_cms_page_or_news_path(page, options = {})
       url_helpers = Rails.application.routes.url_helpers
       if page.collection.item_type == "GobiertoCms::Page"
-        if page.section
-          url_helpers.gobierto_cms_section_item_path(page.section.slug, page.slug, options)
+        section = page.section
+        if section
+          url_helpers.gobierto_cms_section_item_path(section.slug, page.slug, options)
         else
           url_helpers.gobierto_cms_page_path(page.slug, options)
         end

--- a/app/models/concerns/gobierto_common/sectionable.rb
+++ b/app/models/concerns/gobierto_common/sectionable.rb
@@ -5,30 +5,27 @@ module GobiertoCommon
     extend ActiveSupport::Concern
 
     included do
-      def section_id
-        return if GobiertoCms::SectionItem.where(item: self).joins(:section).empty?
+      has_many :section_items, as: :item, class_name: "GobiertoCms::SectionItem"
+      has_many :sections, through: :section_items
 
-        GobiertoCms::SectionItem.where(item: self).first.section.id
+      def section
+        sections.first
+      end
+
+      def section_id
+        section&.id
       end
 
       def parent_id
-        unless GobiertoCms::SectionItem.where(item: self).empty?
-          if GobiertoCms::SectionItem.where(item: self).first.parent_id == 0
-            0
-          else
-            GobiertoCms::SectionItem.where(item: self).first.parent.try(:id)
-          end
-        else
-          nil
-        end
+        return unless section_items.exists?
+
+        section_item = section_items.first
+
+        section_item.parent_id.zero? ? 0 : section_item.parent&.id
       end
 
       def position
-        unless GobiertoCms::SectionItem.where(item: self).empty?
-          GobiertoCms::SectionItem.where(item: self).first.position
-        else
-          nil
-        end
+        section_items.first&.position
       end
     end
   end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -61,10 +61,6 @@ module GobiertoCms
         .where("collection_items.container_id = ?", container.id)
     }
 
-    def section
-      GobiertoCms::SectionItem.find_by(item: self).try(:section)
-    end
-
     def attributes_for_slug
       [title]
     end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -29,7 +29,7 @@ module GobiertoCms
 
     translates :title, :body, :body_source
 
-    belongs_to :site
+    belongs_to :site, touch: true
     has_many :collection_items, as: :item
     has_many :process_stage_pages, class_name: "GobiertoParticipation::ProcessStagePage"
 

--- a/app/models/gobierto_cms/section.rb
+++ b/app/models/gobierto_cms/section.rb
@@ -7,7 +7,7 @@ module GobiertoCms
     include GobiertoCommon::Sortable
     include GobiertoCommon::Sluggable
 
-    belongs_to :site
+    belongs_to :site, touch: true
     has_many :section_items, dependent: :destroy, class_name: "GobiertoCms::SectionItem"
 
     translates :title

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -1,290 +1,294 @@
-<div class="breadcrumb stick_ip" data-budget-line-breadcrumb="<%= budget_line_breadcrumb(@budget_line, @year, @kind) %>"
-                                 data-budget-line-area="<%= @area_name %>" data-budget-line-categories="<%= gobierto_budgets_api_categories_path(format: :json) %>">
-  <div class="column">
-    <div class="clearfix">
-      <span class="open_line_browser"><i class="fas fa-chevron-circle-down"></i></span>
-      <div class="bread_links" data-line-breadcrumb></div>
-    </div>
+<% cache([cache_path, "show_partial"]) do %>
 
-    <div class="line_browser clearfix">
+  <div class="breadcrumb stick_ip" data-budget-line-breadcrumb="<%= budget_line_breadcrumb(@budget_line, @year, @kind) %>"
+                                   data-budget-line-area="<%= @area_name %>" data-budget-line-categories="<%= gobierto_budgets_api_categories_path(format: :json) %>">
+    <div class="column">
       <div class="clearfix">
-        <span class="close_line_browser"><i class="fas fa-chevron-circle-up"></i></span>
-        <div class="bread_links clearfix" data-line-breadcrumb></div>
+        <span class="open_line_browser"><i class="fas fa-chevron-circle-down"></i></span>
+        <div class="bread_links" data-line-breadcrumb></div>
       </div>
 
-      <div class="col" data-level="0">
-        <table class="med_bg">
-          <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
-            <tr>
-              <td data-code="<%= year %>"><%= link_to year, gobierto_budgets_budgets_path %></td>
-            </tr>
-          <% end %>
-        </table>
-      </div>
+      <div class="line_browser clearfix">
+        <div class="clearfix">
+          <span class="close_line_browser"><i class="fas fa-chevron-circle-up"></i></span>
+          <div class="bread_links clearfix" data-line-breadcrumb></div>
+        </div>
 
-      <div class="col" data-level="1">
-        <table class="med_bg" data-current-code=""></table>
-      </div>
+        <div class="col" data-level="0">
+          <table class="med_bg">
+            <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
+              <tr>
+                <td data-code="<%= year %>"><%= link_to year, gobierto_budgets_budgets_path %></td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
 
-      <div class="col" data-level="2">
-        <table class="med_bg" data-current-code=""></table>
-      </div>
+        <div class="col" data-level="1">
+          <table class="med_bg" data-current-code=""></table>
+        </div>
 
-      <div class="col" data-level="3">
-        <table class="med_bg" data-current-code=""></table>
-      </div>
+        <div class="col" data-level="2">
+          <table class="med_bg" data-current-code=""></table>
+        </div>
 
-      <div class="col" data-level="4">
-        <table class="med_bg" data-current-code=""></table>
-      </div>
+        <div class="col" data-level="3">
+          <table class="med_bg" data-current-code=""></table>
+        </div>
 
-      <div class="col" data-level="5">
-        <table class="med_bg" data-current-code=""></table>
-      </div>
+        <div class="col" data-level="4">
+          <table class="med_bg" data-current-code=""></table>
+        </div>
 
-      <div class="col" data-level="6">
-        <table class="med_bg" data-current-code=""></table>
-      </div>
-    </div>
-  </div>
+        <div class="col" data-level="5">
+          <table class="med_bg" data-current-code=""></table>
+        </div>
 
-</div>
-
-<div class="column">
-  <div class="budget_line">
-
-    <% if in_elaboration? %>
-      <div class="pure-u-1-1 metric_box">
-        <div class="highlight-proposal">
-          <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
+        <div class="col" data-level="6">
+          <table class="med_bg" data-current-code=""></table>
         </div>
       </div>
-    <% end %>
+    </div>
 
-    <header>
-      <h1><%= title @budget_line.name %></h1>
-    </header>
+  </div>
 
-    <div class="pure-g metric_boxes">
+  <div class="column">
+    <div class="budget_line">
 
-      <% if @budget_line_stats.amount_per_inhabitant.present? %>
-        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_per_inhabitant_tooltip') %>" data-box="planned_per_inhabitant">
-          <div class="inner">
-            <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant') %></h3>
-
-            <div class="metric">
-              <%= number_to_currency(@budget_line_stats.amount_per_inhabitant_updated || @budget_line_stats.amount_per_inhabitant, precision: 2) %>
-            </div>
-
-            <% if @budget_line_stats.amount_per_inhabitant_updated.present? %>
-              <div class="explanation">
-                <%= t(".initial_estimate") %>: <%= number_to_currency(@budget_line_stats.amount_per_inhabitant, precision: 2) %>
-              </div>
-            <% end %>
+      <% if in_elaboration? %>
+        <div class="pure-u-1-1 metric_box">
+          <div class="highlight-proposal">
+            <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
           </div>
         </div>
       <% end %>
 
-      <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_tooltip') %>" data-box="planned">
-        <div class="inner">
-          <h3><%= kind_literal(@kind, false).capitalize %> <%= planned(@kind) %> </h3>
+      <header>
+        <h1><%= title @budget_line.name %></h1>
+      </header>
 
-          <div class="metric">
-            <%= format_currency @budget_line_stats.amount_updated || @budget_line_stats.amount %>
-          </div>
+      <div class="pure-g metric_boxes">
 
-          <% if @budget_line_stats.amount_updated.present? %>
-            <div class="explanation">
-               <%= t(".initial_estimate") %>: <%= format_currency(@budget_line_stats.amount) %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-
-      <% unless budget_lines_feedback_active? %>
-        <% if !in_elaboration? %>
-          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.real_vs_planned_tooltip') %>" data-box="real_vs_planned">
+        <% if @budget_line_stats.amount_per_inhabitant.present? %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_per_inhabitant_tooltip') %>" data-box="planned_per_inhabitant">
             <div class="inner">
-              <h3><%= t('.real_vs_planned') %></h3>
+              <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant') %></h3>
 
-              <% if @budget_line_stats.execution_percentage %>
-                <div class="metric"><%= @budget_line_stats.execution_percentage %></div>
+              <div class="metric">
+                <%= number_to_currency(@budget_line_stats.amount_per_inhabitant_updated || @budget_line_stats.amount_per_inhabitant, precision: 2) %>
+              </div>
+
+              <% if @budget_line_stats.amount_per_inhabitant_updated.present? %>
                 <div class="explanation">
-                  <%= t('.real_value', kind: kind_literal(@kind, false).capitalize, value: format_currency(@budget_line_stats.amount_executed)) %>
-                </div>
-              <% else %>
-                <div class="metric"><span class="not_av"><%= t('.not_available') %></span></div>
-                <div class="explanation">
-                  <%= t('.last_year', year: @year - 1, value: @budget_line_stats.execution_percentage(@year - 1)) %>
+                  <%= t(".initial_estimate") %>: <%= number_to_currency(@budget_line_stats.amount_per_inhabitant, precision: 2) %>
                 </div>
               <% end %>
             </div>
           </div>
-        <% else %>
-          <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.vs_previous_year_tooltip') %>" data-box="vs_previous_year_tooltip">
+        <% end %>
+
+        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_tooltip') %>" data-box="planned">
+          <div class="inner">
+            <h3><%= kind_literal(@kind, false).capitalize %> <%= planned(@kind) %> </h3>
+
+            <div class="metric">
+              <%= format_currency @budget_line_stats.amount_updated || @budget_line_stats.amount %>
+            </div>
+
+            <% if @budget_line_stats.amount_updated.present? %>
+              <div class="explanation">
+                 <%= t(".initial_estimate") %>: <%= format_currency(@budget_line_stats.amount) %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <% unless budget_lines_feedback_active? %>
+          <% if !in_elaboration? %>
+            <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.real_vs_planned_tooltip') %>" data-box="real_vs_planned">
+              <div class="inner">
+                <h3><%= t('.real_vs_planned') %></h3>
+
+                <% if @budget_line_stats.execution_percentage %>
+                  <div class="metric"><%= @budget_line_stats.execution_percentage %></div>
+                  <div class="explanation">
+                    <%= t('.real_value', kind: kind_literal(@kind, false).capitalize, value: format_currency(@budget_line_stats.amount_executed)) %>
+                  </div>
+                <% else %>
+                  <div class="metric"><span class="not_av"><%= t('.not_available') %></span></div>
+                  <div class="explanation">
+                    <%= t('.last_year', year: @year - 1, value: @budget_line_stats.execution_percentage(@year - 1)) %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% else %>
+            <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.vs_previous_year_tooltip') %>" data-box="vs_previous_year_tooltip">
+              <div class="inner">
+                <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.vs_previous_year') %></h3>
+                <div class="metric"><%= @budget_line_stats.percentage_difference(variable1: :amount_planned, year1: @year, year2: @year-1) %></div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+
+        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.percentage_tooltip') %>" data-box="percentage">
+          <div class="inner">
+            <h3><%= t('.percentage') %></h3>
+            <div class="metric"><%= @budget_line_stats.percentage_of_total %></div>
+          </div>
+        </div>
+
+        <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.avg_province_tooltip') %>" data-box="avg_province">
+          <div class="inner">
+            <h3><%= t('.avg_province', kind: kind_literal(@kind, false)) %></h3>
+            <div class="metric">
+              <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name %>
+                <%= format_currency @budget_line_stats.mean_province %>
+              <% else %>
+                <span class="not_av"><%= t('.not_available') %></span>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <% if budget_lines_feedback_active? %>
+          <div class="pure-u-1-2 pure-u-md-1-5 metric_box cta open_budget_line_feedback tipsit" title="<%= t('.give_your_opinion_cta') %>" data-box="feedback">
             <div class="inner">
-              <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.vs_previous_year') %></h3>
-              <div class="metric"><%= @budget_line_stats.percentage_difference(variable1: :amount_planned, year1: @year, year2: @year-1) %></div>
+              <%= link_to gobierto_budgets_feedback_step1_path(year: @year, id: @budget_line.id), remote: true do %>
+                <div class="main"><%= t('.raise_hand') %> <i class="fas fa-hand-paper-o"></i></div>
+                <div class="lite"><%= t('.give_your_opinion') %></div>
+              <% end %>
             </div>
           </div>
         <% end %>
-      <% end %>
-
-      <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.percentage_tooltip') %>" data-box="percentage">
-        <div class="inner">
-          <h3><%= t('.percentage') %></h3>
-          <div class="metric"><%= @budget_line_stats.percentage_of_total %></div>
-        </div>
-      </div>
-
-      <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.avg_province_tooltip') %>" data-box="avg_province">
-        <div class="inner">
-          <h3><%= t('.avg_province', kind: kind_literal(@kind, false)) %></h3>
-          <div class="metric">
-            <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name %>
-              <%= format_currency @budget_line_stats.mean_province %>
-            <% else %>
-              <span class="not_av"><%= t('.not_available') %></span>
-            <% end %>
-          </div>
-        </div>
       </div>
 
       <% if budget_lines_feedback_active? %>
-        <div class="pure-u-1-2 pure-u-md-1-5 metric_box cta open_budget_line_feedback tipsit" title="<%= t('.give_your_opinion_cta') %>" data-box="feedback">
-          <div class="inner">
-            <%= link_to gobierto_budgets_feedback_step1_path(year: @year, id: @budget_line.id), remote: true do %>
-              <div class="main"><%= t('.raise_hand') %> <i class="fas fa-hand-paper-o"></i></div>
-              <div class="lite"><%= t('.give_your_opinion') %></div>
-            <% end %>
-          </div>
-        </div>
+        <div id="feedback-container"></div>
       <% end %>
-    </div>
 
-    <% if budget_lines_feedback_active? %>
-      <div id="feedback-container"></div>
-    <% end %>
+      <div class="pure-g block">
 
-    <div class="pure-g block">
+        <div class="pure-u-1 pure-u-md-9-24 line_description">
 
-      <div class="pure-u-1 pure-u-md-9-24 line_description">
+          <h2><%= t('.about_this_line') %></h2>
+          <% if @budget_line.description %>
+            <%= simple_format budget_line_description(@budget_line) %>
+          <% else %>
+            <%= t('.no_description') %>
+          <% end %>
+        </div>
 
-        <h2><%= t('.about_this_line') %></h2>
-        <% if @budget_line.description %>
-          <%= simple_format budget_line_description(@budget_line) %>
-        <% else %>
-          <%= t('.no_description') %>
-        <% end %>
-      </div>
+        <div class="pure-u-md-3-24"></div>
 
-      <div class="pure-u-md-3-24"></div>
+        <div class="pure-u-1 pure-u-md-1-2">
 
-      <div class="pure-u-1 pure-u-md-1-2">
+          <h2><%= t('.sub_budget_lines') %></h2>
 
-        <h2><%= t('.sub_budget_lines') %></h2>
+          <% if @budget_line_descendants.any? %>
 
-        <% if @budget_line_descendants.any? %>
+            <table>
+              <thead class="screen-hidden">
+                <tr>
+                  <th><%= t('.budget_line_category') %></th>
+                  <th><%= t('.budget_line_percentage') %></th>
+                  <th><%= t('.budget_line_value') %></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @budget_line_descendants.each do |budget_line| %>
+                  <tr>
+                    <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
+                    <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
+                    <td class="amount"><%= format_currency(budget_line.amount) %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
 
-          <table>
-            <thead class="screen-hidden">
-              <tr>
-                <th><%= t('.budget_line_category') %></th>
-                <th><%= t('.budget_line_percentage') %></th>
-                <th><%= t('.budget_line_value') %></th>
-              </tr>
-            </thead>
-            <tbody>
-              <% @budget_line_descendants.each do |budget_line| %>
+          <% else %>
+
+            <p><%= t('.no_more_descendants') %>. <% if @parent_budget_line %><%= t('.back_to_parent') %>: <a href="<%= gobierto_budgets_budget_line_path(@parent_budget_line.to_param) %>"><%= @parent_budget_line.name %></a>.<% end %></p>
+
+          <% end %>
+
+          <h2><%= t('.budget_lines_distribution') %></h2>
+          <% if @budget_line_composition.any? %>
+            <table>
+              <% @budget_line_composition.each do |budget_line| %>
                 <tr>
                   <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
                   <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                   <td class="amount"><%= format_currency(budget_line.amount) %></td>
                 </tr>
               <% end %>
-            </tbody>
-          </table>
-
-        <% else %>
-
-          <p><%= t('.no_more_descendants') %>. <% if @parent_budget_line %><%= t('.back_to_parent') %>: <a href="<%= gobierto_budgets_budget_line_path(@parent_budget_line.to_param) %>"><%= @parent_budget_line.name %></a>.<% end %></p>
-
-        <% end %>
-
-        <h2><%= t('.budget_lines_distribution') %></h2>
-        <% if @budget_line_composition.any? %>
-          <table>
-            <% @budget_line_composition.each do |budget_line| %>
-              <tr>
-                <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
-                <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
-                <td class="amount"><%= format_currency(budget_line.amount) %></td>
-              </tr>
-            <% end %>
-          </table>
-        <% else %>
-          <p><%= t('.no_distribution') %></p>
-        <% end %>
-
-      </div>
-    </div>
-
-    <div id="lines_chart_wrapper_separator" class="separator"></div>
-
-    <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_context_table_enabled %>
-      <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
-        <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
-          <h2><%= t('.evolution') %></h2>
-          <div id="lines_chart"></div>
-        </div>
-
-        <div class="pure-u-1 pure-u-md-1-2 p_h_r_1">
-          <h2><%= t('gobierto_budgets.budgets.index.context') %></h2>
-          <div id="lines_tooltip"></div>
-          <div class="help">
-            <%= link_to t('gobierto_budgets.budgets.index.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], title: t('gobierto_budgets.budgets.index.note_about_the_data_title'), class: 'tipsit-n' %>
-          </div>
-        </div>
-
-        <div class="pure-u-1 pure-u-md-1-2">
-          <div class="filter m_v_2" role="tablist" aria-label="<%= t('gobierto_budgets.budgets.index.visualize') %>">
-            <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person','aria-controls' => 'lines_chart_wrapper' %>
-            <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" },  role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
-          </div>
-        </div>
-      </div>
-    <% end %>
-
-    <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_compare_municipalities.any? %>
-      <div id="lines_chart_comparison_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
-        <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
-          <h2><%= t('.evolution') %></h2>
-          <div id="lines_chart_comparison"></div>
-        </div>
-
-        <div class="pure-u-1 pure-u-md-1-2 p_h_r_1">
-          <h2><%= t('gobierto_budgets.budgets.index.context') %></h2>
-          <div id="lines_tooltip_comparison"></div>
-          <div class="help">
-            <%= link_to t('gobierto_budgets.budgets.index.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], title: t('gobierto_budgets.budgets.index.note_about_the_data_title'), class: 'tipsit-n' %>
-          </div>
-
-          <% if budgets_comparison_show_widget %>
-            <%= render 'gobierto_budgets/shared/compare' %>
+            </table>
+          <% else %>
+            <p><%= t('.no_distribution') %></p>
           <% end %>
-        </div>
 
-        <div class="pure-u-1 pure-u-md-1-2">
-          <div class="filter m_v_2" role="tablist" aria-label="<%= t('gobierto_budgets.budgets.index.visualize') %>">
-            <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json, comparison: budgets_comparison_compare_municipalities), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person','aria-controls' => 'lines_chart_wrapper' %>
-            <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "comparison", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json, comparison: budgets_comparison_compare_municipalities), "line-widget-type" => "total_budget" },  role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
-          </div>
         </div>
       </div>
-    <% end %>
 
-    <% if budget_lines_feedback_active? %>
-      <%= render 'gobierto_budgets/shared/enough_information' %>
-    <% end %>
+      <div id="lines_chart_wrapper_separator" class="separator"></div>
+
+      <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_context_table_enabled %>
+        <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+          <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
+            <h2><%= t('.evolution') %></h2>
+            <div id="lines_chart"></div>
+          </div>
+
+          <div class="pure-u-1 pure-u-md-1-2 p_h_r_1">
+            <h2><%= t('gobierto_budgets.budgets.index.context') %></h2>
+            <div id="lines_tooltip"></div>
+            <div class="help">
+              <%= link_to t('gobierto_budgets.budgets.index.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], title: t('gobierto_budgets.budgets.index.note_about_the_data_title'), class: 'tipsit-n' %>
+            </div>
+          </div>
+
+          <div class="pure-u-1 pure-u-md-1-2">
+            <div class="filter m_v_2" role="tablist" aria-label="<%= t('gobierto_budgets.budgets.index.visualize') %>">
+              <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "means", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person','aria-controls' => 'lines_chart_wrapper' %>
+              <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "means", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json ), "line-widget-type" => "total_budget" },  role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_compare_municipalities.any? %>
+        <div id="lines_chart_comparison_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+          <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
+            <h2><%= t('.evolution') %></h2>
+            <div id="lines_chart_comparison"></div>
+          </div>
+
+          <div class="pure-u-1 pure-u-md-1-2 p_h_r_1">
+            <h2><%= t('gobierto_budgets.budgets.index.context') %></h2>
+            <div id="lines_tooltip_comparison"></div>
+            <div class="help">
+              <%= link_to t('gobierto_budgets.budgets.index.note_about_the_data'), APP_CONFIG["gobierto_budgets"]["data_note_url"], title: t('gobierto_budgets.budgets.index.note_about_the_data_title'), class: 'tipsit-n' %>
+            </div>
+
+            <% if budgets_comparison_show_widget %>
+              <%= render 'gobierto_budgets/shared/compare' %>
+            <% end %>
+          </div>
+
+          <div class="pure-u-1 pure-u-md-1-2">
+            <div class="filter m_v_2" role="tablist" aria-label="<%= t('gobierto_budgets.budgets.index.visualize') %>">
+              <%= link_to t('gobierto_budgets.budgets.index.per_person'), '#', class:'active',  data: {"line-widget-series" => "comparison", "line-widget-url" => gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "per_person", @kind, @code.parameterize, @area_name, format: :json, comparison: budgets_comparison_compare_municipalities), "line-widget-type" => "per_person" }, role:'tab', tabindex:0, 'aria-selected' => 'true', id:'per_person','aria-controls' => 'lines_chart_wrapper' %>
+              <%= link_to t('gobierto_budgets.budgets.index.in_total'), '#', class:'',  data: {"line-widget-series" => "comparison", "line-widget-url" =>gobierto_budgets_api_data_lines_budget_line_path(current_site.organization_id, @year, "total_budget", @kind, @code.parameterize, @area_name, format: :json, comparison: budgets_comparison_compare_municipalities), "line-widget-type" => "total_budget" },  role:'tab', tabindex:-1, 'aria-selected' => 'false', id:'total_budget', 'aria-controls' => 'lines_chart_wrapper' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <% if budget_lines_feedback_active? %>
+        <%= render 'gobierto_budgets/shared/enough_information' %>
+      <% end %>
+    </div>
   </div>
-</div>
+
+<% end %>

--- a/app/views/gobierto_cms/pages/meta_welcome.html.erb
+++ b/app/views/gobierto_cms/pages/meta_welcome.html.erb
@@ -1,0 +1,6 @@
+<% cache(["gobierto_cms/pages/meta_welcome", current_site, I18n.locale]) do %>
+  <% title(@page.title) %>
+  <% description(truncate(strip_tags(@page.body), length: 100)) %>
+
+  <%= render @page.template %>
+<% end %>

--- a/app/views/gobierto_cms/shared/_page.html.erb
+++ b/app/views/gobierto_cms/shared/_page.html.erb
@@ -1,0 +1,1 @@
+<li><%= link_to page.title, gobierto_cms_page_or_news_path(page) %></li>

--- a/app/views/gobierto_cms/shared/_pages_side_navigation.html.erb
+++ b/app/views/gobierto_cms/shared/_pages_side_navigation.html.erb
@@ -2,13 +2,12 @@
   <% if @section %>
     <!-- This is not clear. Can't we generate the tree just passing the section instead of two arguments? -->
     <%= section_tree(@section.section_items.first_level.not_archived.not_drafted, @section_item.hierarchy_and_children(only_public: true)) %>
+
   <% elsif @collection %>
     <ul>
       <li><%= link_to @collection.title, gobierto_cms_pages_path(@collection.slug) %></a>
         <ul>
-          <% @pages.each do |page| %>
-            <li><%= link_to page.title, gobierto_cms_page_or_news_path(page) %></li>
-          <% end %>
+          <%= render partial: "gobierto_cms/shared/page", collection: @pages, cached: true %>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
Closes #3107
Closes #3106

## :v: What does this PR do?

* Caches a fragment of meta_welcome view which loads slowly
* Refactors some code and uses eager load of some associations to avoid unnecessary queries
* Uses its own view for the meta_welcome page and caches the content depending on locale and site
* Makes CMS resources belonging to site to touch it on updates
* Improves performance of application in gobierto budgets home page and budget lines show and index actions:
  * Using caches_action from controller for not signed in users
  * Using fragment caching from view in show partial

## :mag: How should this be manually tested?

For meta_welcome:
* An index with a lot of subpages was taking around 600ms - 1s
* The current time is about 200ms

For gobierto_budgets:
* Before this changes, the time to load a budget line in staging, taken from browser info has an average of 1.63s with maximum of 3.40s and minimum of 1.06s, regardless the user is logged in or not
* After the changes, in staging:
  * For not signed in users: Average: 0.78, max: 0.87, min: 0.71
  * For signed in users: Average: 0.92, max: 0.99, min: 0.82

Looking at appsignal the performance seems to be much better than these times: https://appsignal.com/populate/sites/5eb0fcfc74782044d1198606/performance/incidents/24?timerange=Wed+May+27+2020+20%3A39%3A00+GMT%2B0200%2CWed+May+27+2020+20%3A40%3A00+GMT%2B0200&incident_tab=host,  from orders of 10^3 to 10 milliseconds to but I'm not sure if I'm reading the stats correctly

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
