### PR TITLE
Fix variable name

### DIFF
--- a/app/views/gobierto_people/person_events/_calendar_template.html.erb
+++ b/app/views/gobierto_people/person_events/_calendar_template.html.erb
@@ -23,11 +23,7 @@
         <tr>
           <% week.each do |day| %>
             <%= content_tag :td, class: calendar.td_classes_for(day) do %>
-              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(block) %>
-                <% capture_haml(day, sorted_events.fetch(day, []), &block) %>
-              <% else %>
-                <% block.call day, sorted_events.fetch(day, []) %>
-              <% end %>
+              <% passed_block.call day, sorted_events.fetch(day, []) %>
             <% end %>
           <% end %>
         </tr>


### PR DESCRIPTION
Fixes simple calendar block variable name

https://github.com/excid3/simple_calendar/commit/77ca99e146477d4c37d2db23786121b473d4f3df

This is breaking production so I'm going to release it.
