### PR TITLE
Include session data on admins login in custom sessions controller

### DIFF
--- a/app/controllers/gobierto_admin/custom_sessions_controller.rb
+++ b/app/controllers/gobierto_admin/custom_sessions_controller.rb
@@ -19,6 +19,7 @@ module GobiertoAdmin
 
       if @admin_session_forms.values.any?(&:save)
         @valid_session_form = @admin_session_forms.values.find(&:valid?)
+        @valid_session_form.admin.update_session_data(remote_ip)
         sign_in_admin(@valid_session_form.admin.id)
         redirect_to after_sign_in_path, notice: t("gobierto_admin.sessions.create.success")
       else


### PR DESCRIPTION
Closes PopulateTools/issues#1011


## :v: What does this PR do?

Includes session data when admins sign in using a custom auth strategy. This prevents errors trying to create activities associated to these admins

## :mag: How should this be manually tested?

Sig in with auth strategy and try to upload a file in a collection

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No