### PR TITLE
CSV response generation improvement

### DIFF
--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -21,6 +21,8 @@ module GobiertoData
           {}.tap do |options|
             if (separator = params[:csv_separator]).present?
               options[:col_sep] = separator_tr.fetch(separator, separator)
+            else
+              options[:col_sep] = separator_tr["comma"]
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -182,7 +182,7 @@ module GobiertoData
 
         def cached_item_csv
           Rails.cache.fetch("#{@item.cache_key}/show.csv?#{csv_options_params.to_json}") do
-            csv_from_query_result(execute_query(@item.rails_model.all), csv_options_params)
+            GobiertoData::Connection.execute_query_output_csv(current_site, @item.rails_model.all.to_sql)
           end
         end
 

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -182,7 +182,7 @@ module GobiertoData
 
         def cached_item_csv
           Rails.cache.fetch("#{@item.cache_key}/show.csv?#{csv_options_params.to_json}") do
-            GobiertoData::Connection.execute_query_output_csv(current_site, @item.rails_model.all.to_sql)
+            GobiertoData::Connection.execute_query_output_csv(current_site, @item.rails_model.all.to_sql, csv_options_params)
           end
         end
 

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -20,7 +20,7 @@ module GobiertoData
             end
 
             format.csv do
-              query_result = GobiertoData::Connection.execute_query_output_csv(current_site, Arel.sql(params[:sql] || {}))
+              query_result = GobiertoData::Connection.execute_query_output_csv(current_site, Arel.sql(params[:sql] || {}), csv_options_params)
 
               render_error_or_continue(query_result) do
                 render_csv(query_result)

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -91,7 +91,7 @@ module GobiertoAdmin
       end
 
       def table_reachable
-        query_result = ::GobiertoData::Connection.execute_query(site, Arel.sql("SELECT COUNT(*) FROM #{table_name} LIMIT 1"), include_draft: true)
+        query_result = ::GobiertoData::Connection.execute_query(site, Arel.sql("SELECT COUNT(1) FROM #{table_name} LIMIT 1"), include_draft: true)
 
         errors.add(:table_name, :invalid_table, error_message: query_result[:error]) if query_result.is_a?(Hash) && query_result.has_key?(:errors)
       end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -44,15 +44,15 @@ module GobiertoData
         with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(write, include_draft)) do
           connection_pool.connection.execute("SET search_path TO draft, public") if include_draft
 
-          csv  = ""
+          csv  = []
           # Get the raw connection (in our case the pg connection object)
           pg_connection = connection_pool.connection.raw_connection
           pg_connection.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *, ESCAPE E'\\\\');") do
             while row = pg_connection.get_copy_data
-              csv += row
+              csv.push(row)
             end
           end
-          return csv
+          return csv.join('')
         end
       rescue ActiveRecord::StatementInvalid, PG::SyntaxError, PG::UndefinedTable => e
         failed_query(e.message)

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -37,6 +37,27 @@ module GobiertoData
         failed_query(e.message)
       end
 
+      def execute_query_output_csv(site, query, include_stats: false, write: false, include_draft: false)
+        raise "This method allows only read only requests" if write
+        raise "This method doesn't allow stats" if include_stats
+
+        with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(write, include_draft)) do
+          connection_pool.connection.execute("SET search_path TO draft, public") if include_draft
+
+          csv  = ""
+          # Get the raw connection (in our case the pg connection object)
+          pg_connection = connection_pool.connection.raw_connection
+          pg_connection.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *, ESCAPE E'\\\\');") do
+            while row = pg_connection.get_copy_data
+              csv += row
+            end
+          end
+          return csv
+        end
+      rescue ActiveRecord::StatementInvalid, PG::SyntaxError, PG::UndefinedTable => e
+        failed_query(e.message)
+      end
+
       def execute_write_query_from_file_using_stdin(site, query, file_path: nil, include_draft: false)
         return unless file_path.present?
 

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -51,7 +51,7 @@ module GobiertoData
           end
           return csv.join('')
         end
-      rescue ActiveRecord::StatementInvalid, PG::SyntaxError, PG::UndefinedTable => e
+      rescue ActiveRecord::StatementInvalid, PG::SyntaxError, PG::UndefinedTable, PG::UndefinedColumn => e
         failed_query(e.message)
       end
 

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -37,17 +37,14 @@ module GobiertoData
         failed_query(e.message)
       end
 
-      def execute_query_output_csv(site, query, include_stats: false, write: false, include_draft: false)
-        raise "This method allows only read only requests" if write
-        raise "This method doesn't allow stats" if include_stats
-
-        with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(write, include_draft)) do
+      def execute_query_output_csv(site, query, csv_options_params, include_draft: false)
+        with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(false, include_draft)) do
           connection_pool.connection.execute("SET search_path TO draft, public") if include_draft
 
           csv  = []
           # Get the raw connection (in our case the pg connection object)
           pg_connection = connection_pool.connection.raw_connection
-          pg_connection.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *, ESCAPE E'\\\\');") do
+          pg_connection.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, DELIMITER '#{csv_options_params[:col_sep]}', FORCE_QUOTE *, ESCAPE E'\\\\');") do
             while row = pg_connection.get_copy_data
               csv.push(row)
             end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -51,7 +51,7 @@ module GobiertoData
           end
           return csv.join('')
         end
-      rescue ActiveRecord::StatementInvalid, PG::SyntaxError, PG::UndefinedTable, PG::UndefinedColumn => e
+      rescue ActiveRecord::StatementInvalid, PG::Error => e
         failed_query(e.message)
       end
 

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -36,7 +36,7 @@ module GobiertoData
       {
         number_of_rows: ::GobiertoData::Connection.execute_query(
           object.site,
-          Arel.sql("SELECT COUNT(*) FROM #{object.table_name} LIMIT 1"),
+          Arel.sql("SELECT COUNT(1) FROM #{object.table_name} LIMIT 1"),
           include_draft: true
         )&.first&.dig("count")
       }

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -56,13 +56,13 @@ module GobiertoData
     end
 
     def test_execute_query_with_output_csv
-      result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) AS test_count FROM users")
+      result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) AS test_count FROM users", {col_sep: ','})
       csv = CSV.parse(result, headers: true)
       assert_equal "7", csv[0]["test_count"]
     end
 
     def test_execute_query_with_output_csv_with_errors
-      result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) FROM not_existing_table")
+      result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) FROM not_existing_table", {col_sep: ','})
       hash_result = JSON.parse(result.to_json)
 
       assert hash_result.has_key?("errors")

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -61,12 +61,20 @@ module GobiertoData
       assert_equal "7", csv[0]["test_count"]
     end
 
-    def test_execute_query_with_output_csv_with_errors
+    def test_execute_query_with_output_csv_with_no_table_error
       result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) FROM not_existing_table", {col_sep: ','})
       hash_result = JSON.parse(result.to_json)
 
       assert hash_result.has_key?("errors")
       assert_match(/ERROR:  relation \"not_existing_table\" does not exist/, hash_result["errors"].first["sql"])
+    end
+
+    def test_execute_query_with_output_csv_with_undefined_column_error
+      result = Connection.execute_query_output_csv(site, "SELECT not_existing_column FROM users", {col_sep: ','})
+      hash_result = JSON.parse(result.to_json)
+
+      assert hash_result.has_key?("errors")
+      assert_match(/ERROR:  column \"not_existing_column\" does not exist/, hash_result["errors"].first["sql"])
     end
 
     def test_execute_query_with_module_disabled

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -55,6 +55,20 @@ module GobiertoData
       assert_match(/UndefinedTable/, hash_result["errors"].first["sql"])
     end
 
+    def test_execute_query_with_output_csv
+      result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) AS test_count FROM users")
+      csv = CSV.parse(result, headers: true)
+      assert_equal "7", csv[0]["test_count"]
+    end
+
+    def test_execute_query_with_output_csv_with_errors
+      result = Connection.execute_query_output_csv(site, "SELECT COUNT(*) FROM not_existing_table")
+      hash_result = JSON.parse(result.to_json)
+
+      assert hash_result.has_key?("errors")
+      assert_match(/ERROR:  relation \"not_existing_table\" does not exist/, hash_result["errors"].first["sql"])
+    end
+
     def test_execute_query_with_module_disabled
       result = Connection.execute_query(site_with_module_disabled, "SELECT COUNT(*) FROM users")
       hash_result = JSON.parse(result.to_json)


### PR DESCRIPTION
## :v: What does this PR do?

This PR replaces how CSV results are generated by using the `\COPY` command from Postgres, which already returns a CSV and we skip Ruby to build it.

## Times

The improvement is very good when the result contains a big number of rows, starting at 10k

```
ab -n 50 -c 1 https://demo-datos.gobify.net/api/v1/data/data.csv?sql=select%20*%20from%20global_mobility_report%20limit%20100000
```

Rows | Before | After
-- | -- | --
100 | 50 | 80
1000 | 70 | 60
10000 | 624 | 151
100000 | 2436 | 1053
224147 | 5708 | 2374
