### PR TITLE
Add external_id and custom_field_id to category_term_decorator

### DIFF
--- a/app/decorators/gobierto_plans/category_term_decorator.rb
+++ b/app/decorators/gobierto_plans/category_term_decorator.rb
@@ -169,8 +169,10 @@ module GobiertoPlans
         {
           value: value_string,
           raw_value: record.raw_value,
+          external_id: record.external_id,
           custom_field_name_translations: record.custom_field.name_translations,
-          custom_field_field_type: record.custom_field.field_type
+          custom_field_field_type: record.custom_field.field_type,
+          custom_field_id: record.custom_field.uid
         }
       end.compact
     end

--- a/app/models/gobierto_common/custom_field_record.rb
+++ b/app/models/gobierto_common/custom_field_record.rb
@@ -41,7 +41,7 @@ module GobiertoCommon
 
     has_paper_trail if: ->(this) { this.item_has_versions }
 
-    delegate :value, :value_string, :raw_value, :value=, :filter_value, :searchable_value, to: :value_processor
+    delegate :value, :value_string, :raw_value, :value=, :filter_value, :searchable_value, :external_id, to: :value_processor
 
     after_save :check_plugin_callbacks, :touch_item
 

--- a/app/models/gobierto_common/custom_field_value/base.rb
+++ b/app/models/gobierto_common/custom_field_value/base.rb
@@ -41,6 +41,8 @@ module GobiertoCommon
           record.payload = { custom_field.uid => value }
         end
       end
+
+      def external_id; end
     end
 
   end

--- a/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
+++ b/app/models/gobierto_common/custom_field_value/vocabulary_options.rb
@@ -15,6 +15,10 @@ module GobiertoCommon::CustomFieldValue
       end
     end
 
+    def external_id
+      value.map(&:external_id).compact.join(",")
+    end
+
     def filter_value
       raw_value.to_s
     end


### PR DESCRIPTION
## :v: What does this PR do?

Includes a `external_id` and `custom_field_id` attributes to `CategoryTermDecorator`, responsible of generating the data of custom fields of plan projects.

## :mag: How should this be manually tested?

From front go to a plan and show a project. The response to the API request used to display the project should include external_id and custom_field_id attributes for each custom field 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
