### PR TITLE
Circle ci move asset compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,19 +28,32 @@ jobs:
       - restore_cache:
           name: "[Bundler] Restore cache"
           keys:
-            - gobierto-{{ checksum "Gemfile.lock" }}
+            - gobierto-bundler-{{ checksum "Gemfile.lock" }}
       - run:
           name: "[Bundler] Install dependencies"
           command: bundle install --path vendor/bundle --jobs=4 --retry=3  --without development
       - save_cache:
           name: "[Bundler] Cache dependencies"
-          key: gobierto-{{ checksum "Gemfile.lock" }}
+          key: gobierto-bundler-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+      - restore_cache:
+          name: "[Yarn] Restore cache"
+          keys:
+            - gobierto-yarn-{{ checksum "yarn.lock" }}
+      - run:
+          name: "[Yarn] Install dependencies"
+          command: yarn install
+      - save_cache:
+          name: "[Yarn] Cache dependencies"
+          key: gobierto-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
       - persist_to_workspace:
           root: ~/gobierto
           paths:
             - vendor/bundle
+            - node_modules
 
   tests:
     <<: *defaults
@@ -69,7 +82,21 @@ jobs:
       - run: bin/rails i18n:js:export
 
       # Precompile assets
+      - restore_cache:
+          name: "Restore cached assets"
+          keys:
+            - v1-asset-cache-{{ arch }}-{{ .Branch }}
+            - v1-asset-cache-
+
       - run: bin/rails assets:precompile
+
+      - save_cache:
+          name: "Cache assets"
+          key: v1-asset-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          paths:
+            - public/packs
+            - public/packs-test
+            - tmp/cache/assets/sprockets
 
       # Run tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,14 +85,14 @@ jobs:
       - restore_cache:
           name: "Restore cached assets"
           keys:
-            - v1-asset-cache-{{ arch }}-{{ .Branch }}
+            - v1-asset-cache-{{ .Branch }}
             - v1-asset-cache-
 
       - run: bin/rails assets:precompile
 
       - save_cache:
           name: "Cache assets"
-          key: v1-asset-cache-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          key: v1-asset-cache-{{ .Branch }}
           paths:
             - public/packs
             - public/packs-test

--- a/test/misc/i18n_test.rb
+++ b/test/misc/i18n_test.rb
@@ -17,22 +17,12 @@ module Misc
       @unused_keys ||= i18n.unused_keys
     end
 
-    def non_normalized_paths
-      @non_normalized_paths ||= i18n.non_normalized_paths
-    end
-
     def test_no_missing_keys
       assert_empty missing_keys, "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
     end
 
     def test_no_unused_keys
       assert_empty unused_keys, "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
-    end
-
-    def test_normalized
-      assert_empty non_normalized_paths, "The following files need to be normalized:\n" \
-        "#{non_normalized_paths.map { |path| "  #{path}" }.join("\n")}\n" \
-        "Please run `i18n-tasks normalize` to fix"
     end
   end
 end

--- a/test/support/contexts.rb
+++ b/test/support/contexts.rb
@@ -46,7 +46,6 @@ def with(params = {})
 
   Capybara.reset_session! if params[:js]
 ensure
-  sign_out_admin if admin
   factory&.teardown
   factories.each(&:teardown)
 

--- a/test/support/drivers.rb
+++ b/test/support/drivers.rb
@@ -13,6 +13,8 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    desired_capabilities: capabilities,
+    clear_local_storage: true,
+    clear_session_storage: true
   )
 end


### PR DESCRIPTION
## :v: What does this PR do?

This PR improves the performance of the tests and the execution in CircleCI

- node_modules are persisted, so we save ~ 2 mins in `yarn install`
- assets are cached in the branch, so if a branch is being executed many times and there are no changes in the assets, the execution will be also ~ 1 min faster
- I've removed the check of normalized I18n files, keeping only missing and unused. This saves around ~ 30 secs, and now we have Husky. Besides that, normalization is not such a reason to raise a failure and won't cause a failure in production
- I've removed a extra step to logout admins, not necessary because we reset the session
