### PR TITLE
Enable save viz button

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -346,11 +346,11 @@ export default {
     //Update the name of Visualization
     this.$root.$on('updateVizName', this.eventToUpdateVizName)
     //Enable input to write a name for query
-    this.$root.$emit('eventToEnabledInputQueries', this.eventToEnabledInputQueries)
+    this.$root.$on('eventToEnabledInputQueries', this.eventToEnabledInputQueries)
     //Reset visualization flow
-    this.$root.$emit('resetVizEvent', this.resetVizEvent)
+    this.$root.$on('resetVizEvent', this.resetVizEvent)
     //Show saving dialog visualization
-    this.$root.$emit('showSavingDialogEvent', this.showSavingDialogEvent)
+    this.$root.$on('showSavingDialogEvent', this.showSavingDialogEvent)
   },
   deactivated() {
     this.$root.$off("deleteSavedQuery");


### PR DESCRIPTION
Closes #https://github.com/PopulateTools/issues/issues/1064


## :v: What does this PR do?

Fix an error to enabled save visualization button when selected a different visualization.


## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
