### PR TITLE
Explicit class name in relation (try to avoid random errors in CI)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   has_many :id_number_verifications, class_name: "User::Verification::IdNumber"
   has_many :subscriptions, dependent: :destroy
   has_many :notifications, dependent: :destroy
-  has_many :api_tokens, dependent: :destroy
+  has_many :api_tokens, dependent: :destroy, class_name: "User::ApiToken"
   has_many :custom_records, dependent: :destroy, class_name: "GobiertoCommon::CustomUserFieldRecord"
   has_many :contributions, dependent: :destroy, class_name: "GobiertoParticipation::Contribution"
   has_many :flags, dependent: :destroy, class_name: "GobiertoParticipation::Flag"


### PR DESCRIPTION
##  :v: What does this PR do?

Forces class name in relation to try to avoid CI random errors
