### PR TITLE
Gobierto Data / Restore Perspective configuration

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -78,18 +78,24 @@ export default {
       this.viewer.load(data);
       if (this.config) {
         this.viewer.restore(this.config);
+        //Perspective can't restore row_pivots, column_pivots and computed_columns, so we need to check if visualization config contains some of these values, if contain them we've need to include these values to viewer
+        this.loadPivots('column-pivots', this.config.column_pivots)
+        this.loadPivots('row-pivots', this.config.row_pivots)
+        this.loadPivots('computed-columns', this.config.computed_columns)
+      }
+    },
+    loadPivots(pivot, data) {
+      // Check if config contains row_pivots, column_pivots or computed_columns
+      if (data) {
+        this.viewer.setAttribute(pivot, JSON.stringify(data))
       }
     },
     getConfig() {
       // export the visualization configuration object
       return this.viewer.save()
     },
-    enableDisabledPerspective(value) {
-      const shadowRootPerspective = document.querySelector('perspective-viewer').shadowRoot
-      const sidePanelPerspective = shadowRootPerspective.getElementById('side_panel')
-      const topPanelPerspective = shadowRootPerspective.getElementById('top_panel')
-      topPanelPerspective.style.display = value
-      sidePanelPerspective.style.display = value
+    toggleConfigPerspective() {
+      this.viewer.toggleConfig()
     },
     listenerPerspective() {
       const shadowRootPerspective = document.querySelector('perspective-viewer').shadowRoot

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
@@ -176,9 +176,8 @@ export default {
       this.$root.$emit('updateVizName')
     },
     showChart() {
-      const showPerspective = "flex"
       this.$root.$emit('disabledSavedVizString')
-      this.$refs.viewer.enableDisabledPerspective(showPerspective);
+      this.$refs.viewer.toggleConfigPerspective();
     },
     showSavingDialog() {
       const userId = getUserId()

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -156,21 +156,19 @@ export default {
       this.$root.$emit("eventIsVizModified", true);
     },
     resetViz() {
-      const hidePerspective = "none"
 
       this.showVisualize = true
       this.perspectiveChanged = false
       this.showResetViz = false
       this.typeChart = 'hypergrid'
 
-      this.$refs.viewer.enableDisabledPerspective(hidePerspective);
+      this.$refs.viewer.toggleConfigPerspective();
       this.$refs.viewer.setColumns();
       this.$root.$emit('resetVizEvent')
     },
     showChart() {
-      const showPerspective = "flex"
       this.showVisualization = true
-      this.$refs.viewer.enableDisabledPerspective(showPerspective);
+      this.$refs.viewer.toggleConfigPerspective();
     },
     showSavingDialog() {
       this.perspectiveChanged = true


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1075


## :v: What does this PR do?

When you create a Visualization with Perspective, we can generate Row pivots, Column Pivots, and Computed columns. Saved a Visualization with these options store values in an object with the configuration, but when we load this configuration, Perspective can't restore these values. So, we need to 'force' to add these values.

Mini-refactor for toggleConfig, use the [native method](https://github.com/finos/perspective/blob/master/packages/perspective-viewer/README.md#perspectiveviewertoggleconfig) to show/hide the menu.


## :mag: How should this be manually tested?

[Staging](https://getafe.gobify.net/datos/censo-barrios-edad-nacionalidad/v/49)


## :eyes: Screenshots

### Before this PR

![before_restore_config](https://user-images.githubusercontent.com/2649175/85839333-164a3f80-b79b-11ea-81e7-e279772497e2.png)

### After this PR

![after_restore_config](https://user-images.githubusercontent.com/2649175/85840565-f9167080-b79c-11ea-99ad-972db01e64f5.png)
