### PR TITLE
1074 visualizations spec content

### DIFF
--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -122,7 +122,17 @@ module GobiertoData
         end
 
         def visualization_params
-          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:query_id, :dataset_id, :name_translations, :name, :privacy_status, :spec, :sql])
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: writable_attributes).tap do |post_params|
+            post_params[:spec] = raw_spec_from_params if post_params.has_key?(:spec)
+          end
+        end
+
+        def raw_spec_from_params
+          JSON.parse(request.raw_post).dig("data", "attributes", "spec")
+        end
+
+        def writable_attributes
+          [:query_id, :dataset_id, :name_translations, :name, :privacy_status, :spec, :sql]
         end
 
         def filter_params

--- a/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/visualizations_controller_test.rb
@@ -127,9 +127,33 @@ module GobiertoData
             privacy_status: "open",
             sql: "select count(*) from users where bio is not null",
             spec: {
-              "x" => 1,
-              "y" => 2,
-              "z" => 3
+              "plugin": "d3_xy_scatter",
+              "columns": [
+                "column_1",
+                "height",
+                nil,
+                nil,
+                "birth_state",
+                "birth_city"
+              ],
+              "selectable": nil,
+              "editable": nil,
+              "row-pivots": nil,
+              "column-pivots": nil,
+              "aggregates": nil,
+              "filters": nil,
+              "sort": nil,
+              "computed-columns": nil,
+              "plugin_config": {
+                "realValues": [
+                  "column_1",
+                  "height",
+                  nil,
+                  nil,
+                  "birth_state",
+                  "birth_city"
+                ]
+              }
             },
             query_id: query.id,
             dataset_id: dataset.id


### PR DESCRIPTION
Closes PopulateTools/issues#1074


## :v: What does this PR do?

* Allows sending arbitrary JSON for the `spec` visualizations attribute in create/update API actions. With the previous controller nil items of arrays were being dropped.

## :mag: How should this be manually tested?

Send for example via API this spec: 

```json
      { 
        "plugin": "d3_xy_scatter",
        "columns": [
          "column_1",
          "height",
          null,
          null,
          "birth_state",
          "birth_city"
        ],
        "selectable": null,
        "editable": null,
        "row-pivots": null,
        "column-pivots": null,
        "aggregates": null,
        "filters": null,
        "sort": null,
        "computed-columns": null,
        "plugin_config": {
          "realValues": [
            "column_1",
            "height",
            null,
            null,
            "birth_state",
            "birth_city"
          ]
        }
      }
```


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
