### PR TITLE
Fix form for text custom fields with translations

### DIFF
--- a/app/decorators/gobierto_common/custom_field_record_decorator.rb
+++ b/app/decorators/gobierto_common/custom_field_record_decorator.rb
@@ -128,7 +128,7 @@ module GobiertoCommon
           ApplicationController.helpers.options_for_select(custom_field.localized_options(I18n.locale), payload.present? && payload[uid])
         end
       else
-        long_text? ? raw_value : value
+        long_text? || has_localized_value? ? raw_value : value
       end
     end
 


### PR DESCRIPTION
## :v: What does this PR do?

Fixes an error in admin forms of text (using translations) custom fields. The value used in the form was wrong, instead of using an object with the translations the value used was a plain string

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
