### PR TITLE
Amend character escaped char

### DIFF
--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -44,7 +44,7 @@ module GobiertoData
           csv  = []
           # Get the raw connection (in our case the pg connection object)
           pg_connection = connection_pool.connection.raw_connection
-          pg_connection.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, DELIMITER '#{csv_options_params[:col_sep]}', FORCE_QUOTE *, ESCAPE E'\\\\');") do
+          pg_connection.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, DELIMITER '#{csv_options_params[:col_sep]}', FORCE_QUOTE *);") do
             while row = pg_connection.get_copy_data
               csv.push(row)
             end


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR fixes an issue in the CSV produced when exporting a query result in the escaped parameters. It was a kind of silent error, which didn't failed in Perspective library but reusing that CSV to import data again in Postgres was causing a failure.

Apart from that, the utility `csvclean` was detecting some issues in the CSV, confirming that the escaping was not correct.

## :mag: How should this be manually tested?

In a dataset with double quotes in a record, try to download the dataset and import it again in Gobierto data. You should get an error. 

After this PR the import works again and `csvclean` reports no format errors.