### PR TITLE
Allow managers to authenticate with LDAP strategy

### DIFF
--- a/vendor/auth_strategies/ldap_strategy/app/forms/gobierto_admin/ldap_session_form.rb
+++ b/vendor/auth_strategies/ldap_strategy/app/forms/gobierto_admin/ldap_session_form.rb
@@ -28,9 +28,9 @@ class GobiertoAdmin::LdapSessionForm < GobiertoAdmin::CustomSessionForm
   end
 
   def find_or_create_admin_by_ldap
-    @admin = GobiertoAdmin::Admin.regular_on_site(site).find_by(ldap_data.slice(:email)) || new_admin(ldap_data)
+    @admin = GobiertoAdmin::Admin.active.find_by(ldap_data.slice(:email)) || new_admin(ldap_data)
 
-    if admin.new_record? && admin.save
+    if admin.new_record? && admin.save || admin.regular? && admin.sites.exclude?(site)
       admin.sites << site
     end
     admin


### PR DESCRIPTION
Closes PopulateTools/issues#1083


## :v: What does this PR do?

* Allows admins with manager permissions to authenticate via LDAP strategy
* For regular admins, if there are more than one site with LDAP, the site where the authentication is done is added to their sites list if not present.
* Adds a pair of tests

## :mag: How should this be manually tested?

Log in in a site via LDAP with a manager admin.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No