### PR TITLE
Small cleanup and CircleCI refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,8 @@ jobs:
           key: v1-asset-cache-{{ .Branch }}
           paths:
             - public/assets
-            - public/packs
             - public/packs-test
-            - tmp/cache/assets/sprockets
-            - tmp/cache/webpacker
+            - tmp/cache
 
       - persist_to_workspace:
           root: ~/gobierto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,25 +49,6 @@ jobs:
           key: gobierto-yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
-      - persist_to_workspace:
-          root: ~/gobierto
-          paths:
-            - vendor/bundle
-            - node_modules
-
-  tests:
-    <<: *defaults
-    parallelism: 4
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/gobierto
-      - run: bundle --path vendor/bundle
-      - run: yarn install
-      # Wait for DB containers to be ready
-      - run: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: dockerize -wait tcp://localhost:9200 -timeout 1m
-      - run: dockerize -wait tcp://localhost:6379 -timeout 1m
 
       # Copy database config
       - run: cp config/database.yml.example config/database.yml
@@ -94,9 +75,43 @@ jobs:
           name: "Cache assets"
           key: v1-asset-cache-{{ .Branch }}
           paths:
+            - public/assets
             - public/packs
             - public/packs-test
             - tmp/cache/assets/sprockets
+            - tmp/cache/webpacker
+
+      - persist_to_workspace:
+          root: ~/gobierto
+          paths:
+            - vendor/bundle
+            - node_modules
+            - public/assets
+            - public/packs-test
+            - tmp/cache
+
+  tests:
+    <<: *defaults
+    parallelism: 4
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/gobierto
+      - run: bundle --path vendor/bundle
+      - run: yarn install
+      # Wait for DB containers to be ready
+      - run: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run: dockerize -wait tcp://localhost:9200 -timeout 1m
+      - run: dockerize -wait tcp://localhost:6379 -timeout 1m
+
+      # Copy database config
+      - run: cp config/database.yml.example config/database.yml
+
+      # Setup the database
+      - run: bin/rails db:create db:migrate
+
+      # Install custom engines
+      - run: script/custom_engines_ci_setup
 
       # Run tests
       - run:

--- a/Gemfile
+++ b/Gemfile
@@ -88,9 +88,6 @@ gem "google-api-client"
 # Microsoft Exchange calendars
 gem "exchanger"
 
-# Web Services
-gem "savon", "~> 2.12.0"
-
 # Image management
 gem "cloudinary"
 

--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem "google-api-client"
 # Microsoft Exchange calendars
 gem "exchanger"
 
-# Web Services
+# Web Services: Alcobendas, Valencia
 gem "savon", "~> 2.12.0"
 
 # Image management

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,9 @@ gem "google-api-client"
 # Microsoft Exchange calendars
 gem "exchanger"
 
+# Web Services
+gem "savon", "~> 2.12.0"
+
 # Image management
 gem "cloudinary"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    akami (1.3.1)
-      gyoku (>= 0.4.0)
-      nokogiri
     algoliasearch (1.27.1)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -201,8 +198,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
-    gyoku (1.3.1)
-      builder (>= 2.1.2)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -210,9 +205,6 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    httpi (2.4.4)
-      rack
-      socksify
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     i18n-js (3.7.1)
@@ -314,7 +306,6 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    nori (2.6.0)
     ntlm-http (0.1.1)
     oj (3.10.6)
     open4 (1.3.4)
@@ -425,14 +416,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
-    savon (2.12.0)
-      akami (~> 1.2)
-      builder (>= 2.1.2)
-      gyoku (~> 1.2)
-      httpi (~> 2.3)
-      nokogiri (>= 1.8.1)
-      nori (~> 2.4)
-      wasabi (~> 3.4)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -455,7 +438,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    socksify (1.7.1)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -491,9 +473,6 @@ GEM
     unicode-display_width (1.7.0)
     url (0.3.2)
     vcr (6.0.0)
-    wasabi (3.5.0)
-      httpi (~> 2.0)
-      nokogiri (>= 1.4.2)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -585,7 +564,6 @@ DEPENDENCIES
   ruby_px
   sass (~> 3.4)
   sassc
-  savon (~> 2.12.0)
   selenium-webdriver
   sidekiq (~> 5.2.7)
   sidekiq-monitor-stats

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    akami (1.3.1)
+      gyoku (>= 0.4.0)
+      nokogiri
     algoliasearch (1.27.1)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -198,6 +201,8 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -205,6 +210,9 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
+    httpi (2.4.4)
+      rack
+      socksify
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     i18n-js (3.7.1)
@@ -306,6 +314,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    nori (2.6.0)
     ntlm-http (0.1.1)
     oj (3.10.6)
     open4 (1.3.4)
@@ -416,6 +425,14 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
+    savon (2.12.0)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.8.1)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -438,6 +455,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    socksify (1.7.1)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -473,6 +491,9 @@ GEM
     unicode-display_width (1.7.0)
     url (0.3.2)
     vcr (6.0.0)
+    wasabi (3.5.0)
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -564,6 +585,7 @@ DEPENDENCIES
   ruby_px
   sass (~> 3.4)
   sassc
+  savon (~> 2.12.0)
   selenium-webdriver
   sidekiq (~> 5.2.7)
   sidekiq-monitor-stats

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
   end
 
   def simple_pluralize(count, singular, plural)
-    if count == 1 || count =~ /^1(\.0+)?$/
+    if count == 1 || count.to_s =~ /^1(\.0+)?$/
       singular
     else
       plural

--- a/app/views/user/shared/_sharing_buttons.html.erb
+++ b/app/views/user/shared/_sharing_buttons.html.erb
@@ -3,7 +3,7 @@
   <a class="social_share twitter"
      data-share-network="twitter"
      target="_blank"
-     href="https://twitter.com/intent/tweet?text=<%= URI.encode(text) %>&url=<%= url %>">
+     href="https://twitter.com/intent/tweet?text=<%= CGI.escape(text) %>&url=<%= url %>">
      <i class="fab fa-twitter"></i> Twitter
   </a>
 
@@ -17,14 +17,14 @@
   <a class="social_share linkedin"
      data-share-network="linkedin"
      target="_blank"
-     href="https://www.linkedin.com/shareArticle?mini=true&url=<%= url %>&title=<%= URI.encode(text) %>">
+     href="https://www.linkedin.com/shareArticle?mini=true&url=<%= url %>&title=<%= CGI.escape(text) %>">
      <i class="fab fa-linkedin"></i> LinkedIn
   </a>
 
   <a class="social_share email"
      data-share-network="email"
      target="_blank"
-     href="mailto:?subject=<%= URI.encode(text) %>&body=<%= url %>">
+     href="mailto:?subject=<%= CGI.escape(text) %>&body=<%= url %>">
      <i class="fas fa-envelope"></i> Correo-e
   </a>
 

--- a/test/integration/gobierto_admin/gobierto_common/custom_field_records/custom_field_records_form_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_field_records/custom_field_records_form_test.rb
@@ -63,7 +63,7 @@ module GobiertoAdmin
           with(site: site, admin: admin) do
             visit resource_with_instance_level_custom_fields_path
 
-            refute has_content? global_custom_field.name
+            assert has_no_content? global_custom_field.name
             assert has_content? instance_level_custom_field.name
           end
         end

--- a/test/integration/gobierto_admin/gobierto_common/custom_fields/delete_custom_field_test.rb
+++ b/test/integration/gobierto_admin/gobierto_common/custom_fields/delete_custom_field_test.rb
@@ -48,7 +48,7 @@ module GobiertoCommon
           end
           assert has_content? "Custom field successfully deleted"
           assert has_content? "Custom fields"
-          refute has_content? global_custom_field.name
+          assert has_no_content? global_custom_field.name
         end
       end
 
@@ -61,7 +61,7 @@ module GobiertoCommon
           end
           assert has_content? "Custom field successfully deleted"
           assert has_content? "Custom fields of #{instance.title}"
-          refute has_content? instance_level_custom_field.name
+          assert has_no_content? instance_level_custom_field.name
         end
       end
     end

--- a/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
+++ b/test/integration/gobierto_admin/gobierto_participation/processes/update_process_test.rb
@@ -223,7 +223,7 @@ module GobiertoAdmin
             click_button "Update"
 
             visit gobierto_participation_issue_attachments_path(old_issue) do
-              refute has_content? gobierto_attachments_attachments(:pdf_collection_attachment).description
+              assert has_no_content? gobierto_attachments_attachments(:pdf_collection_attachment).description
             end
           end
         end

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -301,7 +301,7 @@ module GobiertoAdmin
               select "In progress", from: "project_status_id"
               select "3%", from: "project_progress"
 
-              within(".widget_save_v2") { refute has_content?("Moderation") }
+              within(".widget_save_v2") { assert has_no_content?("Moderation") }
 
               within "div.widget_save_v2" do
                 click_button "Save"

--- a/test/integration/gobierto_citizens_charters/show_charter_test.rb
+++ b/test/integration/gobierto_citizens_charters/show_charter_test.rb
@@ -192,7 +192,7 @@ module GobiertoCitizensCharters
             assert has_content? "100%"
           end
           assert has_no_content? "Reached"
-          refute has_content? "Goal"
+          assert has_no_content? "Goal"
         end
       end
     end

--- a/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_attachments_index_test.rb
@@ -77,8 +77,8 @@ module GobiertoParticipation
 
         assert_equal issue_attachments.size, all(".news_teaser").size
 
-        refute has_link? "XLSX Attachment Event"
-        refute has_link? "PDF Collection Attachment Name"
+        assert has_no_link? "XLSX Attachment Event"
+        assert has_no_link? "PDF Collection Attachment Name"
       end
     end
   end

--- a/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_pages_index_test.rb
@@ -77,8 +77,8 @@ module GobiertoParticipation
 
         assert_equal issue_news.active.size, all(".news_teaser").size
 
-        refute has_link? "Notice 1 title"
-        refute has_link? "Notice 2 title"
+        assert has_no_link? "Notice 1 title"
+        assert has_no_link? "Notice 2 title"
       end
     end
   end

--- a/test/integration/gobierto_participation/issues/issue_show_test.rb
+++ b/test/integration/gobierto_participation/issues/issue_show_test.rb
@@ -193,7 +193,7 @@ module GobiertoParticipation
         visit @path
 
         within "div#processes" do
-          refute has_content? participation_process.title
+          assert has_no_content? participation_process.title
         end
 
         assert has_content? "No related news"

--- a/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_attachments_index_test.rb
@@ -77,8 +77,8 @@ module GobiertoParticipation
 
         assert_equal scope_attachments.size, all(".news_teaser").size
 
-        refute has_link? "XLSX Attachment Event"
-        refute has_link? "PDF Collection Attachment Name"
+        assert has_no_link? "XLSX Attachment Event"
+        assert has_no_link? "PDF Collection Attachment Name"
       end
     end
   end

--- a/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_pages_index_test.rb
@@ -80,8 +80,8 @@ module GobiertoParticipation
 
         assert_equal scope_news.active.size, all(".news_teaser").size
 
-        refute has_link? "Notice 1 title"
-        refute has_link? "Notice 2 title"
+        assert has_no_link? "Notice 1 title"
+        assert has_no_link? "Notice 2 title"
         assert has_link? "Themes in the site"
 
         assert has_content? "News for Old town"

--- a/test/integration/gobierto_participation/scopes/scope_show_test.rb
+++ b/test/integration/gobierto_participation/scopes/scope_show_test.rb
@@ -187,7 +187,7 @@ module GobiertoParticipation
         visit @path
 
         within "div#processes" do
-          refute has_content? participation_process.title
+          assert has_no_content? participation_process.title
         end
 
         assert_equal processes.size, all("div#processes/div").size
@@ -209,7 +209,7 @@ module GobiertoParticipation
         participation_process.events.published.upcoming.each do |event|
           assert has_link? event.title
         end
-        refute has_content? "No related updates"
+        assert has_no_content? "No related updates"
       end
     end
 

--- a/test/integration/user/custom_session_test.rb
+++ b/test/integration/user/custom_session_test.rb
@@ -66,7 +66,7 @@ class User::CustomSessionTest < ActionDispatch::IntegrationTest
       fill_in :user_session_password, with: "gobierto"
       click_on "Submit"
 
-      refute has_message?("Signed in successfully")
+      assert has_no_message?("Signed in successfully")
 
       assert has_message?("Invalid data received. The session could not be created")
     end

--- a/test/support/integration/matcher_helpers.rb
+++ b/test/support/integration/matcher_helpers.rb
@@ -8,6 +8,12 @@ module Integration
       end
     end
 
+    def has_no_message?(text)
+      within ".flash-message" do
+        has_no_content?(text)
+      end
+    end
+
     def has_alert?(text)
       within ".alert" do
         has_content?(text)


### PR DESCRIPTION
##  :v: What does this PR do?

- Fixes some deprecation warnings
- Replaces slow capybara finders
- Moves assets precompilation in CircleCI to the dependencies step which makes the parallel workers to run 2 min faster and reduces 2 minutes the total time of the build
