### PR TITLE
Custom fields reorder

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -36,6 +36,7 @@ module GobiertoAdmin
         def create
           @custom_field_form = form_class.new(custom_field_params.merge(site_id: current_site.id, resource_name: params[:module_resource_name]))
           if @custom_field_form.save
+            touch_instance
             redirect_to(
               admin_common_custom_fields_module_resource_custom_fields_path(
                 module_resource_name: @custom_field_form.resource_param,
@@ -70,6 +71,7 @@ module GobiertoAdmin
 
           @custom_field_form = form_class.new(custom_field_params.merge(id: @custom_field.id, site_id: current_site.id))
           if @custom_field_form.save
+            touch_instance
             redirect_to(
               admin_common_custom_fields_module_resource_custom_fields_path(
                 module_resource_name: @custom_field_form.resource_param,
@@ -92,6 +94,7 @@ module GobiertoAdmin
           module_resource_name = @custom_field_form.resource_param
 
           if @custom_field.destroy
+            touch_instance
             redirect_to(
               admin_common_custom_fields_module_resource_custom_fields_path(
                 module_resource_name: module_resource_name,
@@ -113,6 +116,12 @@ module GobiertoAdmin
         end
 
         private
+
+        def touch_instance
+          return unless @custom_field_form&.instance&.present?
+
+          @custom_field_form.instance.touch
+        end
 
         def check_permissions!
           raise_module_not_allowed unless current_admin.can_edit_custom_fields?

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -118,9 +118,7 @@ module GobiertoAdmin
         private
 
         def touch_instance
-          return unless @custom_field_form&.instance&.present?
-
-          @custom_field_form.instance.touch
+          @custom_field_form&.instance&.touch
         end
 
         def check_permissions!

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/sort_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/sort_controller.rb
@@ -5,6 +5,12 @@ module GobiertoAdmin
     module CustomFields
       class SortController < BaseSortController
 
+        def create
+          collection.update_positions(sort_params)
+          touch_instances
+          head :no_content
+        end
+
         private
 
         def collection
@@ -13,6 +19,12 @@ module GobiertoAdmin
 
                             current_site.custom_fields.where(class_name: params[:module_resource_name].tr("-", "/").camelize).send(params[:localized])
                           end
+        end
+
+        def touch_instances
+          field_ids = params[:positions].values.map { |item| item["id"] }
+          instances = collection.where.not(instance: nil).where(id: field_ids).select(:instance_id, :instance_type).distinct.map(&:instance)
+          instances.each(&:touch)
         end
       end
     end


### PR DESCRIPTION
## :v: What does this PR do?

* When custom fields are reordered, created, updated or deleted if they depend on an instance (for example, custom fields for plans) it is touched to clear cache

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
