### PR TITLE
Vue clickoutside directive

### DIFF
--- a/app/javascript/lib/shared/index.js
+++ b/app/javascript/lib/shared/index.js
@@ -28,6 +28,10 @@ import {
   date,
   truncate
 } from "./modules/vue-filters.js";
+import {
+  VueDirectivesMixin,
+  clickoutside
+} from "./modules/vue-directives.js";
 import { Middleware } from "./modules/middleware.js";
 
 export {
@@ -47,5 +51,7 @@ export {
   translate,
   money,
   date,
-  truncate
+  truncate,
+  VueDirectivesMixin,
+  clickoutside
 };

--- a/app/javascript/lib/shared/modules/vue-directives.js
+++ b/app/javascript/lib/shared/modules/vue-directives.js
@@ -1,0 +1,29 @@
+/**
+ * This Vue directives are widely used throughtout the application.
+ * They're could be reused importing this module:
+ *
+ * import { VueDirectivesMixin } from "lib/shared";
+ *
+ * and then, in a Vue App, like so:
+ *
+ * mixins: [VueDirectivesMixin],
+ *
+ */
+export const clickoutside = {
+  bind(el, binding, vnode) {
+    el.clickOutsideEvent = (event) => {
+      if (!(el === event.target || el.contains(event.target))) {
+        vnode.context[binding.expression](event);
+      }
+    };
+    document.body.addEventListener('click', el.clickOutsideEvent)
+  },
+  unbind(el) { document.body.removeEventListener('click', el.clickOutsideEvent) },
+  stopProp(event) { event.stopPropagation() }
+}
+
+export const VueDirectivesMixin = {
+  directives: {
+    clickoutside
+  }
+}


### PR DESCRIPTION
Move this useful directive to a shared library.

@jorgeatgu the directive has been extracted from gobierto_data, where you've a couple of open PRs. It would be a good idea to remove the current `CommonMixin` there, in favour of this new directive. Just replace the paths.