### PR TITLE
Vue Components / Remove styles from the checkbox component

### DIFF
--- a/app/assets/stylesheets/comp-block-checkbox.scss
+++ b/app/assets/stylesheets/comp-block-checkbox.scss
@@ -46,10 +46,6 @@
     background: transparent;
   }
 
-  &:last-child {
-    padding-bottom: 1em;
-    border-bottom: 1px solid hsla(0, 0, 59.2%, .5);
-  }
 }
 
 .gobierto-filter-checkbox--input + label {

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -9,6 +9,13 @@
   --shadow: 0 2px 20px rgba(0, 0, 0, .3);
 }
 
+.gobierto-filter-checkbox {
+  &:last-child {
+    padding-bottom: 1em;
+    border-bottom: 1px solid hsla(0, 0, 59.2%, .5);
+  }
+}
+
 .gobierto-data {
 
   padding-top: 1rem;

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -9,13 +9,6 @@
   --shadow: 0 2px 20px rgba(0, 0, 0, .3);
 }
 
-.gobierto-filter-checkbox {
-  &:last-child {
-    padding-bottom: 1em;
-    border-bottom: 1px solid hsla(0, 0, 59.2%, .5);
-  }
-}
-
 .gobierto-data {
 
   padding-top: 1rem;
@@ -1039,6 +1032,11 @@
 
   &-filters {
     width: 100%;
+  }
+
+  &-filters-element {
+    padding-bottom: 1em;
+    border-bottom: 1px solid hsla(0, 0, 59.2%, .5);
   }
 
   &-filters-element-no-margin {


### PR DESCRIPTION
This style shouldn't be specific to the checkbox component. We can use the checkbox component in other components than filters.

For example: 
![imagen](https://user-images.githubusercontent.com/2649175/87045322-0baa9400-c1f8-11ea-9204-c85a02bdc539.png)