### PR TITLE
3192 datasets order

### DIFF
--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -89,7 +89,7 @@ module GobiertoCommon
       return unless stale?(custom_fields)
 
       meta_stats = if params[:stats] == "true"
-                     query = GobiertoCommon::CustomFieldsQuery.new(relation: base_relation, custom_fields: custom_fields)
+                     query = GobiertoCommon::CustomFieldsQuery.new(relation: base_relation.unscope(:order), custom_fields: custom_fields)
                      filterable_custom_fields.inject({}) do |stats, custom_field|
                        stats.update(
                          custom_field.uid => query.stats(custom_field, filter_params)

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -193,7 +193,7 @@ module GobiertoData
         end
 
         def base_relation
-          current_site.datasets.send(current_admin.present? || valid_preview_token? ? :itself : :active)
+          current_site.datasets.send(current_admin.present? || valid_preview_token? ? :itself : :active).sorted
         end
 
         def find_item

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -13,6 +13,8 @@ module GobiertoData
     has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
     has_many :visualizations, dependent: :destroy, class_name: "GobiertoData::Visualization"
 
+    scope :sorted, -> { order(data_updated_at: :desc) }
+
     translates :name
 
     enum visibility_level: { draft: 0, active: 1 }


### PR DESCRIPTION
Closes #3192


## :v: What does this PR do?

* Sets a default order by data_updated_at desc for datasets returned by the index endpoint
* Unscopes order in relation used to generate stats of resources with custom fields, provided by the meta action (ORDER BY clause may introduce errors to the queries built to generate stats and the order used is irrelevant for them)

## :mag: How should this be manually tested?

Visit main page of data module

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
