### PR TITLE
Improve CSV parsing for fields with multiple values

### DIFF
--- a/app/decorators/gobierto_common/plain_custom_field_value_decorator.rb
+++ b/app/decorators/gobierto_common/plain_custom_field_value_decorator.rb
@@ -81,7 +81,7 @@ module GobiertoCommon
     end
 
     def splitted_plain_text_value
-      (CSV.parse_line(plain_text_value.tr("\n", ",")) || []).compact.map(&:strip)
+      (CSV.parse_line(plain_text_value.tr("\n", ",").gsub(/\"\s*,\s*\"/, "\",\"").strip, liberal_parsing: true) || []).compact.map(&:strip)
     rescue CSV::MalformedCSVError
       plain_text_value.tr("\n", ",").split(",").compact.map(&:strip)
     end


### PR DESCRIPTION

## :v: What does this PR do?

Adds some changes to improve how the CSV import deal with values for vocabulary custom fields vocabulary with multiple values.

Before CSV parsing:
* Removes all whitespaces in expressions containing a comma between double quotes
* Strip the result

Calls `CSV.parse` using `liberal_parsing: true` option to avoid some errors

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
