### PR TITLE
Use sdgs_assignations of level 0 for sdgs percentages

### DIFF
--- a/app/decorators/gobierto_plans/sdg_decorator.rb
+++ b/app/decorators/gobierto_plans/sdg_decorator.rb
@@ -37,9 +37,9 @@ module GobiertoPlans
     end
 
     def sdg_percentage(sdg)
-      return if nodes_count.zero?
+      return if sdgs_assignations.zero?
 
-      ActionController::Base::helpers.number_with_precision((projects_by_sdg(sdg).count * 100.0) / nodes_count, precision: 1) + "%"
+      ActionController::Base.helpers.number_with_precision((projects_by_sdg(sdg).count * 100.0) / sdgs_assignations, precision: 1) + "%"
     end
 
     def sdg_term(sdg_slug)
@@ -62,6 +62,12 @@ module GobiertoPlans
 
     def nodes_query
       @nodes_query ||= GobiertoCommon::CustomFieldsQuery.new(relation: nodes_relation, custom_fields: site.custom_fields.where(id: sdg_field.id))
+    end
+
+    def sdgs_assignations
+      @sdgs_assignations ||= GobiertoCommon::CustomFieldRecord.where(custom_field: sdg_field, item: nodes_relation).map do |record|
+        record.value.where(level: 0).count
+      end.sum
     end
 
     def nodes_count


### PR DESCRIPTION
## :v: What does this PR do?

Fixes how SDGs percentages are calculated using the total of assignations to SDGs of level 0 as base instead of total projects with SDGs defined

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
