### PR TITLE
Locale change in gobierto people

### DIFF
--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -7,7 +7,6 @@ module GobiertoPeople
     include DatesRangeHelper
 
     before_action :check_active_submodules
-    before_action :overrided_root_redirect, only: [:index]
 
     def index
       @people = current_site.people.active.politician.government.sorted.first(10)

--- a/app/models/gobierto_people.rb
+++ b/app/models/gobierto_people.rb
@@ -34,6 +34,6 @@ module GobiertoPeople
   end
 
   def self.root_path(_)
-    Rails.application.routes.url_helpers.gobierto_people_root_path
+    Rails.application.routes.url_helpers.send("gobierto_people_root_#{I18n.locale}_path")
   end
 end

--- a/lib/middlewares/override_welcome_action.rb
+++ b/lib/middlewares/override_welcome_action.rb
@@ -20,7 +20,11 @@ class OverrideWelcomeAction
     # If the path is the homepage, the route should be the site root path
     if env["PATH_INFO"] == "/" && env["gobierto_site"].present?
       # A CMS page is handled by meta welcome controller
-      if env["gobierto_site"].configuration.home_page != "GobiertoCms"
+      home_page_module = env["gobierto_site"].configuration.home_page
+      if home_page_module != "GobiertoCms"
+        # GobiertoPeople has translations in paths, and the value in the cookie
+        # is overrided
+        I18n.locale = env["gobierto_site"].configuration.default_locale if home_page_module == "GobiertoPeople"
         env["PATH_INFO"] = env["gobierto_site"].root_path
         env["gobierto_welcome_override"] = true
       end


### PR DESCRIPTION
## :v: What does this PR do?

Fixes an error produced on GobiertoPeople module with the root path:

* On "/" path, the root path is provided by the module configured to do it. This path must be translated on the people module
* On the other hand the locale at this point seems to not being obtained from the cookie and the locale switches to :es

This PR:
* Removes overrided_root_redirect filter from people/welcome controller
* Adds translations to module root_path
* Sets locale before obtaining root_path if the module is GobiertoPeople in override_welcome action

## :mag: How should this be manually tested?

Visit "/" in a site with GobiertoPeople as default module

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
