### PR TITLE
Csv plan projects permissions groups

### DIFF
--- a/app/forms/concerns/gobierto_admin/permissions_group_helpers.rb
+++ b/app/forms/concerns/gobierto_admin/permissions_group_helpers.rb
@@ -15,7 +15,7 @@ module GobiertoAdmin
         action_name: action_name
       )
 
-      yield(group)
+      yield(group) if block_given?
     end
   end
 end

--- a/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
@@ -3,6 +3,8 @@
 module GobiertoAdmin
   module GobiertoPlans
     class PlanDataForm < BaseForm
+      include ::GobiertoAdmin::PermissionsGroupHelpers
+
       class CSVRowInvalid < ArgumentError; end
       class StatusMissing < ArgumentError; end
       class ExternalIdTaken < ArgumentError; end
@@ -17,6 +19,8 @@ module GobiertoAdmin
 
       validates :plan, :csv_file, presence: true
       validate :csv_file_format
+
+      delegate :site, to: :plan
 
       def initialize(options = {})
         super(options)
@@ -110,6 +114,7 @@ module GobiertoAdmin
 
           save_custom_fields(row_decorator)
           set_publication(node)
+          set_permissions_group(node, action_name: :edit)
         end
       end
 

--- a/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/import_csv_plan_test.rb
@@ -85,8 +85,12 @@ module GobiertoAdmin
           assert has_content? "247 projects/actions"
 
           plan.reload
+          plan.nodes.reload
           assert_equal 247, plan.nodes.count
           assert_equal 0, plan.nodes.published.count
+
+          visit edit_admin_plans_plan_project_path(plan, plan.nodes.first)
+          assert has_link? "Permissions"
         end
       end
 


### PR DESCRIPTION
## :v: What does this PR do?

Generates automatically an edit permissions group for each project created when a plan is imported from a CSV.

## :mag: How should this be manually tested?

Import projects from a CSV into an empty plan. The edit form of each created project should have a "Permissions" button

## :eyes: Screenshots

### Before this PR

<img width="1082" alt="Screen Shot 2020-07-21 at 21 35 49" src="https://user-images.githubusercontent.com/446459/88098524-34d50800-cb9a-11ea-8c20-b996e1c38a90.png">

### After this PR

<img width="1029" alt="Screen Shot 2020-07-21 at 21 35 23" src="https://user-images.githubusercontent.com/446459/88098552-3dc5d980-cb9a-11ea-920d-ba276e453cde.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
