### PR TITLE
PlansStore with fallbacks

### DIFF
--- a/app/javascript/gobierto_plans/webapp/lib/store.js
+++ b/app/javascript/gobierto_plans/webapp/lib/store.js
@@ -7,18 +7,18 @@ export const PlansStore = {
     status: [],
   },
   setOptions(keys) {
-    this.state.options = keys
+    this.state.options = keys || this.state.options
   },
   setPlainItems(items) {
-    this.state.plainItems = items
+    this.state.plainItems = items || this.state.plainItems
   },
   setMeta(meta) {
-    this.state.meta = meta
+    this.state.meta = meta || this.state.meta
   },
   setProjects(projects) {
-    this.state.projects = projects
+    this.state.projects = projects || this.state.projects
   },
   setStatus(status) {
-    this.state.status = status
+    this.state.status = status || this.state.status
   }
 }


### PR DESCRIPTION
## :v: What does this PR do?
Set a fallback in the plans store in case some field comes `null`, in that way it avoids the frontend throws an error