### PR TITLE
Gobierto Data / Autocomplete removes the separator

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorCode.vue
@@ -195,8 +195,12 @@ export default {
 
       if (searchString.startsWith(".")) {
         resu.forEach(s => {
-          if (s.className == "column") s.score += N;
-          else if (s.className == "sql") s.score -= N;
+          if (s.className === "table") {
+            s.score += N;
+            s.text = `.${s.text}`
+          } else if (s.className === "sql") {
+            s.score -= N;
+          }
           return s;
         });
       }


### PR DESCRIPTION
Closes #3275 


## :v: What does this PR do?

Prevents which autocomplete removed the dot when the user typed an alias.


## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

![2020-07-30 13 59 10](https://user-images.githubusercontent.com/2649175/89025119-8d3ca000-d326-11ea-9b91-580218a8622e.gif)


### After this PR

![autocomplete_alias](https://user-images.githubusercontent.com/2649175/89025125-92015400-d326-11ea-8ded-4ffe74dafd2b.gif)
