### PR TITLE
1095 data visualizations sort

### DIFF
--- a/app/controllers/concerns/gobierto_common/sortable_api.rb
+++ b/app/controllers/concerns/gobierto_common/sortable_api.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module SortableApi
+    extend ActiveSupport::Concern
+    # include GobiertoHelper
+    included do
+      @sortable_attributes_list ||= []
+    end
+
+    class_methods do
+      def sortable_attributes(*args)
+        sortable_attributes_list = @sortable_attributes_list
+
+        sortable_attributes_list |= args
+
+        define_method :sortable_attributes_list do
+          sortable_attributes_list
+        end
+
+        @sortable_attributes_list = sortable_attributes_list
+      end
+    end
+
+    def order_params
+      return unless params[:order].present?
+
+      params.require(:order).permit(sortable_attributes_list).transform_values { |sort| %w(asc desc).include?(sort) ? sort : "asc" }.to_h
+    end
+  end
+end

--- a/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/visualizations_controller.rb
@@ -4,9 +4,12 @@ module GobiertoData
   module Api
     module V1
       class VisualizationsController < BaseController
+        include ::GobiertoCommon::SortableApi
 
         before_action :authenticate_user!, except: [:index, :show, :new]
         before_action :allow_author!, only: [:update, :destroy]
+
+        sortable_attributes :created_at, :updated_at
 
         # GET /api/v1/data/visualizations
         # GET /api/v1/data/visualizations.json
@@ -141,9 +144,9 @@ module GobiertoData
 
         def filtered_relation
           if user_authenticated? && filter_params[:user_id].present? && current_user.id == filter_params[:user_id].to_i
-            base_relation.unscope(where: :privacy_status).where(filter_params)
+            base_relation.unscope(where: :privacy_status).where(filter_params).order(order_params)
           else
-            base_relation.where(filter_params)
+            base_relation.where(filter_params).order(order_params)
           end
         end
 

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -49,6 +49,7 @@ events_count_open_visualization:
   name_translations: <%= { en: "Events count visualization open", es: "Visualización de cuenta de eventos abierta" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
   spec: "{}"
+  created_at: <%= 1.day.from_now %>
 
 visualization_with_sql_and_blank_query:
   dataset: users_dataset


### PR DESCRIPTION
Closes PopulateTools/issues#1095


## :v: What does this PR do?

* Creates a concern to be used in the API to define for which attributes the API can order the results and provides a method to add the order params in the request to the query
* Defines as sortable the `created_at` and `updated_at` attributes in API visualizations index

## :mag: How should this be manually tested?

Visit visualizations index API endpoint and send order params like:

* `/api/v1/data/visualizations?order[created_at]=desc`
* `/api/v1/data/visualizations?order[updated_at]=asc`

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- Suggestion sent to API documentation in gobierto.readme.io
