### PR TITLE
3252 capture gobierto data configuration errors

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_data/configuration/settings_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/configuration/settings_controller.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
           if @settings_form.save
             redirect_to edit_admin_data_configuration_settings_path, notice: t(".success")
           else
-            redirect_to edit_admin_data_configuration_settings_path, alert: t(".error", validation_errors: @settings_form.errors.full_messages.to_sentence)
+            render :edit
           end
         end
 

--- a/app/forms/gobierto_admin/gobierto_data/settings_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/settings_form.rb
@@ -56,7 +56,7 @@ module GobiertoAdmin
         ::GobiertoData::Connection.test_connection_config(config, :read_db_config)
         ::GobiertoData::Connection.test_connection_config(config, :read_draft_db_config) if config&.has_key?(:read_draft_db_config)
         ::GobiertoData::Connection.test_connection_config(config, :write_db_config) if config&.has_key?(:write_db_config)
-      rescue ActiveRecord::ActiveRecordError => e
+      rescue ActiveRecord::ActiveRecordError, PG::Error => e
         errors.add(:db_config, :invalid_connection, error_message: e.message)
       end
 

--- a/app/views/gobierto_admin/gobierto_data/configuration/settings/edit.html.erb
+++ b/app/views/gobierto_admin/gobierto_data/configuration/settings/edit.html.erb
@@ -14,6 +14,8 @@
   </ul>
 </div>
 
+<%= render "gobierto_admin/shared/validation_errors", resource: @settings_form %>
+
 <%= form_for @settings_form, as: :gobierto_data_settings, url: admin_data_configuration_settings_path,  method: :patch, html: { autocomplete: "off" } do |f| %>
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-16-24">

--- a/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/ca.yml
@@ -5,7 +5,6 @@ ca:
       configuration:
         settings:
           update:
-            error: 'Hi ha hagut un error al desar la configuració: %{validation_errors}'
             success: Configuració guardada correctament
       datasets:
         create:

--- a/config/locales/gobierto_admin/gobierto_data/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/en.yml
@@ -5,7 +5,6 @@ en:
       configuration:
         settings:
           update:
-            error: 'There was a problem when saving configuration: %{validation_errors}'
             success: Configuration stored successfully
       datasets:
         create:

--- a/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/controllers/es.yml
@@ -5,7 +5,6 @@ es:
       configuration:
         settings:
           update:
-            error: 'Se ha producido un error al actualizar la configuración: %{validation_errors}'
             success: Configuración guardada correctamente
       datasets:
         create:


### PR DESCRIPTION
Closes #3252


## :v: What does this PR do?

* Captures exceptions when data module database configuration settings fail and stores exception message in a validation error message
* Displays validation error messages and don't clear the form content

## :mag: How should this be manually tested?

visit module settings and use an invalid database connection

## :eyes: Screenshots

### Before this PR

![3252_before](https://user-images.githubusercontent.com/446459/89175139-6c26ba00-d587-11ea-8f2e-d42223c1b07c.gif)


### After this PR

![3252_after](https://user-images.githubusercontent.com/446459/89175149-71840480-d587-11ea-9ecc-7fe6883e0646.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
