### PR TITLE
3007 track gobierto data activities

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/datasets_controller.rb
@@ -61,8 +61,9 @@ module GobiertoAdmin
 
       def destroy
         @dataset = find_dataset
+        @dataset_form = DatasetForm.new(id: params[:id], site_id: current_site.id, admin_id: current_admin.id, ip: remote_ip)
 
-        @dataset.destroy
+        @dataset_form.destroy
 
         redirect_to admin_data_datasets_path, notice: t(".success")
       end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -127,7 +127,7 @@ module GobiertoData
         end
 
         def create
-          @form = DatasetForm.new(dataset_params.merge(site_id: current_site.id))
+          @form = DatasetForm.new(dataset_params.merge(site_id: current_site.id, admin_id: current_admin.id))
 
           if @form.save
             @item = @form.resource
@@ -146,7 +146,7 @@ module GobiertoData
 
         def update
           find_item
-          @form = DatasetForm.new(dataset_params.merge(id: @item.id, site_id: current_site.id))
+          @form = DatasetForm.new(dataset_params.merge(id: @item.id, site_id: current_site.id, admin_id: current_admin.id))
 
           if @form.save
             render(

--- a/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_admin/gobierto_data/dataset_form.rb
@@ -42,6 +42,10 @@ module GobiertoAdmin
         @site ||= Site.find_by(id: site_id)
       end
 
+      def destroy
+        destroy_dataset
+      end
+
       def dataset
         @dataset ||= dataset_class.find_by(id: id).presence || build_dataset
       end
@@ -87,6 +91,12 @@ module GobiertoAdmin
           promote_errors(@dataset.errors)
 
           false
+        end
+      end
+
+      def destroy_dataset
+        run_callbacks(:destroy) do
+          dataset.destroy
         end
       end
 

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -142,7 +142,9 @@ module GobiertoData
         attributes.visibility_level = visibility_level
       end
 
-      if run_callbacks(:save) { @resource.save } && load_data
+      new_record = @resource.new_record?
+
+      if run_callbacks(:save) { @resource.save } && load_data(new_record)
         @resource
       else
         promote_errors(@resource.errors)
@@ -150,7 +152,7 @@ module GobiertoData
       end
     end
 
-    def load_data
+    def load_data(new_record)
       return unless [data_file, data_path].any?(&:present?)
 
       # Use the Array form to enforce an extension in the filename
@@ -169,7 +171,7 @@ module GobiertoData
           errors.add(:schema, @load_status[:db_result][:errors].map(&:values).join("\n"))
           false
         else
-          track_update_data_activity
+          track_update_data_activity unless new_record
           true
         end
       ensure

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -169,6 +169,7 @@ module GobiertoData
           errors.add(:schema, @load_status[:db_result][:errors].map(&:values).join("\n"))
           false
         else
+          track_update_data_activity
           true
         end
       ensure
@@ -185,5 +186,10 @@ module GobiertoData
       end
     end
 
+    def track_update_data_activity
+      Publishers::AdminGobiertoDataActivity.broadcast_event(
+        "dataset_data_updated", event_payload.merge(subject: resource)
+      )
+    end
   end
 end

--- a/app/subscribers/admin_gobierto_data_activity.rb
+++ b/app/subscribers/admin_gobierto_data_activity.rb
@@ -19,7 +19,7 @@ module Subscribers
       author = GobiertoAdmin::Admin.find_by id: event.payload[:admin_id]
       return unless author.present?
 
-      action = "gobierto_data_dataset.dataset_deleted"
+      action = "gobierto_data.dataset_dataset_deleted"
       Activity.create!(
         subject_type: "Site",
         subject_id: event.payload[:site_id],

--- a/app/subscribers/admin_gobierto_data_activity.rb
+++ b/app/subscribers/admin_gobierto_data_activity.rb
@@ -24,7 +24,7 @@ module Subscribers
         subject_type: "Site",
         subject_id: event.payload[:site_id],
         author: author,
-        subject_ip: event.payload[:ip] || author.last_sign_in_ip,
+        subject_ip: subject_ip(event, author),
         action: action,
         admin_activity: true,
         site_id: event.payload[:site_id]
@@ -32,6 +32,10 @@ module Subscribers
     end
 
     private
+
+    def subject_ip(event, author)
+      event.payload[:ip] || author.last_sign_in_ip || "127.0.0.1"
+    end
 
     def create_activity_from_event(event, action)
       subject = GlobalID::Locator.locate event.payload[:gid]
@@ -47,7 +51,7 @@ module Subscribers
 
       Activity.create! subject: subject,
                        author: author,
-                       subject_ip: event.payload[:ip] || author.last_sign_in_ip,
+                       subject_ip: subject_ip(event, author),
                        action: action,
                        admin_activity: true,
                        site_id: event.payload[:site_id]

--- a/app/subscribers/admin_gobierto_data_activity.rb
+++ b/app/subscribers/admin_gobierto_data_activity.rb
@@ -3,6 +3,10 @@
 module Subscribers
   class AdminGobiertoDataActivity < ::Subscribers::Base
 
+    def dataset_data_updated(event)
+      create_activity_from_event(event, "dataset_data_updated")
+    end
+
     def dataset_attribute_changed(event)
       create_activity_from_event(event, "dataset_updated")
     end

--- a/app/subscribers/admin_gobierto_data_activity.rb
+++ b/app/subscribers/admin_gobierto_data_activity.rb
@@ -15,6 +15,22 @@ module Subscribers
       create_activity_from_event(event, "dataset_created")
     end
 
+    def dataset_deleted(event)
+      author = GobiertoAdmin::Admin.find_by id: event.payload[:admin_id]
+      return unless author.present?
+
+      action = "gobierto_data_dataset.dataset_deleted"
+      Activity.create!(
+        subject_type: "Site",
+        subject_id: event.payload[:site_id],
+        author: author,
+        subject_ip: event.payload[:ip] || author.last_sign_in_ip,
+        action: action,
+        admin_activity: true,
+        site_id: event.payload[:site_id]
+      )
+    end
+
     private
 
     def create_activity_from_event(event, action)

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -16,6 +16,8 @@ ca:
       timestampz: data i hora
     events:
       gobierto_data_dataset_dataset_created: Conjunt de dades creat
+      gobierto_data_dataset_dataset_data_updated: Dades de conjunt de dades actualitzats
+      gobierto_data_dataset_dataset_deleted: Conjunt de dades eliminat
       gobierto_data_dataset_dataset_updated: Conjunt de dades actualitzat
     layouts:
       application:

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -16,6 +16,8 @@ en:
       timestampz: time
     events:
       gobierto_data_dataset_dataset_created: Dataset created
+      gobierto_data_dataset_dataset_data_updated: Dataset data updated
+      gobierto_data_dataset_dataset_deleted: Dataset deleted
       gobierto_data_dataset_dataset_updated: Dataset updated
     layouts:
       application:

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -16,6 +16,8 @@ es:
       timestampz: fecha y hora
     events:
       gobierto_data_dataset_dataset_created: Conjunto de datos creado
+      gobierto_data_dataset_dataset_data_updated: Datos de conjunto de datos actualizados
+      gobierto_data_dataset_dataset_deleted: Conjunto de datos eliminado
       gobierto_data_dataset_dataset_updated: Conjunto de datos actualizado
     layouts:
       application:

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -86,7 +86,7 @@ module GobiertoData
             )
 
             assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
-            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -116,7 +116,7 @@ module GobiertoData
             )
 
             assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
-            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -150,7 +150,7 @@ module GobiertoData
             )
 
             assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
-            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -217,7 +217,7 @@ module GobiertoData
             )
 
             assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
-            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -260,7 +260,7 @@ module GobiertoData
             )
 
             assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
-            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -305,7 +305,7 @@ module GobiertoData
             )
 
             assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
-            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -51,6 +51,7 @@ module GobiertoData
               assert_response :unprocessable_entity
               response_data = response.parsed_body
               assert_match(/can't be blank/, response_data.to_s)
+              refute site.activities.where(subject_type: "GobiertoData::Dataset").exists?
             end
           end
         end
@@ -69,6 +70,7 @@ module GobiertoData
               assert_response :unprocessable_entity
               response_data = response.parsed_body
               assert_match(/CSV file malformed or with wrong encoding/, response_data.to_s)
+              refute site.activities.where(subject_type: "GobiertoData::Dataset").exists?
             end
           end
         end
@@ -83,6 +85,8 @@ module GobiertoData
               headers: { "Authorization" => auth_header }
             )
 
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -111,6 +115,8 @@ module GobiertoData
               headers: { "Authorization" => auth_header }
             )
 
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -143,6 +149,8 @@ module GobiertoData
               headers: { "Authorization" => auth_header }
             )
 
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -175,6 +183,7 @@ module GobiertoData
             assert_response :unprocessable_entity
             response_data = response.parsed_body
             assert_match(/Malformed file/, response_data.to_s)
+            refute site.activities.where(subject_type: "GobiertoData::Dataset").exists?
           end
         end
 
@@ -193,6 +202,7 @@ module GobiertoData
             assert_response :unprocessable_entity
             response_data = response.parsed_body
             assert_match(/The type 'invent' is not defined/, response_data.to_s)
+            refute site.activities.where(subject_type: "GobiertoData::Dataset").exists?
           end
         end
 
@@ -206,17 +216,23 @@ module GobiertoData
               headers: { "Authorization" => auth_header }
             )
 
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
             slug = response_data["data"]["attributes"]["slug"]
 
+            site.activities.where(subject_type: "GobiertoData::Dataset").destroy_all
             put(
               gobierto_data_api_v1_dataset_path(slug),
               params: multipart_form_params("dataset2.csv"),
               headers: { "Authorization" => auth_header }
             )
 
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_updated").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :success
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -243,17 +259,23 @@ module GobiertoData
               headers: { "Authorization" => auth_header }
             )
 
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
             slug = response_data["data"]["attributes"]["slug"]
 
+            site.activities.where(subject_type: "GobiertoData::Dataset").destroy_all
             put(
               gobierto_data_api_v1_dataset_path(slug),
               params: multipart_form_params("dataset2.csv").deep_merge(dataset: { append: "true" }),
               headers: { "Authorization" => auth_header }
             )
 
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_updated").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :success
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
@@ -282,17 +304,23 @@ module GobiertoData
               headers: { "Authorization" => auth_header }
             )
 
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :created
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access
             slug = response_data["data"]["attributes"]["slug"]
 
+            site.activities.where(subject_type: "GobiertoData::Dataset").destroy_all
             put(
               gobierto_data_api_v1_dataset_path(slug),
               params: multipart_form_params("dataset2.csv").deep_merge(dataset: { append: "true" }),
               headers: { "Authorization" => auth_header }
             )
 
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_created").exists?
+            refute site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_updated").exists?
+            assert site.activities.where(subject_type: "GobiertoData::Dataset", action: "gobierto_data.dataset.dataset_data_updated").exists?
             assert_response :success
             response_data = response.parsed_body
             attributes = response_data["data"]["attributes"].with_indifferent_access

--- a/test/integration/gobierto_admin/gobierto_data/datasets/delete_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/delete_dataset_test.rb
@@ -25,15 +25,18 @@ module GobiertoAdmin
 
         def test_delete_dataset
           with(site: site, admin: authorized_regular_admin) do
-            visit @path
+            assert_difference "site.activities.where(action: \"gobierto_data_dataset.dataset_deleted\").count", 1 do
+              visit @path
 
-            within "#dataset-item-#{dataset.id}" do
-              find("a[data-method='delete']").click
+              within "#dataset-item-#{dataset.id}" do
+                find("a[data-method='delete']").click
+              end
+
+              assert has_message?("Dataset deleted correctly.")
+
+              refute site.datasets.exists?(id: dataset.id)
+              assert site.activities.where(action: "gobierto_data_dataset.dataset_deleted").exists?
             end
-
-            assert has_message?("Dataset deleted correctly.")
-
-            refute site.datasets.exists?(id: dataset.id)
           end
         end
       end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/delete_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/delete_dataset_test.rb
@@ -25,7 +25,7 @@ module GobiertoAdmin
 
         def test_delete_dataset
           with(site: site, admin: authorized_regular_admin) do
-            assert_difference "site.activities.where(action: \"gobierto_data_dataset.dataset_deleted\").count", 1 do
+            assert_difference "site.activities.where(action: \"gobierto_data.dataset_dataset_deleted\").count", 1 do
               visit @path
 
               within "#dataset-item-#{dataset.id}" do
@@ -35,7 +35,6 @@ module GobiertoAdmin
               assert has_message?("Dataset deleted correctly.")
 
               refute site.datasets.exists?(id: dataset.id)
-              assert site.activities.where(action: "gobierto_data_dataset.dataset_deleted").exists?
             end
           end
         end


### PR DESCRIPTION
Closes #3007


## :v: What does this PR do?

* Adds site activities when Gobierto data API is used to create, update attributes or import data from CSV with datasets.
* Also includes a site activity when a dataset is deleted from admin. This activity is associated with site instead of dataset because otherwise, since the dataset does not exist, the event cannot be created.
* Includes some tests for activities in API controller and admin integration tests

## :mag: How should this be manually tested?

Visit admin and create, edit attributes and delete datasets or use the API to create, update data or change datasets attributes 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
