### PR TITLE
3222 spread custom fields api optimization

### DIFF
--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -57,9 +57,16 @@ module GobiertoCommon
 
     def records_query(relation)
       GobiertoCommon::CustomFieldRecord.where(
-        custom_field: custom_fields,
-        item: relation
+        item_condition(relation).merge(custom_field: custom_fields)
       ).sorted.select(:id, :item_id, :payload)
+    end
+
+    def item_condition(relation)
+      if relation.to_sql.include?("custom_field_records")
+        { item_type: relation.model.name, item_id: relation.pluck(:id) }
+      else
+        { item: relation }
+      end
     end
 
     def versioned_payloads(records, version_index)

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -22,10 +22,10 @@ module GobiertoData
             format.json do
               json = if base_relation.exists?
                        Rails.cache.fetch("#{filtered_relation.cache_key}/#{valid_preview_token? ? "all" : "active"}/datasets_collection") do
-                         render_to_string json: relation, links: links(:index), each_serializer: DatasetSerializer, adapter: :json_api
+                         json_from_relation(relation, :index)
                        end
                      else
-                       render_to_string json: relation, links: links(:index), each_serializer: DatasetSerializer, adapter: :json_api
+                       json_from_relation(relation, :index)
                      end
               render json: json
             end
@@ -263,6 +263,16 @@ module GobiertoData
               schema: schema_json_param
             )
           end
+        end
+
+        def json_from_relation(relation, action)
+          render_to_string(
+            json: relation,
+            links: links(action),
+            each_serializer: DatasetSerializer,
+            preloaded_data: transformed_custom_field_record_values(relation),
+            adapter: :json_api
+          )
         end
 
         def schema_json_param

--- a/app/controllers/gobierto_investments/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_investments/api/v1/projects_controller.rb
@@ -17,7 +17,11 @@ module GobiertoInvestments
           relation = filtered_relation
 
           if stale?(relation)
-            render json: relation, adapter: :json_api
+            render(
+              json: relation,
+              preloaded_data: transformed_custom_field_record_values(relation),
+              adapter: :json_api
+            )
           end
         end
 
@@ -26,7 +30,11 @@ module GobiertoInvestments
         def show
           find_resource
 
-          render json: @resource, adapter: :json_api
+          render(
+            json: @resource,
+            preloaded_data: transformed_custom_field_record_values(base_relation.where(id: params[:id])),
+            adapter: :json_api
+          )
         end
 
         # GET /gobierto_investments/api/v1/projects/new

--- a/app/javascript/gobierto_data/lib/mixins/filters.mixin.js
+++ b/app/javascript/gobierto_data/lib/mixins/filters.mixin.js
@@ -144,7 +144,7 @@ export const FiltersMixin = {
       this.filters.splice(index, 1, filter); // To detect array mutations
 
       const checkboxFilterFn = attrs =>
-        attrs[key] && attrs[key].find(d => checkboxesSelected.get(+d.id));
+        attrs[key] && this.convertToArrayOfIds(attrs[key]).find(d => checkboxesSelected.get(+d));
 
       const callback = size ? checkboxFilterFn : undefined;
       this.filterItems(callback, key);
@@ -159,7 +159,7 @@ export const FiltersMixin = {
         const __items__ = this.applyFiltersCallbacks(__activeFilters__);
 
         return __items__.filter(({ attributes }) =>
-          attributes[key] && attributes[key].map(g => g.id).includes(id)
+          this.convertToArrayOfIds(attributes[key]).includes(id)
         ).length;
       };
       const { key, options = [] } = filter;
@@ -172,6 +172,9 @@ export const FiltersMixin = {
         const index = this.filters.findIndex(d => d.key === key);
         this.filters.splice(index, 1, filter);
       }
+    },
+    convertToArrayOfIds(items) {
+      return Array.isArray(items) ? items.map(item => (+item)) : [+items]
     }
   }
 }

--- a/app/javascript/gobierto_investments/webapp/components/MapTour.vue
+++ b/app/javascript/gobierto_investments/webapp/components/MapTour.vue
@@ -78,6 +78,7 @@ import {
 } from "vue-mapbox";
 import Wkt from "wicket";
 import axios from "axios";
+import { Middleware } from "lib/shared";
 import { CommonsMixin, baseUrl } from "./../mixins/common.js";
 
 export default {
@@ -142,6 +143,10 @@ export default {
       ] = responses;
 
       this.dictionary = attributesDictionary;
+      this.middleware = new Middleware({
+        dictionary: attributesDictionary
+      });
+
       this.items = this.setData(items);
 
       this.subsetItems = this.items;

--- a/app/javascript/gobierto_investments/webapp/containers/home/Home.vue
+++ b/app/javascript/gobierto_investments/webapp/containers/home/Home.vue
@@ -374,9 +374,8 @@ export default {
         // Get the items based on these new active filters
         const __items__ = this.applyFiltersCallbacks(__activeFilters__);
 
-        return __items__.filter(({ attributes }) =>(
+        return __items__.filter(({ attributes }) =>
           this.convertToArrayOfIds(attributes[key]).includes(id)
-          )
         ).length;
       };
       const { key, options = [] } = filter;

--- a/app/javascript/gobierto_investments/webapp/containers/home/Home.vue
+++ b/app/javascript/gobierto_investments/webapp/containers/home/Home.vue
@@ -314,7 +314,7 @@ export default {
       this.filters.splice(index, 1, filter); // To detect array mutations
 
       const checkboxFilterFn = attrs =>
-        attrs[key].find(d => checkboxesSelected.get(+d.id));
+        attrs[key] && this.convertToArrayOfIds(attrs[key]).find(d => checkboxesSelected.get(+d));
 
       const callback = size ? checkboxFilterFn : undefined;
       this.filterItems(callback, key);
@@ -374,8 +374,9 @@ export default {
         // Get the items based on these new active filters
         const __items__ = this.applyFiltersCallbacks(__activeFilters__);
 
-        return __items__.filter(({ attributes }) =>
-          attributes[key].map(g => g.id).includes(id)
+        return __items__.filter(({ attributes }) =>(
+          this.convertToArrayOfIds(attributes[key]).includes(id)
+          )
         ).length;
       };
       const { key, options = [] } = filter;

--- a/app/javascript/gobierto_investments/webapp/mixins/common.js
+++ b/app/javascript/gobierto_investments/webapp/mixins/common.js
@@ -89,7 +89,10 @@ export const CommonsMixin = {
         availableProjectFields
       } = CONFIGURATION;
       const { id: locationId, ...restLocationOptions } = location;
-      const phase_terms = this.convertToArrayOfIds(attributes[phases.id]).map(phase_id => this.middleware.getAttributesByKey(phases.id).vocabulary_terms.find(({ id }) => id === phase_id));
+      const phase_terms = this.convertToArrayOfIds(attributes[phases.id]).map(phase_id => {
+        const { vocabulary_terms= [] } = this.middleware.getAttributesByKey(phases.id) || {}
+        return vocabulary_terms.find(({ id }) => id === phase_id) || attributes[phases.id]
+      }) || [];
 
       return {
         ...element,

--- a/app/javascript/gobierto_investments/webapp/mixins/common.js
+++ b/app/javascript/gobierto_investments/webapp/mixins/common.js
@@ -89,6 +89,7 @@ export const CommonsMixin = {
         availableProjectFields
       } = CONFIGURATION;
       const { id: locationId, ...restLocationOptions } = location;
+      const phase_terms = this.convertToArrayOfIds(attributes[phases.id]).map(phase_id => this.middleware.getAttributesByKey(phases.id).vocabulary_terms.find(({ id }) => id === phase_id));
 
       return {
         ...element,
@@ -98,7 +99,7 @@ export const CommonsMixin = {
         gallery: attributes.gallery || [],
         location: attributes[locationId],
         locationOptions: restLocationOptions || {},
-        phases: attributes[phases.id].map(element => ({
+        phases: phase_terms.map(element => ({
           ...element,
           title: this.translate(element.name_translations)
         })),
@@ -118,6 +119,9 @@ export const CommonsMixin = {
     },
     setData(data) {
       return data.map(element => this.setItem(element));
+    },
+    convertToArrayOfIds(items) {
+      return Array.isArray(items) ? items.map(item => (+item)) : [+items]
     }
   }
 };


### PR DESCRIPTION
Closes #3222


## :v: What does this PR do?

* Extends custom fields API optimization to data and investments Gobierto modules
* Adapts front components to new API response (for vocabulary custom fields the old response was always an array of serialized vocabulary terms and now is the term id)
* Fixes an error mixing API optimization and filters

## :mag: How should this be manually tested?

Visit affected modules. Nothing should change


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
