### PR TITLE
autofocus on admin modals

### DIFF
--- a/app/javascript/lib/shared/modules/globals.js
+++ b/app/javascript/lib/shared/modules/globals.js
@@ -39,6 +39,9 @@ $(document).on("turbolinks:load ajax:complete ajaxSuccess", function() {
         if (window.GobiertoAdmin && window.GobiertoAdmin.terms_controller) {
           window.GobiertoAdmin.terms_controller.form()
         }
+
+        // autofocus on the first modal input field
+        $(".modal .form_item input[type=text]:visible").first().focus()
       }
     }
   });


### PR DESCRIPTION
Closes #3244 

## :v: What does this PR do?
Autofocus to the first available `input[type="text"]` when the modal opens

## :eyes: Screenshots
![2020-08-10 12 55 33](https://user-images.githubusercontent.com/817526/89775807-d9e36080-db08-11ea-8257-71056b0aed96.gif)