### PR TITLE
Select2 caret misplaced

### DIFF
--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -898,6 +898,10 @@ a .global_menu {
   }
 }
 
+.gobierto_admin .select2-container .select2-selection--single {
+  position: relative;
+}
+
 // reset gobierto styles (comp-forms.scss)
 .jsgrid {
   input[type="text"],


### PR DESCRIPTION
Closes #3242 

## :v: What does this PR do?
Places properly the caret within the select2 input

## :eyes: Screenshots
![imagen](https://user-images.githubusercontent.com/817526/89778232-70198580-db0d-11ea-848b-c175ea599e9b.png)
