### PR TITLE
2686 rails upgrade 6 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ Bundler.require(*Rails.groups)
 module Gobierto
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults "5.0"
+    config.load_defaults "5.2"
 
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
 

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -7,20 +7,20 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Don't force requests from old versions of IE to be UTF-8 encoded.
-# Rails.application.config.action_view.default_enforce_utf8 = false
+Rails.application.config.action_view.default_enforce_utf8 = false
 
 # Embed purpose and expiry metadata inside signed and encrypted
 # cookies for increased security.
 #
 # This option is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.0.
-# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
-# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
+Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
 
 # Return false instead of self when enqueuing is aborted from a callback.
-# Rails.application.config.active_job.return_false_on_aborted_enqueue = true
+Rails.application.config.active_job.return_false_on_aborted_enqueue = true
 
 # Send Active Storage analysis and purge jobs to dedicated queues.
 # Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
@@ -37,9 +37,9 @@
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
 # of the relation's cache key into the cache version to support recycling cache key.
-# Rails.application.config.active_record.collection_cache_versioning = true
+Rails.application.config.active_record.collection_cache_versioning = true

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,4 +7,6 @@ production:
   - default
   - user_verifications
   - mailers
+  - active_storage_analysis
+  - active_storage_purge
   - algoliasearch

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,6 +7,4 @@ production:
   - default
   - user_verifications
   - mailers
-  - active_storage_analysis
-  - active_storage_purge
   - algoliasearch


### PR DESCRIPTION
Closes #2686


## :v: What does this PR do?

This PR includes the Rails 6 defaults except autoloading with Zeitwerk and ActiveStorage defaults

This PR is built on top of #3291 and only enables the 6.0 defaults. This is done in a separated PR because introduces breaking changes and should be merged after checking that everything is OK with the previous PR.

## :shipit: Does this PR changes any configuration file?

- Adds an initialization file for Rails 6 defaults. At the end of the process this file can be deleted and set directly in `config/application.rb` `config.load_defaults "5.2"` 

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
