### PR TITLE
Update Amazon SES signature to v4

### DIFF
--- a/config/initializers/action_mailer_settings.rb
+++ b/config/initializers/action_mailer_settings.rb
@@ -6,7 +6,8 @@ if Rails.application.secrets.mailer_delivery_method == "ses"
   ActionMailer::Base.add_delivery_method :ses, AWS::SES::Base,
                                          access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID") { "" },
                                          secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY") { "" },
-                                         server: "email.eu-west-1.amazonaws.com"
+                                         server: "email.eu-west-1.amazonaws.com",
+                                         signature_version: 4
 
 elsif Rails.application.secrets.mailer_delivery_method == "smtp"
   Rails.application.config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates the version of AWS SES gem to support v4 signature ([more info about this](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)) and stop using v3, which will stop working on Sep 30th

## :mag: How should this be manually tested?

Test emails are delivered properly

