### PR TITLE
Capture exception on meta serializer if dataset table can't be accessed

### DIFF
--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -33,12 +33,13 @@ module GobiertoData
     end
 
     attribute :data_summary do
+      count_result = ::GobiertoData::Connection.execute_query(
+        object.site,
+        Arel.sql("SELECT COUNT(1) FROM #{object.table_name} LIMIT 1"),
+        include_draft: true
+      )
       {
-        number_of_rows: ::GobiertoData::Connection.execute_query(
-          object.site,
-          Arel.sql("SELECT COUNT(1) FROM #{object.table_name} LIMIT 1"),
-          include_draft: true
-        )&.first&.dig("count")
+        number_of_rows: count_result.is_a?(PG::Result) ? count_result.first.dig("count") : nil
       }
     end
 


### PR DESCRIPTION
Closes #3329


## :v: What does this PR do?

Avoids a exception when a meta request is sent to API for a dataset which table is not present in the module database

## :mag: How should this be manually tested?

Go to the data module database and delete the table of a dataset. Then make a GET request to `api/v1/data/datasets/dataset-slug/meta`. The response should be successful and the `number_of_rows` summary attribute should be null.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
