### PR TITLE
Remove watched_paths from engines

### DIFF
--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/lib/custom_fields_data_grid_plugin/railtie.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/lib/custom_fields_data_grid_plugin/railtie.rb
@@ -29,12 +29,6 @@ else
 
         conf.i18n.load_path += Dir[File.join(base_path, 'config', 'locales', '**', '*.{rb,yml}')]
       end
-
-      Webpacker::Compiler.watched_paths += [
-        "app/javascript/packs/*.js",
-        "app/javascript/custom_fields_data_grid_plugin/*.js",
-        "app/javascript/custom_fields_data_grid_plugin/**/*.js"
-      ]
     end
   end
 end

--- a/vendor/gobierto_engines/custom-fields-progress-plugin/lib/custom_fields_progress_plugin/railtie.rb
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/lib/custom_fields_progress_plugin/railtie.rb
@@ -38,8 +38,6 @@ else
           load task
         end
       end
-      Webpacker::Compiler.watched_paths << "app/javascript/custom_fields_progress_plugin/**/*.js"
-      Webpacker::Compiler.watched_paths << "app/javascript/packs/*.js"
     end
   end
 end

--- a/vendor/gobierto_engines/custom-fields-table-plugin/lib/custom_fields_table_plugin/railtie.rb
+++ b/vendor/gobierto_engines/custom-fields-table-plugin/lib/custom_fields_table_plugin/railtie.rb
@@ -40,8 +40,6 @@ else
           load task
         end
       end
-      Webpacker::Compiler.watched_paths << "app/javascript/custom_fields_table_plugin/**/*.js"
-      Webpacker::Compiler.watched_paths << "app/javascript/packs/*.js"
     end
   end
 end


### PR DESCRIPTION
Related to #3308


## :v: What does this PR do?

* Removes deprecated `watched_paths` Webpacker configurations in engines railties not required because the Capistrano recipe runs for each one a `create_webpacker_symlinks.sh` script adding the dependencies with a symlink under Gobierto paths

## :mag: How should this be manually tested?

Nothing should change related with plugins used by plans

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No