### PR TITLE
Parse frecuencies and categories

### DIFF
--- a/app/javascript/gobierto_data/lib/mixins/categories.mixin.js
+++ b/app/javascript/gobierto_data/lib/mixins/categories.mixin.js
@@ -15,15 +15,6 @@ export const CategoriesMixin = {
         name: this.translate(attr.name_translations),
         value: value
       };
-    },
-    setItem(element) {
-      return {
-        ...element,
-
-      };
-    },
-    setData(data) {
-      return data.map(element => this.setItem(element));
-    },
+    }
   }
 }

--- a/app/javascript/gobierto_data/lib/mixins/filters.mixin.js
+++ b/app/javascript/gobierto_data/lib/mixins/filters.mixin.js
@@ -51,7 +51,7 @@ export const FiltersMixin = {
         filters: availableFilters
       });
       store.addDatasets(__items__);
-      let items = this.setData(__items__);
+      let items = __items__;
       let filters = [];
 
       if (filtersFromConfiguration) {

--- a/app/javascript/gobierto_data/webapp/components/Index.vue
+++ b/app/javascript/gobierto_data/webapp/components/Index.vue
@@ -1,20 +1,18 @@
 <template>
-  <div v-if="allDatasets">
+  <div v-if="datasets.length">
     <h3 class="gobierto-data-index-title">
       {{ labelDatasetUpdated }}
     </h3>
     <div
       v-for="{
         id,
-        attributes: {
-          slug,
-          name,
-          description,
-          data_updated_at,
-          category: [{ name_translations: category } = {}] = [],
-          frequency: [{ name_translations: frequency } = {}] = [],
-        }
-      } in allDatasets"
+        slug,
+        name,
+        description,
+        data_updated_at,
+        category,
+        frequency,
+      } in datasets"
       :key="id"
       class="gobierto-data-info-list-element"
     >
@@ -27,15 +25,14 @@
 
       <Info
         :description-dataset="description"
-        :category-dataset="category | translate"
-        :frequency-dataset="frequency | translate"
+        :category-dataset="category"
+        :frequency-dataset="frequency"
         :date-updated="data_updated_at"
       />
     </div>
   </div>
 </template>
 <script>
-import { VueFiltersMixin } from "lib/shared";
 import Info from "./commons/Info.vue";
 
 export default {
@@ -43,9 +40,8 @@ export default {
   components: {
     Info
   },
-  mixins: [VueFiltersMixin],
   props: {
-    allDatasets: {
+    datasets: {
       type: Array,
       default: () => []
     }

--- a/app/javascript/gobierto_data/webapp/pages/Main.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Main.vue
@@ -65,16 +65,25 @@ export default {
     };
   },
   computed: {
-    parsedSubsetItems() {
+    categories() {
       const { dictionary = [] } = this.middleware || {};
       // We need to extract the human-readable elements from the dictionary
       const { attributes: { vocabulary_terms: categories = [] } = {} } = dictionary.find(
         ({ attributes: { uid } = {} }) => uid === "category"
       ) || {};
+
+      return categories
+    },
+    frequencies() {
+      const { dictionary = [] } = this.middleware || {};
+      // We need to extract the human-readable elements from the dictionary
       const { attributes:{ vocabulary_terms: frequencies = [] } = {} } = dictionary.find(
         ({ attributes: { uid } = {} }) => uid === "frequency"
       ) || {};
 
+      return frequencies
+    },
+    parsedSubsetItems() {
       return this.subsetItems.map(
         ({
           id,
@@ -87,27 +96,35 @@ export default {
             frequency: frequency_id
           }
         }) => {
-          // convert into arrays
-          const selectedCategories = Array.isArray(category_id)
-            ? +category_id
-            : [+category_id];
-          const selectedFrequencies = Array.isArray(frequency_id)
-            ? +frequency_id
-            : [+frequency_id];
+          let category = null;
+          let frequency = null;
 
-          // get only the translated strings, separated by commas
-          const category = (categories.reduce((acc, { id, name_translations }) => {
-            if (selectedCategories.includes(id)) {
-              acc.push(this.translate(name_translations))
-            }
-            return acc
-          }, []) || []).join(", ");
-          const frequency = (frequencies.reduce((acc, { id, name_translations }) => {
-            if (selectedFrequencies.includes(id)) {
-              acc.push(this.translate(name_translations))
-            }
-            return acc
-          }, []) || []).join(", ");
+          if (category_id) {
+            // convert into arrays
+            const selectedCategories = Array.isArray(category_id)
+              ? category_id
+              : [category_id];
+            // get only the translated strings, separated by commas
+            category = (this.categories.reduce((acc, { id, name_translations }) => {
+              if (selectedCategories.includes(id.toString())) {
+                acc.push(this.translate(name_translations))
+              }
+              return acc
+            }, []) || []).join(", ");
+          }
+
+          if (frequency_id) {
+            const selectedFrequencies = Array.isArray(frequency_id)
+              ? frequency_id
+              : [frequency_id];
+
+            frequency = (this.frequencies.reduce((acc, { id, name_translations }) => {
+              if (selectedFrequencies.includes(id.toString())) {
+                acc.push(this.translate(name_translations))
+              }
+              return acc
+            }, []) || []).join(", ");
+          }
 
           return {
             id,

--- a/app/javascript/gobierto_data/webapp/pages/Main.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Main.vue
@@ -71,7 +71,7 @@ export default {
       const { attributes: { vocabulary_terms: categories = [] } = {} } = dictionary.find(
         ({ attributes: { uid } = {} }) => uid === "category"
       ) || {};
-      const { attributes:{ vocabulary_terms: frecuencies = [] } = {} } = dictionary.find(
+      const { attributes:{ vocabulary_terms: frequencies = [] } = {} } = dictionary.find(
         ({ attributes: { uid } = {} }) => uid === "frequency"
       ) || {};
 
@@ -91,7 +91,7 @@ export default {
           const selectedCategories = Array.isArray(category_id)
             ? +category_id
             : [+category_id];
-          const selectedFrecuencies = Array.isArray(frequency_id)
+          const selectedFrequencies = Array.isArray(frequency_id)
             ? +frequency_id
             : [+frequency_id];
 
@@ -102,8 +102,8 @@ export default {
             }
             return acc
           }, []) || []).join(", ");
-          const frequency = (frecuencies.reduce((acc, { id, name_translations }) => {
-            if (selectedFrecuencies.includes(id)) {
+          const frequency = (frequencies.reduce((acc, { id, name_translations }) => {
+            if (selectedFrequencies.includes(id)) {
               acc.push(this.translate(name_translations))
             }
             return acc


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1111

## :v: What does this PR do?
The error was produced due to the API changes regarding frecuencies and categories format

Check out: https://getafe.gobify.net/datos - https://demo-datos.gobify.net/datos

## :eyes: Screenshots
![imagen](https://user-images.githubusercontent.com/817526/93212729-45050000-f763-11ea-8173-851455fa8a7a.png)

Incomplete fields
![imagen](https://user-images.githubusercontent.com/817526/93235421-d5e8d500-f77d-11ea-8433-876ad2e3ce49.png)



