### PR TITLE
3353 extend api token model

### DIFF
--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -7,7 +7,7 @@ class ApiBaseController < ActionController::API
   include ApplicationConcern
   include ::User::ApiAuthenticationHelper
 
-  before_action :disable_cors, :authenticate_in_site
+  before_action :disable_cors, :check_host, :authenticate_in_site
 
   rescue_from ActiveRecord::RecordNotFound, with: -> { send_not_found }
 

--- a/app/controllers/concerns/application_concern.rb
+++ b/app/controllers/concerns/application_concern.rb
@@ -52,8 +52,12 @@ module ApplicationConcern
     "site-#{current_site.id}-#{params.to_unsafe_h.sort.flatten.join("-")}"
   end
 
+  def site_protected?
+   (Rails.env.production? || Rails.env.staging?) && @site && @site.password_protected?
+  end
+
   def authenticate_user_in_site
-    if (Rails.env.production? || Rails.env.staging?) && @site && @site.password_protected?
+    if site_protected?
       authenticate_or_request_with_http_basic("Gobierto") do |username, password|
         username == @site.configuration.password_protection_username && password == @site.configuration.password_protection_password
       end

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -21,8 +21,10 @@ module User::ApiAuthenticationHelper
     raise_unauthorized unless user_authenticated?
   end
 
+  # The host is not checked if request is internal or the site is not password
+  # protected
   def check_host
-    return if internal_site_request? || !site_protected? || token.present? && valid_token_domain?
+    return if internal_site_request? || !site_protected? || api_token_with_host.present?
 
     raise_unauthorized
   end
@@ -33,25 +35,15 @@ module User::ApiAuthenticationHelper
     authenticate_user_in_site unless internal_site_request?
   end
 
-  def valid_token_domain?
-    return unless api_token.present?
-
-    api_token.domain.blank? || api_token.domain == request.host
-  end
-
   def internal_site_request?
-    Site.where(domain: request.host).exists?
+    @internal_site_request ||= Site.where(domain: request.host).exists?
   end
 
   def find_current_user
-    return unless internal_site_request? || valid_token_domain?
-
     current_site.users.confirmed.joins(:api_tokens).find_by(user_api_tokens: { token: token })
   end
 
   def find_current_admin
-    return unless internal_site_request? || valid_token_domain?
-
     @current_admin ||= ::GobiertoAdmin::Admin.joins(:api_tokens).find_by(admin_api_tokens: { token: token })
   end
 
@@ -66,7 +58,9 @@ module User::ApiAuthenticationHelper
                end
   end
 
-  def api_token
-    @api_token ||= ::User::ApiToken.find_by(token: token) || ::GobiertoAdmin::ApiToken.find_by(token: token)
+  # The ApiToken associated domain must be blank or coincident with the host
+  # request
+  def api_token_with_host
+    @api_token_with_host ||= ::User::ApiToken.where(domain: [nil, request.host]).find_by(token: token) || ::GobiertoAdmin::ApiToken.where(domain: [nil, request.host]).find_by(token: token)
   end
 end

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -21,10 +21,25 @@ module User::ApiAuthenticationHelper
     raise_unauthorized unless user_authenticated?
   end
 
+  def check_host
+    return if internal_site_request? || !site_protected? || token.present? && valid_token_domain?
+
+    raise_unauthorized
+  end
+
   def authenticate_in_site
     return if token.present? && (user_authenticated? || admin_authorized?)
 
-    authenticate_user_in_site
+  end
+
+  def valid_token_domain?
+    return unless api_token.present?
+
+    api_token.domain.blank? || api_token.domain == request.host
+  end
+
+  def internal_site_request?
+    Site.where(domain: request.host).exists?
   end
 
   def find_current_user
@@ -44,5 +59,9 @@ module User::ApiAuthenticationHelper
                  token_and_options = ActionController::HttpAuthentication::Token.token_and_options(request)
                  token_and_options.present? ? token_and_options[0] : params["token"]
                end
+  end
+
+  def api_token
+    @api_token ||= ::User::ApiToken.find_by(token: token) || ::GobiertoAdmin::ApiToken.find_by(token: token)
   end
 end

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -43,10 +43,14 @@ module User::ApiAuthenticationHelper
   end
 
   def find_current_user
+    return unless internal_site_request? || valid_token_domain?
+
     current_site.users.confirmed.joins(:api_tokens).find_by(user_api_tokens: { token: token })
   end
 
   def find_current_admin
+    return unless internal_site_request? || valid_token_domain?
+
     @current_admin ||= ::GobiertoAdmin::Admin.joins(:api_tokens).find_by(admin_api_tokens: { token: token })
   end
 

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -30,6 +30,7 @@ module User::ApiAuthenticationHelper
   def authenticate_in_site
     return if token.present? && (user_authenticated? || admin_authorized?)
 
+    authenticate_user_in_site unless internal_site_request?
   end
 
   def valid_token_domain?

--- a/app/helpers/site_helper.rb
+++ b/app/helpers/site_helper.rb
@@ -35,8 +35,4 @@ module SiteHelper
     current_site.configuration.configuration_variables["favicon_url"].presence
   end
 
-  def site_password_protected?
-    (Rails.env.production? || Rails.env.staging?) && current_site&.password_protected?
-  end
-
 end

--- a/app/javascript/gobierto_data/lib/helpers.js
+++ b/app/javascript/gobierto_data/lib/helpers.js
@@ -1,5 +1,5 @@
 function getToken() {
-  return window.gobiertoAPI.token.length == 0 && window.gobiertoAPI.basic_auth_token ? window.gobiertoAPI.basic_auth_token : window.gobiertoAPI.token
+  return window.gobiertoAPI.token
 }
 
 function getUserId() {

--- a/app/javascript/gobierto_plans/webapp/lib/factory.js
+++ b/app/javascript/gobierto_plans/webapp/lib/factory.js
@@ -2,11 +2,9 @@ import axios from "axios";
 
 const baseUrl = location.origin;
 const endPoint = `${baseUrl}/api/v1/plans`;
-const token = window.gobiertoAPI.token.length == 0 && window.gobiertoAPI.basic_auth_token ? window.gobiertoAPI.basic_auth_token : window.gobiertoAPI.token
 
 const headers = {
-  "Content-type": "application/json",
-  Authorization: token
+  "Content-type": "application/json"
 };
 
 // Plans-endpoint factory to get/post/put/delete API data

--- a/app/models/concerns/gobierto_common/acts_as_api_token.rb
+++ b/app/models/concerns/gobierto_common/acts_as_api_token.rb
@@ -13,6 +13,7 @@ module GobiertoCommon
         validates singularized_name, presence: true
         validates :name, uniqueness: { scope: singularized_name }, unless: :blank_name?
         validates singularized_name, uniqueness: { scope: :primary }, if: :primary?
+        validates :domain, domain: true
 
         scope :primary, -> { where(primary: true) }
         scope :secondary, -> { where(primary: false) }

--- a/app/models/concerns/gobierto_common/acts_as_api_token.rb
+++ b/app/models/concerns/gobierto_common/acts_as_api_token.rb
@@ -11,8 +11,7 @@ module GobiertoCommon
         belongs_to singularized_name, **opts.slice(:class_name, :foreign_key)
         has_secure_token
         validates singularized_name, presence: true
-        validates :name, presence: true, unless: :primary?
-        validates :name, uniqueness: { scope: singularized_name }
+        validates :name, uniqueness: { scope: singularized_name }, unless: :blank_name?
         validates singularized_name, uniqueness: { scope: :primary }, if: :primary?
 
         scope :primary, -> { where(primary: true) }
@@ -22,6 +21,10 @@ module GobiertoCommon
 
     def to_s
       token
+    end
+
+    def blank_name?
+      name.blank?
     end
 
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -186,10 +186,6 @@ class Site < ApplicationRecord
     @configuration ||= SiteConfiguration.new(site_configuration_attributes)
   end
 
-  def basic_auth_token
-    Base64.encode64("#{configuration.password_protection_username}:#{configuration.password_protection_password}").strip
-  end
-
   def password_protected?
     draft?
   end

--- a/app/views/layouts/_gobierto_footer.html.erb
+++ b/app/views/layouts/_gobierto_footer.html.erb
@@ -32,9 +32,6 @@
   };
   window.gobiertoAPI = {
     current_user_id: "<%= current_user&.id %>",
-    <% if site_password_protected? %>
-    basic_auth_token: "Basic <%= current_site.basic_auth_token %>",
-    <% end %>
     token: "<%= user_signed_in? ? "Bearer #{current_user.primary_api_token&.token}" : "" %>"
   };
 </script>

--- a/config/locales/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_common/models/ca.yml
@@ -1,0 +1,18 @@
+---
+ca:
+  activerecord:
+    attributes:
+      gobierto_admin/api_token:
+        domain: Domini
+      user/api_token:
+        domain: Domini
+    errors:
+      models:
+        gobierto_admin/api_token:
+          attributes:
+            domain:
+              not_valid_format: Format invàlid
+        user/api_token:
+          attributes:
+            domain:
+              not_valid_format: Format invàlid

--- a/config/locales/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_common/models/en.yml
@@ -1,0 +1,18 @@
+---
+en:
+  activerecord:
+    attributes:
+      gobierto_admin/api_token:
+        domain: Domain
+      user/api_token:
+        domain: Domain
+    errors:
+      models:
+        gobierto_admin/api_token:
+          attributes:
+            domain:
+              not_valid_format: Invalid format
+        user/api_token:
+          attributes:
+            domain:
+              not_valid_format: Invalid format

--- a/config/locales/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_common/models/es.yml
@@ -1,0 +1,18 @@
+---
+es:
+  activerecord:
+    attributes:
+      gobierto_admin/api_token:
+        domain: Dominio
+      user/api_token:
+        domain: Dominio
+    errors:
+      models:
+        gobierto_admin/api_token:
+          attributes:
+            domain:
+              not_valid_format: Formato inválido
+        user/api_token:
+          attributes:
+            domain:
+              not_valid_format: Formato inválido

--- a/db/migrate/20200921171234_add_domain_column_to_api_tokens_tables.rb
+++ b/db/migrate/20200921171234_add_domain_column_to_api_tokens_tables.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDomainColumnToApiTokensTables < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_api_tokens, :domain, :string
+    add_column :admin_api_tokens, :domain, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -245,7 +245,8 @@ CREATE TABLE public.admin_api_tokens (
     token character varying,
     "primary" boolean DEFAULT false,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    domain character varying
 );
 
 
@@ -2842,7 +2843,8 @@ CREATE TABLE public.user_api_tokens (
     token character varying,
     "primary" boolean DEFAULT false,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    domain character varying
 );
 
 
@@ -6321,6 +6323,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200910112444'),
 ('20200915105712'),
 ('20200915105848'),
-('20200915105920');
+('20200915105920'),
+('20200921171234');
 
 

--- a/test/fixtures/gobierto_admin/api_tokens.yml
+++ b/test/fixtures/gobierto_admin/api_tokens.yml
@@ -3,6 +3,18 @@ tony_primary_api_token:
   primary: true
   token: tony_primary_api_token
 
+tony_domain:
+  admin_id: <%= ActiveRecord::FixtureSet.identify(:tony) %>
+  primary: false
+  token: example_api_token
+  domain: "www.example.com"
+
+tony_other_domain:
+  admin_id: <%= ActiveRecord::FixtureSet.identify(:tony) %>
+  primary: false
+  token: wadus_api_token
+  domain: "www.wadus.com"
+
 steve_primary_api_token:
   admin_id: <%= ActiveRecord::FixtureSet.identify(:steve) %>
   primary: true

--- a/test/models/user/api_token_test.rb
+++ b/test/models/user/api_token_test.rb
@@ -10,4 +10,8 @@ class User::ApiTokenTest < ActiveSupport::TestCase
   def test_valid
     assert user_primary_api_token.valid?
   end
+
+  def test_to_s
+    assert_equal user_primary_api_token.token, "#{user_primary_api_token}"
+  end
 end


### PR DESCRIPTION
Closes #3353


## :v: What does this PR do?

Changes the token models and API behaviour with them:
* Adds a `domain` attribute allowed to be blank
* Changes the `name` attribute allowing blank names for the not primary tokens of a user (if the name is present it can't be duplicated for a same user/admin)
* When a site is protected with password:
  * If the request is internal (the origin host is in the list of sites of the Gobierto instance) no token is required for the open read endpoints (like the datasets index) and if a token is provided the domain of the token is ignored
  * If the request comes from an external site a token is required for all requests and if the token does not exist or has an associated domain which differs from the request origin host the request is unauthorized
* If the site is not protected with password the public endpoints don't require token but the domain is verified in the actions which require authentication when the token has a domain defined.
* Removes the basic_auth_token references in js front apps and application footer because it's because it is no longer needed after consider these calls as internal
* Adds some API tests

## :mag: How should this be manually tested?

Currently the tokens don't have interface, WIP in an upcoming PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- Pending: Documentation has to be updated
