### PR TITLE
3365 pg search 233 bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem "aws-ses", "~> 0.7.0"
 gem "simple_calendar", "~> 2.2"
 
 # Search client
-gem "pg_search"
+gem "pg_search", "2.3.2"
 
 # Search client indexing sanitizer
 gem "rails-html-sanitizer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     parser (2.7.1.4)
       ast (~> 2.4.1)
     pg (1.2.3)
-    pg_search (2.3.3)
+    pg_search (2.3.2)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     public_suffix (4.0.6)
@@ -582,7 +582,7 @@ DEPENDENCIES
   paper_trail
   paranoia
   pg (~> 1.1)
-  pg_search
+  pg_search (= 2.3.2)
   puma
   rack-cors
   rails (~> 6.0)

--- a/test/integration/search_box_test.rb
+++ b/test/integration/search_box_test.rb
@@ -22,6 +22,20 @@ class SearchBoxTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_search_box_use
+    site.people.each(&:update_pg_search_document)
+
+    with(site: site, js: true) do
+      visit gobierto_people_root_path
+
+      find("#gobierto_search").send_keys("ric")
+
+      sleep 2
+
+      assert has_content? "Richard Rider"
+    end
+  end
+
   def test_search_box_without_search_documents
     site.pg_search_documents.destroy_all
 


### PR DESCRIPTION
Closes #3365


## :v: What does this PR do?

* Adds a missing integration test to check that the search box works properly
* Revert and freeze `pg_search` version to 2.3.2, because the 2.3.3 has a bug

## :mag: How should this be manually tested?

Go to the public home and use the search box

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No