### PR TITLE
3355 api tokens admin

### DIFF
--- a/app/controllers/concerns/gobierto_common/api_tokens_concern.rb
+++ b/app/controllers/concerns/gobierto_common/api_tokens_concern.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module ApiTokensConcern
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :owner_type
+    end
+
+    def new
+      @form = api_token_form_class.new(owner: owner)
+
+      render("gobierto_admin/api_tokens/new_modal", layout: false) && return if request.xhr?
+
+      render "gobierto_admin/api_tokens/new"
+    end
+
+    def create
+      @form = api_token_form_class.new(api_token_params.merge(id: params[:id], owner: owner))
+      if @form.save
+        redirect_to(
+          owner_path,
+          notice: t("concerns.gobierto_common.api_tokens_concern.create.success")
+        )
+      else
+        render("gobierto_admin/api_tokens/new_modal", layout: false) && return if request.xhr?
+
+        render "gobierto_admin/api_tokens/new"
+      end
+    end
+
+    def edit
+      @form = api_token_form_class.new(api_token.attributes.except(*ignored_attributes).merge(owner: owner))
+
+      render("gobierto_admin/api_tokens/edit_modal", layout: false) && return if request.xhr?
+
+      render "gobierto_admin/api_tokens/edit"
+    end
+
+    def update
+      @form = api_token_form_class.new(api_token_params.merge(id: params[:id], owner: owner))
+      if @form.save
+        redirect_to(
+          owner_path,
+          notice: t("concerns.gobierto_common.api_tokens_concern.update.success")
+        )
+      else
+        render("gobierto_admin/api_tokens/edit_modal", layout: false) && return if request.xhr?
+
+        render "gobierto_admin/api_tokens/edit"
+      end
+    end
+
+    def destroy
+      if api_token.destroy
+        redirect_to owner_path, notice: t("concerns.gobierto_common.api_tokens_concern.destroy.success")
+      else
+        redirect_to owner_path, alert: t("concerns.gobierto_common.api_tokens_concern.destroy.failed")
+      end
+    end
+
+    private
+
+    def ignored_attributes
+      %w(created_at updated_at admin_id user_id primary token)
+    end
+
+    def api_token
+      @api_token ||= base_relation.find(params[:id])
+    end
+
+    def base_relation
+      @base_relation ||= owner.api_tokens
+    end
+
+    def api_token_form_class
+      ApiTokenForm
+    end
+
+    def api_token_params
+      params.require(:api_token).permit(:name, :domain, :update_token)
+    end
+  end
+end

--- a/app/controllers/concerns/gobierto_common/api_tokens_concern.rb
+++ b/app/controllers/concerns/gobierto_common/api_tokens_concern.rb
@@ -53,7 +53,8 @@ module GobiertoCommon
     end
 
     def destroy
-      if api_token.destroy
+      token = base_relation.secondary.find(params[:id])
+      if token.destroy
         redirect_to owner_path, notice: t("concerns.gobierto_common.api_tokens_concern.destroy.success")
       else
         redirect_to owner_path, alert: t("concerns.gobierto_common.api_tokens_concern.destroy.failed")

--- a/app/controllers/gobierto_admin/admin/settings_controller.rb
+++ b/app/controllers/gobierto_admin/admin/settings_controller.rb
@@ -7,11 +7,14 @@ module GobiertoAdmin
         id: current_admin.id, name: current_admin.name,
         email: current_admin.email
       })
+
+      set_api_tokens
     end
 
     def update
       @admin_settings_form = AdminSettingsForm.new(id: current_admin.id)
       @admin_settings_form.assign_attributes(admin_settings_params.except(*ignored_admin_settings_params))
+      set_api_tokens
 
       if @admin_settings_form.save
         flash[:notice] = t(".success")
@@ -30,6 +33,10 @@ module GobiertoAdmin
 
     def get_user_genders
       User.genders
+    end
+
+    def set_api_tokens
+      @api_tokens = current_admin.api_tokens
     end
 
     def ignored_admin_settings_params

--- a/app/controllers/gobierto_admin/admins/api_tokens_controller.rb
+++ b/app/controllers/gobierto_admin/admins/api_tokens_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module Admins
+    class ApiTokensController < BaseController
+      include ::GobiertoCommon::ApiTokensConcern
+
+      before_action :check_permissions!
+
+      private
+
+      def check_permissions!
+        redirect_to admin_users_path and return false unless current_admin.managing_user? || owner == current_admin
+      end
+
+      def owner_path
+        owner == current_admin ? edit_admin_admin_settings_path : edit_admin_admin_path(owner)
+      end
+
+      def owner_type
+        :admin
+      end
+
+      def owner
+        @owner ||= GobiertoAdmin::Admin.find(params[:admin_id])
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/admins_controller.rb
+++ b/app/controllers/gobierto_admin/admins_controller.rb
@@ -37,6 +37,7 @@ module GobiertoAdmin
       set_admin_groups
       set_authorization_levels
       set_activities
+      set_api_tokens
     end
 
     def create
@@ -76,6 +77,7 @@ module GobiertoAdmin
       set_admin_groups
       set_authorization_levels
       set_activities
+      set_api_tokens
 
       if @admin_form.save
         track_update_activity
@@ -131,6 +133,10 @@ module GobiertoAdmin
 
     def set_activities
       @activities = ActivityCollectionDecorator.new(Activity.admin_activities(@admin).page(params[:page]))
+    end
+
+    def set_api_tokens
+      @api_tokens = @admin.api_tokens
     end
 
     def track_create_activity

--- a/app/controllers/gobierto_admin/users/api_tokens_controller.rb
+++ b/app/controllers/gobierto_admin/users/api_tokens_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module Users
+    class ApiTokensController < BaseController
+      include ::GobiertoCommon::ApiTokensConcern
+
+      private
+
+      def owner_type
+        :user
+      end
+
+      def owner_path
+        edit_admin_user_path(owner)
+      end
+
+      def owner
+        @owner ||= User.find(params[:user_id])
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_admin/users_controller.rb
+++ b/app/controllers/gobierto_admin/users_controller.rb
@@ -20,12 +20,14 @@ module GobiertoAdmin
         @user.attributes.except(*ignored_user_attributes)
       )
       initialize_custom_field_form
+      set_api_tokens
     end
 
     def update
       @user = find_user
       @user_form = UserForm.new(user_params.merge(id: params[:id]))
       initialize_custom_field_form
+      set_api_tokens
 
       if @user_form.save && custom_fields_save
         track_update_activity
@@ -85,6 +87,10 @@ module GobiertoAdmin
 
     def default_activity_params
       { ip: remote_ip, author: current_admin }
+    end
+
+    def set_api_tokens
+      @api_tokens = @user.api_tokens
     end
 
     def get_users_stats

--- a/app/forms/gobierto_common/api_token_form.rb
+++ b/app/forms/gobierto_common/api_token_form.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class ApiTokenForm < BaseForm
+
+    attr_accessor(
+      :id,
+      :name,
+      :domain,
+      :owner
+    )
+
+    attr_writer(
+      :update_token
+    )
+
+    delegate :persisted?, to: :api_token
+
+    def api_token
+      @api_token ||= api_token_relation.find_by(id: id) || build_api_token
+    end
+
+    def update_token
+      @update_token ||= false
+    end
+
+    def update_token?
+      update_token == true || update_token == "1"
+    end
+
+    def save
+      return false unless valid?
+
+      if save_api_token
+        api_token
+      end
+    end
+
+    private
+
+    def build_api_token
+      api_token_relation.secondary.new
+    end
+
+    def api_token_relation
+      owner.api_tokens
+    end
+
+    def save_api_token
+      @api_token = api_token.tap do |attributes|
+        attributes.name = name.presence
+        attributes.domain = domain.presence
+      end
+
+      if @api_token.valid?
+        @api_token.save
+        @api_token.regenerate_token if update_token?
+
+        @api_token
+      else
+        promote_errors(@api_token.errors)
+
+        false
+      end
+    end
+  end
+end

--- a/app/views/gobierto_admin/admin/settings/edit.html.erb
+++ b/app/views/gobierto_admin/admin/settings/edit.html.erb
@@ -41,6 +41,10 @@
 
       </div>
 
+      <div class="form_block" id="api_tokens">
+        <%= render "gobierto_admin/api_tokens/list", { api_tokens: @api_tokens, owner: current_admin, owner_type: :admin } %>
+      </div>
+
       <%= f.submit class: "button" %>
     </div>
 

--- a/app/views/gobierto_admin/admins/_form.html.erb
+++ b/app/views/gobierto_admin/admins/_form.html.erb
@@ -89,6 +89,12 @@
       <% end %>
 
       <% if @admin_form.persisted? %>
+        <div class="form_block" id="api_tokens">
+
+          <%= render "gobierto_admin/api_tokens/list", { api_tokens: @api_tokens, owner: @admin, owner_type: :admin } %>
+
+        </div>
+
         <div class="form_block">
 
           <h2><%= t(".activity_block") %></h2>

--- a/app/views/gobierto_admin/api_tokens/_api_token.html.erb
+++ b/app/views/gobierto_admin/api_tokens/_api_token.html.erb
@@ -1,0 +1,28 @@
+<tr id="api_token-<%= api_token.id %>" class="<%= cycle("odd", "even") %>">
+  <td>
+    <%= link_to send("edit_admin_#{owner_type}_api_token_path", owner, api_token), class: "open_remote_modal" do %>
+      <i class="fas fa-edit"></i>
+    <% end %>
+  </td>
+  <td>
+    <%= api_token.name %>
+  </td>
+  <td>
+    <%= api_token.token %>
+  </td>
+  <td>
+    <%= api_token.domain %>
+  </td>
+  <td>
+    <%= time_ago_in_words(api_token.created_at) %>
+  </td>
+  <td>
+    <% if local_assigns[:primary] %>
+      <%= t(".primary") %>
+    <% else %>
+      <%= link_to send("admin_#{owner_type}_api_token_path", owner, api_token), method: :delete, title: t("views.delete"), data: { confirm: t("views.delete_confirm") } do %>
+        <i class="fas fa-trash"></i>
+      <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/gobierto_admin/api_tokens/_form.html.erb
+++ b/app/views/gobierto_admin/api_tokens/_form.html.erb
@@ -1,0 +1,33 @@
+<%= render "gobierto_admin/shared/validation_errors", resource: @form %>
+
+<%= form_for(
+  @form, as: :api_token,
+  url: @form.persisted? ? send("admin_#{owner_type}_api_token_path", @owner, @form) : send("admin_#{owner_type}_api_tokens_path", @owner)) do |f| %>
+  <div class="form_item input_text">
+    <%= f.label :name do %>
+      <%= t("gobierto_admin.api_tokens.list.header.name") %>
+    <% end %>
+    <%= f.text_field :name, placeholder: t(".placeholders.name") %>
+  </div>
+
+  <div class="form_item input_text">
+    <%= f.label :domain do %>
+      <%= t("gobierto_admin.api_tokens.list.header.domain") %>
+    <% end %>
+    <%= f.text_field :domain, placeholder: t(".placeholders.domain") %>
+  </div>
+
+  <% if @form.persisted? %>
+    <div class="form_item site-check-boxes">
+      <%= f.check_box :update_token %>
+      <%= f.label :update_token do %>
+        <span></span>
+        <%= t(".update_token")  %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="actions right">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/gobierto_admin/api_tokens/_list.html.erb
+++ b/app/views/gobierto_admin/api_tokens/_list.html.erb
@@ -1,0 +1,23 @@
+<% if api_tokens.exists? %>
+  <h2><%= t(".title") %></h2>
+  <div class="admin_tools right">
+    <%= link_to t(".new"), send("new_admin_#{local_assigns[:owner_type]}_api_token_path", local_assigns[:owner]), class: "button open_remote_modal" %>
+  </div>
+  <table class="admin-list">
+    <thead>
+      <tr>
+        <th class='icon_col'></th>
+        <th><%= t(".header.name") %></th>
+        <th><%= t(".header.token") %></th>
+        <th><%= t(".header.domain") %></th>
+        <th><%= t(".header.created_at") %></th>
+        <th class='icon_col'></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <%= render partial: "gobierto_admin/api_tokens/api_token", collection: local_assigns[:api_tokens].primary, locals: { primary: true }.merge(local_assigns.slice(:owner, :owner_type)) %>
+      <%= render partial: "gobierto_admin/api_tokens/api_token", collection: local_assigns[:api_tokens].secondary, locals: local_assigns.slice(:owner, :owner_type) %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/gobierto_admin/api_tokens/edit.html.erb
+++ b/app/views/gobierto_admin/api_tokens/edit.html.erb
@@ -1,0 +1,24 @@
+<% unless current_admin == @owner %>
+  <div class="tabs">
+    <ul>
+      <li<%== " class=\"active\"" if owner_type == :user %>>
+        <%= link_to admin_users_path do %>
+          <%= t("gobierto_admin.admins.index.users_section") %>
+        <% end %>
+      </li>
+      <li<%== " class=\"active\"" if owner_type == :admin %>>
+        <%= link_to admin_admins_path do %>
+          <%= t("gobierto_admin.admins.index.title") %>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+
+  <div class='admin_breadcrumb'>
+    <%= link_to @owner.name, send("edit_admin_#{owner_type}_path", @owner) %> »
+    <%= t(".api_token", name: @form.name) %>
+  </div>
+<% end %>
+
+<h1><%= t(".api_token", name: @form.name) %></h1>
+<%= render "gobierto_admin/api_tokens/form" %>

--- a/app/views/gobierto_admin/api_tokens/edit_modal.html.erb
+++ b/app/views/gobierto_admin/api_tokens/edit_modal.html.erb
@@ -1,0 +1,5 @@
+<div class="modal">
+<h2><%= t("gobierto_admin.api_tokens.edit.api_token", name: @form.name) %></h2>
+  <%= render "gobierto_admin/api_tokens/form" %>
+</div>
+

--- a/app/views/gobierto_admin/api_tokens/new.html.erb
+++ b/app/views/gobierto_admin/api_tokens/new.html.erb
@@ -1,0 +1,24 @@
+<% unless current_admin == @owner %>
+  <div class="tabs">
+    <ul>
+      <li<%== " class=\"active\"" if owner_type == :user %>>
+        <%= link_to admin_users_path do %>
+          <%= t("gobierto_admin.admins.index.users_section") %>
+        <% end %>
+      </li>
+      <li<%== " class=\"active\"" if owner_type == :admin %>>
+        <%= link_to admin_admins_path do %>
+          <%= t("gobierto_admin.admins.index.title") %>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+
+  <div class='admin_breadcrumb'>
+    <%= link_to @owner.name, send("edit_admin_#{owner_type}_path", @owner) %> »
+    <%= t(".api_token", name: @form.name) %>
+  </div>
+<% end %>
+
+<h1><%= t(".api_token", name: @form.name) %></h1>
+<%= render "gobierto_admin/api_tokens/form" %>

--- a/app/views/gobierto_admin/api_tokens/new_modal.html.erb
+++ b/app/views/gobierto_admin/api_tokens/new_modal.html.erb
@@ -1,0 +1,5 @@
+<div class="modal">
+<h2><%= t("gobierto_admin.api_tokens.new.api_token") %></h2>
+  <%= render "gobierto_admin/api_tokens/form" %>
+</div>
+

--- a/app/views/gobierto_admin/users/_form.html.erb
+++ b/app/views/gobierto_admin/users/_form.html.erb
@@ -47,6 +47,12 @@
 
       </div>
 
+      <% if @user_form.persisted? %>
+        <div class="form_block" id="api_tokens">
+          <%= render "gobierto_admin/api_tokens/list", { api_tokens: @api_tokens, owner: @user, owner_type: :user } %>
+        </div>
+      <% end %>
+
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/config/locales/concerns/gobierto_common/ca.yml
+++ b/config/locales/concerns/gobierto_common/ca.yml
@@ -1,0 +1,12 @@
+---
+ca:
+  concerns:
+    gobierto_common:
+      api_tokens_concern:
+        create:
+          success: El Token de l'API s'ha creat correctament
+        destroy:
+          failed: El Token de l'API no ha pogut ser eliminat
+          success: El Token de l'API s'ha eliminat correctament
+        update:
+          success: El Token de l'API s'ha actualizat correctament

--- a/config/locales/concerns/gobierto_common/en.yml
+++ b/config/locales/concerns/gobierto_common/en.yml
@@ -1,0 +1,12 @@
+---
+en:
+  concerns:
+    gobierto_common:
+      api_tokens_concern:
+        create:
+          success: API Token was successfully created
+        destroy:
+          failed: API Token couldn't be deleted
+          success: API Token deleted successfully
+        update:
+          success: API Token was successfully updated

--- a/config/locales/concerns/gobierto_common/es.yml
+++ b/config/locales/concerns/gobierto_common/es.yml
@@ -1,0 +1,12 @@
+---
+es:
+  concerns:
+    gobierto_common:
+      api_tokens_concern:
+        create:
+          success: El Token de la API se ha creado correctamente
+        destroy:
+          failed: El Token de la API no ha podido ser eliminado
+          success: El Token de la API ha sido eliminado correctamente
+        update:
+          success: El Token de la API se ha actualizado correctamente

--- a/config/locales/gobierto_admin/views/api_tokens/ca.yml
+++ b/config/locales/gobierto_admin/views/api_tokens/ca.yml
@@ -1,0 +1,23 @@
+---
+ca:
+  gobierto_admin:
+    api_tokens:
+      api_token:
+        primary: Primari
+      edit:
+        api_token: Token de l'API %{name}
+      form:
+        placeholders:
+          domain: www.example.org
+          name: Token per a aplicacions externes
+        update_token: Actualitzar Token
+      list:
+        header:
+          created_at: Creat
+          domain: Domini
+          name: Nom
+          token: Token
+        new: Nou
+        title: Tokens de l'API
+      new:
+        api_token: Nou Token de l'API

--- a/config/locales/gobierto_admin/views/api_tokens/en.yml
+++ b/config/locales/gobierto_admin/views/api_tokens/en.yml
@@ -1,0 +1,23 @@
+---
+en:
+  gobierto_admin:
+    api_tokens:
+      api_token:
+        primary: Primary
+      edit:
+        api_token: API Token %{name}
+      form:
+        placeholders:
+          domain: www.example.org
+          name: External apps Token
+        update_token: Update Token
+      list:
+        header:
+          created_at: Created at
+          domain: Domain
+          name: Name
+          token: Token
+        new: New
+        title: API Tokens
+      new:
+        api_token: New API Token

--- a/config/locales/gobierto_admin/views/api_tokens/es.yml
+++ b/config/locales/gobierto_admin/views/api_tokens/es.yml
@@ -1,0 +1,23 @@
+---
+es:
+  gobierto_admin:
+    api_tokens:
+      api_token:
+        primary: Primario
+      edit:
+        api_token: Token de la API %{name}
+      form:
+        placeholders:
+          domain: www.example.org
+          name: Token para aplicaciones externas
+        update_token: Actualizar Token
+      list:
+        header:
+          created_at: Creado
+          domain: Dominio
+          name: Nombre
+          token: Token
+        new: Nuevo
+        title: Tokens de la API
+      new:
+        api_token: Nuevo Token de la API

--- a/config/locales/gobierto_common/models/ca.yml
+++ b/config/locales/gobierto_common/models/ca.yml
@@ -4,8 +4,13 @@ ca:
     attributes:
       gobierto_admin/api_token:
         domain: Domini
+        name: Nom
+      gobierto_common/api_token_form:
+        domain: Domini
+        name: Nom
       user/api_token:
         domain: Domini
+        name: Nom
     errors:
       models:
         gobierto_admin/api_token:

--- a/config/locales/gobierto_common/models/en.yml
+++ b/config/locales/gobierto_common/models/en.yml
@@ -4,8 +4,13 @@ en:
     attributes:
       gobierto_admin/api_token:
         domain: Domain
+        name: Name
+      gobierto_common/api_token_form:
+        domain: Domain
+        name: Name
       user/api_token:
         domain: Domain
+        name: Name
     errors:
       models:
         gobierto_admin/api_token:

--- a/config/locales/gobierto_common/models/es.yml
+++ b/config/locales/gobierto_common/models/es.yml
@@ -4,8 +4,13 @@ es:
     attributes:
       gobierto_admin/api_token:
         domain: Dominio
+        name: Nombre
+      gobierto_common/api_token_form:
+        domain: Dominio
+        name: Nombre
       user/api_token:
         domain: Dominio
+        name: Nombre
     errors:
       models:
         gobierto_admin/api_token:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,10 @@ Rails.application.routes.draw do
         resource :sessions, only: [:create, :destroy]
       end
 
-      resources :admins, only: [:index, :show, :new, :create, :edit, :update]
+      resources :admins, only: [:index, :show, :new, :create, :edit, :update] do
+        resources :api_tokens, only: [:new, :create, :edit, :update, :destroy], controller: "admins/api_tokens"
+      end
+
       resources :admin_groups, only: [:index, :new, :create, :edit, :update] do
         resources :admins, only: [:index, :new, :create, :destroy], controller: "admin_groups/admins"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       resources :users, only: [:index, :show, :edit, :update] do
         resource :welcome_messages, only: [:create], controller: "users/welcome_messages"
         resource :passwords, only: [:new, :create], controller: "users/passwords"
+        resources :api_tokens, only: [:new, :create, :edit, :update, :destroy], controller: "users/api_tokens"
       end
 
       namespace :census do

--- a/test/fixtures/user/api_tokens.yml
+++ b/test/fixtures/user/api_tokens.yml
@@ -8,6 +8,13 @@ reed_primary_api_token:
   primary: true
   token: reed_primary_api_token
 
+reed_secondary_api_token:
+  user: reed
+  primary: false
+  domain: www.example.org
+  name: Reed secondary token
+  token: reed_secondary_api_token
+
 susan_primary_api_token:
   user: susan
   primary: true

--- a/test/integration/gobierto_admin/admins/admin_api_tokens_test.rb
+++ b/test/integration/gobierto_admin/admins/admin_api_tokens_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  class AdminApiTokensTest < ActionDispatch::IntegrationTest
+
+    def regular_admin
+      @regular_admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def manager_admin
+      @manager_admin ||= gobierto_admin_admins(:nick)
+    end
+
+    def primary_token
+      @primary_token ||= gobierto_admin_api_tokens(:tony_primary_api_token)
+    end
+
+    def secondary_token
+      @secondary_token ||= gobierto_admin_api_tokens(:tony_domain)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def test_manager_admin_manage_admin_api_tokens
+      with(admin: manager_admin) do
+        visit edit_admin_admin_path(regular_admin)
+
+        within "#api_tokens" do
+          assert has_content?("API Tokens")
+
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?(primary_token.token)
+              assert has_content?("Primary")
+              assert has_no_selector?("a[data-method='delete']")
+            end
+
+            within "#api_token-#{secondary_token.id}" do
+              assert has_content?(secondary_token.token)
+              assert has_selector?("a[data-method='delete']")
+            end
+          end
+        end
+      end
+    end
+
+    def test_create_api_token_errors
+      with(admin: manager_admin, js: true) do
+        visit edit_admin_admin_path(regular_admin)
+
+        within "#api_tokens" do
+          click_link "New"
+        end
+
+        fill_in "api_token_name", with: "New token"
+        fill_in "api_token_domain", with: "invalid domain name"
+
+        click_button "Create"
+
+        assert has_alert?("Domain Invalid format")
+
+        visit edit_admin_admin_path(regular_admin)
+        within "#api_tokens" do
+          within "table tbody" do
+            assert has_no_content?("New token")
+          end
+        end
+      end
+    end
+
+    def test_create_api_token
+      with(admin: manager_admin, js: true) do
+        visit edit_admin_admin_path(regular_admin)
+
+        within "#api_tokens" do
+          click_link "New"
+        end
+
+        fill_in "api_token_name", with: "New token"
+        fill_in "api_token_domain", with: "www.organization.com"
+
+        click_button "Create"
+
+        assert has_message?("API Token was successfully created")
+
+        within "#api_tokens" do
+          within "table tbody" do
+            assert has_content?("New token")
+            assert has_content?("www.organization.com")
+          end
+        end
+      end
+    end
+
+    def test_update_primary_api_token
+      initial_token_content = primary_token.token
+
+      with(admin: manager_admin, js: true) do
+        visit edit_admin_admin_path(regular_admin)
+
+        find(:xpath, %(//a[@href="#{edit_admin_admin_api_token_path(regular_admin, primary_token)}"])).click
+
+        within "#edit_api_token" do
+          fill_in "api_token_name", with: "Updated primary token"
+          fill_in "api_token_domain", with: "www.primary-token.com"
+
+          click_button "Update"
+        end
+
+        assert has_message?("API Token was successfully updated")
+
+        primary_token.reload
+
+        assert_equal initial_token_content, primary_token.token
+        within "#api_tokens" do
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?("Updated primary token")
+              assert has_content?("www.primary-token.com")
+              assert has_content?(initial_token_content)
+            end
+          end
+        end
+      end
+    end
+
+    def test_update_primary_api_token_content
+      initial_token_content = primary_token.token
+
+      with(admin: manager_admin, js: true) do
+        visit edit_admin_admin_path(regular_admin)
+
+        find(:xpath, %(//a[@href="#{edit_admin_admin_api_token_path(regular_admin, primary_token)}"])).click
+
+        within "#edit_api_token" do
+          fill_in "api_token_name", with: "Updated primary token"
+          fill_in "api_token_domain", with: "www.primary-token.com"
+          find("label[for='api_token_update_token']", visible: false).execute_script("this.click()")
+
+          click_button "Update"
+        end
+
+        assert has_message?("API Token was successfully updated")
+
+        primary_token.reload
+
+        refute_equal initial_token_content, primary_token.token
+        within "#api_tokens" do
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?("Updated primary token")
+              assert has_content?("www.primary-token.com")
+              assert has_no_content?(initial_token_content)
+              assert has_content?(primary_token.token)
+            end
+          end
+        end
+      end
+    end
+
+    def test_delete_secondary_api_token
+      token_id = secondary_token.id
+      with(admin: manager_admin, js: true) do
+        visit edit_admin_admin_path(regular_admin)
+
+        within "#api_tokens" do
+          within "#api_token-#{token_id}" do
+            find("a[data-method='delete']").click
+          end
+        end
+
+        page.accept_alert
+
+        assert has_message?("API Token deleted successfully")
+        refute regular_admin.api_tokens.exists?(id: token_id)
+      end
+    end
+  end
+end

--- a/test/integration/gobierto_admin/admins/admin_api_tokens_test.rb
+++ b/test/integration/gobierto_admin/admins/admin_api_tokens_test.rb
@@ -179,5 +179,84 @@ module GobiertoAdmin
         refute regular_admin.api_tokens.exists?(id: token_id)
       end
     end
+
+    def test_regular_admin_manages_own_tokens
+      with(admin: regular_admin) do
+        visit edit_admin_admin_settings_path
+
+        within "#api_tokens" do
+          assert has_content?("API Tokens")
+
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?(primary_token.token)
+              assert has_content?("Primary")
+              assert has_no_selector?("a[data-method='delete']")
+            end
+
+            within "#api_token-#{secondary_token.id}" do
+              assert has_content?(secondary_token.token)
+              assert has_selector?("a[data-method='delete']")
+            end
+          end
+        end
+      end
+    end
+
+    def test_regular_admin_creates_own_token
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_admin_settings_path
+
+        within "#api_tokens" do
+          click_link "New"
+        end
+
+        fill_in "api_token_name", with: "New token"
+        fill_in "api_token_domain", with: "www.organization.com"
+
+        click_button "Create"
+
+        assert has_message?("API Token was successfully created")
+
+        within "#api_tokens" do
+          within "table tbody" do
+            assert has_content?("New token")
+            assert has_content?("www.organization.com")
+          end
+        end
+      end
+    end
+
+    def test_regular_admin_updates_secondary_api_token
+      initial_token_content = secondary_token.token
+
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_admin_settings_path
+
+        find(:xpath, %(//a[@href="#{edit_admin_admin_api_token_path(regular_admin, secondary_token)}"])).click
+
+        within "#edit_api_token" do
+          fill_in "api_token_name", with: "Updated secondary token"
+          fill_in "api_token_domain", with: "www.secondary-token.com"
+          find("label[for='api_token_update_token']", visible: false).execute_script("this.click()")
+
+          click_button "Update"
+        end
+
+        assert has_message?("API Token was successfully updated")
+
+        secondary_token.reload
+
+        refute_equal initial_token_content, secondary_token.token
+        within "#api_tokens" do
+          within "table tbody" do
+            assert has_content?("Updated secondary token")
+            assert has_content?("www.secondary-token.com")
+            assert has_no_content?(initial_token_content)
+            assert has_content?(secondary_token.token)
+          end
+        end
+      end
+    end
   end
 end

--- a/test/integration/gobierto_admin/user_api_tokens_test.rb
+++ b/test/integration/gobierto_admin/user_api_tokens_test.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoAdmin
+  class UserApiTokensTest < ActionDispatch::IntegrationTest
+
+    def manager_admin
+      @manager_admin ||= gobierto_admin_admins(:nick)
+    end
+
+    def regular_admin
+      @regular_admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def user
+      @user ||= users(:reed)
+    end
+
+    def primary_token
+      @primary_token ||= user_api_tokens(:reed_primary_api_token)
+    end
+
+    def secondary_token
+      @secondary_token ||= user_api_tokens(:reed_secondary_api_token)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def test_regular_admin_manage_user_api_tokens
+      with(admin: regular_admin) do
+        visit edit_admin_user_path(user)
+
+        within "#api_tokens" do
+          assert has_content?("API Tokens")
+
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?(primary_token.token)
+              assert has_content?("Primary")
+              assert has_no_selector?("a[data-method='delete']")
+            end
+
+            within "#api_token-#{secondary_token.id}" do
+              assert has_content?(secondary_token.token)
+              assert has_selector?("a[data-method='delete']")
+            end
+          end
+        end
+      end
+    end
+
+    def test_create_api_token_errors
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_user_path(user)
+
+        within "#api_tokens" do
+          click_link "New"
+        end
+
+        fill_in "api_token_name", with: "New token"
+        fill_in "api_token_domain", with: "invalid domain name"
+
+        click_button "Create"
+
+        assert has_alert?("Domain Invalid format")
+
+        visit edit_admin_user_path(user)
+        within "#api_tokens" do
+          within "table tbody" do
+            assert has_no_content?("New token")
+          end
+        end
+      end
+    end
+
+    def test_create_api_token
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_user_path(user)
+
+        within "#api_tokens" do
+          click_link "New"
+        end
+
+        fill_in "api_token_name", with: "New token"
+        fill_in "api_token_domain", with: "www.organization.com"
+
+        click_button "Create"
+
+        assert has_message?("API Token was successfully created")
+
+        within "#api_tokens" do
+          within "table tbody" do
+            assert has_content?("New token")
+            assert has_content?("www.organization.com")
+          end
+        end
+      end
+    end
+
+    def test_update_primary_api_token
+      initial_token_content = primary_token.token
+
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_user_path(user)
+
+        find(:xpath, %(//a[@href="#{edit_admin_user_api_token_path(user, primary_token)}"])).click
+
+        within "#edit_api_token" do
+          fill_in "api_token_name", with: "Updated primary token"
+          fill_in "api_token_domain", with: "www.primary-token.com"
+
+          click_button "Update"
+        end
+
+        assert has_message?("API Token was successfully updated")
+
+        primary_token.reload
+
+        assert_equal initial_token_content, primary_token.token
+        within "#api_tokens" do
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?("Updated primary token")
+              assert has_content?("www.primary-token.com")
+              assert has_content?(initial_token_content)
+            end
+          end
+        end
+      end
+    end
+
+    def test_update_primary_api_token_content
+      initial_token_content = primary_token.token
+
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_user_path(user)
+
+        find(:xpath, %(//a[@href="#{edit_admin_user_api_token_path(user, primary_token)}"])).click
+
+        within "#edit_api_token" do
+          fill_in "api_token_name", with: "Updated primary token"
+          fill_in "api_token_domain", with: "www.primary-token.com"
+          find("label[for='api_token_update_token']", visible: false).execute_script("this.click()")
+
+          click_button "Update"
+        end
+
+        assert has_message?("API Token was successfully updated")
+
+        primary_token.reload
+
+        refute_equal initial_token_content, primary_token.token
+        within "#api_tokens" do
+          within "table tbody" do
+            within("tr", match: :first) do
+              assert has_content?("Updated primary token")
+              assert has_content?("www.primary-token.com")
+              assert has_no_content?(initial_token_content)
+              assert has_content?(primary_token.token)
+            end
+          end
+        end
+      end
+    end
+
+    def test_delete_secondary_api_token
+      token_id = secondary_token.id
+      with(admin: regular_admin, js: true) do
+        visit edit_admin_user_path(user)
+
+        within "#api_tokens" do
+          within "#api_token-#{token_id}" do
+            find("a[data-method='delete']").click
+          end
+        end
+
+        page.accept_alert
+
+        assert has_message?("API Token deleted successfully")
+        refute user.api_tokens.exists?(id: token_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #3355


## :v: What does this PR do?

* Adds management of users and admins API tokens from admin section:
  * Any admin can manage their own tokens from settings
  * Regular admins can manage users API tokens in their edition forms
  * Manager admins also can manage other admin tokens in their edition forms
  * The management of tokens includes the actions:
    * Creation and deletion of secondary tokens
    * Edition of `name` and `domain` attributes and mark for update token content (this last action is automatic, the token content is replaced with a randomly generated 24-character unique token using `SecureRandom::base58`, collisions are highly unlike and there is also a uniqueness validation)
* Adds integration tests for admin section on users/admins managements and own admin profile settings

**blocked** This PR is built on top of #3366
  
## :mag: How should this be manually tested?

As admin go to a user/admin edition form and play with the API Tokens section

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No