### PR TITLE
Fix Rails 6.1 deprecation warning

### DIFF
--- a/app/models/gobierto_citizens_charters/edition.rb
+++ b/app/models/gobierto_citizens_charters/edition.rb
@@ -49,7 +49,7 @@ module GobiertoCitizensCharters
 
     def self.progress
       p_rel = where.not(percentage: nil)
-      p_val = where(percentage: nil).where.not(value: nil, max_value: nil)
+      p_val = where(percentage: nil).where.not(value: nil).where.not(max_value: nil)
       (p_rel.sum(:percentage) + p_val.sum("value/max_value") * 100) / (p_rel.count + p_val.count)
     end
 


### PR DESCRIPTION

## :v: What does this PR do?

WIP - Adds some changes to fix deprecation warnings after the update to Rails 6.0:

 * `DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually`



## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
