### PR TITLE
Disable plans turbolinks

### DIFF
--- a/app/views/gobierto_plans/layouts/application.html.erb
+++ b/app/views/gobierto_plans/layouts/application.html.erb
@@ -6,4 +6,8 @@
   <%= stylesheet_pack_tag 'plans', 'data-turbolinks-track': true %>
 <% end %>
 
+<% content_for :body_attributes  do %>
+  data-turbolinks="false"
+<% end %>
+
 <%= render template: "layouts/application" %>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1114

## :v: What does this PR do?
Submenu turbolinks were blocking the Vue app reloading