### PR TITLE
2773 cache downloads

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_data/base_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_data/base_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "#{Rails.root}/app/models/gobierto_data"
+
 module GobiertoAdmin
   module GobiertoData
     class BaseController < GobiertoAdmin::BaseController

--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -37,25 +37,6 @@ module GobiertoData
           end.force_encoding("utf-8")
         end
 
-        def xlsx_from_query_result(result, options = {})
-          row_index = 0
-          book = RubyXL::Workbook.new
-
-          sheet = book.worksheets.first
-          sheet.sheet_name = options.fetch(:name, "data")
-          result.fields.each_with_index do |value, col_index|
-            sheet.add_cell(row_index, col_index, value)
-          end
-          result.each_row do |row|
-            row_index += 1
-            row.each_with_index do |value, col_index|
-              sheet.add_cell(row_index, col_index, value)
-            end
-          end
-
-          book.stream
-        end
-
         def csv_from_relation(relation, options = {})
           with_serialized_data_from_relation(relation) do |data, new|
             return "" if data.blank?

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -70,23 +70,25 @@ module GobiertoData
         def download
           find_item
           return if @item.draft? && !valid_preview_token?
+
           filename = "#{@item.slug}.#{request.format.symbol}"
 
           respond_to do |format|
             format.json do
-              @cache_uri = cached_data.source("download.json") do
+              @cache_uri = cached_data.source(filename) do
                 execute_query(@item.rails_model.all).to_json
               end
             end
 
             format.csv do
-              @cache_uri = cached_data.source("download_#{csv_options_params.to_query}.csv") do
-                GobiertoData::Connection.execute_query_output_csv(current_site, @item.rails_model.all.to_sql, csv_options_params)
+              # Download cache only supports comma separated CSVs
+              @cache_uri = cached_data.source(filename) do
+                GobiertoData::Connection.execute_query_output_csv(current_site, @item.rails_model.all.to_sql, { col_sep: "," })
               end
             end
 
             format.xlsx do
-              @cache_uri = cached_data.source("download.xlsx") do
+              @cache_uri = cached_data.source(filename) do
                 GobiertoData::Connection.execute_query_output_xlsx(current_site, @item.rails_model.all.to_sql, { name: @item.name }).read
               end
             end

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -69,20 +69,33 @@ module GobiertoData
         # GET /api/v1/data/datasets/dataset-slug/download.xlsx
         def download
           find_item
-          basename = @item.slug
+          return if @item.draft? && !valid_preview_token?
+          filename = "#{@item.slug}.#{request.format.symbol}"
 
           respond_to do |format|
             format.json do
-              send_download(cached_item_download_json, :json, basename)
+              @cache_uri = cached_data.source("download.json") do
+                execute_query(@item.rails_model.all).to_json
+              end
             end
 
             format.csv do
-              send_download(cached_item_csv, :csv, basename)
+              @cache_uri = cached_data.source("download_#{csv_options_params.to_query}.csv") do
+                GobiertoData::Connection.execute_query_output_csv(current_site, @item.rails_model.all.to_sql, csv_options_params)
+              end
             end
 
             format.xlsx do
-              send_download(cached_item_xlsx, :xlsx, basename)
+              @cache_uri = cached_data.source("download.xlsx") do
+                xlsx_from_query_result(execute_query(@item.rails_model.all), name: @item.name).read
+              end
             end
+          end
+
+          if cached_data.local?
+            send_file @cache_uri, filename: filename
+          else
+            redirect_to @cache_uri
           end
         end
 
@@ -172,12 +185,6 @@ module GobiertoData
               meta: query_result,
               links: links(:data)
             }.to_json
-          end
-        end
-
-        def cached_item_download_json
-          Rails.cache.fetch("#{@item.cache_key_with_version}/download.json") do
-            execute_query(@item.rails_model.all).to_json
           end
         end
 
@@ -274,6 +281,10 @@ module GobiertoData
             preloaded_data: transformed_custom_field_record_values(relation),
             adapter: :json_api
           )
+        end
+
+        def cached_data
+          @cached_data ||= CachedData.new(@item)
         end
 
         def schema_json_param

--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -87,7 +87,7 @@ module GobiertoData
 
             format.xlsx do
               @cache_uri = cached_data.source("download.xlsx") do
-                xlsx_from_query_result(execute_query(@item.rails_model.all), name: @item.name).read
+                GobiertoData::Connection.execute_query_output_xlsx(current_site, @item.rails_model.all.to_sql, { name: @item.name }).read
               end
             end
           end
@@ -196,7 +196,7 @@ module GobiertoData
 
         def cached_item_xlsx
           Rails.cache.fetch("#{@item.cache_key_with_version}/show.xlsx") do
-            xlsx_from_query_result(execute_query(@item.rails_model.all), name: @item.name).read
+            GobiertoData::Connection.execute_query_output_xlsx(current_site, @item.rails_model.all.to_sql, { name: @item.name }).read
           end
         end
 

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -53,7 +53,15 @@ module GobiertoData
             end
 
             format.xlsx do
-              send_data xlsx_from_query_result(query_result, name: @item.name).read, filename: "#{@item.id}.xlsx"
+              send_data(
+                GobiertoData::Connection.execute_query_output_xlsx(
+                  current_site,
+                  @item.sql,
+                  { name: @item.name },
+                  include_draft: valid_preview_token?
+                ).read,
+                filename: "#{@item.id}.xlsx"
+              )
             end
           end
         end
@@ -75,7 +83,16 @@ module GobiertoData
             end
 
             format.xlsx do
-              send_download(xlsx_from_query_result(query_result, name: @item.name).read, :xlsx, basename)
+              send_download(
+                GobiertoData::Connection.execute_query_output_xlsx(
+                  current_site,
+                  @item.sql,
+                  { name: @item.name },
+                  include_draft: valid_preview_token?
+                ).read,
+                :xlsx,
+                basename
+              )
             end
           end
         end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -31,7 +31,15 @@ module GobiertoData
               query_result = execute_query(params[:sql] || {}, include_stats: false)
 
               render_error_or_continue(query_result) do
-                send_data xlsx_from_query_result(query_result).read, filename: "data.xlsx"
+                send_data(
+                  GobiertoData::Connection.execute_query_output_xlsx(
+                    current_site,
+                    Arel.sql(params[:sql] || {}),
+                    { name: "data" },
+                    include_draft: valid_preview_token?
+                  ).read,
+                  filename: "data.xlsx"
+                )
               end
             end
           end

--- a/app/controllers/gobierto_data/application_controller.rb
+++ b/app/controllers/gobierto_data/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "#{Rails.root}/app/models/gobierto_data"
+
 class GobiertoData::ApplicationController < ApplicationController
   include User::SessionHelper
 

--- a/app/jobs/gobierto_data/cache_datasets_downloads.rb
+++ b/app/jobs/gobierto_data/cache_datasets_downloads.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class CacheDatasetsDownloads < ActiveJob::Base
+    queue_as :default
+
+    def perform(*datasets)
+      datasets.each do |dataset|
+        cached_data = CachedData.new(dataset)
+
+        cached_data.source("download.json", update: true) do
+          Connection.execute_query(dataset.site, dataset.rails_model.all.to_sql).to_json
+        end
+
+        %w(, ;).each do |separator|
+          csv_options_params = { col_sep: separator }
+          cached_data.source("download_#{csv_options_params.to_query}.csv", update: true) do
+            Connection.execute_query_output_csv(dataset.site, dataset.rails_model.all.to_sql, csv_options_params)
+          end
+        end
+
+        cached_data.source("download.xlsx", update: true) do
+          Connection.execute_query_output_xlsx(dataset.site, dataset.rails_model.all.to_sql, { name: dataset.name }).read
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/gobierto_data/cache_datasets_downloads.rb
+++ b/app/jobs/gobierto_data/cache_datasets_downloads.rb
@@ -2,7 +2,7 @@
 
 module GobiertoData
   class CacheDatasetsDownloads < ActiveJob::Base
-    queue_as :default
+    queue_as :cached_data
 
     def perform(*datasets)
       datasets.each do |dataset|

--- a/app/models/gobierto_data/cached_data.rb
+++ b/app/models/gobierto_data/cached_data.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class CachedData
+    CACHED_DATA_BASE_PATH = "gobierto_data/cache/"
+
+    attr_reader :resource, :resource_path
+
+    def initialize(resource)
+      @resource = resource
+      @resource_path = "#{CACHED_DATA_BASE_PATH}#{resource.class.name.underscore}/#{resource.id}"
+      @local = ::GobiertoCommon::FileUploadService.new(file_name: resource_path).adapter.is_a? ::FileUploader::Local
+    end
+
+    def local?
+      @local
+    end
+
+    def source(name, update: false)
+      update_method = update ? :upload! : :call
+      service = GobiertoCommon::FileUploadService.new(file_name: "#{resource_path}/#{name}")
+      service = GobiertoCommon::FileUploadService.new(file_name: "#{resource_path}/#{name}", content: yield) if update || !service.uploaded_file_exists?
+      local? ? Rails.root.join("public#{service.send(update_method)}") : service.send(update_method)
+    end
+  end
+end

--- a/app/models/gobierto_data/cached_data.rb
+++ b/app/models/gobierto_data/cached_data.rb
@@ -21,6 +21,10 @@ module GobiertoData
       @local
     end
 
+    def delete_cached_data
+      ::GobiertoCommon::FileUploadService.new(file_name: resource_path).delete_children
+    end
+
     def source(name, update: false, content_type: nil)
       update_method = update ? :upload! : :call
       service = GobiertoCommon::FileUploadService.new(file_name: "#{resource_path}/#{name}")

--- a/app/models/gobierto_data/cached_data.rb
+++ b/app/models/gobierto_data/cached_data.rb
@@ -9,11 +9,12 @@ module GobiertoData
       ".xlsx" => "application/xlsx"
     }.freeze
 
-    attr_reader :resource, :resource_path
+    attr_reader :resource, :resource_path, :resource_basename
 
     def initialize(resource)
       @resource = resource
       @resource_path = "#{CACHED_DATA_BASE_PATH}#{resource.class.name.underscore}/#{resource.id}"
+      @resource_basename = resource.is_a?(GobiertoData::Dataset) ? resource.slug : resource.id
       @local = ::GobiertoCommon::FileUploadService.new(file_name: resource_path).adapter.is_a? ::FileUploader::Local
     end
 
@@ -22,7 +23,9 @@ module GobiertoData
     end
 
     def delete_cached_data
-      ::GobiertoCommon::FileUploadService.new(file_name: resource_path).delete_children
+      CONTENT_TYPES.each_key do |extension|
+        ::GobiertoCommon::FileUploadService.new(file_name: "#{resource_path}/#{resource_basename}#{extension}").delete
+      end
     end
 
     def source(name, update: false, content_type: nil)

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -55,6 +55,27 @@ module GobiertoData
         failed_query(e.message)
       end
 
+      def execute_query_output_xlsx(site, query, xlsx_options_params, include_draft: false)
+        result = execute_query(site, query, include_draft: include_draft)
+
+        row_index = 0
+        book = RubyXL::Workbook.new
+
+        sheet = book.worksheets.first
+        sheet.sheet_name = xlsx_options_params.fetch(:name, "data")
+        result.fields.each_with_index do |value, col_index|
+          sheet.add_cell(row_index, col_index, value)
+        end
+        result.each_row do |row|
+          row_index += 1
+          row.each_with_index do |value, col_index|
+            sheet.add_cell(row_index, col_index, value)
+          end
+        end
+
+        book.stream
+      end
+
       def execute_write_query_from_file_using_stdin(site, query, file_path: nil, include_draft: false)
         return unless file_path.present?
 

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -58,6 +58,8 @@ module GobiertoData
       def execute_query_output_xlsx(site, query, xlsx_options_params, include_draft: false)
         result = execute_query(site, query, include_draft: include_draft)
 
+        return result if result.is_a?(Hash) && result.has_key?(:errors)
+
         row_index = 0
         book = RubyXL::Workbook.new
 

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -31,6 +31,7 @@ module GobiertoData
     validates :slug, :table_name, uniqueness: { scope: :site_id }
 
     before_save :set_schema, if: :will_save_change_to_visibility_level?
+    before_destroy :delete_cached_data
 
     def attributes_for_slug
       [name]
@@ -105,6 +106,10 @@ module GobiertoData
     end
 
     private
+
+    def delete_cached_data
+      CachedData.new(self).delete_cached_data
+    end
 
     def refresh_cached_downloads
       CacheDatasetsDownloads.perform_later self

--- a/app/services/gobierto_common/file_upload_service.rb
+++ b/app/services/gobierto_common/file_upload_service.rb
@@ -26,7 +26,7 @@ module GobiertoCommon
       @add_suffix = args[:add_suffix] || true
     end
 
-    delegate :call, :uploaded_file_exists?, :upload!, to: :adapter
+    delegate :call, :uploaded_file_exists?, :upload!, :delete, to: :adapter
 
     def adapter
       if Rails.env.development?

--- a/app/services/gobierto_common/file_upload_service.rb
+++ b/app/services/gobierto_common/file_upload_service.rb
@@ -26,7 +26,7 @@ module GobiertoCommon
       @add_suffix = args[:add_suffix] || true
     end
 
-    delegate :call, :uploaded_file_exists?, :upload!, :delete, to: :adapter
+    delegate :call, :uploaded_file_exists?, :upload!, :delete, :delete_children, to: :adapter
 
     def adapter
       if Rails.env.development?

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,10 @@
 ---
 staging:
-  :concurrency: 2
+  :concurrency: 5
 production:
-  :concurrency: 2
+  :concurrency: 5
 :queues:
   - default
   - user_verifications
   - mailers
-  - algoliasearch
+  - cached_data

--- a/lib/file_uploader/local.rb
+++ b/lib/file_uploader/local.rb
@@ -32,6 +32,19 @@ module FileUploader
       File.exists?(file_path)
     end
 
+    def delete
+      !uploaded_file_exists? || File.delete(file_path)
+    end
+
+    def delete_children
+      return unless File.directory?(file_path)
+
+      Dir.each_child(file_path) do |file|
+        File.delete(File.join(file_path, file))
+      end
+      Dir.delete(file_path)
+    end
+
     private
 
     def file_uri

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -51,9 +51,10 @@ module FileUploader
     end
 
     def delete_children
-      objects = resource.bucket(bucket_name).objects({ prefix: file_name }).each do |object|
-        object.delete
-      end
+      resource.bucket(bucket_name).objects({ prefix: file_name }).each(&:delete)
+      true
+    rescue Aws::S3::Errors::AccessDenied
+      false
     end
 
     private

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -50,6 +50,12 @@ module FileUploader
       !uploaded_file_exists? || object.delete
     end
 
+    def delete_children
+      objects = resource.bucket(bucket_name).objects({ prefix: file_name }).each do |object|
+        object.delete
+      end
+    end
+
     private
 
     def resource

--- a/lib/file_uploader/s3.rb
+++ b/lib/file_uploader/s3.rb
@@ -52,8 +52,10 @@ module FileUploader
 
     def delete_children
       resource.bucket(bucket_name).objects({ prefix: file_name }).each(&:delete)
+      Rails.logger.debug "[gobierto_data] Successful deletion of children of #{file_name}"
       true
     rescue Aws::S3::Errors::AccessDenied
+      Rails.logger.debug "[gobierto_data] Failed deletion of children of #{file_name}"
       false
     end
 


### PR DESCRIPTION
Closes #2773


## :v: What does this PR do?

Adds caching of datasets downloads in all formats:

* Creates a model to store all cached data related with a GobiertoData resource. It accepts a block which result can be used to store in cache. In this case it's going to be used by datasets, but can be used with other models.
* From API controller if a download request is sent and no cached data is available then is created and served otherwise the cached version is used
* Adds a job to generate all cached data in all formats when a dataset data is updated using the API.
* Adds checks in tests for cached files existence on download endpoints requests

## :mag: How should this be manually tested?

Visit downloads section of a dataset and download data in each format. In staging, with the use of S3 the source should be there.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No