### PR TITLE
Solve accessibility issues

### DIFF
--- a/app/javascript/gobierto_budgets/modules/application.js
+++ b/app/javascript/gobierto_budgets/modules/application.js
@@ -108,6 +108,28 @@ $(document).on('turbolinks:load', function() {
     $('.line_browser').velocity("fadeOut", { duration: 50 });
   });
 
+  $('.bread_links a').focus(function() {
+    $(this).attr('aria-expanded', true);
+    $('.bread_links').addClass('hasFocus');
+    $('.line_browser').velocity("fadeIn", { duration: 50 });
+  });
+
+  $('#popup-year table tr a').blur(function() {
+    $(window).keyup(function (e) {
+      var code = (e.keyCode ? e.keyCode : e.which);
+      if (code == 9 && $('#popup-year table tr a').not(':focus') && $('.bread_links a').not(':focus')) {
+        $('.bread_links').removeClass('hasFocus')
+      }
+      if (code == 9 && $('#popup-year table tr a').is(':focus')) {
+        $('.bread_links').addClass('hasFocus')
+      }
+      if (code == 9 && $('#popup-year table tr a').not(':focus') && !$('.bread_links').hasClass("hasFocus")) {
+        $('.bread_links a').attr('aria-expanded', false);
+        $('.line_browser').velocity("fadeOut", { duration: 50 });
+      }
+    });
+  });
+
   $('.open_line_browser').click(function(e) {
     e.preventDefault();
     e.stopPropagation();

--- a/app/javascript/gobierto_budgets/modules/application.js
+++ b/app/javascript/gobierto_budgets/modules/application.js
@@ -114,13 +114,15 @@ $(document).on('turbolinks:load', function() {
     $('.line_browser').velocity("fadeIn", { duration: 50 });
   });
 
+
+  // Function to make the menu accessible with the keyboard
   $('#popup-year table tr a').blur(function() {
     $(window).keyup(function (e) {
       var code = (e.keyCode ? e.keyCode : e.which);
       if (code == 9 && $('#popup-year table tr a').not(':focus') && $('.bread_links a').not(':focus')) {
         $('.bread_links').removeClass('hasFocus')
       }
-      if (code == 9 && $('#popup-year table tr a').is(':focus')) {
+      if (code == 9 && $('#popup-year table tr a').is(':focus') || $('.bread_links a').is(':focus')) {
         $('.bread_links').addClass('hasFocus')
       }
       if (code == 9 && $('#popup-year table tr a').not(':focus') && !$('.bread_links').hasClass("hasFocus")) {

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -234,7 +234,7 @@
       <div class="separator"></div>
 
       <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_context_table_enabled %>
-        <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+        <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel">
           <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
             <h2><%= t('.evolution') %></h2>
             <div id="lines_chart"></div>
@@ -258,7 +258,7 @@
       <% end %>
 
       <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_compare_municipalities.any? %>
-        <div id="lines_chart_comparison_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+        <div id="lines_chart_comparison_wrapper" class="pure-g block" data-vis-lines role="tabpanel">
           <div class="pure-u-1 pure-u-md-1-2 p_h_l_1">
             <h2><%= t('.evolution') %></h2>
             <div id="lines_chart_comparison"></div>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -15,7 +15,7 @@
         </div>
 
         <div class="col" data-level="0">
-          <table class="med_bg">
+          <table class="med_bg" role="presentation">
             <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year| %>
               <tr>
                 <td data-code="<%= year %>"><%= link_to year, gobierto_budgets_budgets_path %></td>
@@ -25,27 +25,27 @@
         </div>
 
         <div class="col" data-level="1">
-          <table class="med_bg" data-current-code=""></table>
+          <table class="med_bg" data-current-code="" role="presentation"></table>
         </div>
 
         <div class="col" data-level="2">
-          <table class="med_bg" data-current-code=""></table>
+          <table class="med_bg" data-current-code="" role="presentation"></table>
         </div>
 
         <div class="col" data-level="3">
-          <table class="med_bg" data-current-code=""></table>
+          <table class="med_bg" data-current-code="" role="presentation"></table>
         </div>
 
         <div class="col" data-level="4">
-          <table class="med_bg" data-current-code=""></table>
+          <table class="med_bg" data-current-code="" role="presentation"></table>
         </div>
 
         <div class="col" data-level="5">
-          <table class="med_bg" data-current-code=""></table>
+          <table class="med_bg" data-current-code="" role="presentation"></table>
         </div>
 
         <div class="col" data-level="6">
-          <table class="med_bg" data-current-code=""></table>
+          <table class="med_bg" data-current-code="" role="presentation"></table>
         </div>
       </div>
     </div>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -231,7 +231,7 @@
         </div>
       </div>
 
-      <div id="lines_chart_wrapper_separator" class="separator"></div>
+      <div class="separator"></div>
 
       <% if params[:area_name] != GobiertoBudgets::CustomArea.area_name && budgets_comparison_context_table_enabled %>
         <div id="lines_chart_wrapper" class="pure-g block" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">

--- a/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
+++ b/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
@@ -3,7 +3,7 @@
 <% tabs = ["total_budget"].tap { |this| this.unshift("per_person") if @site_stats.population_data? } %>
 <% i18n_scope ||= "gobierto_budgets.budgets.index" %>
 
-<%= content_tag :div, id: wrapper_id, class: "pure-g", role: "tabpanel", "aria-controlledby": tabs.join(", "), data: {"vis-lines": ""} do -%>
+<%= content_tag :div, id: wrapper_id, class: "pure-g", role: "tabpanel", data: {"vis-lines": ""} do -%>
   <div class=" pure-u-1 pure-u-md-1-2 block" >
     <h2><%= t(:at_a_glance, scope: i18n_scope) %></h2>
 

--- a/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
+++ b/app/views/gobierto_budgets/budgets/_comparison_chart.html.erb
@@ -34,7 +34,6 @@
           role: "tab",
           tabindex: 0,
           "aria-selected": "true",
-          id: "per_person",
           "aria-controls": "lines_chart_wrapper" %>
       <% end %>
       <%= link_to t(:in_total, scope: i18n_scope), "#",
@@ -45,7 +44,6 @@
         role: "tab",
         tabindex:-1,
         "aria-selected": !@site_stats.population_data?,
-        id: "total_budget",
         "aria-controls": "lines_chart_comparison_wrapper" %>
     </div>
   </div>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -300,7 +300,7 @@
 
 
   <% if budgets_comparison_context_table_enabled %>
-    <div id="lines_chart_wrapper_separator" class="separator"></div>
+    <div class="separator"></div>
     <%= render partial: "comparison_chart", locals: { wrapper_id: "lines_chart_wrapper",
                                                       chart_id: "lines_chart",
                                                       tooltip_id: "lines_tooltip",
@@ -311,7 +311,7 @@
   <% end %>
 
   <% if budgets_comparison_compare_municipalities.any? %>
-    <div id="lines_chart_wrapper_separator" class="separator"></div>
+    <div class="separator"></div>
     <%= render partial: "comparison_chart", locals: { wrapper_id: "lines_chart_comparison_wrapper",
                                                       chart_id: "lines_chart_comparison",
                                                       tooltip_id: "lines_tooltip_comparison",

--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -57,7 +57,7 @@
   </div>
 
   <% if budgets_comparison_context_table_enabled %>
-    <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel" aria-controlledby="per_person, total_budget">
+    <div id="lines_chart_wrapper" class="pure-g" data-vis-lines role="tabpanel">
       <div class=" pure-u-1 pure-u-md-1-2 block" >
         <h2><%= t('.at_a_glance') %></h2>
 

--- a/app/views/gobierto_budgets/shared/_compare.html.erb
+++ b/app/views/gobierto_budgets/shared/_compare.html.erb
@@ -1,14 +1,16 @@
 <div id="comparison_widget_wrapper">
   <div class="img-container">
-    <%= image_tag("illustrations/integra.jpg", class: "img-fluid") %>
+    <%= image_tag("illustrations/integra.jpg", alt:'illustration', class: "img-fluid") %>
   </div>
   <div class="box p_1 flex" aria-label="<%= t("gobierto_budgets.budgets.index.budgets_comparision.text", site: @site) %> presupuestos.gobierto.es">
     <div class="compare-text">
       <%= t("gobierto_budgets.budgets.index.budgets_comparision.text", site: @site) %>&nbsp;<strong><%= link_to "presupuestos.gobierto.es", "https://presupuestos.gobierto.es", target: "_blank" %></strong>
     </div>
-    <%= link_to external_comparison_link, target: "_blank" do %>
-      <button><%= t("gobierto_budgets.budgets.index.budgets_comparision.button") %></button>
-    <% end %>
+    <button>
+      <%= link_to external_comparison_link, target: "_blank" do %>
+        <%= t("gobierto_budgets.budgets.index.budgets_comparision.button") %>
+      <% end %>
+    </button>
   </div>
 </div>
 

--- a/app/views/gobierto_budgets/shared/_year_breadcrumb.html.erb
+++ b/app/views/gobierto_budgets/shared/_year_breadcrumb.html.erb
@@ -14,10 +14,10 @@
         </div>
 
         <div class="col" data-level="0">
-          <table class="med_bg">
+          <table class="med_bg" role="presentation">
 
             <% available_years.each do |year| %>
-              <tr role="presentation" >
+              <tr>
                 <td data-code="<%= year %>"><%= link_to year, url_for(current_parameters_with_year(year)) %></td>
               </tr>
             <% end %>

--- a/app/views/gobierto_plans/layouts/_year_breadcrumb.html.erb
+++ b/app/views/gobierto_plans/layouts/_year_breadcrumb.html.erb
@@ -13,9 +13,9 @@
         </div>
 
         <div class="col" data-level="0">
-          <table class="med_bg">
+          <table class="med_bg" role="presentation">
             <% @years.each do |year| %>
-              <tr role="presentation" >
+              <tr>
                 <td data-code="<%= year %>">
                 <%= link_to year, gobierto_plans_plan_path(slug: @plan_type.slug, year: year) %>
                 </td>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="pure-u-1 pure-u-md-9-24">
-        <%= link_to(image_tag(@site.configuration.logo_with_fallback, class: 'logo'), root_url) %>
+        <%= link_to(image_tag(@site.configuration.logo_with_fallback, class: 'logo', alt: @site.name), root_url) %>
       </div>
 
       <div class="pure-u-1 pure-u-md-15-24 custom_html_footer">

--- a/app/views/layouts/_year_breadcrumb.html.erb
+++ b/app/views/layouts/_year_breadcrumb.html.erb
@@ -13,9 +13,9 @@
         </div>
 
         <div class="col" data-level="0">
-          <table class="med_bg">
+          <table class="med_bg" role="presentation">
             <% @years.each do |year| %>
-              <tr role="presentation" >
+              <tr>
                 <td data-code="<%= year %>">
                 <%= link_to year, url_for(current_parameters_with_year(year)) %>
                 </td>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1115


## :v: What does this PR do?

- Remove duplicate `id`
- Include the `alt` attribute in those images where it's necessary. If the image is only decorative isn't required, for example, illustrations.
- Add `role="presentation"` to some `tables`, and remove in `th`.
- Refactor HTML, the tag `a` should always go inside the tag `button`
- Make the dropdown/select accessible so that it can be navigated with the keyboard. 
- Remove non-existent attributes like `aria-controlledby`

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

![navigation-not-work](https://user-images.githubusercontent.com/2649175/94664882-bf10b980-030b-11eb-9cd2-e36d8611a916.gif)

### After this PR

![select_navigation_keyboard](https://user-images.githubusercontent.com/2649175/94664849-b4562480-030b-11eb-93b1-f6fc6d020191.gif)