### PR TITLE
Gobierto Dashboards / Nowrap and padding for date-price columns

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -294,6 +294,22 @@ a.soft_cta:hover {
   padding-bottom: 4em;
 }
 
+.pr0 {
+  padding-right: 0;
+}
+
+.pr1 {
+  padding-right: 1em;
+}
+
+.pl0 {
+  padding-left: 0;
+}
+
+.pl1 {
+  padding-left: 1em;
+}
+
 .pl-xs {
   padding-left: 0.75rem;
 

--- a/app/assets/stylesheets/module-dashboards.scss
+++ b/app/assets/stylesheets/module-dashboards.scss
@@ -170,14 +170,6 @@
       &-text {
         display: block;
       }
-
-      &.padding-right .dashboards-home-main--th-text {
-        padding-right: 1em;
-      }
-
-      &.padding-left .dashboards-home-main--th-text {
-        padding-left: 1em;
-      }
     }
 
     &--td {
@@ -223,13 +215,6 @@
         display: block;
       }
 
-      &.padding-right .dashboards-home-main--td-text {
-        padding-right: 1em;
-      }
-
-      &.padding-left .dashboards-home-main--td-text {
-        padding-left: 1em;
-      }
     }
 
     .largest-width-td {

--- a/app/assets/stylesheets/module-dashboards.scss
+++ b/app/assets/stylesheets/module-dashboards.scss
@@ -167,11 +167,15 @@
         }
       }
 
-      &.padding-right div {
+      &-text {
+        display: block;
+      }
+
+      &.padding-right .dashboards-home-main--th-text {
         padding-right: 1em;
       }
 
-      &.padding-left div {
+      &.padding-left .dashboards-home-main--th-text {
         padding-left: 1em;
       }
     }
@@ -215,11 +219,15 @@
         text-transform: uppercase;
       }
 
-      &.padding-right div {
+      &-text {
+        display: block;
+      }
+
+      &.padding-right .dashboards-home-main--td-text {
         padding-right: 1em;
       }
 
-      &.padding-left div {
+      &.padding-left .dashboards-home-main--td-text {
         padding-left: 1em;
       }
     }

--- a/app/assets/stylesheets/module-dashboards.scss
+++ b/app/assets/stylesheets/module-dashboards.scss
@@ -166,6 +166,14 @@
           padding-right: 20px;
         }
       }
+
+      &.padding-right div {
+        padding-right: 1em;
+      }
+
+      &.padding-left div {
+        padding-left: 1em;
+      }
     }
 
     &--td {
@@ -205,6 +213,14 @@
 
       &:not(:first-child):not(:last-child) > *::first-letter {
         text-transform: uppercase;
+      }
+
+      &.padding-right div {
+        padding-right: 1em;
+      }
+
+      &.padding-left div {
+        padding-left: 1em;
       }
     }
 

--- a/app/javascript/gobierto_dashboards/webapp/components/Table.vue
+++ b/app/javascript/gobierto_dashboards/webapp/components/Table.vue
@@ -8,7 +8,7 @@
           class="dashboards-home-main--th"
           :class="cssClass"
         >
-          <div>{{ translation }}</div>
+          <span class="dashboards-home-main--th-text">{{ translation }}</span>
         </th>
       </thead>
       <TableRow

--- a/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/components/TableRow.vue
@@ -10,7 +10,7 @@
       class="dashboards-home-main--td"
       :class="cssClass"
     >
-      <div>{{ formattedItem[field] }}</div>
+      <span class="dashboards-home-main--td-text">{{ formattedItem[field] }}</span>
     </td>
   </router-link>
 </template>

--- a/app/javascript/gobierto_dashboards/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config/contracts.js
@@ -2,8 +2,8 @@
 export const contractsColumns = [
   { field: 'assignee', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null, cssClass: '' },
   { field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: 'truncated', cssClass: 'largest-width-td' },
-  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'right nowrap padding-right' },
-  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap padding-left' },
+  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'right nowrap pr1' },
+  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap pl1' },
 ];
 
 export const tendersColumns = [
@@ -20,8 +20,8 @@ export const assigneesColumns = [
 
 export const assigneesShowColumns = [
   { field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null, cssClass: '' },
-  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'nowrap padding-right' },
-  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap padding-left' },
+  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'nowrap pr1' },
+  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap pl1' },
 ];
 
 // filters config

--- a/app/javascript/gobierto_dashboards/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config/contracts.js
@@ -20,8 +20,8 @@ export const assigneesColumns = [
 
 export const assigneesShowColumns = [
   { field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null, cssClass: '' },
-  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: '' },
-  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: '' },
+  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'nowrap' },
+  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap' },
 ];
 
 // filters config

--- a/app/javascript/gobierto_dashboards/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_dashboards/webapp/lib/config/contracts.js
@@ -2,8 +2,8 @@
 export const contractsColumns = [
   { field: 'assignee', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null, cssClass: '' },
   { field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.contractor'), format: 'truncated', cssClass: 'largest-width-td' },
-  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'right nowrap' },
-  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap' },
+  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'right nowrap padding-right' },
+  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap padding-left' },
 ];
 
 export const tendersColumns = [
@@ -20,8 +20,8 @@ export const assigneesColumns = [
 
 export const assigneesShowColumns = [
   { field: 'title', translation: I18n.t('gobierto_dashboards.dashboards.contracts.assignee'), format: null, cssClass: '' },
-  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'nowrap' },
-  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap' },
+  { field: 'final_amount_no_taxes', translation: I18n.t('gobierto_dashboards.dashboards.contracts.final_amount_no_taxes'), format: 'currency', cssClass: 'nowrap padding-right' },
+  { field: 'start_date', translation: I18n.t('gobierto_dashboards.dashboards.contracts.date'), format: null, cssClass: 'nowrap padding-left' },
 ];
 
 // filters config


### PR DESCRIPTION
Closes #3378 


## :v: What does this PR do?

- Includes a nowrap `class` for date/price columns, and another `class` for separate these elements with padding.


## :mag: How should this be manually tested?
Staging

## :eyes: Screenshots

### Before this PR

- Nowrap
![gobierto_dashboards_nowrap_before](https://user-images.githubusercontent.com/2649175/94703743-7672f380-033f-11eb-90c5-dc9de1517a27.png)

- Padding
![gobierto_dashboards_padding_before](https://user-images.githubusercontent.com/2649175/94703966-b043fa00-033f-11eb-898b-981bffe0e80a.png)



### After this PR

- Nowrap
![gobierto_dashboards_nowrap_after](https://user-images.githubusercontent.com/2649175/94703821-8db1e100-033f-11eb-9a9c-83099c744234.png)

- Padding
![gobierto_dashboards_padding_after](https://user-images.githubusercontent.com/2649175/94703956-ad490980-033f-11eb-8974-8b03b35a4301.png)
