### PR TITLE
Gobierto Data / Update URL when selecting a category

### DIFF
--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -1052,6 +1052,14 @@
   &-filters-element {
     padding-bottom: 1em;
     border-bottom: 1px solid hsla(0, 0, 59.2%, .5);
+
+    .disabled {
+      pointer-events: none;
+
+      i {
+        display: none;
+      }
+    }
   }
 
   &-filters-element-no-margin {

--- a/app/javascript/gobierto_data/lib/mixins/filters.mixin.js
+++ b/app/javascript/gobierto_data/lib/mixins/filters.mixin.js
@@ -130,8 +130,10 @@ export const FiltersMixin = {
       );
 
       const size = [...checkboxesSelected.values()].filter(Boolean).length;
+      //Filter by those that have at least one element
+      const optionsActive = options.filter(({ counter: element = 0 }) => element > 0 );
       // Update the property when all isEverythingChecked
-      if (size === options.length) {
+      if (size === optionsActive.length) {
         filter.isEverythingChecked = true;
       }
 

--- a/app/javascript/gobierto_data/lib/router.js
+++ b/app/javascript/gobierto_data/lib/router.js
@@ -20,11 +20,17 @@ export const router = new VueRouter({
       name: 'Visualizations'
     },
     {
-      path: '/datos',
+      path: '/datos/',
       component: Main,
       children: [
         {
           path: '',
+          name:'index',
+          component: Index
+        },
+        {
+          path: '/datos/terms/*',
+          name:' terms',
           component: Index
         },
         {

--- a/app/javascript/gobierto_data/webapp/components/Index.vue
+++ b/app/javascript/gobierto_data/webapp/components/Index.vue
@@ -65,7 +65,7 @@ export default {
       topMenu.addEventListener('click', (e) => {
         e.preventDefault()
         // eslint-disable-next-line no-unused-vars
-        this.$router.push('/datos').catch(err => {})
+        this.$router.push('/datos/').catch(err => {})
       })
     }
   }

--- a/app/javascript/gobierto_data/webapp/components/Sidebar.vue
+++ b/app/javascript/gobierto_data/webapp/components/Sidebar.vue
@@ -30,7 +30,7 @@
     <keep-alive>
       <component
         :is="currentTabComponent"
-        :filters="filters"
+        :filters="reFilters"
         :items="items"
       />
     </keep-alive>
@@ -77,6 +77,10 @@ export default {
   },
   created() {
     this.currentTabComponent = COMPONENTS[this.activeTab];
+
+    this.reFilters = this.filters.map((element) => {
+      return { ...element, options: element.options.filter((subElement) => subElement.counter > 0) }
+    })
   },
   methods: {
     activateTab(index) {

--- a/app/javascript/gobierto_data/webapp/components/Sidebar.vue
+++ b/app/javascript/gobierto_data/webapp/components/Sidebar.vue
@@ -30,7 +30,7 @@
     <keep-alive>
       <component
         :is="currentTabComponent"
-        :filters="reFilters"
+        :filters="mutatedFilters"
         :items="items"
       />
     </keep-alive>
@@ -65,7 +65,8 @@ export default {
       labelSets: I18n.t("gobierto_data.projects.sets") || "",
       labelQueries: I18n.t("gobierto_data.projects.queries") || "",
       labelCategories: I18n.t("gobierto_data.projects.categories") || "",
-      currentTabComponent: null
+      currentTabComponent: null,
+      mutatedFilters: []
     };
   },
   watch: {
@@ -78,7 +79,7 @@ export default {
   created() {
     this.currentTabComponent = COMPONENTS[this.activeTab];
 
-    this.reFilters = this.filters.map((element) => {
+    this.mutatedFilters = this.filters.map((element) => {
       return { ...element, options: element.options.filter((subElement) => subElement.counter > 0) }
     })
   },

--- a/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Queries.vue
@@ -48,7 +48,7 @@
         <Dropdown @is-content-visible="showPublicQueries = !showPublicQueries">
           <template v-slot:trigger>
             <h3 class="gobierto-data-summary-queries-panel-title">
-              <Caret :rotate="!showPublicQueries" />
+              <Caret :rotate="showPublicQueries" />
 
               {{ labelAll }}
               <template v-if="publicQueries.length">

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -111,10 +111,6 @@ export default {
       this.checkSelectedCheckbox()
     },
     updateURLwithSelectedCategories(values) {
-      if (this.$route.name === 'Dataset') {
-        // eslint-disable-next-line no-unused-vars
-        this.$router.push('/datos/').catch(err => {})
-      }
 
       const { options: optionsChecked } = values
       const { key } = values
@@ -142,16 +138,9 @@ export default {
       routeItems = [...new Set(routeItems)];
       routeItems = routeItems.toString().replace(/,/gi, '')
 
-      //If the user accesses through a permalink we change the route
-      let backSlashRoute = this.$route.fullPath === '/datos' ? `${this.$route.path}/terms/` : `${this.$route.path}terms/`
-      let urlTerms = this.isPermalinkActive ? `${location.origin}/datos/terms/` : backSlashRoute
-      urlTerms = routeItems.length === 0 ? `${this.$route.path}` : urlTerms
+      // eslint-disable-next-line no-unused-vars
+      this.$router.push(`/datos/terms/${routeItems}`).catch(err => {})
 
-      history.pushState(
-        {},
-        null,
-        `${urlTerms}${routeItems}`
-      )
     },
     getElements(ids) {
       let list = []
@@ -166,15 +155,16 @@ export default {
     reFilterElements(category) {
       let elements = []
       elements = this.filters.filter(({ key }) => key === category)
-      const { options } = elements[0]
+      const [{ options } = {}] = elements || []
       const isItemCounter = options.filter(({ isOptionChecked, counter }) => isOptionChecked === true && counter > 0)
       const getIdFromItemsCounter = [...new Set(isItemCounter.map(({ id }) => id))]
       elements = this.getElements(getIdFromItemsCounter)
       return elements
     },
     selectedCheckbox(values) {
-      //When the user accesses through a permalink we capture the selected elements, select them and filter the datasets
+      //Remove undefined values to prevent error when converting the rest into an array of numbers.
       const categoriesSelected = values.filter(item => item).map(item => +item);
+      //When the user accesses through a permalink we capture the selected elements, select them and filter the datasets
       for (let item of this.filters) {
         item.options.forEach((d) => {
           if (categoriesSelected.includes(d.id)) {

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -5,7 +5,7 @@
       class="gobierto-data-filters"
     >
       <div
-        v-for="filter in filtersModify"
+        v-for="filter in filters"
         :key="filter.title"
         :class="!filter.isToggle ? 'gobierto-data-filters-element-no-margin' : ''"
         class="gobierto-data-filters-element"
@@ -34,6 +34,7 @@
               :title="title"
               :checked="isOptionChecked"
               :counter="counter"
+              :class="counter === 0 ? 'disabled' : ''"
               @checkbox-change="e => sendCheckboxStatus_TEMP({ ...e, filter })"
             />
           </div>
@@ -84,9 +85,6 @@ export default {
       return ((this.filters[0] && (this.filters[0] || {}).count >= 1)
         || (this.filters[1] && (this.filters[1] || {}).count >= 1));
     },
-    filtersModify() {
-      return this.filters.length ? this.filters.map(d => ({ ...d, isToggle: true })) : []
-    },
     isAllChecked() {
       return this.routeItemsFrequency.length !== 0 || this.routeItemsCategory.length !== 0
     }
@@ -104,16 +102,13 @@ export default {
       this.$root.$emit("sendCheckbox_TEMP", { id, value, filter })
 
       this.updateURLwithSelectedCategories(filter)
-      this.checkSelectedCheckbox(filter)
+      this.checkSelectedCheckbox()
     },
     selectAllCheckbox_TEMP({ filter }) {
       this.$root.$emit("selectAll_TEMP", { filter })
 
       this.updateURLwithSelectedCategories(filter)
-      this.checkSelectedCheckbox(filter)
-    },
-    filteredOptions(filter) {
-      return filter.options.filter(({ counter: element = 0 }) => element > 0 );
+      this.checkSelectedCheckbox()
     },
     updateURLwithSelectedCategories(values) {
       if (this.$route.name === 'Dataset') {
@@ -127,6 +122,7 @@ export default {
       const isItemSelected = optionsChecked.filter(({ isOptionChecked, counter }) => isOptionChecked === true && counter > 0)
       //Now we get only the id of them
       const getIdFromItems = [...new Set(isItemSelected.map(({ id }) => id))]
+      this.selectedCheckbox(getIdFromItems)
 
       //Create an array which contains only the id from selected elements
       let routeItems = []

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -28,7 +28,7 @@
           </template>
           <div>
             <Checkbox
-              v-for="{ id, title, isOptionChecked, counter } in filteredOptions(filter)"
+              v-for="{ id, title, isOptionChecked, counter } in filter.options"
               :id="id"
               :key="id"
               :title="title"
@@ -107,7 +107,6 @@ export default {
       this.checkSelectedCheckbox(filter)
     },
     selectAllCheckbox_TEMP({ filter }) {
-      filter.options = this.filteredOptions(filter)
       this.$root.$emit("selectAll_TEMP", { filter })
 
       this.updateURLwithSelectedCategories(filter)

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -163,7 +163,11 @@ export default {
     },
     selectedCheckbox(values) {
       //Remove undefined values to prevent error when converting the rest into an array of numbers.
-      const categoriesSelected = values.filter(item => item).map(item => +item);
+      const categoriesSelected = values.reduce((acc, item) => {
+        if (item) acc.push(+item)
+        return acc
+        },
+      [])
       //When the user accesses through a permalink we capture the selected elements, select them and filter the datasets
       for (let item of this.filters) {
         item.options.forEach((d) => {

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -97,8 +97,10 @@ export default {
     //TODO temporary functions, waiting for the filter refactor
     sendCheckboxStatus_TEMP({ id, value, filter }) {
       this.$root.$emit("sendCheckbox_TEMP", { id, value, filter })
-      // eslint-disable-next-line no-unused-vars
-      this.$router.push('/datos/').catch(err => {})
+      if (!this.$route.params.pathMatch) {
+        // eslint-disable-next-line no-unused-vars
+        this.$router.push('/datos/').catch(err => {})
+      }
       const { key } = filter
       if (key === 'category') {
         this.updateURLwithCategoriesSelected(filter)
@@ -106,6 +108,11 @@ export default {
     },
     selectAllCheckbox_TEMP({ filter }) {
       this.$root.$emit("selectAll_TEMP", { filter })
+
+      const { key } = filter
+      if (key === 'category') {
+        this.updateURLwithCategoriesSelected(filter)
+      }
     },
     filteredOptions(filter) {
       return filter.options.filter(({ counter: element = 0 }) => element > 0 );
@@ -115,7 +122,7 @@ export default {
       const isItemSelected = optionsChecked.filter(({ isOptionChecked }) => isOptionChecked === true)
       const getIdFromItems = [...new Set(isItemSelected.map(({ id }) => id))]
       let routeItems = []
-      for (let index = 0; index < getIdFromItems.length - 1; index++) {
+      for (let index = 0; index < getIdFromItems.length; index++) {
         let item = `${getIdFromItems[index]}:`
         routeItems.push(item)
       }
@@ -128,16 +135,14 @@ export default {
     },
     selectedCheckbox(values) {
       const categoriesSelected = values.filter(item => item).map(item => +item);
-      const categories = this.filters.filter(({ key }) => key === 'category')
-      const filterCategories = categories.map((element) => {
-        return { ...element, options: element.options.filter((option) => categoriesSelected.includes(option.id)) }
+      let categories = this.filters.filter(({ key }) => key === 'category')
+      categories = categories[0]
+      categories.options.forEach((d) => {
+        if (categoriesSelected.includes(d.id)) {
+          d.isOptionChecked = true
+        }
       })
-
-      const [{ options: [{ id }] }] = filterCategories
-      const value = true
-      this.$nextTick(() => {
-        this.$root.$emit("sendCheckbox_TEMP", { id, value, filterCategories })
-      })
+      this.$root.$emit("selectChecboxPermalink_TEMP", categories)
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -23,9 +23,7 @@
               <a
                 class="gobierto-block-header--link"
                 @click.stop="e => selectAllCheckbox_TEMP({ ...e, filter })"
-              >{{
-                filter.isEverythingChecked ? labelNone : labelAll
-              }}</a>
+              >{{ checkIfEverythingChecked(filter.isEverythingChecked) }}</a>
             </div>
           </template>
           <div>
@@ -106,12 +104,14 @@ export default {
       this.$root.$emit("sendCheckbox_TEMP", { id, value, filter })
 
       this.updateURLwithSelectedCategories(filter)
-      this.checkSelectedCheckbox(filter)
+      this.checkSelectedCheckbox()
     },
     selectAllCheckbox_TEMP({ filter }) {
       filter.options = this.filteredOptions(filter)
       this.$root.$emit("selectAll_TEMP", { filter })
+
       this.updateURLwithSelectedCategories(filter)
+      this.checkSelectedCheckbox()
     },
     filteredOptions(filter) {
       return filter.options.filter(({ counter: element = 0 }) => element > 0 );
@@ -154,7 +154,7 @@ export default {
       routeItems = routeItems.toString().replace(/,/gi, '')
 
       //If the user accesses through a permalink we change the route
-      let urlTerms = this.isPermalinkActive ? `${location.origin}/datos/terms/` : `${this.$route.path}/terms/`
+      let urlTerms = this.isPermalinkActive ? `${location.origin}/datos/terms/` : `${this.$route.path}terms/`
       urlTerms = routeItems.length === 0 ? `${this.$route.path}` : urlTerms
 
       history.pushState(
@@ -174,6 +174,7 @@ export default {
         })
         this.$root.$emit("selectCheckboxPermalink_TEMP", item)
       }
+
     },
     checkSelectedCheckbox() {
       //If all checkbox are unselected update URL and goes to datos
@@ -181,6 +182,9 @@ export default {
         // eslint-disable-next-line no-unused-vars
         this.$router.push('/datos/').catch(err => {})
       }
+    },
+    checkIfEverythingChecked(value) {
+      return value === true ? this.labelNone : this.labelAll
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -74,7 +74,8 @@ export default {
       labelQueries: I18n.t("gobierto_data.projects.queries") || '',
       labelCategories: I18n.t("gobierto_data.projects.categories") || '',
       labelAll: I18n.t("gobierto_common.vue_components.block_header.all") || '',
-      labelNone: I18n.t("gobierto_common.vue_components.block_header.none") || ''
+      labelNone: I18n.t("gobierto_common.vue_components.block_header.none") || '',
+      isPermalinkActive: false
     }
   },
   computed: {
@@ -90,6 +91,7 @@ export default {
   created() {
     if (this.$route.params.pathMatch !== undefined) {
       let paramsRouter = this.$route.params.pathMatch.split(':')
+      this.isPermalinkActive = true
       this.selectedCheckbox(paramsRouter)
     }
   },
@@ -97,14 +99,12 @@ export default {
     //TODO temporary functions, waiting for the filter refactor
     sendCheckboxStatus_TEMP({ id, value, filter }) {
       this.$root.$emit("sendCheckbox_TEMP", { id, value, filter })
-      if (!this.$route.params.pathMatch) {
-        // eslint-disable-next-line no-unused-vars
-        this.$router.push('/datos/').catch(err => {})
-      }
-      const { key } = filter
-      if (key === 'category') {
-        this.updateURLwithCategoriesSelected(filter)
-      }
+
+      // eslint-disable-next-line no-unused-vars
+      this.$router.push('/datos/').catch(err => {})
+
+      this.updateURLwithCategoriesSelected(filter)
+      this.checkSelectedCheckbox(filter)
     },
     selectAllCheckbox_TEMP({ filter }) {
       this.$root.$emit("selectAll_TEMP", { filter })
@@ -126,12 +126,14 @@ export default {
         let item = `${getIdFromItems[index]}:`
         routeItems.push(item)
       }
+      let urlTerms = this.isPermalinkActive ? `${location.origin}/datos/terms/` : `${this.$route.path}terms/`
       routeItems = routeItems.toString().replace(/,/gi, '');
-       history.pushState(
-         {},
-         null,
-         `${this.$route.path}terms/${routeItems}`
-       )
+      urlTerms = routeItems.length === 0 ? `${this.$route.path}` : urlTerms
+      history.pushState(
+        {},
+        null,
+        `${urlTerms}${routeItems}`
+      )
     },
     selectedCheckbox(values) {
       const categoriesSelected = values.filter(item => item).map(item => +item);
@@ -143,6 +145,13 @@ export default {
         }
       })
       this.$root.$emit("selectChecboxPermalink_TEMP", categories)
+    },
+    checkSelectedCheckbox(values) {
+      const isItemSelected = values.options.filter(({ isOptionChecked }) => isOptionChecked)
+      if (isItemSelected.length === 0) {
+        // eslint-disable-next-line no-unused-vars
+        this.$router.push('/datos/').catch(err => {})
+      }
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -89,7 +89,7 @@ export default {
     filtersModify() {
       return this.filters.length ? this.filters.map(d => ({ ...d, isToggle: true })) : []
     },
-    isAllUnChecked() {
+    isAllUnchecked() {
       return this.routeItemsFrequency.length !== 0 || this.routeItemsCategory.length !== 0
     }
   },
@@ -105,26 +105,31 @@ export default {
     sendCheckboxStatus_TEMP({ id, value, filter }) {
       this.$root.$emit("sendCheckbox_TEMP", { id, value, filter })
 
-      this.updateURLwithCategoriesSelected(filter)
+      this.updateURLwithSelectedCategories(filter)
       this.checkSelectedCheckbox(filter)
     },
     selectAllCheckbox_TEMP({ filter }) {
       filter.options = this.filteredOptions(filter)
       this.$root.$emit("selectAll_TEMP", { filter })
-      this.updateURLwithCategoriesSelected(filter)
+      this.updateURLwithSelectedCategories(filter)
     },
     filteredOptions(filter) {
       return filter.options.filter(({ counter: element = 0 }) => element > 0 );
     },
-    updateURLwithCategoriesSelected(values) {
+    updateURLwithSelectedCategories(values) {
       if (this.$route.name === 'Dataset') {
         // eslint-disable-next-line no-unused-vars
         this.$router.push('/datos/').catch(err => {})
       }
+
       const { options: optionsChecked } = values
       const { key } = values
+      //We filter by selected elements
       const isItemSelected = optionsChecked.filter(({ isOptionChecked }) => isOptionChecked === true)
+      //Now we get only the id of them
       const getIdFromItems = [...new Set(isItemSelected.map(({ id }) => id))]
+
+      //Create an array which contains only the id from selected elements
       let routeItems = []
       if (key === 'frequency') {
         this.routeItemsFrequency = []
@@ -142,11 +147,16 @@ export default {
         }
       }
 
-      let urlTerms = this.isPermalinkActive ? `${location.origin}/datos/terms/` : `${this.$route.path}terms/`
+      //Create an array with all elements
       routeItems = [...this.routeItemsFrequency, ...this.routeItemsCategory]
+      //Remove duplicate elements, and remove commas
       routeItems = [...new Set(routeItems)];
       routeItems = routeItems.toString().replace(/,/gi, '')
+
+      //If the user accesses through a permalink we change the route
+      let urlTerms = this.isPermalinkActive ? `${location.origin}/datos/terms/` : `${this.$route.path}/terms/`
       urlTerms = routeItems.length === 0 ? `${this.$route.path}` : urlTerms
+
       history.pushState(
         {},
         null,
@@ -154,6 +164,7 @@ export default {
       )
     },
     selectedCheckbox(values) {
+      //When the user accesses through a permalink we capture the selected elements, select them and filter the datasets
       const categoriesSelected = values.filter(item => item).map(item => +item);
       for (let item of this.filters) {
         item.options.forEach((d) => {
@@ -161,11 +172,12 @@ export default {
             d.isOptionChecked = true
           }
         })
-        this.$root.$emit("selectChecboxPermalink_TEMP", item)
+        this.$root.$emit("selectCheckboxPermalink_TEMP", item)
       }
     },
     checkSelectedCheckbox() {
-      if (!this.isAllUnChecked) {
+      //If all checkbox are unselected update URL and goes to datos
+      if (!this.isAllUnchecked) {
         // eslint-disable-next-line no-unused-vars
         this.$router.push('/datos/').catch(err => {})
       }

--- a/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
+++ b/app/javascript/gobierto_data/webapp/components/sidebar/SidebarCategories.vue
@@ -109,12 +109,9 @@ export default {
       this.checkSelectedCheckbox(filter)
     },
     selectAllCheckbox_TEMP({ filter }) {
+      filter.options = this.filteredOptions(filter)
       this.$root.$emit("selectAll_TEMP", { filter })
-
-      const { key } = filter
-      if (key === 'category') {
-        this.updateURLwithCategoriesSelected(filter)
-      }
+      this.updateURLwithCategoriesSelected(filter)
     },
     filteredOptions(filter) {
       return filter.options.filter(({ counter: element = 0 }) => element > 0 );

--- a/app/javascript/gobierto_data/webapp/pages/Main.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Main.vue
@@ -152,13 +152,13 @@ export default {
   created() {
     this.$root.$on("sendCheckbox_TEMP", this.handleCheckboxStatus);
     this.$root.$on("selectAll_TEMP", this.handleIsEverythingChecked);
-    this.$root.$on("selectChecboxPermalink_TEMP", this.handleCheckboxFilter);
+    this.$root.$on("selectCheckboxPermalink_TEMP", this.handleCheckboxFilter);
     this.pageTitle = document.title;
   },
   deactivated() {
     this.$root.$off("sendCheckbox_TEMP");
     this.$root.$off("selectAll_TEMP");
-    this.$root.$off("selectChecboxPermalink_TEMP");
+    this.$root.$off("selectCheckboxPermalink_TEMP");
   }
 };
 </script>

--- a/app/javascript/gobierto_data/webapp/pages/Main.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Main.vue
@@ -152,11 +152,13 @@ export default {
   created() {
     this.$root.$on("sendCheckbox_TEMP", this.handleCheckboxStatus);
     this.$root.$on("selectAll_TEMP", this.handleIsEverythingChecked);
+    this.$root.$on("selectChecboxPermalink_TEMP", this.handleCheckboxFilter);
     this.pageTitle = document.title;
   },
   deactivated() {
     this.$root.$off("sendCheckbox_TEMP");
     this.$root.$off("selectAll_TEMP");
+    this.$root.$off("selectChecboxPermalink_TEMP");
   }
 };
 </script>

--- a/app/javascript/gobierto_data/webapp/pages/Main.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Main.vue
@@ -157,13 +157,6 @@ export default {
   deactivated() {
     this.$root.$off("sendCheckbox_TEMP");
     this.$root.$off("selectAll_TEMP");
-  },
-  methods: {
-    setActiveSidebar() {
-      if (this.$route.name === "Dataset") {
-        this.activeSidebarTab = 1;
-      }
-    }
   }
 };
 </script>

--- a/app/javascript/lib/vue-components/modules/Checkbox.vue
+++ b/app/javascript/lib/vue-components/modules/Checkbox.vue
@@ -59,6 +59,10 @@ export default {
   watch: {
     marked(value) {
       this.$emit("checkbox-change", { id: this.id, value })
+    },
+    //If the user uses selectAll from BlockHeader component, the state of 'marked' doesn't change, so we need to add a 'watcher' for 'checked' and update 'marked' when 'checked' changes.
+    checked(value) {
+      this.marked = value
     }
   }
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -601,7 +601,7 @@ Rails.application.routes.draw do
     # Gobierto Data module
     namespace :gobierto_data, path: "/" do
       constraints GobiertoSiteConstraint.new do
-        get "/datos" => "welcome#index", as: :root
+        get "/datos/" => "welcome#index", as: :root
         get "/datos/v/visualizaciones" => "welcome#index"
         get "/datos/:id" => "welcome#index", as: :datasets
         get "/datos/:id/resumen" => "welcome#index"
@@ -611,6 +611,7 @@ Rails.application.routes.draw do
         get "/datos/:id/visualizaciones" => "welcome#index"
         get "/datos/:id/v/(:queryId)" => "welcome#index"
         get "/datos/:id/descarga" => "welcome#index"
+        get "/datos/terms/(:vocabId)" => "welcome#index"
 
         # API
         namespace :api, path: "/" do


### PR DESCRIPTION
Closes https://github.com/PopulateTools/gobierto/issues/3363

## :v: What does this PR do?

When the user clicks on one or more of the sidebar filters, we update the URL, including the ids of the selected filters.

## :mag: How should this be manually tested?

Staging


## :eyes: Screenshots

### After this PR

![Screen Recording 2020-10-07 at 12 18 27 2020-10-07 12_19_32](https://user-images.githubusercontent.com/2649175/95318859-64410a00-0897-11eb-92bf-09bc013633e2.gif)
