### PR TITLE
Avoid errors if no plan type is available for plans in admin index

### DIFF
--- a/app/views/gobierto_admin/gobierto_plans/plans/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/plans/index.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       </td>
       <td>
-        <%= plan.plan_type.name %>
+        <%= plan.plan_type&.name %>
       </td>
       <td>
         <% if current_admin_can_manage_plans? %>
@@ -103,7 +103,7 @@
             <% end %>
           </td>
           <td>
-            <%= link_to plan.plan_type.name, edit_admin_plans_plan_path(plan) %>
+            <%= plan.plan_type&.name %>
           </td>
           <td>
             <%= plan.title %>

--- a/test/integration/gobierto_admin/gobierto_plans/plans/archive_plan_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/plans/archive_plan_test.rb
@@ -8,6 +8,7 @@ module GobiertoAdmin
       def setup
         super
         @path = admin_plans_plans_path
+        plan.update_attribute(:plan_type_id, plan_type.id)
       end
 
       def admin
@@ -20,6 +21,27 @@ module GobiertoAdmin
 
       def plan
         @plan ||= gobierto_plans_plans(:strategic_plan)
+      end
+
+      def plan_type
+        @plan_type ||= gobierto_plans_plan_types(:pu)
+      end
+
+      def test_archive_plan_and_delete_plan_type
+        with(site: site, admin: admin, js: true) do
+          visit @path
+
+          within "#plan-item-#{plan.id}" do
+            find("a[data-method='delete']").click
+          end
+
+          page.accept_alert
+
+          assert has_message?("Plan archived successfully")
+          plan_type.destroy
+          visit @path
+          assert has_no_content? plan.title
+        end
       end
 
       def test_archive_restore_plan


### PR DESCRIPTION
Closes PopulateTools/issues#1122


## :v: What does this PR do?

* Avoids exceptions in plans index when a deleted plan belongs to a deleted plan type. The application prevents deletion of plan types for existing plans but not for deleted ones (with logical deletion)
* Adds an integration test

## :mag: How should this be manually tested?

Create a plan type and a plan of that type. Delete the plan and then the plan type. Visit plans index. No errors should raise

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
