### PR TITLE
Revert to Amazon SES 0.7.0 to avoid error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "sidekiq-monitor-stats"
 gem "aws-sdk-s3", "~> 1"
 
 # AWS SES client
-gem "aws-ses", "~> 0.7.0"
+gem "aws-ses", "= 0.7.0"
 
 # Calendar view component
 gem "simple_calendar", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-ses (0.7.1)
+    aws-ses (0.7.0)
       builder
       mail (> 2.2.5)
       mime-types
@@ -532,7 +532,7 @@ DEPENDENCIES
   active_model_serializers
   appsignal
   aws-sdk-s3 (~> 1)
-  aws-ses (~> 0.7.0)
+  aws-ses (= 0.7.0)
   bcrypt (~> 3.1.0)
   before_renders
   bootsnap


### PR DESCRIPTION
## :v: What does this PR do?

Reverts Amazon AWS SES version to 0.7.0 due to this error: https://github.com/drewblas/aws-ses/issues/78

Reported in this appsignal notification: https://appsignal.com/populate/sites/5ebb88520264445dc7e68b5c/exceptions/incidents/252?timestamp=2020-10-06T08%3A06%3A12Z
