### PR TITLE
Import budgets task

### DIFF
--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+namespace :gobierto_budgets do
+  namespace :data do
+    desc "Import CSV. Index valid values: forecast, forecast_updated, execution"
+    task :import, [:site_domain, :csv_path, :index, :year] => [:environment] do |_t, args|
+      def get_population(site)
+        from_year = Date.today.year
+        to_year = 2010
+        stats = GobiertoBudgets::SiteStats.new site: site, year: from_year
+        population = stats.population
+        year = from_year
+        while population.nil? && year >= to_year
+          year -= 1
+          population = stats.population(year)
+        end
+        population
+      end
+
+      site = Site.find_by(domain: args[:site_domain])
+
+      if site.nil?
+        puts "[ERROR] No site found for domain: #{args[:site_domain]}"
+        exit -1
+      end
+
+      year = args[:year]
+      if year !~ /\A\d+\z/
+        puts "[ERROR] Invalid year argument: #{year}"
+        exit -1
+      end
+
+      csv_path = args[:csv_path]
+      unless File.file?(csv_path)
+        puts "[ERROR] No CSV file found: #{csv_path}"
+        exit -1
+      end
+
+      index = case args[:index]
+                when "forecast"
+                  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+                when "forecast_updated"
+                  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+                when "execution"
+                  GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED
+                else
+                  puts "[ERROR] Invalid argument index: #{args[:index]}"
+                  exit -1
+                end
+
+      base_data = {
+        organization_id: site.place.id,
+        ine_code: site.place.id.to_i,
+        province_id: site.place.province.id.to_i,
+        autonomous_region_id: site.place.province.autonomous_region.id.to_i,
+        year: year,
+        population: get_population(site)
+      }
+
+      data = []
+      CSV.read(csv_path, headers: true).each do |row|
+        code = row["Codigo"].to_s
+        amount = row["Importe"].to_f.round(2)
+        kind = row["Tipo"]
+        type = row["Area"] == "E" ? GobiertoData::GobiertoBudgets::ECONOMIC_BUDGET_TYPE : GobiertoData::GobiertoBudgets::FUNCTIONAL_BUDGET_TYPE
+        level = code.length
+        parent_code = level == 1 ? nil : code[0..-2]
+
+        data.push(base_data.merge({
+          amount: amount,
+          code: code,
+          level: level,
+          kind: kind,
+          amount_per_inhabitant: (amount / base_data[:population]).round(2),
+          parent_code: parent_code,
+          type: type
+        }).stringify_keys)
+      end
+
+      nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year.to_i, data: data).import!
+      puts "[SUCCESS] Imported #{nitems} in index #{index} for year #{year}"
+
+      action = "budgets_updated"
+      Publishers::GobiertoBudgetsActivity.broadcast_event(action, {
+        action: action,
+        site_id: site.id
+      })
+    end
+  end
+end

--- a/lib/tasks/gobierto_budgets/data/extra_data.rake
+++ b/lib/tasks/gobierto_budgets/data/extra_data.rake
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+namespace :gobierto_budgets do
+  namespace :data do
+    desc "Import CSV with extra data"
+    task :import_extra_data, [:site_domain, :csv_path] => [:environment] do |_t, args|
+      site = Site.find_by(domain: args[:site_domain])
+
+      if site.nil?
+        puts "[ERROR] No site found for domain: #{args[:site_domain]}"
+        exit -1
+      end
+
+      csv_path = args[:csv_path]
+      unless File.file?(csv_path)
+        puts "[ERROR] No CSV file found: #{csv_path}"
+        exit -1
+      end
+
+      CSV.read(csv_path, headers: true).each do |row|
+        year = row["Fecha"].to_s
+        population = row["Habitantes"].to_i
+        debt = row["Deuda"].to_f.round(2)
+
+        place_id = site.place.id
+        id = [place_id, year].join('/')
+        province_id = site.place.province.id.to_i
+        autonomous_region_id = site.place.province.autonomous_region.id.to_i
+
+        item = {
+          "organization_id" => place_id,
+          "ine_code" => place_id,
+          "year" => year,
+          "value" => debt,
+          "province_id" => province_id,
+          "autonomy_id" => autonomous_region_id
+        }
+
+        debt_data = [
+          {
+            index: {
+              _index: GobiertoData::GobiertoBudgets::ES_INDEX_DATA,
+              _type: GobiertoData::GobiertoBudgets::DEBT_TYPE,
+              _id: id,
+              data: item
+            }
+          }
+        ]
+
+        GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: debt_data)
+        puts "[SUCCESS] Debt #{debt} for #{year}"
+
+        item = {
+          "organization_id" => place_id,
+          "ine_code" => place_id,
+          "year" => year,
+          "value" => population,
+          "province_id" => province_id,
+          "autonomy_id" => autonomous_region_id
+        }
+
+        population_data = [
+          {
+            index: {
+              _index: GobiertoData::GobiertoBudgets::ES_INDEX_DATA,
+              _type: GobiertoData::GobiertoBudgets::POPULATION_TYPE,
+              _id: id,
+              data: item
+            }
+          }
+        ]
+        GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: population_data)
+
+        puts "[SUCCESS] Population #{population} for #{year}"
+      end
+    end
+  end
+end

--- a/lib/tasks/gobierto_common/cache.rake
+++ b/lib/tasks/gobierto_common/cache.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :common do
+  desc "Clear cache"
+  task clear_cache: :environment do
+    Rails.cache.clear
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

This PR creates a task to import budgets, debt and population from a CSV.  This was something missing from a long time that let's Gobierto users to have some autonomy to load budgets data (and the required extra data, such as debt and population).

## :mag: How should this be manually tested?

```
# load forecast data for 2020
bin/rails gobierto_budgets:data:import[madrid.gobierto.test,budgets.csv,forecast,2020]

# load debt and population
bin/rails gobierto_budgets:data:import_extra_data[madrid.gobierto.test,extra_data.csv]
```

## :shipit: Does this PR changes any configuration file?

No

## :book: Does this PR require updating the documentation?

Yes, I'll update the documentation with the tasks and the links to the CSV templates.