### PR TITLE
Gobierto Costs / Rename columns and changes the position of the tooltip

### DIFF
--- a/app/javascript/gobierto_dashboards/modules/costs_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/costs_controller.js
@@ -108,7 +108,7 @@ export class CostsController {
       if (amount === '') {
         return nanToZero(amount)
       } else {
-        return Number(parseFloat(amount.replace(/\./g,'').replace(',','.')))
+        return Number(parseFloat(amount))
       }
     }
 
@@ -119,14 +119,14 @@ export class CostsController {
     }
 
     //Array with all the strings that we've to convert to Number
-    const amountStrings = [ 'cost_directe', 'cost_indirecte', 'cost_total', 'cost_per_habitant', 'cost_personal', 'costos_resta_directes', 'ingressos', 'taxa_o_preu_public', 'subvencions', 'ingressos_cost', 'cost_directe_personal', 'cost_directe_bens_i_serveis', 'cost_directe_serveis_exteriors', 'cost_directe_transferencies', 'cost_directe_equipaments', 'cost_directe_financer']
+    const amountStrings = [ 'costdirecte', 'costindirecte', 'costtotal', 'costperhabit', 'costpersonal', 'costrestadir', 'ingressos', 'taxapreupub', 'subvencions', 'ingressos_cost', 'costdirectepers', 'costdirebens', 'costdirservext', 'costdirtransf', 'costdirequip', 'costdirfin']
 
     const population = ['126988']
 
     for (let index = 0; index < rawData.length; index++) {
       let d = rawData[index]
 
-      if (d['any'] === '2019') {
+      if (d['any_'] === '2019') {
         d['population'] = population[0]
       }
 
@@ -135,14 +135,14 @@ export class CostsController {
       }
     }
 
-    let yearsCosts = [...new Set(rawData.map(item => item.any))]
+    let yearsCosts = [...new Set(rawData.map(item => item.any_))]
 
     let groupDataByYears = []
 
     //Create an array of objects with all years
     for (let index = 0; index < yearsCosts.length; index++) {
       const data = rawData.reduce((acc, item) => {
-        if (item.any === yearsCosts[index]) {
+        if (item.any_ === yearsCosts[index]) {
           acc.push({ ...item, population: population[index] })
         }
         return acc
@@ -153,35 +153,35 @@ export class CostsController {
 
     function groupDataByYear(data, year) {
       //Filter groupData by "sumadatos": https://github.com/PopulateTools/issues/issues/1097
-      let dataFilterSum = data.filter(({ suma_datos }) => suma_datos === '')
+      let dataFilterSum = data.filter(({ sumadatos }) => sumadatos === '')
       let groupData = [...dataFilterSum.reduce((r, o) => {
         const key = o.agrupacio
 
         const item = r.get(key) || Object.assign({}, o, {
-          cost_directe: 0,
-          cost_indirecte: 0,
-          cost_total: 0,
+          costdirecte: 0,
+          costindirecte: 0,
+          costtotal: 0,
           ingressos: 0,
           total: 0,
           totalPerHabitant: 0,
           coverage: 0,
         });
 
-        item.cost_directe += o.cost_directe
-        item.cost_indirecte += o.cost_indirecte
-        item.cost_total += o.cost_total
+        item.costdirecte += o.costdirecte
+        item.costindirecte += o.costindirecte
+        item.costtotal += o.costtotal
         item.ingressos += o.ingressos
         //New item with the sum of values of each agrupacio
         item.total += (o.total || 0) + 1
-        item.coverage = (item.ingressos * 100) / item.cost_total
-        item.totalPerHabitant = item.cost_total / o.population
+        item.coverage = (item.ingressos * 100) / item.costtotal
+        item.totalPerHabitant = item.costtotal / o.population
 
         return r.set(key, item);
       }, new Map).values()];
-      return groupData = groupData.filter(({ agrupacio, any }) => agrupacio !== '' && any === year)
+      return groupData = groupData.filter(({ agrupacio, any_ }) => agrupacio !== '' && any_ === year)
     }
 
-    groupDataByYears = groupDataByYears.flat().sort(({ cost_total: a }, { cost_total: b }) => (a > b) ? -1 : 1)
+    groupDataByYears = groupDataByYears.flat().sort(({ costtotal: a }, { costtotal: b }) => (a > b) ? -1 : 1)
 
     this.data = {
       costData: rawData,

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/Distribution.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/Distribution.vue
@@ -96,11 +96,11 @@ export default {
   },
   computed: {
     totalCost() {
-      const total = this.dataFilter.reduce((accum,element) => accum + element.cost_total, 0)
+      const total = this.dataFilter.reduce((accum,element) => accum + element.costtotal, 0)
       return (total / 1000000).toFixed(1).replace(/\./, ',') + ' M€';
     },
     totalCostPerHabitant() {
-      return this.dataFilter.reduce((accum,element) => accum + element.cost_total, 0) / this.population
+      return this.dataFilter.reduce((accum,element) => accum + element.costtotal, 0) / this.population
     }
   },
   watch: {
@@ -126,7 +126,7 @@ export default {
   },
   methods: {
     updateYear(value) {
-      this.dataFilter = this.data.filter(element => element.any === value)
+      this.dataFilter = this.data.filter(element => element.any_ === value)
       const [{
         population: population
       }] = this.dataFilter

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/Home.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/Home.vue
@@ -97,8 +97,8 @@ export default {
     if (!year) yearFiltered = '2019'
     this.yearFiltered = yearFiltered
 
-    const costDataFilter = this.costData.filter(element => element.any === yearFiltered).sort((a, b) => (a.cost_total > b.cost_total) ? -1 : 1)
-    const groupDataFilter = this.groupData.filter(element => element.any === yearFiltered).sort((a, b) => (a.cost_total > b.cost_total) ? -1 : 1)
+    const costDataFilter = this.costData.filter(element => element.any_ === yearFiltered).sort((a, b) => (a.costtotal > b.costtotal) ? -1 : 1)
+    const groupDataFilter = this.groupData.filter(element => element.any_ === yearFiltered).sort((a, b) => (a.costtotal > b.costtotal) ? -1 : 1)
 
     this.costDataFilter = costDataFilter
     this.groupDataFilter = groupDataFilter
@@ -118,8 +118,8 @@ export default {
         year = value.target.value
         this.yearFiltered = value.target.value
       }
-      const costDataFilter = this.costData.filter(element => element.any === year)
-      const groupDataFilter = this.groupData.filter(element => element.any === year)
+      const costDataFilter = this.costData.filter(element => element.any_ === year)
+      const groupDataFilter = this.groupData.filter(element => element.any_ === year)
 
       this.costDataFilter = costDataFilter
       this.groupDataFilter = groupDataFilter
@@ -133,8 +133,8 @@ export default {
         const {
           target: {
             __data__: {
-              ordre_agrupacio: order,
-              any: year
+              ordreagrup: order,
+              year: year
             }
           }
         } = e

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/Table.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/Table.vue
@@ -94,7 +94,7 @@ export default {
       this.currentComponent = COMPONENTS_TABLE[value];
     },
     changeTitleSecondLevel(id) {
-      const filterItems = this.itemsFilter.filter(element => element.ordre_agrupacio === id)
+      const filterItems = this.itemsFilter.filter(element => element.ordreagrup === id)
 
       const [{
         agrupacio: titleAgrupacio

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableFirstLevel.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableFirstLevel.vue
@@ -4,13 +4,13 @@
     <table class="gobierto-dashboards-table gobierto-dashboards-table-first-level">
       <tbody>
         <tr
-          v-for="{ agrupacio, cost_directe, cost_indirecte, cost_total, cost_per_habitant, ingressos, coverage, ordre_agrupacio, totalPerHabitant, any } in itemsFilter"
+          v-for="{ agrupacio, costdirecte, costindirecte, costtotal, costperhabit, ingressos, coverage, ordreagrup, totalPerHabitant, any_ } in itemsFilter"
           :key="agrupacio"
           class="gobierto-dashboards-tablerow--header"
         >
           <td class="gobierto-dashboards-table-header--nav">
             <router-link
-              :to="{ name: 'TableSecondLevel', params: { id: ordre_agrupacio, year: any, description: agrupacio } }"
+              :to="{ name: 'TableSecondLevel', params: { id: ordreagrup, year: any_, description: agrupacio } }"
               class="gobierto-dashboards-table-header--link"
               @click.native="loadTable"
             >
@@ -21,19 +21,19 @@
             :data-th="labelCostDirect"
             class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-direct"
           >
-            <span>{{ cost_directe | money }}</span>
+            <span>{{ costdirecte | money }}</span>
           </td>
           <td
             :data-th="labelCostIndirect"
             class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-indirect"
           >
-            <span>{{ cost_indirecte | money }}</span>
+            <span>{{ costindirecte | money }}</span>
           </td>
           <td
             :data-th="labelCostTotal"
             class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-total"
           >
-            <span>{{ cost_total | money }}</span>
+            <span>{{ costtotal | money }}</span>
           </td>
           <td
             :data-th="labelCostInhabitant"

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableHeader.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableHeader.vue
@@ -59,12 +59,12 @@ export default {
       {
         item: I18n.t("gobierto_dashboards.dashboards.costs.total") || "",
         classItem: 'total',
-        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.costtotal") || ""
+        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.cost_total") || ""
       },
       {
         item: I18n.t("gobierto_dashboards.dashboards.costs.cost_inhabitant") || "",
         classItem: 'inhabitant',
-        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.costperhabit") || ""
+        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.cost_per_habitant") || ""
       },
       {
         item: I18n.t("gobierto_dashboards.dashboards.costs.income") || "",

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableHeader.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableHeader.vue
@@ -59,12 +59,12 @@ export default {
       {
         item: I18n.t("gobierto_dashboards.dashboards.costs.total") || "",
         classItem: 'total',
-        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.cost_total") || ""
+        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.costtotal") || ""
       },
       {
         item: I18n.t("gobierto_dashboards.dashboards.costs.cost_inhabitant") || "",
         classItem: 'inhabitant',
-        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.cost_per_habitant") || ""
+        tooltipText: I18n.t("gobierto_dashboards.dashboards.costs.tooltips.costperhabit") || ""
       },
       {
         item: I18n.t("gobierto_dashboards.dashboards.costs.income") || "",

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableItem.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableItem.vue
@@ -258,19 +258,6 @@
                   {{ subsidies | money }}
                 </span>
               </div>
-              <i
-                class="far fa-question-circle"
-                style="color: var(--color-base); cursor: pointer;"
-                @mouseover="showTooltipItem = labelSubsidies"
-                @mouseleave="showTooltipItem = null"
-              >
-                <div
-                  v-show="showTooltipItem === labelSubsidies"
-                  class="gobierto-dashboards-item--tooltip"
-                >
-                  {{ tooltipTextIncomeCost }}
-                </div>
-              </i>
             </div>
             <div class="gobierto-dashboards-table-item-right-table-element gobierto-dashboards-table-item-right-table-element-bold">
               <div class="gobierto-dashboards-table-item-right-table-container">
@@ -281,6 +268,19 @@
                   {{ totalIncomes | money }}
                 </span>
               </div>
+              <i
+                class="far fa-question-circle"
+                style="color: var(--color-base); cursor: pointer;"
+                @mouseover="showTooltipItem = labelSubsidies"
+                @mouseleave="showTooltipItem = null"
+              >
+                <div
+                  v-show="showTooltipItem === labelSubsidies"
+                  class="gobierto-dashboards-item--tooltip"
+                >
+                  {{ tooltipTextSubvencions }}
+                </div>
+              </i>
             </div>
           </div>
         </div>
@@ -429,25 +429,25 @@ export default {
   methods: {
     agrupacioData(id) {
       const yearFiltered = this.year
-      this.dataGroup = this.items.filter(element => element.codiact === id && element.any === yearFiltered)
+      this.dataGroup = this.items.filter(element => element.codiact === id && element.any_ === yearFiltered)
 
       const [{
         descripcio: description,
         competencia: competence,
         tipus_de_competencia: types,
         marc_legal: legal,
-        cost_indirecte: costIndirect,
-        cost_directe_personal: costPersonal,
-        cost_directe_bens_i_serveis: goodServices,
-        cost_directe_serveis_exteriors: externalServices,
-        cost_directe_transferencies: transferences,
-        cost_directe_equipaments: equiptments,
-        taxa_o_preu_public: taxs,
+        costindirecte: costIndirect,
+        costdirectepers: costPersonal,
+        costdirebens: goodServices,
+        costdirservext: externalServices,
+        costdirtransf: transferences,
+        costdirequip: equiptments,
+        taxapreupub: taxs,
         subvencions: subsidies,
         ingressos_cost: incomeCost,
         ingressos: income,
         agrupacio: agrupacio,
-        cost_total: costTotal
+        costtotal: costTotal
       }] = this.dataGroup
 
       this.description = description

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableItem.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableItem.vue
@@ -434,8 +434,8 @@ export default {
       const [{
         descripcio: description,
         competencia: competence,
-        tipus_de_competencia: types,
-        marc_legal: legal,
+        tipus: types,
+        marclegal: legal,
         costindirecte: costIndirect,
         costdirectepers: costPersonal,
         costdirebens: goodServices,

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableRow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableRow.vue
@@ -221,7 +221,9 @@ export default {
       this.$emit('loadTable', value)
     },
     calculateCoverage(income, cost) {
-      return ((income * 100) / cost).toFixed(0)
+      let coverage = ((income * 100) / cost).toFixed(2)
+      coverage = +coverage
+      return coverage === 0 ? coverage.toFixed(0) : coverage.toFixed(2)
     }
   }
 }

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableRow.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableRow.vue
@@ -3,7 +3,7 @@
     class="gobierto-dashboards-table"
     :class="{'gobierto-dashboards-table--subheader': blueHeader }"
   >
-    <template v-for="{ nomact, codiact, cost_directe, cost_indirecte, cost_total, total, index, cost_per_habitant, ingressos, act_intermitja, agrupacio, ordre_agrupacio, totalPerHabitant, any } in items">
+    <template v-for="{ nomact, codiact, costdirecte, costindirecte, costtotal, total, index, costperhabit, ingressos, actintermitja, agrupacio, ordreagrup, totalPerHabitant, any_ } in items">
       <tr
         :key="nomact"
         class="gobierto-dashboards-tablerow--header"
@@ -12,7 +12,7 @@
         <template v-if="total > 0 && !tableHeader">
           <td
             class="gobierto-dashboards-table-header--nav"
-            @click="handleToggle(act_intermitja)"
+            @click="handleToggle(actintermitja)"
           >
             <div class="gobierto-dashboards-table-header--nav-has-children">
               <span class="gobierto-dashboards-table-header--nav-text">{{ nomact }}</span>
@@ -33,7 +33,7 @@
         <template v-else>
           <td class="gobierto-dashboards-table-header--nav">
             <router-link
-              :to="{ name: 'TableItem', params: { item: codiact, id: ordre_agrupacio, section: agrupacio, year: any, description: nomact } }"
+              :to="{ name: 'TableItem', params: { item: codiact, id: ordreagrup, section: agrupacio, year: any_, description: nomact } }"
               class="gobierto-dashboards-table-header--link"
               tag="a"
               @click.native="loadTable(2)"
@@ -46,19 +46,19 @@
           :data-th="labelCostDirect"
           class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-direct"
         >
-          <span>{{ cost_directe | money }}</span>
+          <span>{{ costdirecte | money }}</span>
         </td>
         <td
           :data-th="labelCostIndirect"
           class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-indirect"
         >
-          <span>{{ cost_indirecte | money }}</span>
+          <span>{{ costindirecte | money }}</span>
         </td>
         <td
           :data-th="labelCostTotal"
           class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-total"
         >
-          <span>{{ cost_total | money }}</span>
+          <span>{{ costtotal | money }}</span>
         </td>
         <template v-if="total > 0">
           <td
@@ -73,7 +73,7 @@
             :data-th="labelCostInhabitant"
             class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-inhabitant"
           >
-            <span>{{ cost_per_habitant | money }}</span>
+            <span>{{ costperhabit | money }}</span>
           </td>
         </template>
         <td
@@ -86,22 +86,22 @@
           :data-th="labelCoverage"
           class="gobierto-dashboards-table-header--elements gobierto-dashboards-table-color-coverage"
         >
-          <span>{{ calculateCoverage(ingressos, cost_total) }}%</span>
+          <span>{{ calculateCoverage(ingressos, costtotal) }}%</span>
         </td>
       </tr>
-      <template v-if="showChildren && selectedToggle === act_intermitja">
+      <template v-if="showChildren && selectedToggle === actintermitja">
         <tbody
           :key="codiact"
           class="gobierto-dashboards-table--secondlevel gobierto-dashboards-table--secondlevel-nested"
         >
           <tr
-            v-for="{ nomact, codiact, cost_directe, cost_indirecte, cost_total, total, index, cost_per_habitant, ingressos, coverage, agrupacio, ordre_agrupacio, any } in subItems"
+            v-for="{ nomact, codiact, costdirecte, costindirecte, costtotal, total, index, costperhabit, ingressos, coverage, agrupacio, ordreagrup, any_ } in subItems"
             :key="codiact"
             class="gobierto-dashboards-tablerow--header"
           >
             <td class="gobierto-dashboards-table--secondlevel-elements gobierto-dashboards-table-header--nav">
               <router-link
-                :to="{ name: 'TableItem', params: { item: codiact, id: ordre_agrupacio, section: agrupacio, year: any, description: nomact } }"
+                :to="{ name: 'TableItem', params: { item: codiact, id: ordreagrup, section: agrupacio, year: any_, description: nomact } }"
                 class="gobierto-dashboards-table-header--link"
                 tag="a"
                 @click="loadTable(2)"
@@ -113,25 +113,25 @@
               :data-th="labelCostDirect"
               class="gobierto-dashboards-table-header--elements gobierto-dashboards-table--secondlevel-elements gobierto-dashboards-table-color-direct"
             >
-              <span>{{ cost_directe | money }}</span>
+              <span>{{ costdirecte | money }}</span>
             </td>
             <td
               :data-th="labelCostIndirect"
               class="gobierto-dashboards-table-header--elements gobierto-dashboards-table--secondlevel-elements gobierto-dashboards-table-color-indirect"
             >
-              <span>{{ cost_indirecte | money }}</span>
+              <span>{{ costindirecte | money }}</span>
             </td>
             <td
               :data-th="labelCostTotal"
               class="gobierto-dashboards-table-header--elements gobierto-dashboards-table--secondlevel-elements gobierto-dashboards-table-color-total"
             >
-              <span>{{ cost_total | money }}</span>
+              <span>{{ costtotal | money }}</span>
             </td>
             <td
               :data-th="labelCostInhabitant"
               class="gobierto-dashboards-table-header--elements gobierto-dashboards-table--secondlevel-elements gobierto-dashboards-table-color-inhabitant"
             >
-              <span>{{ cost_per_habitant | money }}</span>
+              <span>{{ costperhabit | money }}</span>
             </td>
             <td
               :data-th="labelIncome"
@@ -143,7 +143,7 @@
               :data-th="labelCoverage"
               class="gobierto-dashboards-table-header--elements gobierto-dashboards-table--secondlevel-elements gobierto-dashboards-table-color-coverage"
             >
-              <span>{{ calculateCoverage(ingressos, cost_total) }}%</span>
+              <span>{{ calculateCoverage(ingressos, costtotal) }}%</span>
             </td>
           </tr>
         </tbody>

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableSecondLevel.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableSecondLevel.vue
@@ -88,39 +88,39 @@ export default {
   methods: {
     intermediaData() {
       const filterActIntermedia = this.$route.params.id
-      let dataAgrupacio = this.items.filter(element => element.ordre_agrupacio === filterActIntermedia)
-      let dataActIntermedia = dataAgrupacio.filter(element => element.act_intermitja !== '')
+      let dataAgrupacio = this.items.filter(element => element.ordreagrup === filterActIntermedia)
+      let dataActIntermedia = dataAgrupacio.filter(element => element.actintermitja !== '')
       let dataActIntermediaValues = [...dataActIntermedia.reduce((r, o) => {
-        let key = o.act_intermitja
+        let key = o.actintermitja
 
         const item = r.get(key) || Object.assign({}, o, {
-          cost_directe: 0,
-          cost_indirecte: 0,
-          cost_total: 0,
+          costdirecte: 0,
+          costindirecte: 0,
+          costtotal: 0,
           ingressos: 0,
           total: 0,
           nomact: '',
           totalPerHabitant: 0
         });
 
-        item.cost_directe += o.cost_directe
-        item.cost_indirecte += o.cost_indirecte
-        item.cost_total += o.cost_total
+        item.costdirecte += o.costdirecte
+        item.costindirecte += o.costindirecte
+        item.costtotal += o.costtotal
         item.ingressos += o.ingressos
         item.total += (o.total || 0) + 1
-        item.nomact = o.act_intermitja
-        item.totalPerHabitant = item.cost_total / o.population
+        item.nomact = o.actintermitja
+        item.totalPerHabitant = item.costtotal / o.population
 
         return r.set(key, item);
       }, new Map).values()];
 
-      const dataActIntermediaWithoutValues = dataAgrupacio.filter(element => element.act_intermitja === '')
-      dataActIntermediaValues = dataActIntermediaValues.sort((a, b) => (a.cost_total > b.cost_total) ? -1 : 1)
+      const dataActIntermediaWithoutValues = dataAgrupacio.filter(element => element.actintermitja === '')
+      dataActIntermediaValues = dataActIntermediaValues.sort((a, b) => (a.costtotal > b.costtotal) ? -1 : 1)
       this.dataActIntermediaTotal = [...dataActIntermediaValues, ...dataActIntermediaWithoutValues]
 
     },
     agrupacioDataFilter(actIntermedia) {
-      const dataGroupIntermedia = this.items.filter(element => element.act_intermitja === actIntermedia)
+      const dataGroupIntermedia = this.items.filter(element => element.actintermitja === actIntermedia)
       this.dataGroupIntermedia = dataGroupIntermedia
       if (actIntermedia === '') {
         this.totalElements = 0

--- a/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableSubHeader.vue
+++ b/app/javascript/gobierto_dashboards/webapp/containers/costs/table/TableSubHeader.vue
@@ -53,7 +53,7 @@ export default {
   },
   methods: {
     agrupacioData(id) {
-      this.dataGroup = this.items.filter(element => element.ordre_agrupacio === id)
+      this.dataGroup = this.items.filter(element => element.ordreagrup === id)
     }
   }
 }

--- a/app/javascript/lib/visualizations/modules/bubble_cost.js
+++ b/app/javascript/lib/visualizations/modules/bubble_cost.js
@@ -98,20 +98,20 @@ export class VisBubble {
       this.nodes = rawData.map(function (d) {
         return {
           id: d.agrupacio,
-          radius: (+d.cost_total / (d.population * this.radiusReponsive)),
+          radius: (+d.costtotal / (d.population * this.radiusReponsive)),
           x: Math.random() * 600,
-          y: this.nodeScale(+d.cost_total / (d.population * this.radiusReponsive)),
-          cost_total: d.cost_total,
-          year: d.year,
-          ordre_agrupacio: +d.ordre_agrupacio,
-          cost_per_habitant: (d.cost_total / d.population).toFixed(2)
+          y: this.nodeScale(+d.costtotal / (d.population * this.radiusReponsive)),
+          costtotal: d.costtotal,
+          year: d.any_,
+          ordreagrup: d.ordreagrup,
+          costperhabit: (d.costtotal / d.population).toFixed(2)
         };
       }.bind(this))
     } else {
       this.nodes.forEach(function(d) {
         d.id = d.agrupacio,
-        d.radius = (+d.cost_total / (d.population * this.radiusReponsive)),
-        d.cost_per_habitant = (d.cost_total / d.population).toFixed(2)
+        d.radius = (+d.costtotal / (d.population * this.radiusReponsive)),
+        d.costperhabit = (d.costtotal / d.population).toFixed(2)
       }.bind(this))
     }
 
@@ -148,7 +148,7 @@ export class VisBubble {
   updateRender() {
 
     const year = this.year
-    const data = this.data.filter(element => element.any === year)
+    const data = this.data.filter(element => element.any_ === year)
 
     // var budgetCategory = this.budget_category;
     this.nodes = this.createNodes(data, year);
@@ -170,13 +170,13 @@ export class VisBubble {
 
     var bubblesG = this.bubbles.append('a')
       .attr('xlink:href', function(d) {
-        return `/dashboards/costes/${d.year}/${d.ordre_agrupacio}`
+        return `/dashboards/costes/${d.year}/${d.ordreagrup}`
       }.bind(this))
       .attr('target', '_top')
       .attr('class', 'bubbles-links')
       .append('circle')
       .attr('class', d => `${d.year} bubble`)
-      .attr('data-order', d => d.ordre_agrupacio)
+      .attr('data-order', d => d.ordreagrup)
       .attr('data-year', d => d.year)
       .attr('r', d => d.radius)
       .attr('fill', function(d) { return this.budgetColor(d.radius)}.bind(this))
@@ -210,8 +210,8 @@ export class VisBubble {
       .style('top', `${y + 40}px`)
 
     this.tooltip.html(`<div class="line-name"><strong>${d.id}</strong></div>
-                      <div>${I18n.t('gobierto_dashboards.dashboards.costs.total_cost')}: ${accounting.formatMoney(d.cost_total, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator"))}</div>
-                        ${d.cost_per_habitant}€ ${I18n.t('gobierto_dashboards.dashboards.costs.per_inhabitant')}`);
+                      <div>${I18n.t('gobierto_dashboards.dashboards.costs.total_cost')}: ${accounting.formatMoney(d.costtotal, "€", 0, I18n.t("number.currency.format.delimiter"), I18n.t("number.currency.format.separator"))}</div>
+                        ${d.costperhabit}€ ${I18n.t('gobierto_dashboards.dashboards.costs.per_inhabitant')}`);
   }
 
   _mouseleft() {


### PR DESCRIPTION
Closes #N


## :v: What does this PR do?

- Remap the columns of the costs_dataset.
- Change the position of the income's tooltip in the table item. 


## :mag: How should this be manually tested?

Staging