### PR TITLE
HTTP cache dataset queries

### DIFF
--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -36,7 +36,7 @@ module User::ApiAuthenticationHelper
   end
 
   def internal_site_request?
-    @internal_site_request ||= Site.where(domain: request.host).exists?
+    @internal_site_request ||= request.host == current_site.domain || Site.where(domain: request.host).exists?
   end
 
   def find_current_user

--- a/app/models/gobierto_data/cache.rb
+++ b/app/models/gobierto_data/cache.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class Cache
+    def self.etag(str, current_site)
+      current_site.datasets.cache_key + Digest::MD5.hexdigest(str)
+    end
+
+    def self.last_modified(current_site)
+      current_site.datasets.select("MAX(updated_at) as timestamp").to_a.first.timestamp
+    end
+  end
+end
+

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -115,9 +115,8 @@ class Site < ApplicationRecord
   end
 
   def self.find_by_allowed_domain(domain)
-    unless reserved_domains.include?(domain)
-      find_by(domain: domain)
-    end
+    @cached_sites ||= {}
+    @cached_sites[domain] ||= find_by(domain: domain) unless reserved_domains.include?(domain)
   end
 
   def issues

--- a/test/models/gobierto_data/cache_test.rb
+++ b/test/models/gobierto_data/cache_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  class CacheTest < ActiveSupport::TestCase
+    def dataset
+      @dataset ||= gobierto_data_datasets(:users_dataset)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    def test_etag_updated_by_updating_param
+      etag_old = GobiertoData::Cache.etag("foo", site)
+      etag_new = GobiertoData::Cache.etag("bar", site)
+      refute_equal etag_old, etag_new
+    end
+
+    def test_last_modified_updated
+      last_modified_old = nil
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
+        last_modified_old = GobiertoData::Cache.last_modified(site)
+      end
+      dataset.touch
+      last_modified_new = GobiertoData::Cache.last_modified(site)
+      refute_equal last_modified_old, last_modified_new
+    end
+  end
+end


### PR DESCRIPTION
Closes #2854 

## :v: What does this PR do?

This PR adds proper HTTP caching to queries endpoint, providing a custom Etag and Last Modified time to help the browser caching. It also deals with http caching in the server side, to prevent running the whole request if the cache hasn't expired.

It also introduces

- a class that will be helpful to cache the queries in the server
- memoizes sites, to prevent the query that loads a site by domain for each request
- halts internal domain check in case to check first with current site (which happens quite often) and prevents another query

Therefore, when a query is properly cached, just a single query is done in the database, and times are really fast:

```
I, [2020-10-16T13:04:48.277394 #1171931]  INFO -- : [mataro.gobify.net] [0933dd4d-b341-41d4-838b-8f4c0a8442a6] Started GET "/api/v1/data/data.csv?sql=select%20*%20from%20costes" for 47.62.73.183 at 2020-10-16 13:04:48 +0200
I, [2020-10-16T13:04:48.302323 #1171931]  INFO -- : [mataro.gobify.net] [0933dd4d-b341-41d4-838b-8f4c0a8442a6] Processing by GobiertoData::Api::V1::QueryController#index as CSV
I, [2020-10-16T13:04:48.302471 #1171931]  INFO -- : [mataro.gobify.net] [0933dd4d-b341-41d4-838b-8f4c0a8442a6]   Parameters: {"sql"=>"select * from costes"}
D, [2020-10-16T13:04:48.307010 #1171931] DEBUG -- : [mataro.gobify.net] [0933dd4d-b341-41d4-838b-8f4c0a8442a6]   GobiertoData::Dataset Load (0.9ms)  SELECT MAX(updated_at) as timestamp FROM "gdata_datasets" WHERE "gdata_datasets"."site_id" = $1  [["site_id", 8]]
I, [2020-10-16T13:04:48.308653 #1171931]  INFO -- : [mataro.gobify.net] [0933dd4d-b341-41d4-838b-8f4c0a8442a6] Completed 304 Not Modified in 6ms (ActiveRecord: 0.9ms | Allocations: 768)
```

## :mag: How should this be manually tested?

Play around with queries in Gobierto Data, now when you get a 304 Not Modified it's a really cached