### PR TITLE
Fix buble legend error on client

### DIFF
--- a/app/javascript/lib/visualizations/modules/bubble_legend.js
+++ b/app/javascript/lib/visualizations/modules/bubble_legend.js
@@ -64,7 +64,7 @@ export class VisBubbleLegend {
       .enter()
       .append('stop')
       .attr('stop-color', d => d)
-      .attr('offset', d => `scale(${d})%`);
+      .attr('offset', d => { return scale(d) + '%'; });
 
     svg.append('line')
       .attr('transform', 'translate(' + width / 2 + ',' + 0 + ')')

--- a/app/javascript/lib/visualizations/modules/bubble_legend.js
+++ b/app/javascript/lib/visualizations/modules/bubble_legend.js
@@ -64,7 +64,7 @@ export class VisBubbleLegend {
       .enter()
       .append('stop')
       .attr('stop-color', d => d)
-      .attr('offset', d => { return scale(d) + '%'; });
+      .attr('offset', d => `${scale(d)}%`);
 
     svg.append('line')
       .attr('transform', 'translate(' + width / 2 + ',' + 0 + ')')


### PR DESCRIPTION
## :v: What does this PR do?

Fix error `attr.js:31 Error: <stop> attribute offset: Expected number or percentage, "scale(#b2182b)%".` than hides color of vertical legend on bubbles widget

## :mag: How should this be manually tested?

Open a gobierto instance with two or more budgets and bubbles generated

### Before this PR

![Captura de pantalla de 2020-10-19 10-53-45](https://user-images.githubusercontent.com/747459/96423359-83c22600-11f9-11eb-8313-a1494966a00b.png)

### After this PR

![Captura de pantalla de 2020-10-19 10-53-35](https://user-images.githubusercontent.com/747459/96423417-989eb980-11f9-11eb-90cc-d24e9cfb2b02.png)

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
