### PR TITLE
Reduce JS translations bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,7 @@ yarn-debug.log*
 .yarn-integrity
 
 # I18njs
-app/javascript/i18n/modules/translations.js
-app/javascript/lib/i18n/modules/translations.js
+app/javascript/lib/i18n/modules/*
 
 # Gobierto Engines
 vendor/gobierto_engines/*

--- a/app/javascript/lib/i18n/index.js
+++ b/app/javascript/lib/i18n/index.js
@@ -1,1 +1,1 @@
-import './modules/translations.js'
+import(`./modules/translations_${I18n.locale}`);

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -27,4 +27,5 @@
 #
 export_i18n_js: false
 translations:
-  - file: "app/javascript/lib/i18n/modules/translations.js"
+  - file: "app/javascript/lib/i18n/modules/translations_%{locale}.js"
+    only: '*'


### PR DESCRIPTION
Closes https://github.com/PopulateTools/gobierto/issues/2687

## :v: What does this PR do?

It creates a javascript translation file for each locale. Then, using webpack's dynamic loading it creates a bundle for each locale and only loads the translations of the current locale. 

By doing this we'll be saving around **86Kb of gzipped Javascript** (downloading and parsing). On the other hand we are going to do an extra request since the translations bundle will be loaded "on demand" (handled by webpack). 

## :mag: How should this be manually tested?

- Check that the frontend translations work (make sure that you go to a place where frontend translations are used, most of the views use backend provided translations).

- Check changing your locale.

## :eyes: Screenshots

These screenshots were generated with webpack-analyzer-plugin in production mode.

### Before this PR

![Screen Shot 2020-10-20 at 09 00 21](https://user-images.githubusercontent.com/935744/96552718-115e4e00-12ac-11eb-8acc-1ce67ea7a8e1.png)

### After this PR

![Screen Shot 2020-10-20 at 09 05 31](https://user-images.githubusercontent.com/935744/96552740-1ae7b600-12ac-11eb-8368-4699f22f3e8d.png)
![Screen Shot 2020-10-20 at 09 05 38](https://user-images.githubusercontent.com/935744/96552746-1c18e300-12ac-11eb-9ac6-ee87df9b1557.png)
![Screen Shot 2020-10-20 at 09 05 44](https://user-images.githubusercontent.com/935744/96552751-1d4a1000-12ac-11eb-8779-b5c22ae7bf90.png)

## :shipit: Does this PR changes any configuration file?

🧘‍♂️ 

## :book: Does this PR require updating the documentation?

🧘‍♂️ 