### PR TITLE
Disable cache key recycling

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -115,8 +115,7 @@ class Site < ApplicationRecord
   end
 
   def self.find_by_allowed_domain(domain)
-    @cached_sites ||= {}
-    @cached_sites[domain] ||= find_by(domain: domain) unless reserved_domains.include?(domain)
+    find_by(domain: domain) unless reserved_domains.include?(domain)
   end
 
   def issues

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -25,3 +25,7 @@ Rails.application.config.ssl_options = { hsts: { subdomains: true } }
 # Unknown asset fallback will return the path passed in when the given
 # asset is not present in the asset pipeline.
 Rails.application.config.assets.unknown_asset_fallback = false
+
+# Disable cache versioning
+# https://github.com/rails/rails/pull/34378/files
+ActiveRecord::Base.collection_cache_versioning = false


### PR DESCRIPTION
Unexpected

##  :v: What does this PR do?

This PR disables an active record option to disable cache key recycling that was preventing the user of the timestamps calculated by the cache key query in production.

## :mag: How should this be manually tested?

In the Rails console this script should return different cache keys:

```
s = Site.find_by domain: 'demo-datos.gobify.net'
puts s.datasets.cache_key

sleep 1
d = s.datasets.last
d.touch
s.reload
puts s.datasets.cache_key
```
