### PR TITLE
3405 invalid date 404

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::UnknownFormat, with: :render_404
+  rescue_from Errors::InvalidParameters, with: :render_bad_request
 
   helper_method(
     :helpers,
@@ -26,6 +27,10 @@ class ApplicationController < ActionController::Base
 
   def render_404
     render file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]
+  end
+
+  def render_bad_request
+    render status: :bad_request, file: "public/404", layout: false, handlers: [:erb], format: [:html]
   end
 
   def helpers

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -60,6 +60,8 @@ module GobiertoPeople
       @calendar_events = GobiertoCalendars::Event.by_site(current_site).person_events.published.within_range(calendar_date_range)
       @calendar_events = @calendar_events.by_person_category(@person_category) if @person_category
       @calendar_events = @calendar_events.by_person_party(@person_party) if @person_party
+    rescue Date::Error
+      raise Errors::InvalidParameters
     end
 
     def set_people

--- a/lib/errors/invalid_parameters.rb
+++ b/lib/errors/invalid_parameters.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Errors
+  class InvalidParameters < StandardError; end
+end

--- a/test/controllers/gobierto_people/people_controller_test.rb
+++ b/test/controllers/gobierto_people/people_controller_test.rb
@@ -56,12 +56,12 @@ gobierto_people_default_filter_end_date: "#{options[:end_date]}"
       set_default_dates(wide_date_range_params)
       get gobierto_people_person_path(person.slug)
       assert_response :success
+    end
+  end
 
-      person.events.destroy_all
-
-      get gobierto_people_person_path(person.slug)
-      assert_response :success
-
+  def test_redirect_with_default_dates_and_person_path
+    with_current_site(site) do
+      set_default_dates(wide_date_range_params)
 
       person.events.destroy_all
       person.invitations.destroy_all
@@ -70,6 +70,16 @@ gobierto_people_default_filter_end_date: "#{options[:end_date]}"
       get gobierto_people_person_path(person.slug)
       assert_response :redirect
       assert_redirected_to(gobierto_people_person_gifts_path(@person.slug))
+    end
+  end
+
+  def test_redirect_with_default_dates_and_person_path_with_ranges
+    with_current_site(site) do
+      set_default_dates(wide_date_range_params)
+
+      person.events.destroy_all
+      person.invitations.destroy_all
+      person.trips.destroy_all
 
       get gobierto_people_person_path(person.slug, start_date: "2012-01-01", end_date: "2019-01-01")
       assert_response :redirect

--- a/test/controllers/gobierto_people/people_controller_test.rb
+++ b/test/controllers/gobierto_people/people_controller_test.rb
@@ -32,6 +32,13 @@ gobierto_people_default_filter_end_date: "#{options[:end_date]}"
     @wide_date_range_params ||= { start_date: 10.years.ago.strftime("%Y-%m-%d"), end_date: 10.years.from_now.strftime("%Y-%m-%d") }
   end
 
+  def test_wrong_dates_cause_bad_request
+    with_current_site(site) do
+      get gobierto_people_past_events_path(date: '2018-04-27', start_date: '700')
+      assert_response :bad_request
+    end
+  end
+
   def test_redirect_without_default_dates
     with_current_site(site) do
       get gobierto_people_person_path(person.slug)


### PR DESCRIPTION
Closes #3405

## :v: What does this PR do?

Fixes a recurring and noisy error when dates provided by a bot are invalid

Rollbar: https://rollbar.com/Populate/gobierto/items/4285/?item_page=0&#instances

## :mag: How should this be manually tested?

Visit a site with a calendar and check that the invalid request returns 400 Bad request status
