### PR TITLE
Fix JSON error on cache result

### DIFF
--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -16,14 +16,15 @@ module GobiertoData
             format.json do
               if expired_http_cache?
                 query_result = GobiertoData::Cache.query_cache(current_site, query, format: 'json') do
-                  GobiertoData::Connection.execute_query(current_site, query, include_stats: true, include_draft: valid_preview_token?)
+                  query_result = GobiertoData::Connection.execute_query(current_site, query, include_stats: true, include_draft: valid_preview_token?)
+                  { data: query_result.delete(:result), meta: query_result }.to_json
                 end
 
                 if query_result.is_a?(File)
                   send_file query_result.path, x_sendfile: true, type: 'application/json', disposition: 'inline'
                 else
                   render_error_or_continue(query_result) do
-                    render json: { data: query_result.delete(:result), meta: query_result }, adapter: :json_api
+                    render json: query_result, adapter: :json_api
                   end
                 end
               end

--- a/app/controllers/gobierto_data/api/v1/query_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/query_controller.rb
@@ -17,7 +17,11 @@ module GobiertoData
               if expired_http_cache?
                 query_result = GobiertoData::Cache.query_cache(current_site, query, format: 'json') do
                   query_result = GobiertoData::Connection.execute_query(current_site, query, include_stats: true, include_draft: valid_preview_token?)
-                  { data: query_result.delete(:result), meta: query_result }.to_json
+                  if !query_result.has_key?(:errors)
+                    { data: query_result.delete(:result), meta: query_result }.to_json
+                  else
+                    query_result
+                  end
                 end
 
                 if query_result.is_a?(File)


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes the JSON response when a query was cached, it wasn't properly parsing the JSON

## How to test it?

Run a JSON request against data API and make sure the response is cached, then repeat the request, and you should obtain the same result