### PR TITLE
Gobierto Dashboards / Update receiver type detection

### DIFF
--- a/app/javascript/gobierto_dashboards/modules/subsidies_controller.js
+++ b/app/javascript/gobierto_dashboards/modules/subsidies_controller.js
@@ -129,8 +129,6 @@ export class SubsidiesController {
 
       subsidy.beneficiary_id = beneficiary_id
       subsidy.beneficiary_name = beneficiary_name.join(' ')
-      // it's an individual if the beneficiary id is hidden with asterisks
-      subsidy.isIndividual = (/\*+/).test(beneficiary_id)
 
       if (!subsidy.id) {
         subsidy.id = `${subsidy.grant_date.replace(/\D+/g,'')}${subsidy.beneficiary_id.replace(/\D+/g, '')}${parseInt(subsidy.amount) || 0}`;
@@ -164,8 +162,8 @@ export class SubsidiesController {
   _renderSubsidiesMetricsBox(){
     const subsidiesData = this._currentDataSource().subsidiesData;
 
-    const individualsData = subsidiesData.filter(subsidy => subsidy.isIndividual);
-    const collectivesData = subsidiesData.filter(subsidy => !subsidy.isIndividual);
+    const individualsData = subsidiesData.filter(( { beneficiary_type }) => beneficiary_type === 'persona');
+    const collectivesData = subsidiesData.filter(( { beneficiary_type }) => beneficiary_type === 'colectivo');
 
     // Calculations
     const amountsArray = subsidiesData.map(({ amount = 0 }) => parseFloat(amount) );


### PR DESCRIPTION
Closes #https://github.com/PopulateTools/issues/issues/1132


## :v: What does this PR do?

Adapt the code to filter the new dataset by type of beneficiary: collective or person.


## :mag: How should this be manually tested?
Staging

## :eyes: Screenshots

### Before this PR

![97003204-5fd54c00-153b-11eb-93f9-070b12c62f6b](https://user-images.githubusercontent.com/2649175/97722178-9fb3aa80-1aca-11eb-856c-0448464f588b.png)

### After this PR

![Screenshot 2020-10-30 at 16 11 28](https://user-images.githubusercontent.com/2649175/97722182-a0e4d780-1aca-11eb-903b-87740d869891.png)
