### PR TITLE
Change text of metric boxes

### DIFF
--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -44,16 +44,19 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
   end
 
   def load_year
-    if params[:year].nil?
-      default_year = if budgets_elaboration_active?
-        GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data - 1
-      else
-        GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data
-      end
+    default_year = if budgets_elaboration_active?
+                     GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data - 1
+                   else
+                     GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data
+                   end
 
+    if params[:year].nil?
       redirect_to gobierto_budgets_budgets_path(default_year)
     else
       @year = params[:year].to_i
+      if @year > default_year
+        redirect_to gobierto_budgets_budgets_path(default_year)
+      end
     end
   end
 

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -72,15 +72,15 @@
         <% if @budget_line_stats.amount_per_inhabitant.present? %>
           <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_per_inhabitant_tooltip') %>" data-box="planned_per_inhabitant">
             <div class="inner">
-              <h3><%= kind_literal(@kind, false).capitalize %> <%= t('.planned_per_inhabitant') %></h3>
+              <h3><%= t('.planned_per_inhabitant') %></h3>
 
               <div class="metric">
-                <%= number_to_currency(@budget_line_stats.amount_per_inhabitant_updated || @budget_line_stats.amount_per_inhabitant, precision: 2) %>
+                <%= number_to_currency(@budget_line_stats.amount_per_inhabitant, precision: 2) %>
               </div>
 
               <% if @budget_line_stats.amount_per_inhabitant_updated.present? %>
                 <div class="explanation">
-                  <%= t(".initial_estimate") %>: <%= number_to_currency(@budget_line_stats.amount_per_inhabitant, precision: 2) %>
+                  <%= t(".current_amount_per_inhabitant") %>: <%= number_to_currency(@budget_line_stats.amount_per_inhabitant_updated, precision: 2) %>
                 </div>
               <% end %>
             </div>
@@ -89,15 +89,15 @@
 
         <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.planned_tooltip') %>" data-box="planned">
           <div class="inner">
-            <h3><%= kind_literal(@kind, false).capitalize %> <%= planned(@kind) %> </h3>
+            <h3><%= t(".initial_estimate") %></h3>
 
             <div class="metric">
-              <%= format_currency @budget_line_stats.amount_updated || @budget_line_stats.amount %>
+              <%= format_currency @budget_line_stats.amount %>
             </div>
 
             <% if @budget_line_stats.amount_updated.present? %>
               <div class="explanation">
-                 <%= t(".initial_estimate") %>: <%= format_currency(@budget_line_stats.amount) %>
+                 <%= t(".current_amount") %>: <%= format_currency(@budget_line_stats.amount_updated) %>
               </div>
             <% end %>
           </div>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -34,25 +34,25 @@
 
         <% if @site_stats.population_data? %>
           <%= render("metric_box",
-                title: t(".expenses_per_inhabitant"),
-                value: @site_stats.total_budget_per_inhabitant_updated(fallback: true),
+                title: t(".initial_estimate_per_inhabitant"),
+                value: @site_stats.total_budget_per_inhabitant,
                 tooltip: t(".expenses_per_inhabitant_tooltip"),
                 data_box: "expenses_per_inhabitant",
                 explanation: {
                   if: @site_stats.total_budget_per_inhabitant_updated(fallback: false).present?,
-                  text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget_per_inhabitant)}"
+                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant_updated(fallback: true))}"
                 }
               ) %>
         <% end %>
 
         <%= render("metric_box",
-              title: t(".total_expenses"),
-              value: @site_stats.total_budget_updated(fallback: true),
+              title: t(".initial_estimate"),
+              value: @site_stats.total_budget,
               tooltip: t(".total_expenses_tooltip"),
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget_updated(fallback: false).present?,
-                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)}"
+                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget_updated(fallback: true))}"
               }
             ) %>
 

--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="highlight-proposal">
-    <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
+    <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year + 1) %></p>
   </div>
 
   <div class="pure-g metric_boxes">

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -15,7 +15,7 @@ ca:
     - dv
     - ds
     abbr_month_names:
-    - 
+    -
     - gen
     - feb
     - mar
@@ -43,7 +43,7 @@ ca:
       short: "%d %b"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - gener
     - febrer
     - març

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -15,7 +15,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       short: "%b %d %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - January
     - February
     - March

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -15,7 +15,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       short: "%d %b %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -30,11 +30,13 @@ ca:
         budget_line_percentage: Percentatge
         budget_line_value: Quantitat
         budget_lines_distribution: Distribució de les despeses d'aquesta partida
+        current_amount: Pressupost actual
+        current_amount_per_inhabitant: Pressupost actual / hab.
         evolution: Evolució
         give_your_opinion: Opina sobre aquesta partida
         give_your_opinion_cta: Entens de què va aquesta partida? Et sembla molt, poc?
           Opina
-        initial_estimate: Estimació inicial
+        initial_estimate: Pressupost inicial
         last_year: L'any passat %{value}
         no_description: No hi ha una descripció associada a aquesta partida.
         no_distribution: No hi ha distribució associada a aquesta partida.
@@ -44,7 +46,7 @@ ca:
         percentage_tooltip: Percentage del pressupost total que suposa aquesta partida
         planned: pressupostat
         planned_female: pressupostada
-        planned_per_inhabitant: pres. / hab.
+        planned_per_inhabitant: Pressupost inicial / hab.
         planned_per_inhabitant_tooltip: Quantitat pressupostada dividida pel nombre
           d'habitants
         planned_tooltip: Quantitat pressupostada
@@ -244,7 +246,7 @@ ca:
         description: En aquesta pàgina pots aprendre sobre la distribució del pressupost,
           l'estat d'execució de cada partida i com ha evolucionat la despesa per habitant
         executed: Execució
-        executed_percent: "%{percentage}% del pressupost"
+        executed_percent: "%{percentage}% del pressupost actual"
         executed_percent_other_year_html: En %{year} va ser un %{link}
         executed_tooltip: Despesa executada respecte el pressupost actual (pressupost
           inicial més modificacions)
@@ -258,6 +260,7 @@ ca:
         expenses: Despeses
         expenses_per_inhabitant: Despesa per habitant
         expenses_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
+        expenses_per_inhabitant_updated: Despesa per habitant actual
         header: Pressupostos
         in_total: En total
         income: Ingressos
@@ -265,7 +268,8 @@ ca:
         income_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
         inhabitants: Habitants
         inhabitants_tooltip: Nombre d’habitants
-        initial_estimate: Estimació inicial
+        initial_estimate: Pressupost inicial
+        initial_estimate_per_inhabitant: Pressupost inicial per habitant
         less: menys
         level_1_category: Categoria nivell 1
         level_2_category: Categoria nivell 2
@@ -316,6 +320,7 @@ ca:
         top_income_value: Quantitat
         total_expenses: Despesa total
         total_expenses_tooltip: Pressupost inicial de despesa
+        total_expenses_updated: Despesa total actual
         visualize: Visualitza les despeses per habitant o el total
     budgets_elaboration:
       index:
@@ -399,7 +404,8 @@ ca:
         higher_execution: Més execució
         income_executed: Ingressos executats
         income_planned: Ingressos pressupostats
-        initial_estimate: Estimació inicial
+        initial_estimate: Pressupost inicial
+        initial_estimate_per_inhabitant: Pressupost inicial per habitant
         lower_execution: Menys execució
         metric:
           execution:
@@ -593,6 +599,7 @@ ca:
       I_economic: En què s'ingressa
       category_per_inhabitant: "%{category} per habitant"
       expenses_per_inhabitant: Despesa per habitant
+      expenses_per_inhabitant_updated: Despesa per habitant actual
       inhabitant_short: hab
       mean_autonomy: Mitjana autonòmica
       mean_national: Mitjana estatal

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -260,7 +260,7 @@ ca:
         expenses: Despeses
         expenses_per_inhabitant: Despesa per habitant
         expenses_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
-        expenses_per_inhabitant_updated: Despesa per habitant actual
+        expenses_per_inhabitant_updated: Pressupost per habitant actual
         header: Pressupostos
         in_total: En total
         income: Ingressos

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -244,7 +244,7 @@ en:
         expenses: Expenses
         expenses_per_inhabitant: Expenses per inhabitant
         expenses_per_inhabitant_tooltip: Starting budget divided by the inhabitants
-        expenses_per_inhabitant_updated: Expenses per inhabitant updated
+        expenses_per_inhabitant_updated: Budget per inhabitant updated
         header: Budgets
         in_total: Total
         income: Income

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -30,11 +30,13 @@ en:
         budget_line_percentage: Percentage
         budget_line_value: Amount
         budget_lines_distribution: Expense budget lines distribution
+        current_amount: Current amount
+        current_amount_per_inhabitant: Current amount / hab.
         evolution: Evolution
         give_your_opinion: Give your opinion about this budget line
         give_your_opinion_cta: Do you understand this budget line? Do you think it's
           enough, too much? Give your opinion
-        initial_estimate: Initial estimate
+        initial_estimate: Initial budget
         last_year: Last year %{value}
         no_description: There's no description for this budget line.
         no_distribution: There aren't any related budget lines.
@@ -44,7 +46,7 @@ en:
         percentage_tooltip: Percentage of the total budget this budget line implies
         planned: planned
         planned_female: planned
-        planned_per_inhabitant: plan. / inh.
+        planned_per_inhabitant: Initial budget / inh.
         planned_per_inhabitant_tooltip: Budgeted amount divided by the inhabitants
         planned_tooltip: Budgeted amount
         raise_hand: Raise your hand
@@ -228,7 +230,7 @@ en:
           the status of the execution, the different providers we work with and the
           evolution of the expense per inhabitant.
         executed: Executed
-        executed_percent: "%{percentage}% of the budget"
+        executed_percent: "%{percentage}% of the current budget"
         executed_percent_other_year_html: In %{year} it was a %{link}
         executed_tooltip: The execution is the quantity that has been spent from the
           initial budget.
@@ -242,6 +244,7 @@ en:
         expenses: Expenses
         expenses_per_inhabitant: Expenses per inhabitant
         expenses_per_inhabitant_tooltip: Starting budget divided by the inhabitants
+        expenses_per_inhabitant_updated: Expenses per inhabitant updated
         header: Budgets
         in_total: Total
         income: Income
@@ -249,7 +252,8 @@ en:
         income_per_inhabitant_tooltip: Starting budget divided by the inhabitants
         inhabitants: Inhabitants
         inhabitants_tooltip: Number of inhabitants
-        initial_estimate: Initial estimate
+        initial_estimate: Initial budget
+        initial_estimate_per_inhabitant: Initial budget per inhabitant
         less: less
         level_1_category: Level 1 category
         level_2_category: Level 2 category
@@ -299,6 +303,7 @@ en:
         top_income_value: Amount
         total_expenses: Total expenses
         total_expenses_tooltip: Starting budget
+        total_expenses_updated: Total expenses today
         visualize: Visualize expenses per inhabitant or the total
     budgets_elaboration:
       index:
@@ -379,7 +384,8 @@ en:
         higher_execution: Higher execution
         income_executed: Executed income
         income_planned: Planned income
-        initial_estimate: Initial estimate
+        initial_estimate: Initial budget
+        initial_estimate_per_inhabitant: Initial budget per inhabitant
         lower_execution: Lower execution
         metric:
           execution:
@@ -569,6 +575,7 @@ en:
       I_economic: How
       category_per_inhabitant: "%{category} per inhabitant"
       expenses_per_inhabitant: Expenses per inhabitant
+      expenses_per_inhabitant_updated: Expenses per inhabitant updated
       inhabitant_short: inh
       mean_autonomy: Autonomy mean
       mean_national: National mean

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -249,7 +249,7 @@ es:
         expenses_per_inhabitant: Gasto por habitante
         expenses_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
           de habitantes
-        expenses_per_inhabitant_updated: Gasto por habitante actual
+        expenses_per_inhabitant_updated: Presupuesto por habitante actual
         header: Presupuestos
         in_total: En total
         income: Ingresos

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -30,11 +30,13 @@ es:
         budget_line_percentage: Porcentaje
         budget_line_value: Cantidad
         budget_lines_distribution: Distribución de los gastos de esta partida
+        current_amount: Presupuesto actual
+        current_amount_per_inhabitant: Presupuesto actual / hab.
         evolution: Evolución
         give_your_opinion: Opina sobre esta partida
         give_your_opinion_cta: "¿Entiendes de qué va esta partida? ¿Te parece mucho,
           poco? Opina"
-        initial_estimate: Estimación inicial
+        initial_estimate: Presupuesto inicial
         last_year: El año pasado %{value}
         no_description: No hay una descripción asociada a esta partida.
         no_distribution: No hay distribución asociada a esta partida.
@@ -44,7 +46,7 @@ es:
         percentage_tooltip: Porcentaje del presupuesto total que supone esta partida
         planned: presupuestado
         planned_female: presupuestada
-        planned_per_inhabitant: pres. / hab.
+        planned_per_inhabitant: Presupuesto inicial / hab.
         planned_per_inhabitant_tooltip: Cantidad presupuestada dividida por el número
           de habitantes
         planned_tooltip: Cantidad presupuestada
@@ -232,7 +234,7 @@ es:
           cuál es el estado de ejecución de cada partida, quiénes son los proveedores
           con los que trabajamos, y cómo ha evolucionado el gasto por habitante.
         executed: Ejecución
-        executed_percent: "%{percentage}% de lo presupuestado"
+        executed_percent: "%{percentage}% del presupuesto actual"
         executed_percent_other_year_html: En %{year} fue un %{link}
         executed_tooltip: Cantidad ejecutada respecto al presupuesto actual (presupuesto
           inicial más modificaciones)
@@ -247,6 +249,7 @@ es:
         expenses_per_inhabitant: Gasto por habitante
         expenses_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
           de habitantes
+        expenses_per_inhabitant_updated: Gasto por habitante actual
         header: Presupuestos
         in_total: En total
         income: Ingresos
@@ -255,7 +258,8 @@ es:
           de habitantes
         inhabitants: Habitantes
         inhabitants_tooltip: Número de habitantes
-        initial_estimate: Estimación inicial
+        initial_estimate: Presupuesto inicial
+        initial_estimate_per_inhabitant: Presupuesto inicial por habitante
         less: menos
         level_1_category: Categoría nivel 1
         level_2_category: Categoría nivel 2
@@ -306,6 +310,7 @@ es:
         top_income_value: Cantidad
         total_expenses: Gasto total
         total_expenses_tooltip: Presupuesto inicial
+        total_expenses_updated: Gasto total actual
         visualize: Visualiza los gastos por habitante o el total
     budgets_elaboration:
       index:
@@ -392,7 +397,8 @@ es:
         higher_execution: Mayor ejecución
         income_executed: Ingresos ejecutados
         income_planned: Ingresos presupuestados
-        initial_estimate: Estimación inicial
+        initial_estimate: Presupuesto inicial
+        initial_estimate_per_inhabitant: Presupuesto inicial por habitante
         lower_execution: Menor ejecución
         metric:
           execution:
@@ -587,6 +593,7 @@ es:
       I_economic: En qué se ingresa
       category_per_inhabitant: "%{category} por habitante"
       expenses_per_inhabitant: Gasto por habitante
+      expenses_per_inhabitant_updated: Gasto por habitante actual
       inhabitant_short: hab
       mean_autonomy: Media autonómica
       mean_national: Media estatal

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -66,13 +66,13 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
       visit @path
 
       within(metric_box(:planned)) do
-        assert has_content?("Expense planned\n#{amount_updated}")
-        assert has_content?("Initial estimate: #{amount}")
+        assert has_content?("Initial budget\n#{amount}")
+        assert has_content?("Current amount: #{amount_updated}")
       end
 
       within(metric_box(:planned_per_inhabitant)) do
-        assert has_content?("Expense plan. / inh.\n20.00")
-        assert has_content?("Initial estimate: 15.00")
+        assert has_content?("Initial budget / inh.\n15.00")
+        assert has_content?("Current amount / hab.: 20.00")
       end
 
       assert has_css?(".metric_box h3", text: "% execution")
@@ -162,7 +162,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
       assert has_content? feedback_ack_message
 
       fill_in :email, with: "spam@email.com"
-      
+
       # find("#ic_email", visible: false).set("spam@email.com")
       page.execute_script('document.getElementById("ic_email").innerText = "spam@email.com"')
 

--- a/test/integration/gobierto_budgets/budgets_test.rb
+++ b/test/integration/gobierto_budgets/budgets_test.rb
@@ -132,8 +132,6 @@ class GobiertoBudgets::BudgetsTest < ActionDispatch::IntegrationTest
 
       assert has_css?(".metric_box h3", text: "Initial budget")
       assert has_css?(".metric_box h3", text: "Executed")
-      assert has_no_css?(".metric_box h3", text: "Debt")
-      assert has_css?(".metric_box h3", text: "Net savings")
       assert page.all(".metric_box .metric").all? { |e| e.text =~ /(\d+)|Not avail./ }
     end
   end

--- a/test/integration/gobierto_budgets/budgets_test.rb
+++ b/test/integration/gobierto_budgets/budgets_test.rb
@@ -117,8 +117,8 @@ class GobiertoBudgets::BudgetsTest < ActionDispatch::IntegrationTest
     with_current_site(placed_site) do
       visit @path
 
-      assert has_css?(".metric_box h3", text: "Expenses per inhabitant")
-      assert has_css?(".metric_box h3", text: "Total expenses")
+      assert has_css?(".metric_box h3", text: "Initial budget per inhabitant")
+      assert has_css?(".metric_box h3", text: "Initial budget")
       assert has_css?(".metric_box h3", text: "Executed")
       assert has_css?(".metric_box h3", text: "Inhabitants")
       assert has_css?(".metric_box h3", text: "Debt")
@@ -130,9 +130,10 @@ class GobiertoBudgets::BudgetsTest < ActionDispatch::IntegrationTest
     with_current_site(organization_site) do
       visit @path
 
-      assert has_css?(".metric_box h3", text: "Total expenses")
+      assert has_css?(".metric_box h3", text: "Initial budget")
       assert has_css?(".metric_box h3", text: "Executed")
-      assert has_css?(".metric_box h3", text: "Debt")
+      assert has_no_css?(".metric_box h3", text: "Debt")
+      assert has_css?(".metric_box h3", text: "Net savings")
       assert page.all(".metric_box .metric").all? { |e| e.text =~ /(\d+)|Not avail./ }
     end
   end

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -49,11 +49,11 @@ class GobiertoBudgets::ExecutionPageTest < ActionDispatch::IntegrationTest
         assert has_content?("BUDGET EXECUTION")
 
         assert income_summary_box.include? "Planned income"
-        assert income_summary_box.include? "Initial estimate"
+        assert income_summary_box.include? "Initial budget"
         assert income_summary_box.include? "Executed income"
 
         assert expenses_summary_box.include? "Planned expenses"
-        assert expenses_summary_box.include? "Initial estimate"
+        assert expenses_summary_box.include? "Initial budget"
         assert expenses_summary_box.include? "Executed expenses"
       end
     end


### PR DESCRIPTION
## :v: What does this PR do?

- Fixes the year in the elaboration message
- Changes current budget and initial budget order and texts in the summary boxes
- When elaboration is enabled, users can't browse next year data

## :mag: How should this be manually tested?

- Review the new summary boxes
- In a site with elaboration enabled
  - check the year in the message
  - check that you can't browse to 2021 budgets or any budget line

