### PR TITLE
Fix translations

### DIFF
--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -320,7 +320,7 @@ ca:
         top_income_value: Quantitat
         total_expenses: Despesa total
         total_expenses_tooltip: Pressupost inicial de despesa
-        total_expenses_updated: Despesa total actual
+        total_expenses_updated: Pressupost actual
         visualize: Visualitza les despeses per habitant o el total
     budgets_elaboration:
       index:

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -303,7 +303,7 @@ en:
         top_income_value: Amount
         total_expenses: Total expenses
         total_expenses_tooltip: Starting budget
-        total_expenses_updated: Total expenses today
+        total_expenses_updated: Current budget
         visualize: Visualize expenses per inhabitant or the total
     budgets_elaboration:
       index:

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -310,7 +310,7 @@ es:
         top_income_value: Cantidad
         total_expenses: Gasto total
         total_expenses_tooltip: Presupuesto inicial
-        total_expenses_updated: Gasto total actual
+        total_expenses_updated: Presupuesto actual
         visualize: Visualiza los gastos por habitante o el total
     budgets_elaboration:
       index:


### PR DESCRIPTION
## :v: What does this PR do?

Replaces "Despesa total actual" by "Pressupost actual"

## :mag: How should this be manually tested?

Check the string has changed in budgets home

Before:

![Screenshot 2020-11-06 at 08 35 39](https://user-images.githubusercontent.com/17616/98338825-13920d80-200b-11eb-9122-6c6119771c46.png)

After: 

![Screenshot 2020-11-06 at 08 35 37](https://user-images.githubusercontent.com/17616/98338826-14c33a80-200b-11eb-9742-fad199e24a9d.png)
