### PR TITLE
Allow navigate on future budgets and budget lines

### DIFF
--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -1,6 +1,5 @@
 class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationController
   before_action :load_params
-  before_action :check_elaboration, only: [:show]
 
   caches_action(
     :show,
@@ -58,12 +57,6 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     @area_name = params[:area_name] || GobiertoBudgets::FunctionalArea.area_name
     @level = params[:level].present? ? params[:level].to_i : 1
     @code = params[:id]
-  end
-
-  def check_elaboration
-    if @year > Date.today.year && !budgets_elaboration_active?
-      raise GobiertoBudgets::BudgetLine::RecordNotFound
-    end
   end
 
   def common_params

--- a/app/helpers/gobierto_budgets/application_helper.rb
+++ b/app/helpers/gobierto_budgets/application_helper.rb
@@ -167,7 +167,7 @@ module GobiertoBudgets
     end
 
     def in_elaboration?
-      @year && @year > Date.today.year
+      @year && @year > Date.today.year && budgets_elaboration_active?
     end
   end
 end

--- a/app/javascript/lib/visualizations/modules/slider.js
+++ b/app/javascript/lib/visualizations/modules/slider.js
@@ -60,27 +60,6 @@ export class VisSlider {
       .attr('class', 'slider')
       .attr('transform', 'translate(0,' + height / 4 + ')');
 
-    if (maxYear > (new Date().getFullYear())) {
-      var proposal = slider.append('g')
-        .attr('transform', 'translate(' + (x(maxYear) - (2 / 3 * (x(maxYear) - x(years[years.length - 2])))) + ',0)')
-        .attr('class', 'proposal');
-
-      proposal.append('rect')
-        .attr('x', 0)
-        .attr('y', -(height / 4))
-        .attr('rx', 12)
-        .attr('ry', 12)
-        .attr('width', x(maxYear) - x(years[years.length - 2]))
-        .attr('height', height);
-
-      proposal.append('text')
-        .attr('class', 'highlight-proposal')
-        .attr('y', '60%')
-        .attr('text-anchor', 'end')
-        .attr('x', (2 / 3 * (x(maxYear) - x(years[years.length - 2]))))
-    }
-
-
     slider.append('line')
       .attr('class', 'track')
       .attr('x1', x.range()[0])
@@ -131,7 +110,6 @@ export class VisSlider {
         return x(d)
       })
       .text(function(year) {
-        if (year > new Date().getFullYear()) { return I18n.t('gobierto_common.visualizations.project') }
         return year;
       })
       .classed('active', function(d) {

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -58,7 +58,7 @@
       <% if in_elaboration? %>
         <div class="pure-u-1-1 metric_box">
           <div class="highlight-proposal">
-            <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
+            <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year + 1) %></p>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
Closes #3468 

## :v: What does this PR do?

- fixes budget lines message for elaboration 
- allows to visit future years budget lines if exist and elaboration is disabled
- fixes the error in the vis slider for future years

## :mag: How should this be manually tested?

In a site with elaboration enabled check the points above
