### PR TITLE
Don't override current scope in the controller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,14 +63,14 @@ jobs:
       - restore_cache:
           name: "Restore cached assets"
           keys:
-            - v1-asset-cache-{{ .Branch }}
-            - v1-asset-cache-
+            - v2-asset-cache-{{ .Branch }}
+            - v2-asset-cache-
 
       - run: bin/rails assets:precompile
 
       - save_cache:
           name: "Cache assets"
-          key: v1-asset-cache-{{ .Branch }}
+          key: v2-asset-cache-{{ .Branch }}
           paths:
             - public/assets
             - public/packs-test

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,11 +26,11 @@ class ApplicationController < ActionController::Base
   before_action :apply_engines_overrides, :authenticate_user_in_site
 
   def render_404
-    render file: "public/404", status: 404, layout: false, handlers: [:erb], formats: [:html]
+    render file: Rails.root.join("public/404.html"), status: 404, layout: false, handlers: [:erb], formats: [:html]
   end
 
   def render_bad_request
-    render status: :bad_request, file: "public/404", layout: false, handlers: [:erb], format: [:html]
+    render status: :bad_request, file: Rails.root.join("public/404.html"), layout: false, handlers: [:erb], format: [:html]
   end
 
   def helpers

--- a/app/controllers/concerns/application_concern.rb
+++ b/app/controllers/concerns/application_concern.rb
@@ -9,15 +9,7 @@ module ApplicationConcern
   end
 
   def current_site
-    @current_site ||= begin
-                        site = if request.env["gobierto_site"].present?
-                                 request.env["gobierto_site"]
-                               elsif Rails.env.test?
-                                 Site.first
-                               end
-                        ::GobiertoCore::CurrentScope.current_site = site
-                        site
-                      end
+    GobiertoCore::CurrentScope.current_site
   end
 
   private

--- a/lib/middlewares/override_welcome_action.rb
+++ b/lib/middlewares/override_welcome_action.rb
@@ -15,8 +15,8 @@ class OverrideWelcomeAction
     end
 
     if Rails.env.test? && site.nil?
-      env["gobierto_site"] = Site.first
-      GobiertoCore::CurrentScope.current_site = Site.first
+      GobiertoCore::CurrentScope.current_site ||= Site.first
+      env["gobierto_site"] = GobiertoCore::CurrentScope.current_site
     end
 
     # If the path is the homepage, the route should be the site root path

--- a/lib/middlewares/override_welcome_action.rb
+++ b/lib/middlewares/override_welcome_action.rb
@@ -11,10 +11,12 @@ class OverrideWelcomeAction
 
     if site = Site.find_by_allowed_domain(full_domain)
       env["gobierto_site"] = site
+      GobiertoCore::CurrentScope.current_site = site
     end
 
     if Rails.env.test? && site.nil?
-      env["gobierto_site"] = ::GobiertoCore::CurrentScope.current_site || Site.first
+      env["gobierto_site"] = Site.first
+      GobiertoCore::CurrentScope.current_site = Site.first
     end
 
     # If the path is the homepage, the route should be the site root path

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -111,7 +111,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   def test_request_more_information_and_subscribe_as_spam
     enable_budget_line_feedback
 
-    with(default_test_context.merge(js: :deprecated)) do
+    with(default_test_context) do
       visit @path
 
       click_link "Ask your #{placed_site.organization_name}"
@@ -152,7 +152,7 @@ class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTe
   def test_send_feedback_and_subscribe_as_spam
     enable_budget_line_feedback
 
-    with(default_test_context.merge(js: :deprecated)) do
+    with(default_test_context) do
       visit @path
 
       click_link "Raise your hand"


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes an old error on setting the CurrentScope of a request, the site was overloaded in the controller, instead of keepin the value set in the middleware, which was loaded by the domain.

It was causing that it randomly changed the loaded site, and in methods like `GobiertoBudgets::Year.last` it was picking the last year of budgets from other sites.

It also fixes a broken test in master

## :mag: How should this be manually tested?

You should be able to visit a site with 2021 budgets data and it should stop appearing budgets data randomly
