### PR TITLE
Gobierto Data / Transforms Booelan values and show errors

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -657,7 +657,7 @@ export default {
     },
     setPublicQueries(response) {
       const {
-        data: { data: items = [] },
+        data: { data: items = [] }
       } = response;
 
       this.publicQueries = items
@@ -710,16 +710,7 @@ export default {
         try {
           ({ status } = await this.putQuery(queryId, { data }));
         } catch (error) {
-          const {
-            response: {
-              data: {
-                errors: arrayError
-              }
-            }
-          } = error;
-          const [ sqlError ] = arrayError
-          const { detail } = sqlError
-          this.queryError = detail
+          this.queryError = this.destructuringStoreQueryError(error)
         }
 
         //Update revert query
@@ -729,16 +720,7 @@ export default {
         try {
           ({ status, data: { data: newQuery } } = await this.postQuery({ data }));
         } catch (error) {
-          const {
-            response: {
-              data: {
-                errors: arrayError
-              }
-            }
-          } = error;
-          const [ sqlError ] = arrayError
-          const { detail } = sqlError
-          this.queryError = detail
+          this.queryError = this.destructuringStoreQueryError(error)
         }
       }
 
@@ -784,16 +766,7 @@ export default {
         this.isQueryRunning = false;
         this.getColumnsQuery(this.items)
         this.queryError = null
-      } catch (error) {
-        const {
-          response: {
-            data: {
-              errors: arrayError
-            }
-          }
-        } = error;
-        const [ sqlError ] = arrayError
-        const { sql: stringError } = sqlError
+      } catch ({ response: { data: { errors: [{ sql: stringError } = {}] = [] } } } ) {
         this.queryError = stringError
         this.isQueryRunning = false;
         this.enabledQuerySavedButton = false
@@ -1085,6 +1058,10 @@ export default {
       this.isVizModified = false
       this.activatedSavedVizButton(value)
       this.showPrivatePublicIconViz = true
+    },
+    destructuringStoreQueryError(error) {
+      const { response: { data: { errors: [{ detail } = {}] = [] } } } = error
+      return detail
     }
   },
 };

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -715,10 +715,14 @@ export default {
         } catch (error) {
           const {
             response: {
-              statusText
+              data: {
+                errors: arrayError
+              }
             }
           } = error;
-          this.queryError = statusText
+          const [ sqlError ] = arrayError
+          const { detail } = sqlError
+          this.queryError = detail
         }
 
         //Update revert query
@@ -730,10 +734,14 @@ export default {
         } catch (error) {
           const {
             response: {
-              statusText
+              data: {
+                errors: arrayError
+              }
             }
           } = error;
-          this.queryError = statusText
+          const [ sqlError ] = arrayError
+          const { detail } = sqlError
+          this.queryError = detail
         }
       }
 

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -648,10 +648,7 @@ export default {
     },
     setPrivateQueries(response) {
 
-      const {
-        data: { data: items },
-        status
-      } = response;
+      const { data: { data: items } } = response;
       this.privateQueries = items;
     },
     async getPublicQueries() {

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -647,8 +647,10 @@ export default {
       });
     },
     setPrivateQueries(response) {
+
       const {
         data: { data: items },
+        status
       } = response;
       this.privateQueries = items;
     },
@@ -708,13 +710,31 @@ export default {
       if (name === this.queryName && userId === this.queryUserId) {
         const { queryId } = this.$route.params;
         // factory method
-        ({ status } = await this.putQuery(queryId, { data }));
+        try {
+          ({ status } = await this.putQuery(queryId, { data }));
+        } catch (error) {
+          const {
+            response: {
+              statusText
+            }
+          } = error;
+          this.queryError = statusText
+        }
 
         //Update revert query
         this.queryRevert = this.currentQuery
       } else {
         // factory method
-        ({ status, data: { data: newQuery } } = await this.postQuery({ data }));
+        try {
+          ({ status, data: { data: newQuery } } = await this.postQuery({ data }));
+        } catch (error) {
+          const {
+            response: {
+              statusText
+            }
+          } = error;
+          this.queryError = statusText
+        }
       }
 
       // reload the queries if the response was successfull

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -93,10 +93,10 @@ export default {
       const sameColumns = arrayColumnsFromAPI.length === arrayColumnsFromQuery.length && arrayColumnsFromAPI.every(column => arrayColumnsFromQuery.includes(column))
 
       //Check if any columns contains Boolean values
-      const datasetsHasBoleanColumns = this.checkIfBooleanExist(this.objectColumns)
+      const datasetsHasBooleanColumns = this.checkIfBooleanExist(this.objectColumns)
 
       //If columns contains Boolean values goes to replace them
-      let replaceItems = datasetsHasBoleanColumns.length > 0 ? this.replaceBooleanValues(datasetsHasBoleanColumns) : this.items
+      let replaceItems = datasetsHasBooleanColumns.length > 0 ? this.replaceBooleanValues(this.items) : this.items
 
       if (sameColumns) {
         this.initPerspectiveWithSchema(replaceItems)
@@ -211,54 +211,9 @@ export default {
       });
       return columnsBoolean
     },
-    replaceBooleanValues(values) {
-      //Values is an array with the Boolean values
-      //First convert the response(now is a sad string) to JSON
-      const jsonItems = this.csvToJson(this.items)
-      /*Search if a key is a boolean value, it is true, and the key-value is a T(PostgreSQL true)
-      converts T to TRUE, same for F(PostgreSQL FALSE) */
-      jsonItems.forEach((element) => {
-        for (let key in element) {
-          if (values.some(v => key.includes(v)) && element[key] === 't' ) {
-              element[key] = 'true'
-          }
-          if (values.some(v => key.includes(v)) && element[key] === 'f' ) {
-              element[key] = 'false'
-          }
-        }
-      });
-
-      //The last step, converts again, in this case, JSON to CSV with the Boolean values as TRUE or FALSE
-      const csvBooleans = this.convertToCSV(jsonItems)
-      return csvBooleans
-    },
-    csvToJson(str, headerList, quotechar = '"', delimiter = ','){
-      //https://stackoverflow.com/questions/59218548/what-is-the-best-way-to-convert-from-csv-to-json-when-commas-and-quotations-may/59219146#59219146
-      const cutlast = (_, i, a) => i < a.length - 1;
-      const regex = new RegExp(`(?:[\\t ]?)+(${quotechar}+)?(.*?)\\1(?:[\\t ]?)+(?:${delimiter}|$)`, 'gm');
-      const lines = str.split('\n');
-      let headers = headerList || lines.splice(0, 1)[0].match(regex).filter(cutlast);
-      // @jorge: remove commas
-      headers = headers.map(item => item.replace(',',''));
-
-      const list = [];
-
-      for (const line of lines) {
-        const val = {};
-        for (const [i, m] of [...line.matchAll(regex)].filter(cutlast).entries()) {
-          // Attempt to convert to Number if possible, also use null if blank
-          val[headers[i]] = (m[2].length > 0) ? Number(m[2]) || m[2] : null;
-        }
-        list.push(val);
-      }
-
-      return list;
-    },
-    convertToCSV(arr) {
-      const array = [Object.keys(arr[0])].concat(arr)
-      return array.map(it => {
-        return Object.values(it).toString()
-      }).join('\n')
+    replaceBooleanValues(columns) {
+      const replaceBooleanValues = this.items.replace(/"t"/g, '"true"').replace(/"f"/g, '"false"')
+      return replaceBooleanValues
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -92,8 +92,10 @@ export default {
       /* We compare the columns, if it returns true we pass the schema to Perspective, if false Perspective will convert the columns*/
       const sameColumns = arrayColumnsFromAPI.length === arrayColumnsFromQuery.length && arrayColumnsFromAPI.every(column => arrayColumnsFromQuery.includes(column))
 
-      const datasetsHasBoleanColumns = this.checkIfBoleeanExist(this.objectColumns)
+      //Check if any columns contains Boolean values
+      const datasetsHasBoleanColumns = this.checkIfBooleanExist(this.objectColumns)
 
+      //If columns contains Boolean values goes to replace them
       let replaceItems = datasetsHasBoleanColumns.length > 0 ? this.replaceBooleanValues(datasetsHasBoleanColumns) : this.items
 
       if (sameColumns) {
@@ -199,7 +201,7 @@ export default {
         this.viewer.setAttribute(attributesTopMenu[index], null)
       }
     },
-    checkIfBoleeanExist(columns) {
+    checkIfBooleanExist(columns) {
       let columnsBoolean = []
       Object.keys(columns).forEach(key => {
         const value = columns[key]
@@ -210,7 +212,11 @@ export default {
       return columnsBoolean
     },
     replaceBooleanValues(values) {
+      //Values is an array with the Boolean values
+      //First convert the response(now is a sad string) to JSON
       const jsonItems = this.csvToJson(this.items)
+      /*Search if a key is a boolean value, it is true, and the key-value is a T(PostgreSQL true)
+      converts T to TRUE, same for F(PostgreSQL FALSE) */
       jsonItems.forEach((element) => {
         for (let key in element) {
           if (values.some(v => key.includes(v)) && element[key] === 't' ) {
@@ -222,14 +228,17 @@ export default {
         }
       });
 
+      //The last step, converts again, in this case, JSON to CSV with the Boolean values as TRUE or FALSE
       const csvBooleans = this.convertToCSV(jsonItems)
       return csvBooleans
     },
     csvToJson(str, headerList, quotechar = '"', delimiter = ','){
+      //https://stackoverflow.com/questions/59218548/what-is-the-best-way-to-convert-from-csv-to-json-when-commas-and-quotations-may/59219146#59219146
       const cutlast = (_, i, a) => i < a.length - 1;
       const regex = new RegExp(`(?:[\\t ]?)+(${quotechar}+)?(.*?)\\1(?:[\\t ]?)+(?:${delimiter}|$)`, 'gm');
       const lines = str.split('\n');
       let headers = headerList || lines.splice(0, 1)[0].match(regex).filter(cutlast);
+      // @jorge: remove commas
       headers = headers.map(item => item.replace(',',''));
 
       const list = [];

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -92,11 +92,11 @@ export default {
       /* We compare the columns, if it returns true we pass the schema to Perspective, if false Perspective will convert the columns*/
       const sameColumns = arrayColumnsFromAPI.length === arrayColumnsFromQuery.length && arrayColumnsFromAPI.every(column => arrayColumnsFromQuery.includes(column))
 
-      //Check if any columns contains Boolean values
-      const datasetsHasBooleanColumns = this.checkIfBooleanExist(this.objectColumns)
-
       //If columns contains Boolean values goes to replace them
-      let replaceItems = datasetsHasBooleanColumns.length > 0 ? this.replaceBooleanValues(this.items) : this.items
+      let replaceItems = this.items
+      if (Object.values(this.objectColumns).some(value => value === "boolean")) {
+        replaceItems = this.items.replace(/"t"/g, '"true"').replace(/"f"/g, '"false"')
+      }
 
       if (sameColumns) {
         this.initPerspectiveWithSchema(replaceItems)
@@ -200,20 +200,6 @@ export default {
       for (let index = 0; index < attributesTopMenu.length; index++) {
         this.viewer.setAttribute(attributesTopMenu[index], null)
       }
-    },
-    checkIfBooleanExist(columns) {
-      let columnsBoolean = []
-      Object.keys(columns).forEach(key => {
-        const value = columns[key]
-        if (value === 'boolean') {
-          columnsBoolean.push(key)
-        }
-      });
-      return columnsBoolean
-    },
-    replaceBooleanValues(columns) {
-      const replaceBooleanValues = this.items.replace(/"t"/g, '"true"').replace(/"f"/g, '"false"')
-      return replaceBooleanValues
     }
   }
 };

--- a/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Visualizations.vue
@@ -92,10 +92,12 @@ export default {
       /* We compare the columns, if it returns true we pass the schema to Perspective, if false Perspective will convert the columns*/
       const sameColumns = arrayColumnsFromAPI.length === arrayColumnsFromQuery.length && arrayColumnsFromAPI.every(column => arrayColumnsFromQuery.includes(column))
 
+      //Postgresql returns booleans values as "t" and "f", so we need to transform them, "t" as "true" and "f" as false.
+      const replaceBooleanValues = this.items.replace(/"t"/g, '"true"').replace(/"f"/g, '"false"')
       if (sameColumns) {
-        this.initPerspectiveWithSchema(this.items)
+        this.initPerspectiveWithSchema(replaceBooleanValues)
       } else {
-        this.initPerspective(this.items)
+        this.initPerspective(replaceBooleanValues)
       }
     },
     initPerspectiveWithSchema(data) {


### PR DESCRIPTION
Closes #3436 
Closes #3434

## :v: What does this PR do?

Postgresql returns boolean values as `t` and `f`, doesn't understand that `f` is `false` and `t` is `true,` so we have to transform those values.

When the user tries to save an invalid query, nothing happens. Now we catch the error and show it.

## :mag: How should this be manually tested?

Staging

## Screenshots

Show error

![Screen Recording 2020-11-26 at 08 15 43 2020-11-26 08_19_30](https://user-images.githubusercontent.com/2649175/100320115-07252300-2fc1-11eb-8187-10eebbc47bb0.gif)
