### PR TITLE
Gobierto Data / Hide JSON and XLS options from the download menu

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -327,10 +327,11 @@ export default {
       formats: arrayFormats
     } = attributes;
 
+    const { csv: csvURL } = arrayFormats
     this.titleDataset = titleDataset;
     this.tableName = tableName;
     this.objectColumns = objectColumns;
-    this.arrayFormats = arrayFormats;
+    this.arrayFormats = { csv: csvURL }
 
     // Once we have the dataset info, we request both kind of queries
     const queriesPromises = [];


### PR DESCRIPTION
Closes 

https://github.com/PopulateTools/gobierto/issues/3421


## :v: What does this PR do?

Hide JSON and XLS options from the download menu

## :mag: How should this be manually tested?

Staging
