### PR TITLE
Remove NaN in percentage of total budget

### DIFF
--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -55,6 +55,7 @@ module GobiertoBudgets
 
     def percentage_of_total
       total_amount = total || GobiertoBudgets::BudgetTotal.for(@attributes[:organization_id], @attributes[:year])
+      return 0 if total_amount == 0
       ((amount.to_f / total_amount.to_f)*100).round(2)
     end
 


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR fixes the calculation of the percentage of budget that corresponds to the current budget line

## :mag: How should this be manually tested?

In staging, search for a budget line with amount 0

## :eyes: Screenshots

### Before this PR

![Screenshot from 2020-11-30 05-46-00](https://user-images.githubusercontent.com/17616/100570360-e61a4600-32d0-11eb-9701-a16fc1ff19dc.png)

### After this PR

![Screenshot from 2020-11-30 05-46-17](https://user-images.githubusercontent.com/17616/100570362-e74b7300-32d0-11eb-83d1-8521d993b7b6.png)

