### PR TITLE
Show initial budget

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 6292904905333bd36d4597e6b50bf2c617cfa5ac
+  revision: d9914edfe52b1e1e10f16668601b174cf4836ba5
   specs:
     gobierto_data (0.1.0)
       actionpack
@@ -96,7 +96,7 @@ GEM
       rack
     ast (2.4.1)
     aws-eventstream (1.1.0)
-    aws-partitions (1.397.0)
+    aws-partitions (1.399.0)
     aws-sdk-core (3.109.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -322,7 +322,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     ntlm-http (0.1.1)
-    oj (3.10.6)
+    oj (3.10.16)
     open4 (1.3.4)
     os (1.1.1)
     paper_trail (11.0.0)
@@ -520,7 +520,7 @@ GEM
     xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -137,7 +137,7 @@ module GobiertoBudgets
           type: @area,
           variable: field,
           organization_id: params[:organization_id],
-          updated_forecast: true
+          updated_forecast: false
         )
 
         result ? { value: result[field] } : nil

--- a/app/controllers/gobierto_budgets/budget_line_descendants_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_line_descendants_controller.rb
@@ -10,7 +10,7 @@ class GobiertoBudgets::BudgetLineDescendantsController < GobiertoBudgets::Applic
       conditions.merge!(level: 1)
     end
 
-    @budget_lines = GobiertoBudgets::BudgetLine.all(where: conditions, updated_forecast: true)
+    @budget_lines = GobiertoBudgets::BudgetLine.all(where: conditions, updated_forecast: false)
 
     if !request.format.json? && @parent_code && @parent_code.length >= 1
       @budget_lines = expand_children(@budget_lines, conditions)
@@ -27,7 +27,7 @@ class GobiertoBudgets::BudgetLineDescendantsController < GobiertoBudgets::Applic
   def expand_children(budget_lines, conditions)
     budget_lines.concat(budget_lines.map do |budget_line|
       if budget_line.level < 4
-        expand_children(GobiertoBudgets::BudgetLine.all(where: conditions.merge(parent_code: budget_line.code), updated_forecast: true), conditions)
+        expand_children(GobiertoBudgets::BudgetLine.all(where: conditions.merge(parent_code: budget_line.code), updated_forecast: false), conditions)
       end
     end.flatten.compact)
   end

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -63,8 +63,9 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
     { site: current_site, year: @year, kind: @kind, area_name: @area_name }
   end
 
+  # TODO: rename?
   def updated_forecast(params = {})
-    GobiertoBudgets::BudgetLine.all(where: common_params.merge(params), updated_forecast: true)
+    GobiertoBudgets::BudgetLine.all(where: common_params.merge(params), updated_forecast: false)
   end
 
   def budget_line_composition

--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -77,7 +77,7 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
       area_name: @area_name
     }
 
-    @place_budget_lines = GobiertoBudgets::BudgetLine.all(where: conditions, updated_forecast: true)
+    @place_budget_lines = GobiertoBudgets::BudgetLine.all(where: conditions, updated_forecast: false)
   end
 
   def load_interesting_expenses
@@ -89,7 +89,7 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
       area_name: @interesting_area
     }
 
-    @interesting_expenses = GobiertoBudgets::BudgetLine.all(where: conditions, updated_forecast: true)
+    @interesting_expenses = GobiertoBudgets::BudgetLine.all(where: conditions, updated_forecast: false)
   end
 
 end

--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -11,7 +11,7 @@ module GobiertoBudgets
           level: { ge: 3 },
           amount: { gt: 0 }
         },
-        updated_forecast: true
+        updated_forecast: false
       )['hits']
 
       if results.any?

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -82,7 +82,7 @@
         <td class="budget_line"><strong>Total</strong></td>
         <td class="qty big_qty">
           <%= number_to_currency(
-                kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget_updated(fallback: true) : @site_stats.total_budget_updated(fallback: true),
+                kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget(fallback: true) : @site_stats.total_budget(fallback: true),
                 precision: 0
               ) %></td>
         <%= content_tag :td, number_to_currency(kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget_per_inhabitant : @site_stats.total_budget_per_inhabitant, precision: 2), class: "qty big_qty" if @site_stats.population_data? %>

--- a/app/views/gobierto_budgets/budgets/guide.html.erb
+++ b/app/views/gobierto_budgets/budgets/guide.html.erb
@@ -59,7 +59,7 @@
 
         <div class="number">
           <p><%= t('.income_p2', year: @year) %></p>
-          <div><%= format_currency @site_stats.total_budget_updated(fallback: true) %></div>
+          <div><%= format_currency @site_stats.total_budget(fallback: true) %></div>
         </div>
 
         <h3><%= t('.expenses') %></h3>
@@ -68,7 +68,7 @@
         <% if @site_stats.population_data? %>
           <div class="number">
             <p><%= t('.expenses_per_inhabitant') %></p>
-            <div><%= format_currency @site_stats.total_budget_per_inhabitant_updated %>/hab</div>
+            <div><%= format_currency @site_stats.total_budget_per_inhabitant %>/hab</div>
           </div>
         <% end %>
 

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -39,8 +39,8 @@
                 tooltip: t(".expenses_per_inhabitant_tooltip"),
                 data_box: "expenses_per_inhabitant",
                 explanation: {
-                  if: @site_stats.total_budget_per_inhabitant_updated(fallback: false).present?,
-                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant_updated(fallback: true))}"
+                  if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
+                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant(fallback: true))}"
                 }
               ) %>
         <% end %>
@@ -51,8 +51,8 @@
               tooltip: t(".total_expenses_tooltip"),
               data_box: "total_expenses",
               explanation: {
-                if: @site_stats.total_budget_updated(fallback: false).present?,
-                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget_updated(fallback: true))}"
+                if: @site_stats.total_budget(fallback: false).present?,
+                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget(fallback: true))}"
               }
             ) %>
 


### PR DESCRIPTION
## :v: What does this PR do?

This PR changes the data source of budget lines for the whole budget section (excluding execution) to display the initial budget amounts by default

## :mag: How should this be manually tested?

Review the section to check the values displayed correspond to the initial budget and not the updated budget

## :eyes: Screenshots

Not yet as it hasn't been released to staging

### Before this PR

### After this PR

