### PR TITLE
3482 disable datasets downloads formats

### DIFF
--- a/app/jobs/gobierto_data/cache_datasets_downloads.rb
+++ b/app/jobs/gobierto_data/cache_datasets_downloads.rb
@@ -5,16 +5,8 @@ module GobiertoData
     queue_as :cached_data
 
     def perform(dataset)
-      GobiertoData::Cache.dataset_cache(dataset, format: 'json', update: true) do
-        GobiertoData::Connection.execute_query(dataset.site, dataset.rails_model.all.to_sql).to_json
-      end
-
       GobiertoData::Cache.dataset_cache(dataset, format: 'csv', update: true) do
         GobiertoData::Connection.execute_query_output_csv(dataset.site, dataset.rails_model.all.to_sql, { col_sep: "," })
-      end
-
-      GobiertoData::Cache.dataset_cache(dataset, format: 'xlsx', update: true) do
-        GobiertoData::Connection.execute_query_output_xlsx(dataset.site, dataset.rails_model.all.to_sql, { name: dataset.name })
       end
     end
   end

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -38,7 +38,7 @@ module GobiertoData
     end
 
     def available_formats
-      [:csv, :json, :xlsx]
+      [:csv]
     end
 
     def rails_model

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -624,7 +624,12 @@ Rails.application.routes.draw do
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
-            resources :datasets, param: :slug, defaults: { format: "json" } do
+            resources :datasets, only: [:show], param: :slug, defaults: { format: "csv" } do
+              member do
+                get :download, format: true
+              end
+            end
+            resources :datasets, except: [:show], param: :slug, defaults: { format: "json" } do
               resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]
               collection do
@@ -633,7 +638,6 @@ Rails.application.routes.draw do
               member do
                 get "meta" => "datasets#dataset_meta"
                 get "stats" => "datasets#stats"
-                get :download, format: true
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -624,11 +624,6 @@ Rails.application.routes.draw do
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1/data" do
             get "data" => "query#index", as: :root, defaults: { format: "json" }
-            resources :datasets, only: [:show], param: :slug, defaults: { format: "csv" } do
-              member do
-                get :download, format: true
-              end
-            end
             resources :datasets, except: [:show], param: :slug, defaults: { format: "json" } do
               resource :favorite, only: [:create, :destroy]
               resources :favorites, only: [:index]
@@ -638,6 +633,11 @@ Rails.application.routes.draw do
               member do
                 get "meta" => "datasets#dataset_meta"
                 get "stats" => "datasets#stats"
+              end
+            end
+            resources :datasets, only: [:show], param: :slug, defaults: { format: "csv" } do
+              member do
+                get :download, format: true
               end
             end
             resources :queries, except: [:edit], defaults: { format: "json" } do

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -274,23 +274,6 @@ module GobiertoData
           end
         end
 
-        # GET /api/v1/data/datasets/dataset-slug.json
-        def test_dataset_data
-          with(site: site) do
-            get gobierto_data_api_v1_dataset_path(dataset.slug), as: :json
-
-            assert_response :success
-            response_data = response.parsed_body
-            assert response_data.has_key? "data"
-            assert_equal dataset.rails_model.count, response_data["data"].count
-            assert_equal dataset.rails_model.all.map(&:id).sort, response_data["data"].map { |row| row["id"] }.sort
-
-            assert response_data.has_key? "links"
-            assert_includes response_data["links"].values, gobierto_data_api_v1_datasets_path
-            assert_includes response_data["links"].values, meta_gobierto_data_api_v1_datasets_path
-          end
-        end
-
         # GET /api/v1/data/datasets/dataset-slug.csv
         def test_dataset_data_as_csv
           with(site: site) do
@@ -302,22 +285,6 @@ module GobiertoData
             parsed_csv = CSV.parse(response_data)
 
             assert_equal dataset.rails_model.count + 1, parsed_csv.count
-          end
-        end
-
-        # GET /api/v1/data/datasets/dataset-slug.xlsx
-        def test_dataset_data_as_xlsx
-          with(site: site) do
-            get gobierto_data_api_v1_dataset_path(dataset.slug, format: :xlsx), as: :xlsx
-
-            assert_response :success
-
-            parsed_xlsx = RubyXL::Parser.parse_buffer response.parsed_body
-
-            assert_equal 1, parsed_xlsx.worksheets.count
-            sheet = parsed_xlsx.worksheets.first
-            refute_nil sheet[dataset.rails_model.count]
-            assert_nil sheet[dataset.rails_model.count + 1]
           end
         end
 
@@ -363,22 +330,6 @@ module GobiertoData
           end
         end
 
-        # GET /api/v1/data/datasets/dataset-slug/download.json
-        def test_dataset_download_as_json
-          with(site: site) do
-            get download_gobierto_data_api_v1_dataset_path(dataset.slug, format: :json), as: :json
-
-            assert_response :success
-            response_data = response.parsed_body
-
-            assert_equal dataset.rails_model.count, response_data.count
-            assert_equal dataset.rails_model.all.map(&:id).sort, response_data.map { |row| row["id"] }.sort
-
-            assert File.exist? Rails.root.join("#{GobiertoData::Cache::BASE_PATH}/datasets/#{dataset.id}.json")
-            delete_cached_files
-          end
-        end
-
         # GET /api/v1/data/datasets/dataset-slug/download.csv
         def test_dataset_download_as_csv
           with(site: site) do
@@ -391,24 +342,6 @@ module GobiertoData
             assert_equal dataset.rails_model.count + 1, parsed_csv.count
 
             assert File.exist? Rails.root.join("#{GobiertoData::Cache::BASE_PATH}/datasets/#{dataset.id}.csv")
-            delete_cached_files
-          end
-        end
-
-        # GET /api/v1/data/datasets/dataset-slug/download.xlsx
-        def test_dataset_download_as_xlsx
-          with(site: site) do
-            get download_gobierto_data_api_v1_dataset_path(dataset.slug, format: :xlsx), as: :xlsx
-
-            assert_response :success
-            parsed_xlsx = RubyXL::Parser.parse_buffer response.parsed_body
-
-            assert_equal 1, parsed_xlsx.worksheets.count
-            sheet = parsed_xlsx.worksheets.first
-            refute_nil sheet[dataset.rails_model.count]
-            assert_nil sheet[dataset.rails_model.count + 1]
-
-            assert File.exist? Rails.root.join("#{GobiertoData::Cache::BASE_PATH}/datasets/#{dataset.id}.xlsx")
             delete_cached_files
           end
         end

--- a/test/controllers/gobierto_data/api/v1/drafts_controllers_test.rb
+++ b/test/controllers/gobierto_data/api/v1/drafts_controllers_test.rb
@@ -116,7 +116,7 @@ module GobiertoData
         # GET /api/v1/data/datasets/dataset-slug.json
         def test_draft_dataset_data_without_preview_token
           with(site: site) do
-            get gobierto_data_api_v1_dataset_path(draft_dataset.slug), as: :json
+            get gobierto_data_api_v1_dataset_path(draft_dataset.slug), as: :csv
 
             assert_response :not_found
           end
@@ -125,7 +125,7 @@ module GobiertoData
         # GET /api/v1/data/datasets/dataset-slug.json
         def test_draft_dataset_data_with_valid_preview_token
           with(site: site) do
-            get gobierto_data_api_v1_dataset_path(draft_dataset.slug, preview_token: admin.preview_token), as: :json
+            get gobierto_data_api_v1_dataset_path(draft_dataset.slug, preview_token: admin.preview_token), as: :csv
 
             assert_response :success
           end


### PR DESCRIPTION
Closes #3482


## :v: What does this PR do?

* Removes XLSX and JSON responses from datasets controller for show and download actions
* Changes routes to provide CSV format by default for these actions
* Removes some API tests checking XLSX and JSON responses

## :mag: How should this be manually tested?

In front application when visiting a dataset the download dropdown should only offer CSV

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Pending changes in https://gobierto.readme.io/
