### PR TITLE
Total budget updated in metric boxes

### DIFF
--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -40,7 +40,7 @@
                 data_box: "expenses_per_inhabitant",
                 explanation: {
                   if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
-                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant(fallback: true))}"
+                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant_updated(fallback: true))}"
                 }
               ) %>
         <% end %>
@@ -52,7 +52,7 @@
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget(fallback: false).present?,
-                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget(fallback: true))}"
+                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget_updated(fallback: true))}"
               }
             ) %>
 


### PR DESCRIPTION

## :v: What does this PR do?

Fix the total amount updated in the metric boxes, it should show:

- the current budget in the middle big figure
- the updated budget at the bottom 

## :mag: How should this be manually tested?

![Screenshot from 2020-12-01 08-13-45](https://user-images.githubusercontent.com/17616/100708753-2a7b1400-33ad-11eb-9b9f-209979e4ece4.png)
