### PR TITLE
3522 people list change

### DIFF
--- a/app/controllers/gobierto_people/welcome_controller.rb
+++ b/app/controllers/gobierto_people/welcome_controller.rb
@@ -9,7 +9,7 @@ module GobiertoPeople
     before_action :check_active_submodules
 
     def index
-      @people = current_site.people.active.politician.government.sorted.first(10)
+      @people = current_site.people.active.politician.government.sorted
       @posts  = current_site.person_posts.active.sorted.last(10)
       @political_groups = get_political_groups
       @home_text = load_home_text

--- a/app/views/gobierto_people/people/_index.html.erb
+++ b/app/views/gobierto_people/people/_index.html.erb
@@ -15,7 +15,7 @@
   <% else %>
 
     <div class="people-summary people-grid pure-g" id="people-list">
-      <% @people.sort_by(&:name).each do |person| %>
+      <% @people.each do |person| %>
         <div class="pure-u-1 pure-u-md-1-3">
           <%= render person, avatar: !current_site.departments_available? %>
         </div>


### PR DESCRIPTION
Closes #3522


## :v: What does this PR do?
* Disables limit of 10 people in welcome people page
* Uses the same order in people index, welcome people page and admin people index

## :mag: How should this be manually tested?

Visit https://madrid.gobify.net/admin/people/people, https://madrid.gobify.net/cargos-y-agendas and https://madrid.gobify.net/personas. The same list of people in the same order should appear

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
