### PR TITLE
1152 custom fields tanslatable attributes

### DIFF
--- a/app/controllers/concerns/gobierto_common/custom_fields_api.rb
+++ b/app/controllers/concerns/gobierto_common/custom_fields_api.rb
@@ -40,7 +40,7 @@ module GobiertoCommon
       md_uids = md_custom_fields.pluck(:uid)
       raw_values.transform_values do |attributes|
         transform(attributes, localized_uids, :translate)
-        transform(attributes, md_uids, :markdown)
+        transform(attributes, md_uids, :safe_markdown)
         attributes
       end
 
@@ -85,7 +85,15 @@ module GobiertoCommon
       custom_fields_save
     end
 
+    # This function prevents errors when a md custom field is passed
+    # as a Hash because it is localized
+    def safe_markdown(value)
+      markdown(value.is_a?(Hash) ? translate(value) : value)
+    end
+
     def translate(hash)
+      return hash.to_s unless hash.is_a?(Hash)
+
       hash = hash.with_indifferent_access
       hash[I18n.locale] || hash[I18n.default_locale] || hash.slice(I18n.available_locales).values&.first || ""
     end

--- a/app/models/gobierto_common/custom_field_value/localized_text.rb
+++ b/app/models/gobierto_common/custom_field_value/localized_text.rb
@@ -20,7 +20,7 @@ module GobiertoCommon::CustomFieldValue
     end
 
     def raw_value
-      super || {}
+      super.is_a?(Hash) ? super : { I18n.locale.to_s => super.to_s }
     end
   end
 end

--- a/app/models/gobierto_common/custom_field_value/text.rb
+++ b/app/models/gobierto_common/custom_field_value/text.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
 module GobiertoCommon::CustomFieldValue
-  class Text < Base; end
+  class Text < Base
+    def raw_value
+      return super unless super.is_a?(Hash)
+
+      hash = super.with_indifferent_access
+      hash[I18n.locale] || hash[I18n.default_locale] || hash.slice(I18n.available_locales).values&.first || ""
+    end
+  end
 end

--- a/test/fixtures/gobierto_common/custom_field_records.yml
+++ b/test/fixtures/gobierto_common/custom_field_records.yml
@@ -305,6 +305,20 @@ users_dataset_category_custom_field_record:
      "category" => ActiveRecord::FixtureSet.identify(:culture_term).to_s
    }.to_json %>
 
+users_dataset_md_without_translations_custom_field_record:
+  item: users_dataset (GobiertoData::Dataset)
+  custom_field: madrid_data_datasets_custom_field_md_without_translations
+  payload: <%= {
+    "md-without-translations" => "Paragraph without translations!"
+   }.to_json %>
+
+users_dataset_md_with_translations_custom_field_record:
+  item: users_dataset (GobiertoData::Dataset)
+  custom_field: madrid_data_datasets_custom_field_md_with_translations
+  payload: <%= {
+    "md-with-translations" => { en: "Paragraph with translations!", es: "¡Párrafo con traducciones!" }
+   }.to_json %>
+
 ## Users
 
 peter_custom_field_issue:

--- a/test/fixtures/gobierto_common/custom_fields.yml
+++ b/test/fixtures/gobierto_common/custom_fields.yml
@@ -328,6 +328,22 @@ madrid_data_datasets_custom_field_category:
     vocabulary_id: ActiveRecord::FixtureSet.identify(:issues_vocabulary)
   }.to_json %>
 
+madrid_data_datasets_custom_field_md_without_translations:
+  site: madrid
+  class_name: GobiertoData::Dataset
+  position: 2
+  name_translations: <%= { en: "MD without translations", es: "MD sin traducciones" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:paragraph] %>
+  uid: md-without-translations
+
+madrid_data_datasets_custom_field_md_with_translations:
+  site: madrid
+  class_name: GobiertoData::Dataset
+  position: 3
+  name_translations: <%= { en: "MD with translations", es: "MD con traducciones" }.to_json %>
+  field_type: <%= GobiertoCommon::CustomField.field_types[:localized_paragraph] %>
+  uid: md-with-translations
+
 madrid_custom_field_human_resources_table_plugin:
   site: madrid
   class_name: GobiertoPlans::Node

--- a/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/create_dataset_test.rb
@@ -59,9 +59,11 @@ module GobiertoAdmin
           with(site: site, admin: admin, js: true) do
             visit @path
 
-            fill_in "dataset_name_translations_en", with: "Vocabularies"
-            switch_locale "ES"
-            fill_in "dataset_name_translations_es", with: "Vocabularios"
+            within "div.globalized_fields", match: :first do
+              fill_in "dataset_name_translations_en", with: "Vocabularies"
+              switch_locale "ES"
+              fill_in "dataset_name_translations_es", with: "Vocabularios"
+            end
             select "vocabularies", from: "dataset_table_name"
             fill_in "dataset_slug", with: "vocabularies-slug"
 
@@ -72,9 +74,11 @@ module GobiertoAdmin
             click_button "Create"
 
             assert has_message?("Dataset created correctly.")
-            assert has_field?("dataset_name_translations_en", with: "Vocabularies")
-            switch_locale "ES"
-            assert has_field?("dataset_name_translations_es", with: "Vocabularios")
+            within "div.globalized_fields", match: :first do
+              assert has_field?("dataset_name_translations_en", with: "Vocabularies")
+              switch_locale "ES"
+              assert has_field?("dataset_name_translations_es", with: "Vocabularios")
+            end
             assert has_field?("dataset_slug", with: "vocabularies-slug")
             assert has_select?("Table name", selected: "vocabularies")
           end

--- a/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
+++ b/test/integration/gobierto_admin/gobierto_data/datasets/update_dataset_test.rb
@@ -60,18 +60,22 @@ module GobiertoAdmin
           with(site: site, admin: admin, js: true) do
             visit @path
 
-            fill_in "dataset_name_translations_en", with: "Vocabulary updated"
-            switch_locale "ES"
-            fill_in "dataset_name_translations_es", with: "Vocabulario actualizado"
+            within "div.globalized_fields", match: :first do
+              fill_in "dataset_name_translations_en", with: "Vocabulary updated"
+              switch_locale "ES"
+              fill_in "dataset_name_translations_es", with: "Vocabulario actualizado"
+            end
             select "terms", from: "dataset_table_name"
             fill_in "dataset_slug", with: "vocabularies-updated-slug"
 
             click_button "Update"
 
             assert has_message?("Dataset updated correctly.")
-            assert has_field? "dataset_name_translations_en", with: "Vocabulary updated"
-            switch_locale "ES"
-            assert has_field?("dataset_name_translations_es", with: "Vocabulario actualizado")
+            within "div.globalized_fields", match: :first do
+              assert has_field? "dataset_name_translations_en", with: "Vocabulary updated"
+              switch_locale "ES"
+              assert has_field?("dataset_name_translations_es", with: "Vocabulario actualizado")
+            end
             assert has_field?("dataset_slug", with: "vocabularies-updated-slug")
             assert has_select?("Table name", selected: "terms")
           end
@@ -89,9 +93,11 @@ module GobiertoAdmin
               with_current_site(site) do
                 visit @path
 
-                fill_in "dataset_name_translations_en", with: ""
-                switch_locale "ES"
-                fill_in "dataset_name_translations_es", with: ""
+                within "div.globalized_fields", match: :first do
+                  fill_in "dataset_name_translations_en", with: ""
+                  switch_locale "ES"
+                  fill_in "dataset_name_translations_es", with: ""
+                end
 
                 click_button "Update"
 

--- a/test/models/gobierto_common/custom_field_record_test.rb
+++ b/test/models/gobierto_common/custom_field_record_test.rb
@@ -7,12 +7,20 @@ class GobiertoCommon::CustomFieldRecordTest < ActiveSupport::TestCase
     @custom_field_single_option ||= gobierto_common_custom_fields(:madrid_custom_field_country)
   end
 
+  def custom_field_string
+    @custom_field_string ||= gobierto_common_custom_fields(:madrid_site_custom_field)
+  end
+
   def custom_field_localized_string
     @custom_field_localized_string ||= gobierto_common_custom_fields(:madrid_custom_field_position)
   end
 
   def custom_field_paragraph
     @custom_field_paragraph ||= gobierto_common_custom_fields(:madrid_custom_field_bio)
+  end
+
+  def custom_field_localized_paragraph
+    @custom_field_localized_paragraph ||= gobierto_common_custom_fields(:madrid_custom_field_localized_bio)
   end
 
   def custom_field_multiple_options
@@ -40,7 +48,7 @@ class GobiertoCommon::CustomFieldRecordTest < ActiveSupport::TestCase
   end
 
   def test_raw_value
-    [custom_field_localized_string,
+    [custom_field_string,
      custom_field_paragraph,
      custom_field_single_option,
      custom_field_multiple_options,
@@ -51,6 +59,16 @@ class GobiertoCommon::CustomFieldRecordTest < ActiveSupport::TestCase
        subject.value = "randomstring1"
        assert_equal "randomstring1", subject.raw_value
      end
+  end
+
+  def test_raw_value_localized
+    [custom_field_localized_string,
+     custom_field_localized_paragraph].each do |custom_field|
+      subject = GobiertoCommon::CustomFieldRecord.new
+      subject.custom_field = custom_field
+      subject.value = "randomstring1"
+      assert_equal({ "en" => "randomstring1" }, subject.raw_value)
+    end
   end
 
   def test_values

--- a/test/support/integration/page_helpers.rb
+++ b/test/support/integration/page_helpers.rb
@@ -8,7 +8,7 @@ module Integration
 
     def switch_locale(new_locale)
       if javascript_driver?
-        page.find("[data-toggle-edit-locale='#{new_locale.downcase}']", visible: false).execute_script("this.click()")
+        find("[data-toggle-edit-locale='#{new_locale.downcase}']", visible: false).execute_script("this.click()")
       else
         begin
           within(".language_selector") { click_link new_locale.upcase }


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1152


## :v: What does this PR do?

* Avoids errors in API and admin when custom field of type text/markdown changes from not translatable to translatable and vice versa.
* The API always returns a string and detects for not translatable fields if the payload is a hash and selects a value according to locale
* In the admin interface, in the edit form the values are taken from the payload (if not saved nothing changes in the record):
  * For fields changed from not translatable to translatable the content is stored in current locale and the others are kept blank
  * For fields changed from translatable to not translatable the value for the current locale is used in the text field.
These changes 

## :mag: How should this be manually tested?

Create translatable and not translatable text and long text custom fields. Fill the values on some resource using them. Edit the custom fields and flip the translatable feature.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No