### PR TITLE
Only redirect the specific paths, avoiding the redirection with urls like /api/v1/dashboards

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -100,7 +100,9 @@ module Gobierto
 
     # Redirections
     config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
-      r301 %r{/dashboards/(.*)}, '/visualizaciones/$1'
+      r301 %r{^/dashboards/contratos(.*)}, '/visualizaciones/contratos$1'
+      r301 %r{^/dashboards/subvenciones(.*)}, '/visualizaciones/subvenciones$1'
+      r301 %r{^/dashboards/costes(.*)}, '/visualizaciones/costes$1'
     end
   end
 end


### PR DESCRIPTION
## :v: What does this PR do?

Fixes a bug with old dashboards urls redirections. Previously it would redirect anything that included the string `/dashboards`, which would redirect something ike `/api/v1/dashboards`. Now it will only redirect a very specific set of old urls that start with `/dashboards/contratos`, `/dashboards/subvenciones` or `/dashboards/costes`

## :mag: How should this be manually tested?

https://madrid.gobify.net/api/v1/dashboards/ should not redirect

https://madrid.gobify.net/dashboards/contratos/ should redirect to https://madrid.gobify.net/visualizaciones/contratos/