### PR TITLE
Fix velocity missing require

### DIFF
--- a/app/javascript/gobierto_participation/modules/process_polls_controller.js
+++ b/app/javascript/gobierto_participation/modules/process_polls_controller.js
@@ -1,4 +1,5 @@
 import Lightbox from 'lightbox2'
+import 'velocity-animate/velocity.ui'
 
 window.GobiertoParticipation.ProcessPollsController = (function() {
 


### PR DESCRIPTION
Closes #3546 


## :v: What does this PR do?

This PR adds a missing velocity library import which prevented the polls to advance to the next question 

## :mag: How should this be manually tested?

Try to answer a poll in staging
