### PR TITLE
1147 detect boolean values

### DIFF
--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -59,7 +59,7 @@ module GobiertoData
         boolean: {
           input_type: "text",
           output_type: "boolean",
-          sql: "select (case\n  when trim($1) = '#true_value' then true\n  when trim($1) = '#false_value' then false\n  else NULL\nend)",
+          sql: "select (case\n  when trim($1) = '#true_value' then 'true'\n  when trim($1) = '#false_value' then 'false'\n else trim($1)\nend)::boolean",
           optional_params: { false_value: "0", true_value: "1" }
         }
       }.freeze

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -428,6 +428,54 @@ module GobiertoData
             assert_equal false, query_result[:result][1]["is_cool"]
           end
         end
+
+        # POST /api/v1/data/datasets
+        #
+        def test_dataset_create_with_boolean_columns_and_no_options
+          with(site: site) do
+            post(
+              gobierto_data_api_v1_datasets_path,
+              params: multipart_form_params("dataset_boolean_columns.csv").deep_merge(
+                dataset: { schema_file: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/files/gobierto_data/schema_boolean_columns_without_options.json") }
+              ),
+              headers: { "Authorization" => auth_header }
+            )
+
+            assert_response :created
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
+            assert_equal 6, query_result[:rows]
+            assert_equal 1, query_result[:result][0]["id"]
+            assert_equal "Ruby", query_result[:result][0]["name"]
+            assert_equal true, query_result[:result][0]["is_cool"]
+            assert_equal 2, query_result[:result][1]["id"]
+            assert_equal "Javascript", query_result[:result][1]["name"]
+            assert_equal false, query_result[:result][1]["is_cool"]
+          end
+        end
+
+        # POST /api/v1/data/datasets
+        #
+        def test_dataset_create_with_boolean_columns_and_custom_values
+          with(site: site) do
+            post(
+              gobierto_data_api_v1_datasets_path,
+              params: multipart_form_params("dataset_boolean_custom_columns.csv").deep_merge(
+                dataset: { schema_file: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/files/gobierto_data/schema_boolean_custom_columns.json") }
+              ),
+              headers: { "Authorization" => auth_header }
+            )
+
+            assert_response :created
+            query_result = GobiertoData::Connection.execute_query(site, "select * from uploaded_dataset", include_stats: true)
+            assert_equal 6, query_result[:rows]
+            assert_equal 1, query_result[:result][0]["id"]
+            assert_equal "Ruby", query_result[:result][0]["name"]
+            assert_equal true, query_result[:result][0]["is_cool"]
+            assert_equal 2, query_result[:result][1]["id"]
+            assert_equal "Javascript", query_result[:result][1]["name"]
+            assert_equal false, query_result[:result][1]["is_cool"]
+          end
+        end
       end
     end
   end

--- a/test/fixtures/files/gobierto_data/dataset_boolean_custom_columns.csv
+++ b/test/fixtures/files/gobierto_data/dataset_boolean_custom_columns.csv
@@ -1,0 +1,7 @@
+id,name,is_cool
+1,Ruby,Me encanta
+2,Javascript,Pues no me gusta
+3,Crystal,Me encanta
+4,Cobol,Pues no me gusta
+5,Python,Me encanta
+6,C++,Pues no me gusta

--- a/test/fixtures/files/gobierto_data/schema_boolean_columns_without_options.json
+++ b/test/fixtures/files/gobierto_data/schema_boolean_columns_without_options.json
@@ -1,0 +1,5 @@
+{
+  "id":{"type":"integer"},
+  "name":{"type":"text"},
+  "is_cool":{"type":"boolean"}
+}

--- a/test/fixtures/files/gobierto_data/schema_boolean_custom_columns.json
+++ b/test/fixtures/files/gobierto_data/schema_boolean_custom_columns.json
@@ -1,0 +1,5 @@
+{
+  "id":{"type":"integer"},
+  "name":{"type":"text"},
+  "is_cool":{"type":"boolean", "optional_params": { "false_value": "Pues no me gusta", "true_value": "Me encanta"}}
+}


### PR DESCRIPTION
Closes PopulateTools/issues#1147

## :v: What does this PR do?

Allows importing boolean columns from csv accepting all the representations of the true/false values the database can understand

## :mag: How should this be manually tested?

There are some csv and schema files in the testing fixtures files to import

## :eyes: Screenshots

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
