### PR TITLE
3338 fix bad file uploads

### DIFF
--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -198,7 +198,7 @@ module GobiertoData
     end
 
     def data_file_upload
-      unless data_file.is_a? ActionDispatch::Http::UploadedFile
+      unless data_file.nil? || data_file.is_a?(ActionDispatch::Http::UploadedFile)
         errors.add :data_file, I18n.t("activemodel.errors.models.gobierto_data/dataset_form.attributes.data_file.no_file_included")
       end
     end

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -32,6 +32,7 @@ module GobiertoData
     validates :name_translations, translated_attribute_presence: true
     validates :visibility_level, inclusion: { in: Dataset.visibility_levels.keys }
     validate :data_file_upload
+    validate :module_configuration_presence
 
     delegate :persisted?, :data_updated_at, to: :resource
 
@@ -200,6 +201,10 @@ module GobiertoData
       unless data_file.is_a? ActionDispatch::Http::UploadedFile
         errors.add :data_file, I18n.t("activemodel.errors.models.gobierto_data/dataset_form.attributes.data_file.no_file_included")
       end
+    end
+
+    def module_configuration_presence
+      errors.add(:base, I18n.t("activerecord.errors.models.gobierto_data/connection.missing_configuration")) if Connection.db_config(site).blank?
     end
   end
 end

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -27,6 +27,7 @@ module GobiertoData
       :visibility_level
     )
 
+    validates :csv_separator, length: { is: 1 }
     validates :table_name, :name, :visibility_level, presence: true
     validates :name_translations, translated_attribute_presence: true
     validates :visibility_level, inclusion: { in: Dataset.visibility_levels.keys }

--- a/app/forms/gobierto_data/dataset_form.rb
+++ b/app/forms/gobierto_data/dataset_form.rb
@@ -30,6 +30,7 @@ module GobiertoData
     validates :table_name, :name, :visibility_level, presence: true
     validates :name_translations, translated_attribute_presence: true
     validates :visibility_level, inclusion: { in: Dataset.visibility_levels.keys }
+    validate :data_file_upload
 
     delegate :persisted?, :data_updated_at, to: :resource
 
@@ -192,6 +193,12 @@ module GobiertoData
       Publishers::AdminGobiertoDataActivity.broadcast_event(
         "dataset_data_updated", event_payload.merge(subject: resource)
       )
+    end
+
+    def data_file_upload
+      unless data_file.is_a? ActionDispatch::Http::UploadedFile
+        errors.add :data_file, I18n.t("activemodel.errors.models.gobierto_data/dataset_form.attributes.data_file.no_file_included")
+      end
     end
   end
 end

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -83,7 +83,7 @@ module GobiertoData
       def execute_write_query_from_file_using_stdin(site, query, file_path: nil, include_draft: false)
         return unless file_path.present?
 
-        with_connection(db_config(site), fallback: null_query, connection_key: :write_db_config) do
+        with_connection(db_config(site), fallback: configuration_missing_error, connection_key: :write_db_config) do
           connection_pool.connection.execute("CREATE SCHEMA IF NOT EXISTS draft") if include_draft
 
           raw_connection = connection_pool.connection.raw_connection
@@ -140,6 +140,10 @@ module GobiertoData
 
       def failed_query(message)
         { errors: [{ sql: message }] }
+      end
+
+      def configuration_missing_error
+        failed_query(I18n.t("activerecord.errors.models.gobierto_data/connection.missing_configuration"))
       end
 
     end

--- a/config/locales/gobierto_admin/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/ca.yml
@@ -21,3 +21,9 @@ ca:
               invalid_connection: 'No es pot connectar amb les dades de configuració.
                 Missatge d''error: "%{error_message}"'
               invalid_format: La configuració no té un format JSON vàlid
+        gobierto_data/dataset_form:
+          attributes:
+            data_file:
+              no_file_included: L'arxiu no s'ha pogut carregar. Si us plau, revisa
+                la petició i assegura't que el contingut de l'arxiu s'hagi inclòs
+                en ella

--- a/config/locales/gobierto_admin/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/en.yml
@@ -21,3 +21,8 @@ en:
               invalid_connection: 'Unable to connect using configuration data. Error
                 message: "%{error_message}"'
               invalid_format: The configuration does not have a valid JSON format
+        gobierto_data/dataset_form:
+          attributes:
+            data_file:
+              no_file_included: The file hasn't been uploaded. Please, review the
+                request and ensure the file content has been sent in the request

--- a/config/locales/gobierto_admin/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_data/models/es.yml
@@ -21,3 +21,9 @@ es:
               invalid_connection: 'No se puede conectar con los datos de configuración.
                 Mensaje de error: "%{error_message}"'
               invalid_format: La configuración no tiene un formato JSON válido
+        gobierto_data/dataset_form:
+          attributes:
+            data_file:
+              no_file_included: El archivo no se ha podido cargar. Por favor, revisa
+                la petición y asegúrate de que el contenido del archivo se haya incluido
+                en ella

--- a/config/locales/gobierto_data/models/ca.yml
+++ b/config/locales/gobierto_data/models/ca.yml
@@ -1,6 +1,10 @@
 ---
 ca:
   activerecord:
+    errors:
+      models:
+        gobierto_data/connection:
+          missing_configuration: La base de dades no està configurada
     models:
       gobierto_data/dataset:
         one: Conjunt de dades

--- a/config/locales/gobierto_data/models/en.yml
+++ b/config/locales/gobierto_data/models/en.yml
@@ -1,6 +1,10 @@
 ---
 en:
   activerecord:
+    errors:
+      models:
+        gobierto_data/connection:
+          missing_configuration: Database configuration missing
     models:
       gobierto_data/dataset:
         one: Dataset

--- a/config/locales/gobierto_data/models/es.yml
+++ b/config/locales/gobierto_data/models/es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   activerecord:
+    errors:
+      models:
+        gobierto_data/connection:
+          missing_configuration: La base de datos no está configurada
     models:
       gobierto_data/dataset:
         one: Conjunto de datos

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -126,6 +126,8 @@ module GobiertoData
         # POST /api/v1/data/datasets
         #
         def test_dataset_creation_with_upload_missing
+          ::Mime::Type.any_instance.stubs(:symbol).returns(:multipart_form)
+
           with(site: site) do
             assert_no_difference "GobiertoData::Dataset.count" do
               post(


### PR DESCRIPTION
Closes #3338
Closes #3339
Closes #3526

## :v: What does this PR do?

* Prevents exceptions when a file is incorrectly uploaded in the multipart-form version and a string is sent in the `data-file` attribute instead of an uploaded file and makes the application to return an error message.
* Prevents exceptions when the csv_separator is sent in the request as an empty string validating the attribute length in the form
* Validates the presence of database configuration for module and prevents creation of datasets if not present. Also changes the fallback of query used in `execute_write_query_from_file_using_stdin` to send an error message instead of a blank array.
* Adds some tests.

## :mag: How should this be manually tested?

Use a valid curl request but remove the @ before the file path and send the csv_separator attribute empty

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
