### PR TITLE
Return by default 50 rows when size can't be obtained / is nil

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -4,6 +4,8 @@ require_relative "../gobierto_data"
 
 module GobiertoData
   class Dataset < ApplicationRecord
+    DEFAULT_LIMIT = 50
+
     include GobiertoCommon::Sluggable
     include GobiertoData::Favoriteable
     include GobiertoAttachments::Attachable
@@ -113,10 +115,11 @@ module GobiertoData
     end
 
     def default_limit
-      return 50 unless api_settings.present?
+      return DEFAULT_LIMIT unless api_settings.present?
+      return DEFAULT_LIMIT if format_size.nil?
 
       max_size = api_settings.max_dataset_size_for_queries
-      return 50 if max_size.present? && format_size.present? && max_size.positive? && max_size <= format_size
+      return DEFAULT_LIMIT if max_size.present? && max_size.positive? && max_size <= format_size
     end
 
     private

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -51,6 +51,10 @@ module GobiertoData
         end
         alias small_dataset other_dataset
 
+        def no_size_dataset
+          @no_size_dataset ||= gobierto_data_datasets(:no_size_dataset)
+        end
+
         def datasets_category
           @datasets_category ||= gobierto_common_custom_fields(:madrid_data_datasets_custom_field_category)
         end
@@ -142,14 +146,14 @@ module GobiertoData
             get gobierto_data_api_v1_datasets_path, as: :json
             response_data = response.parsed_body
             datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
-            assert_equal [dataset.name, other_dataset.name], datasets_names
+            assert_equal [no_size_dataset.name, dataset.name, other_dataset.name], datasets_names
 
             other_dataset.update_attribute(:data_updated_at, 1.second.ago)
 
             get gobierto_data_api_v1_datasets_path, as: :json
             response_data = response.parsed_body
             datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
-            assert_equal [other_dataset.name, dataset.name], datasets_names
+            assert_equal [no_size_dataset.name, other_dataset.name, dataset.name], datasets_names
           end
         end
 
@@ -270,8 +274,11 @@ module GobiertoData
             big_dataset_response_data = response.parsed_body
             get meta_gobierto_data_api_v1_dataset_path(small_dataset.slug), as: :json
             small_dataset_response_data = response.parsed_body
+            get meta_gobierto_data_api_v1_dataset_path(no_size_dataset.slug), as: :json
+            no_size_dataset_response_data = response.parsed_body
 
             assert_equal 50, big_dataset_response_data["data"]["attributes"]["default_limit"]
+            assert_equal 50, no_size_dataset_response_data["data"]["attributes"]["default_limit"]
             assert_nil small_dataset_response_data["data"]["attributes"]["default_limit"]
 
             assert_equal 15, big_dataset_response_data["data"]["attributes"]["size"]["csv"]

--- a/test/fixtures/gobierto_data/datasets.yml
+++ b/test/fixtures/gobierto_data/datasets.yml
@@ -35,3 +35,13 @@ santander_dataset:
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
   visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
+
+no_size_dataset:
+  site: madrid
+  name_translations: <%= { en: "No size", es: "No se el size" }.to_json %>
+  table_name: sites
+  slug: no-size
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+  visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
+


### PR DESCRIPTION
Related with #3635

## :v: What does this PR do?

While in that issue you should investigate why a big big dataset doesn't have the size recorded, this PR patches the behaviour of the query editor to add a default limit of 50 rows when the size is nil.

## :mag: How should this be manually tested?

In staging

- update the size of a dataset to nil
- check the default query contains a LIMIT 50
