### PR TITLE
3637 fix dashboards index

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/dashboards_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/dashboards_controller.rb
@@ -17,6 +17,13 @@ module GobiertoAdmin
         ).allowed_actions
       end
 
+      def destroy
+        dashboard = base_relation.find(params[:id])
+        dashboard.destroy
+
+        redirect_to admin_plans_plan_dashboards_path(plan), notice: t("gobierto_admin.gobierto_dashboards.dashboards.destroy.success")
+      end
+
       protected
 
       def dashboard_preview_path(dashboard, options = {})

--- a/app/controllers/gobierto_admin/gobierto_plans/dashboards_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/dashboards_controller.rb
@@ -46,7 +46,7 @@ module GobiertoAdmin
       alias context_resource plan
 
       def base_relation
-        current_site.dashboards.for_context(@plan)
+        current_site.dashboards.for_context(@plan).order(id: :desc)
       end
 
       def raise_action_not_allowed

--- a/app/views/gobierto_admin/gobierto_plans/dashboards/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/dashboards/index.html.erb
@@ -25,6 +25,7 @@
     <th><%= t(".headers.status") %></th>
     <th></th>
     <th></th>
+    <th class="icon_col"></th>
   </tr>
 
   <% @dashboards.each do |dashboard| %>
@@ -64,6 +65,14 @@
             <i class="fas fa-eye"></i>
             <%= t(".view_public_dashboard") %>
           <% end %>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to admin_plans_plan_dashboard_path(@plan.id, dashboard.id),
+                    title: t("gobierto_dashboards.delete"),
+                    method: :delete,
+                    data: { confirm: t("views.delete_confirm") } do %>
+          <i class="fas fa-trash"></i>
         <% end %>
       </td>
     </tr>

--- a/app/views/gobierto_admin/gobierto_plans/dashboards/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/dashboards/index.html.erb
@@ -23,6 +23,7 @@
     <th class="icon"></th>
     <th><%= t(".headers.title") %></th>
     <th><%= t(".headers.status") %></th>
+    <th><%= t(".headers.updated") %></th>
     <th></th>
     <th class="icon_col"></th>
   </tr>
@@ -52,6 +53,7 @@
         <% end %>
         <%= t(".visibility_level.#{dashboard.visibility_level}") %>
       </td>
+      <td><%= time_ago_in_words(dashboard.updated_at) %></td>
       <td>
         <% unless dashboard.draft? %>
           <%= link_to preview_path, target: "_blank", class: "view_item" do %>

--- a/app/views/gobierto_admin/gobierto_plans/dashboards/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/dashboards/index.html.erb
@@ -24,7 +24,6 @@
     <th><%= t(".headers.title") %></th>
     <th><%= t(".headers.status") %></th>
     <th></th>
-    <th></th>
     <th class="icon_col"></th>
   </tr>
 
@@ -54,16 +53,10 @@
         <%= t(".visibility_level.#{dashboard.visibility_level}") %>
       </td>
       <td>
-        <%= link_to admin_dashboards_modal_path(id: dashboard.id, context: @context, pipe: "project_metrics", preview_path: preview_path), data: { turbolinks: false, dashboards_maker: false }, class: "open_remote_modal" do %>
-          <i class="fas fa-eye"></i>
-          <%= t(".view_dashboard") %>
-        <% end %>
-      </td>
-      <td>
         <% unless dashboard.draft? %>
           <%= link_to preview_path, target: "_blank", class: "view_item" do %>
             <i class="fas fa-eye"></i>
-            <%= t(".view_public_dashboard") %>
+            <%= t("gobierto_dashboards.view_item") %>
           <% end %>
         <% end %>
       </td>

--- a/config/locales/gobierto_admin/gobierto_dashboards/controllers/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_dashboards/controllers/ca.yml
@@ -1,0 +1,7 @@
+---
+ca:
+  gobierto_admin:
+    gobierto_dashboards:
+      dashboards:
+        destroy:
+          success: El dashboard s'ha esborrat correctament.

--- a/config/locales/gobierto_admin/gobierto_dashboards/controllers/en.yml
+++ b/config/locales/gobierto_admin/gobierto_dashboards/controllers/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  gobierto_admin:
+    gobierto_dashboards:
+      dashboards:
+        destroy:
+          success: Dashboard deleted correctly.

--- a/config/locales/gobierto_admin/gobierto_dashboards/controllers/es.yml
+++ b/config/locales/gobierto_admin/gobierto_dashboards/controllers/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  gobierto_admin:
+    gobierto_dashboards:
+      dashboards:
+        destroy:
+          success: El dashboard ha sido eliminado correctamente.

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -14,6 +14,7 @@ ca:
           headers:
             status: Visibilitat
             title: Títol
+            updated: Actualitzat
           new: Nou
           visibility_level:
             active: Públic

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -15,8 +15,6 @@ ca:
             status: Visibilitat
             title: Títol
           new: Nou
-          view_dashboard: Veure dashboard
-          view_public_dashboard: Vista pública
           visibility_level:
             active: Públic
             draft: Privat

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -15,8 +15,6 @@ en:
             status: Visibility
             title: Title
           new: New
-          view_dashboard: View dashboard
-          view_public_dashboard: Public view
           visibility_level:
             active: Public
             draft: Private

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -14,6 +14,7 @@ en:
           headers:
             status: Visibility
             title: Title
+            updated: Updated
           new: New
           visibility_level:
             active: Public

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -14,6 +14,7 @@ es:
           headers:
             status: Visibilidad
             title: Título
+            updated: Actualizado
           new: Nuevo
           visibility_level:
             active: Público

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -15,8 +15,6 @@ es:
             status: Visibilidad
             title: Título
           new: Nuevo
-          view_dashboard: Ver dashboard
-          view_public_dashboard: Vista pública
           visibility_level:
             active: Público
             draft: Privado

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,7 +192,9 @@ Rails.application.routes.draw do
               get :accumulated_values
             end
           end
-          resources :dashboards, only: [:index]
+
+          resources :dashboards, only: [:index, :destroy]
+
           resources :projects do
             member do
               post :publish


### PR DESCRIPTION
Closes #3637


## :v: What does this PR do?

* Adds link to destroy dashboards in index
* Removes a redundant column
* Renames the public view link name
* Add an updated column
* Orders by default dashboards by id descending

## :mag: How should this be manually tested?

Visit dashboards index in a plan

## :eyes: Screenshots

### Before this PR

<img width="1045" alt="Screen Shot 2021-01-20 at 21 50 50" src="https://user-images.githubusercontent.com/446459/105233057-9ab24480-5b69-11eb-9523-216dd2bb786c.png">

### After this PR

<img width="1044" alt="Screen Shot 2021-01-20 at 21 49 53" src="https://user-images.githubusercontent.com/446459/105233072-a140bc00-5b69-11eb-8726-00a8da2c994f.png">

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No