### PR TITLE
Internal site request should check the referrer instead of the current host

### DIFF
--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -36,7 +36,13 @@ module User::ApiAuthenticationHelper
   end
 
   def internal_site_request?
-    @internal_site_request ||= request.host == current_site.domain || Site.where(domain: request.host).exists?
+    @internal_site_request ||= begin
+                                 if request.referrer.present? && (referrer_host = URI.parse(request.referrer)&.host)
+                                   referrer_host == current_site.domain || Site.where(domain: referrer_host).exists?
+                                 else
+                                   false
+                                 end
+                               end
   end
 
   def find_current_user

--- a/test/controllers/gobierto_investments/api/v1/projects_controller_test.rb
+++ b/test/controllers/gobierto_investments/api/v1/projects_controller_test.rb
@@ -176,16 +176,16 @@ module GobiertoInvestments
             Rails.stub(:env, ActiveSupport::StringInquirer.new(environment)) do
               with(site: site) do
                 self.host = "santander.gobierto.test"
-                get gobierto_investments_api_v1_projects_path, as: :json
+                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "HTTP_REFERER" => "http://#{site.domain}/wadus.html" }
                 assert_response :success
 
-                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "Authorization" => basic_auth_header }
+                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "Authorization" => basic_auth_header, "HTTP_REFERER" => "http://#{site.domain}/wadus.html" }
                 assert_response :success
 
-                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "Authorization" => "Bearer #{token_with_domain}" }
+                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "Authorization" => "Bearer #{token_with_domain}", "HTTP_REFERER" => "http://#{site.domain}/wadus.html" }
                 assert_response :success
 
-                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "Authorization" => "Bearer #{token_with_other_domain}" }
+                get gobierto_investments_api_v1_projects_path, as: :json, headers: { "Authorization" => "Bearer #{token_with_other_domain}", "HTTP_REFERER" => "http://#{site.domain}/wadus.html"  }
                 assert_response :success
               end
             end

--- a/test/support/concerns/api/api_protection_test.rb
+++ b/test/support/concerns/api/api_protection_test.rb
@@ -60,16 +60,16 @@ module Api
             get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
+            get @api_protection_test_path, as: :json, headers: { "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => @api_protection_test_basic_auth_header, "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => @api_protection_test_basic_auth_header, "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}", "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}", "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html" }
             assert_response :success
           end
         end

--- a/test/support/concerns/api/api_protection_test.rb
+++ b/test/support/concerns/api/api_protection_test.rb
@@ -52,17 +52,24 @@ module Api
       %w(staging production).each do |environment|
         Rails.stub(:env, ActiveSupport::StringInquirer.new(environment)) do
           with(site: @api_protection_test_site) do
-            self.host = "santander.gobierto.test"
-            get @api_protection_test_path, as: :json
+            # Nil referrer and no authorization provides unauthorized
+            get @api_protection_test_path, as: :json, headers: { "HTTP_REFERER" => "" }
+            assert_response :unauthorized
+
+            # Nil referrer authorized should success
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => @api_protection_test_basic_auth_header }
+            get @api_protection_test_path, as: :json, headers: { "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => @api_protection_test_basic_auth_header, "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
             assert_response :success
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
+            assert_response :success
+
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}", "HTTP_REFERER" => "http://santander.gobierto.test/wadus.html" }
             assert_response :success
           end
         end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1131

## :v: What does this PR do?

This PR fixes a bug in the check of internal request, making the check against the request referrer instead of the request host, which was always returning true

## :mag: How should this be manually tested?

Straight api requests without any authorization should fail
