### PR TITLE
Versions in project metrics

### DIFF
--- a/app/models/gobierto_dashboards/data_pipes/project_metrics.rb
+++ b/app/models/gobierto_dashboards/data_pipes/project_metrics.rb
@@ -26,14 +26,21 @@ module GobiertoDashboards
       end
 
       def indicators(record)
-        return unless record.value.is_a? Array
+        published_version = record.item.published_version
+        return unless published_version.present?
 
-        grouped_values(record.value).map do |key, values|
+        published_value = ::GobiertoCommon::CustomFieldFunctions::Indicator.new(record, version: published_version).value
+        return unless published_value.is_a? Array
+
+        published_project = ::GobiertoPlans::ProjectDecorator.new(record.item, opts: { plan: @context.resource }).at_current_version
+        project = published_project.to_global_id.to_s
+        project_name = published_project.name
+        grouped_values(published_value).map do |key, values|
           {
             name: values.first["indicator"].strip.squeeze(" "),
             id: key,
-            project: record.item.to_global_id.to_s,
-            project_name: record.item.name,
+            project: project,
+            project_name: project_name,
             values: values.map { |value| value.except("indicator") }
           }
         end


### PR DESCRIPTION
## :v: What does this PR do?

* Changes project metrics data pipe to use published versions of projects and indicators contained
* Updates API test to take this into account

## :mag: How should this be manually tested?

Visit a published project, update the project title and indicators values and save (don't check minor version or publish automatically)
The dashboard shouldn't change
Publish the last version of the project
The dashboard should reflect the new version changes 

## :eyes: Screenshots

### After this PR

![versions_in_indicators](https://user-images.githubusercontent.com/446459/105513950-3ca17080-5cd3-11eb-8bfd-da5add00f787.gif)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
