### PR TITLE
Gobierto Visualizations / Add a new field to contract's page

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
@@ -54,6 +54,12 @@
             :label="labelBidDescription"
             :value="initial_amount_no_taxes | money"
           />
+          <template v-if="showEstimatedValue">
+            <ContractsShowLabelGroup
+              :label="labelEstimatedValue"
+              :value="estimated_value | money"
+            />
+          </template>
           <ContractsShowLabelGroup
             :label="labelBiddersDescription"
             :value="number_of_proposals"
@@ -140,6 +146,7 @@ export default {
       number_of_proposals: '',
       cpvs: '',
       category_title: '',
+      estimated_value: '',
       labelAwardingEntity: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding_entity') || '',
       labelAssigneeDescription: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.assignee_description') || '',
       labelContractAmount: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.contract_amount') || '',
@@ -151,6 +158,7 @@ export default {
       labelCategory: I18n.t('gobierto_visualizations.visualizations.subsidies.category') || '',
       labelProcess: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.process') || '',
       labelType: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.type') || '',
+      labelEstimatedValue: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.estimated_value') || '',
       filterContractsBatches: []
     }
   },
@@ -163,6 +171,9 @@ export default {
     },
     showArrowDate() {
       return this.submission_date && this.open_proposals_date
+    },
+    showEstimatedValue() {
+      return this.initial_amount_no_taxes !== this.final_amount_no_taxes
     }
   },
   created() {
@@ -194,7 +205,8 @@ export default {
         minor_contract,
         open_proposals_date,
         submission_date,
-        number_of_proposals
+        number_of_proposals,
+        estimated_value
       } = this.contract
 
       this.title = title
@@ -220,6 +232,7 @@ export default {
       this.cpvs = cpvs
       this.category_title = category_title
       this.number_of_proposals = number_of_proposals
+      this.estimated_value = estimated_value
     }
 
     if (this.hasBatch) this.groupBatches()

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
@@ -173,7 +173,7 @@ export default {
       return this.submission_date && this.open_proposals_date
     },
     showEstimatedValue() {
-      return this.initial_amount_no_taxes !== this.final_amount_no_taxes
+      return this.initial_amount_no_taxes !== this.estimated_value
     }
   },
   created() {
@@ -232,7 +232,7 @@ export default {
       this.cpvs = cpvs
       this.category_title = category_title
       this.number_of_proposals = number_of_proposals
-      this.estimated_value = estimated_value
+      this.estimated_value = +estimated_value
     }
 
     if (this.hasBatch) this.groupBatches()

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -34,6 +34,7 @@ ca:
           bidders_description: Numero d'empreses que s'han presentat al procés (Licitadors)
           contract_amount: Import d'adjudicació
           entity: Entitat
+          estimated_value: Valor estimat
           process: Procés
           question_description: Què % del pressupost suposa aquest contracte?
           tender: Licitació

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -35,6 +35,7 @@ en:
             (Bidders)
           contract_amount: Contract amount
           entity: Entity
+          estimated_value: Estimated value
           process: Process
           question_description: What % of the budget is this contract?
           tender: Tender

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -35,6 +35,7 @@ es:
             (Licitadores)
           contract_amount: Importe de adjudicación
           entity: Entidad
+          estimated_value: Valor estimado
           process: Proceso
           question_description: "¿Qué % del presupuesto supone este contrato?"
           tender: Licitación


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1182


## :v: What does this PR do?

In a few contracts, the initial amount and final amount are different. In this case, we show too the estimated value of the contract.

## :mag: How should this be manually tested?

[Contract with estimated value](https://santfeliu.gobify.net/visualizaciones/contratos/adjudicaciones/1272536)

## :eyes: Screenshots

### Before this PR
![Screenshot 2021-01-25 at 08 22 09](https://user-images.githubusercontent.com/2649175/105673627-98901300-5ee6-11eb-9b04-56703a70a913.png)
### After this PR
![Screenshot 2021-01-25 at 13 54 34](https://user-images.githubusercontent.com/2649175/105708521-e15ec080-5f14-11eb-93d2-6328e947b123.png)


