### PR TITLE
Allow gobierto-data to be startpage

### DIFF
--- a/app/javascript/gobierto_data/lib/router.js
+++ b/app/javascript/gobierto_data/lib/router.js
@@ -21,6 +21,7 @@ export const router = new VueRouter({
     },
     {
       path: '/datos/',
+      alias: "/",
       component: Main,
       children: [
         {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1155

## :v: What does this PR do?
Run gobierto-data frontend when path is also the root folder

## :mag: How should this be manually tested?
https://demo-datos.gobify.net/