### PR TITLE
Restores two digit precission in budgets module

### DIFF
--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -32,7 +32,7 @@ module GobiertoBudgets
             value: format_currency(budget_data[:value]),
             delta_percentage: helpers.number_with_precision(delta_percentage(budget_data[:value], budget_data_previous_year[:value]), precision: 2),
             ranking_position: position,
-            ranking_total_elements: helpers.number_with_precision(budget_data[:total_elements], precision: 0),
+            ranking_total_elements: helpers.number_with_precision(budget_data[:total_elements], precision: 2),
             ranking_url: ''
           }
         else
@@ -84,7 +84,7 @@ module GobiertoBudgets
             value: format_currency(budget_data[:value]),
             delta_percentage: helpers.number_with_precision(delta_percentage(budget_data[:value], budget_data_previous_year[:value]), precision: 2),
             ranking_position: position,
-            ranking_total_elements: helpers.number_with_precision(budget_data[:total_elements], precision: 0),
+            ranking_total_elements: helpers.number_with_precision(budget_data[:total_elements], precision: 2),
             ranking_url: ''
           }
         else

--- a/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
@@ -8,8 +8,8 @@
 
     <%= link_to budget_line.name, gobierto_budgets_budget_line_path(budget_line.to_param) %>
   </td>
-  <td class="qty big_qty"><%= number_to_currency budget_line.amount, precision: 0 %></td>
-  <%= content_tag :td, number_to_currency(budget_line.amount_per_inhabitant, precision: 0), class: "qty" if budget_line.amount_per_inhabitant %>
+  <td class="qty big_qty"><%= number_to_currency budget_line.amount, precision: 2 %></td>
+  <%= content_tag :td, number_to_currency(budget_line.amount_per_inhabitant, precision: 2), class: "qty" if budget_line.amount_per_inhabitant %>
   <td class="qty"><%= number_with_precision(budget_line.percentage_of_total, precision: 2) + ' %' %></td>
   <td class="bar"><div class="bar" style="width:<%= budget_line.percentage_of_total %>%"></div></td>
 </tr>

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -83,7 +83,7 @@
         <td class="qty big_qty">
           <%= number_to_currency(
                 kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget(fallback: true) : @site_stats.total_budget(fallback: true),
-                precision: 0
+                precision: 2
               ) %></td>
         <%= content_tag :td, number_to_currency(kind == GobiertoBudgets::BudgetLine::INCOME ? @site_stats.total_income_budget_per_inhabitant : @site_stats.total_budget_per_inhabitant, precision: 2), class: "qty big_qty" if @site_stats.population_data? %>
         <td class="qty"></td>

--- a/app/views/gobierto_budgets/budgets/_sub_budget_line.html.erb
+++ b/app/views/gobierto_budgets/budgets/_sub_budget_line.html.erb
@@ -1,5 +1,5 @@
 <td><%= link_to sub_budget_line.name, gobierto_budgets_budget_line_path(sub_budget_line.to_param) %></td>
-<td style="<%= class_if("border-radius: 0 0 0 4px", last_item) %>" class="qty big_qty <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><%= number_to_currency sub_budget_line.amount, precision:0 %></td>
+<td style="<%= class_if("border-radius: 0 0 0 4px", last_item) %>" class="qty big_qty <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><%= number_to_currency sub_budget_line.amount, precision: 2 %></td>
 <td class="qty <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><%= percentage_format(sub_budget_line.percentage_of_total) %></td>
 <% unless controller_name == 'budgets_elaboration' %>
   <td class="bar <%= class_if("highlight-proposal", @interesting_expenses_previous_year.present?) %>"><div class="bar" style="width:<%= sub_budget_line.percentage_of_total %>%"></div></td>

--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="highlight-proposal">
-    <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year + 1) %></p>
+    <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
   </div>
 
   <div class="pure-g metric_boxes">


### PR DESCRIPTION
Requested by Mataro

## :v: What does this PR do?

This PR adds 2 decimal digits to budgets amounts, not sure why we removed them so long ago, but truth is that the info is interesting to make the sums properly

## :mag: How should this be manually tested?

Check any budgets homepage in staging

## :eyes: Screenshots

### Before this PR

![Screenshot from 2021-02-03 08-13-19](https://user-images.githubusercontent.com/17616/106711375-b6046180-65f7-11eb-9581-02d56f117df9.png)

### After this PR

![Screenshot from 2021-02-03 08-14-14](https://user-images.githubusercontent.com/17616/106711453-d2a09980-65f7-11eb-8ef1-1cca6956aebb.png)


