### PR TITLE
Show one dashboard

### DIFF
--- a/app/javascript/gobierto_dashboards/webapp/ViewerManager.vue
+++ b/app/javascript/gobierto_dashboards/webapp/ViewerManager.vue
@@ -71,7 +71,8 @@ export default {
     if (this.id) {
       this.currentDashboard = this.dashboards.find(({ id }) => +id === +this.id)
     } else if (this.dashboards.length === 1) {
-      this.currentDashboard = this.dashboards[0]
+      const [{ id }] = this.dashboards
+      this.handleClick(id)
     }
 
     // Emit to his parent, if there was any

--- a/app/javascript/gobierto_dashboards/webapp/ViewerManager.vue
+++ b/app/javascript/gobierto_dashboards/webapp/ViewerManager.vue
@@ -70,6 +70,8 @@ export default {
 
     if (this.id) {
       this.currentDashboard = this.dashboards.find(({ id }) => +id === +this.id)
+    } else if (this.dashboards.length === 1) {
+      this.currentDashboard = this.dashboards[0]
     }
 
     // Emit to his parent, if there was any


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1191

## :v: What does this PR do?
When there's only one dashboard, set it up as currentDashboard (load it)

Demo: https://diba-plan.gobify.net/planes/pla-de-mandat/2019/dashboards