### PR TITLE
Gobierto Visualizations / Bug on resize and don't paint some elements in the DOM

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/CategoriesTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/CategoriesTreeMapNested.vue
@@ -88,7 +88,6 @@ export default {
           }
           if (key === value_key) {
             root.value = parseFloat(root[value_key]);
-            delete root[value_key];
           }
         }
         return root;

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/EntityTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/EntityTreeMapNested.vue
@@ -119,7 +119,6 @@ export default {
           }
           if (key === value_key) {
             root.value = parseFloat(root[value_key]);
-            delete root[value_key];
           }
         }
         return root;

--- a/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
@@ -373,6 +373,10 @@ window.addEventListener("resize", this.resizeListener)
           .attr("class", "foreignobj")
           .append("xhtml:div")
           .html(d => {
+            const { x0, x1, y0, y1 } = d
+            const rectWidth = x1 - x0
+            const rectHeight = y1 - y0
+            if (rectWidth < 100 || rectHeight < 100) return
             let htmlTreeMap
             if (depthEntity && deepLevel === 4) {
               htmlTreeMap = treeMapThreeDepth(d)
@@ -721,7 +725,7 @@ window.addEventListener("resize", this.resizeListener)
       if (this.updateData) {
         this.deepCloneData(this.dataNewValues)
       } else {
-        this.transformDataTreemap(this.data);
+        this.transformDataTreemap(this.dataTreeMapWithoutCoordinates);
       }
     },
     injectRouter() {


### PR DESCRIPTION
## :v: What does this PR do?

Resize:
When resizing the browser, we lose the value(final_amount) that gives the circles' size. Its happens because transforming the treemap data, the value was removed, and the main array was updated without this value.

DOM:
We do not build the elements that are not seen. If the text doesn't fit in the rectangle, we don't show it, so there's no point in building something that won't be seen.


## :mag: How should this be manually tested?

Staging


## :eyes: Screenshots

### Before this PR
![Screen Recording 2021-02-03 at 12 53 56 2021-02-03 12_59_18](https://user-images.githubusercontent.com/2649175/106744153-aa2c9580-661f-11eb-9889-2fa3d8b9ff3f.gif)

### After this PR

![Screen Recording 2021-02-03 at 13 13 26 2021-02-03 13_14_14](https://user-images.githubusercontent.com/2649175/106745694-c5000980-6621-11eb-977f-c92cce005933.gif)
