### PR TITLE
Fix referrer check and refactor

### DIFF
--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -37,7 +37,7 @@ module User::ApiAuthenticationHelper
 
   def internal_site_request?
     @internal_site_request ||= begin
-                                 if request.referrer.present? && (referrer_host = URI.parse(request.referrer)&.host)
+                                 if referrer_host.present?
                                    referrer_host == current_site.domain || Site.where(domain: referrer_host).exists?
                                  else
                                    false
@@ -67,6 +67,10 @@ module User::ApiAuthenticationHelper
   # The ApiToken associated domain must be blank or coincident with the host
   # request
   def api_token_with_host
-    @api_token_with_host ||= ::User::ApiToken.where(domain: [nil, request.host]).find_by(token: token) || ::GobiertoAdmin::ApiToken.where(domain: [nil, request.host]).find_by(token: token)
+    @api_token_with_host ||= ::User::ApiToken.where(domain: [nil, referrer_host]).find_by(token: token) || ::GobiertoAdmin::ApiToken.where(domain: [nil, referrer_host]).find_by(token: token)
+  end
+
+  def referrer_host
+    @referrer_host ||= URI.parse(request.referrer)&.host if request.referrer.present?
   end
 end

--- a/test/support/concerns/api/api_protection_test.rb
+++ b/test/support/concerns/api/api_protection_test.rb
@@ -56,9 +56,9 @@ module Api
             get @api_protection_test_path, as: :json, headers: { "HTTP_REFERER" => "" }
             assert_response :unauthorized
 
-            # Nil referrer authorized should success
+            # Nil referrer and token with domain should fail
             get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "" }
-            assert_response :success
+            assert_response :unauthorized
 
             get @api_protection_test_path, as: :json, headers: { "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html" }
             assert_response :success
@@ -90,18 +90,16 @@ module Api
             get @api_protection_test_path, as: :json, headers: { "Authorization" => @api_protection_test_basic_auth_header }
             assert_response :unauthorized
 
-            self.host = @api_protection_test_token_with_domain.domain
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}", "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html"  }
             assert_response :success
 
             get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}" }
             assert_response :unauthorized
 
-            self.host = @api_protection_test_token_with_other_domain.domain
             get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_domain}" }
             assert_response :unauthorized
 
-            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}" }
+            get @api_protection_test_path, as: :json, headers: { "Authorization" => "Bearer #{@api_protection_test_token_with_other_domain}", "HTTP_REFERER" => "http://#{@api_protection_test_site.domain}/wadus.html"   }
             assert_response :success
           end
         end


### PR DESCRIPTION
## :v: What does this PR do?

This PR solves how the referrer was being checked when in the token finder request (follows #3354)

Besides that, refactors a bit the code and fixes the checks of the test that allowed to authorize a request with a token with domain and no referrer.

