### PR TITLE
Gobierto Subsidies / Amount data is missing

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/CategoriesTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/CategoriesTreeMapNested.vue
@@ -89,7 +89,6 @@ export default {
           }
           if (key === value_key) {
             root.value = parseFloat(root[value_key]);
-            delete root[value_key];
           }
         }
         return root;

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -15,7 +15,7 @@ ca:
     - dv
     - ds
     abbr_month_names:
-    -
+    - 
     - gen
     - feb
     - mar
@@ -43,7 +43,7 @@ ca:
       short: "%d %b"
       shortest: "%d %b %y"
     month_names:
-    -
+    - 
     - gener
     - febrer
     - març

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -15,7 +15,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       short: "%b %d %Y"
       shortest: "%d %b %y"
     month_names:
-    -
+    - 
     - January
     - February
     - March

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -15,7 +15,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       short: "%d %b %Y"
       shortest: "%d %b %y"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -7,9 +7,6 @@ ca:
           contracts: Contractes i licitacions
           costs: Costos
           subsidies: Subvencions
-      menu_subsections:
-        contracts: Contractes
-        subsidies: Subvencions
     shared:
       download_data: Descarregueu les dades en format reutilitzable
       loading: Carregant dades...
@@ -51,7 +48,7 @@ ca:
         main_assignees: Principals adjudicataris
         more: Més de
         nav:
-          contracts: Contracts
+          contracts: Contractes
           summary: Resum
           tenders: Licitacions
         process_type: Tipus de procés

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -7,9 +7,6 @@ en:
           contracts: Contracts and tenders
           costs: Costs
           subsidies: Subsidies
-      menu_subsections:
-        contracts: Contracts
-        subsidies: Subsidies
     shared:
       download_data: Download the full dataset in a reusable format
       loading: Loading data...

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -7,9 +7,6 @@ es:
           contracts: Contratos y licitaciones
           costs: Costes
           subsidies: Subvenciones
-      menu_subsections:
-        contracts: Contratos
-        subsidies: Subvenciones
     shared:
       download_data: Descarga los datos completos en formatos reutilizables
       loading: Cargando datos...

--- a/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
@@ -95,7 +95,7 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
       assert process_type_container.has_content?(/Negociado con publicidad\d*0,4 %/)
 
       # Assignees table
-      first_contract = find(".visualizations-home-main--tr", match: :first)
+      first_contract = find(".gobierto-table__tr", match: :first)
 
       assert first_contract.has_content?('FLODI, S.L.')
       assert first_contract.has_content?('599.015,70 €')
@@ -115,19 +115,19 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
       # Active tab is Contracts
       assert find(".visualizations-home-nav--tab.is-active").text, 'CONTRACTS'
 
-      first_contract = find(".visualizations-home-main--tr", match: :first)
+      first_contract = find(".gobierto-table__tr", match: :first)
 
       # Assignee
-      assert first_contract.has_content?('Grupo Conforsa Análisis, Desarrollo y Formación , S.A.')
+      assert first_contract.has_content?('UTE ABALA - FACTO -ORTHEM')
 
       # Contract
-      assert first_contract.has_content?('Prestación del servicio de plataforma de formación online "E...')
+      assert first_contract.has_content?('Construcción de dos edificios de viviendas con protección púb')
 
       # Amount
-      assert first_contract.has_content?('€28,400.00')
+      assert first_contract.has_content?('€12,207,444.40')
 
       # Date
-      assert first_contract.has_content?('7/1/2020')
+      assert first_contract.has_content?('12/16/2019')
 
       # Contracts Show
       ################
@@ -137,41 +137,41 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
       assert find(".visualizations-home-nav--tab.is-active").text, 'CONTRACTS'
 
       # Url is updated
-      assert_equal current_path, "/visualizaciones/contratos/adjudicaciones/807094"
+      assert_equal current_path, "/visualizaciones/contratos/adjudicaciones/260522"
 
       # Title
-      assert page.has_content?('Prestación del servicio de plataforma de formación online "Escuela Virtual Formalef Getafe".')
+      assert page.has_content?('Construcción de dos edificios de viviendas con protección pública, garajes y trasteros de consumo energético casi nulo.')
 
       # Assignee
-      assert page.has_content?('Grupo Conforsa Análisis, Desarrollo y Formación , S.A.')
+      assert page.has_content?('UTE ABALA - FACTO -ORTHEM')
 
       # Contract amount
-      assert page.has_content?('€28,400.00')
+      assert page.has_content?('€12,459,118.59')
 
-      # Tender amount
-      assert page.has_content?('€40,000.00')
+      # Contract amount no taxes
+      assert page.has_content?('€12,207,444.40')
 
       # Status
       assert page.has_content?('Formalizado')
 
       # Type
-      assert page.has_content?('Abierto simplificado')
+      assert page.has_content?('Abierto')
 
       # Assignees Show
       ################
       find("#assignee_show_link").click
 
       # Url is updated
-      assert_equal current_path, "/visualizaciones/contratos/adjudicatario/0d25ed58b4e09e6985b0d5cf27e7fa98"
+      assert_equal current_path, "/visualizaciones/contratos/adjudicatario/cd0db88d9c0da8d17bc82cbad2b3a235"
 
       assert page.has_content?("Contracts assigned to")
-      assert page.has_content?('Prestación del servicio de plataforma de formación online "Escuela Virtual Formalef Getafe".')
+      assert page.has_content?('Construcción de dos edificios de viviendas con protección pública, garajes y trasteros de consumo energético casi nulo.')
 
       # We can go back to the contract page
-      first_contract = find(".visualizations-home-main--tr", match: :first)
+      first_contract = find(".gobierto-table__tr", match: :first)
       first_contract.click
 
-      assert_equal current_path, "/visualizaciones/contratos/adjudicaciones/807094"
+      assert_equal current_path, "/visualizaciones/contratos/adjudicaciones/260522"
 
     end
   end

--- a/test/integration/gobierto_visualizations/visualizations_subsidies_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_subsidies_test.rb
@@ -79,10 +79,10 @@ class GobiertoVisualizations::VisualizationsSubsidiesTest < ActionDispatch::Inte
       assert category_container.has_content?("3,3 %")
 
       # Beneficiaries table
-      first_beneficiary = find(".visualizations-home-main--tr", match: :first)
+      first_beneficiary = find(".gobierto-table__tr", match: :first)
 
-      assert first_beneficiary.has_content?('REGIONAL DE EXTREMADURA')
-      assert first_beneficiary.has_content?('756,00 €')
+      assert first_beneficiary.has_content?('1')
+      assert first_beneficiary.has_content?('146,00 €')
     end
   end
 
@@ -99,17 +99,16 @@ class GobiertoVisualizations::VisualizationsSubsidiesTest < ActionDispatch::Inte
       # Active tab is Subsidies
       assert find(".visualizations-home-nav--tab.is-active").text, 'SUBSIDIES'
 
-      first_subsidy = find(".visualizations-home-main--tr", match: :first)
+      first_subsidy = find(".gobierto-table__tr", match: :first)
 
       # Beneficiary
       assert first_subsidy.has_content?('1')
 
       # Amount
-      assert first_subsidy.has_content?('€146.00')
+      assert first_subsidy.has_content?('€1,305.05')
 
       # Date
-      assert first_subsidy.has_content?('2016-12-27')
-
+      assert first_subsidy.has_content?('2016-08-02')
 
       # Subsidies Show
       ################
@@ -119,13 +118,13 @@ class GobiertoVisualizations::VisualizationsSubsidiesTest < ActionDispatch::Inte
       assert find(".visualizations-home-nav--tab.is-active").text, 'SUBSIDIES'
 
       # Url is updated
-      assert_equal current_path, "/visualizaciones/subvenciones/subvenciones/2016122714613"
+      assert_equal current_path, "/visualizaciones/subvenciones/subvenciones/2016080213050"
 
       # Title
-      assert page.has_content?('CONVOCATORIA DE AYUDAS PARA LA ESCOLARIZACIÓN DE NIÑOS Y NIÑAS EN EL PRIMER CICLO DE EDUCACIÓN INFANTIL DE 0 A 3 AÑOS, EN ESCUELAS INFANTILES Y CASAS DE NIÑOS PÚBLICAS DE GETAFE 2016/2017')
+      assert page.has_content?('CONVOCATORIA DE SUBVENCIONES DIRIGIDAS A ASOCIACIONES DE VECINOS DE GETAFE PARA LA REALIZACIÓN DE SUS PROGRAMAS DE ACTIVIDADES DURANTE EL AÑO 2016')
 
       # Beneficiary
-      assert page.has_content?('1')
+      assert page.has_content?('AA.VV. CASERIO DE PERALES')
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1202

## :v: What does this PR do?

Show the amount in the subsidies table. The error occurred when transforming the data for the treemap, and removing the `final_amount` value from the dataset.


## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-02-10 at 07 50 46](https://user-images.githubusercontent.com/2649175/107476450-1e15f300-6b76-11eb-835e-fecb96cd120b.png)

### After this PR

![Screenshot 2021-02-10 at 07 58 27](https://user-images.githubusercontent.com/2649175/107476459-24a46a80-6b76-11eb-80a9-c3dd4b3d443e.png)