### PR TITLE
Gobierto Contracts / Sum the price if the contract has batches

### DIFF
--- a/app/assets/stylesheets/module-visualizations.scss
+++ b/app/assets/stylesheets/module-visualizations.scss
@@ -575,7 +575,7 @@
   &-contracts-show-table {
     td,
     th {
-      padding: .25rem 0;
+      padding: .25rem;
       border: 0;
       text-align: left;
       font-weight: 400;

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
@@ -72,7 +72,7 @@
           />
           <ContractsShowLabelGroup
             :label="labelContractAmount"
-            :value="final_amount_no_taxes | money"
+            :value="calculateFinalAmount | money"
           />
           <template v-if="!hasBatch">
             <div class="pure-u-1 pure-u-lg-1-1 visualizations-contracts-show__body__group">
@@ -173,6 +173,11 @@ export default {
     },
     showEstimatedValue() {
       return this.initial_amount_no_taxes !== this.estimated_value
+    },
+    calculateFinalAmount() {
+      return this.batch_number > 0
+        ? this.filterContractsBatches.reduce((acc, { final_amount_no_taxes }) => acc + final_amount_no_taxes, 0)
+        : this.final_amount_no_taxes
     }
   },
   created() {


### PR DESCRIPTION
Closes PopulateTools/issues#1203


## :v: What does this PR do?

When the contract contains batches sum the `final_amount` of all batches.

## :mag: How should this be manually tested?
[Staging](https://esplugues.gobify.net/visualizaciones/contratos/adjudicaciones/1258524)

## :eyes: Screenshots

### Before this PR
![Screenshot 2021-02-12 at 07 51 07](https://user-images.githubusercontent.com/2649175/107738725-9102a380-6d07-11eb-9929-0812a8171817.png)
### After this PR

![Screenshot 2021-02-12 at 08 02 11](https://user-images.githubusercontent.com/2649175/107739200-a5936b80-6d08-11eb-890c-dbe4a391ec48.png)


