### PR TITLE
Fix department used in example

### DIFF
--- a/test/queries/gobierto_people/trips_query_test.rb
+++ b/test/queries/gobierto_people/trips_query_test.rb
@@ -26,7 +26,7 @@ module GobiertoPeople
       @other_site = sites(:santander)
 
       @department = gobierto_people_departments(:culture_department)
-      @other_department = gobierto_people_departments(:tourism_department_very_old)
+      @other_department = gobierto_people_departments(:cosmogony_department)
 
       @site_trips_query = GobiertoPeople::TripsQuery.new(
         site: @site,


### PR DESCRIPTION

Related to #3708


## :v: What does this PR do?

With the new charges model the department on trips is taken from the
charge instead of the trip itself. This PR fixes the examples using the
department related with the charge

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
