### PR TITLE
3653 cache data queries

### DIFF
--- a/app/controllers/gobierto_data/api/v1/base_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/base_controller.rb
@@ -26,17 +26,6 @@ module GobiertoData
           end
         end
 
-        def csv_from_query_result(result, options = {})
-          return if result.blank?
-
-          CSV.generate(**options) do |csv|
-            csv << result.fields
-            result.each_row do |row|
-              csv << row
-            end
-          end.force_encoding("utf-8")
-        end
-
         def csv_from_relation(relation, options = {})
           with_serialized_data_from_relation(relation) do |data, new|
             return "" if data.blank?

--- a/app/controllers/gobierto_data/api/v1/queries_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/queries_controller.rb
@@ -36,16 +36,7 @@ module GobiertoData
           find_item
           respond_to do |format|
             format.json do
-              query_result = @item.result(include_draft: valid_preview_token?, include_stats: true)
-              render(
-                json:
-                {
-                  data: query_result.delete(:result),
-                  meta: query_result,
-                  links: links(:data)
-                },
-                adapter: :json_api
-              )
+              render json: cached_item_json, adapter: :json_api
             end
 
             format.csv do
@@ -175,6 +166,17 @@ module GobiertoData
         def cached_item_csv
           Rails.cache.fetch("#{@item.cache_key_with_version}/show.csv?#{csv_options_params.to_json}") do
             @item.csv_result(csv_options_params, include_draft: valid_preview_token?)
+          end
+        end
+
+        def cached_item_json
+          Rails.cache.fetch("#{@item.cache_key_with_version}/show.json") do
+            query_result = @item.result(include_draft: valid_preview_token?, include_stats: true)
+            {
+              data: query_result.delete(:result).to_a,
+              meta: query_result,
+              links: links(:data)
+            }
           end
         end
 

--- a/app/models/gobierto_data/query.rb
+++ b/app/models/gobierto_data/query.rb
@@ -21,6 +21,10 @@ module GobiertoData
       Connection.execute_query(site, sql, include_draft: include_draft, include_stats: include_stats)
     end
 
+    def csv_result(csv_options_params, include_draft: false)
+      GobiertoData::Connection.execute_query_output_csv(site, sql, csv_options_params, include_draft: include_draft)
+    end
+
     def file_basename
       [dataset.slug, name].join("-").tr("_", " ").parameterize
     end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/gobierto/issues/3653


## :v: What does this PR do?

* Changes queries controller to cache data in csv format for show and download actions
* Removes a method which is no longer required with the previous changes

## :mag: How should this be manually tested?

Currently the performance improvement can't be seen in the front because the app doesn't make use of the queries show or download endpoints, but it can be observed calling directly to the API:

* `GET /api/v1/data/queries/ID/download.csv` 
* `GET /api/v1/data/queries/ID`

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
