### PR TITLE
Gobierto Contracts / Enable link to subsidies and fix tabs

### DIFF
--- a/app/assets/stylesheets/comp-vue-treemap-nested.scss
+++ b/app/assets/stylesheets/comp-vue-treemap-nested.scss
@@ -123,10 +123,17 @@
     .link-last-depth {
       display: block;
       height: 100%;
+      color: var(--white);
+      text-decoration: none;
+      &:hover {
+        .text,
+        .title {
+          text-decoration: underline;
+        }
+      }
       .text,
       .title {
         text-decoration: none;
-        color: var(--white);
         pointer-events: none;
       }
     }
@@ -140,6 +147,7 @@
     padding: 12px;
 
     &.hide-text {
+      padding: 0;
       .title,
       .text-depth-third,
       .text {

--- a/app/assets/stylesheets/comp-vue-treemap-nested.scss
+++ b/app/assets/stylesheets/comp-vue-treemap-nested.scss
@@ -120,6 +120,16 @@
       line-height: 1;
     }
 
+    .link-last-depth {
+      display: block;
+      height: 100%;
+      .text,
+      .title {
+        text-decoration: none;
+        color: var(--white);
+      }
+    }
+
   }
 
   .treemap-nested-container-text {

--- a/app/assets/stylesheets/comp-vue-treemap-nested.scss
+++ b/app/assets/stylesheets/comp-vue-treemap-nested.scss
@@ -127,6 +127,7 @@
       .title {
         text-decoration: none;
         color: var(--white);
+        pointer-events: none;
       }
     }
 

--- a/app/assets/stylesheets/module-visualizations.scss
+++ b/app/assets/stylesheets/module-visualizations.scss
@@ -92,6 +92,8 @@
       text-align: center;
       margin-left: 20px;
       flex: 1 0 auto;
+      position: relative;
+      z-index: 2;
 
       @include min-screen(768) {
         flex: 0 0 auto;

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/CategoriesTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/CategoriesTreeMapNested.vue
@@ -18,6 +18,7 @@
     :key-for-third-depth="'title'"
     @transformData="nestedData"
     @showTooltip="showTooltipTreemap"
+    @on-treemap-click="goesToTreemapItem"
   />
 </template>
 <script>
@@ -215,6 +216,11 @@ export default {
         <p class="text-depth-third">${I18n.t('gobierto_visualizations.visualizations.contracts.contract_amount')}: <b>${money(contractAmount)}</b></p>
         <p class="text-depth-third">${I18n.t('gobierto_visualizations.visualizations.contracts.tender_amount')}: <b>${money(initial_amount_no_taxes)}</b></p>
       </div>`
+    },
+    goesToTreemapItem(data) {
+      const { assignee_routing_id } = data
+      // eslint-disable-next-line no-unused-vars
+      this.$router.push(`/visualizaciones/contratos/adjudicatario/${assignee_routing_id}`).catch(err => {})
     }
   }
 }

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/EntityTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/EntityTreeMapNested.vue
@@ -20,6 +20,7 @@
     :key-for-third-depth="'title'"
     @transformData="nestedData"
     @showTooltip="showTooltipTreemap"
+    @on-treemap-click="goesToTreemapItem"
   />
 </template>
 <script>
@@ -370,6 +371,11 @@ export default {
         </div>`
       }
 
+    },
+    goesToTreemapItem(data) {
+      const { assignee_routing_id } = data
+      // eslint-disable-next-line no-unused-vars
+      this.$router.push(`/visualizaciones/contratos/adjudicatario/${assignee_routing_id}`).catch(err => {})
     }
   }
 }

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -216,10 +216,14 @@ export default {
   },
   computed: {
     visualizationsDataExcludeNoCategory() {
-      return this.visualizationsData.filter(({ category_id }) => !!category_id)
+      return this.visualizationsData
+        .filter(({ category_id }) => !!category_id)
+        .map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
     },
     visualizationsDataExcludeMinorContract() {
-      return this.visualizationsData.filter(({ minor_contract: minor }) => minor === 'f')
+      return this.visualizationsData
+        .filter(({ minor_contract: minor }) => minor === 'f')
+        .map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
     }
   },
   created() {

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/CategoriesTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/CategoriesTreeMapNested.vue
@@ -61,6 +61,9 @@ export default {
       const dataFilter = data.filter(contract => contract.amount !== 0)
       dataFilter.forEach(d => {
         d.number_of_contract = 1
+        if (d.beneficiary_type === 'persona') {
+          d.beneficiary_type = 'persona física'
+        }
       })
       // d3v6
       //

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/CategoriesTreeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/CategoriesTreeMapNested.vue
@@ -19,6 +19,7 @@
       :key-for-third-depth="'call'"
       @transformData="nestedData"
       @showTooltip="showTooltipTreemap"
+      @on-treemap-click="goesToTreemapItem"
     />
   </div>
 </template>
@@ -185,6 +186,11 @@ export default {
         <p class="depth-second-title">${beneficiary}</p>
         <p class="text-depth-third">${I18n.t('gobierto_visualizations.visualizations.contracts.contract_amount')}: <b>${money(contractAmount)}</b></p>
       </div>`
+    },
+    goesToTreemapItem(data) {
+      const { id } = data
+      // eslint-disable-next-line no-unused-vars
+      this.$router.push(`/visualizaciones/subvenciones/subvenciones/${id}`).catch(err => {})
     }
   }
 }

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
@@ -232,6 +232,10 @@ export default {
           return;
         }
 
+        if (beneficiary_name === 'física') {
+          beneficiary_name = 'PERSONA FÍSICA'
+        }
+
         if (groupedByBeneficiary[beneficiary_name] === undefined) {
           groupedByBeneficiary[beneficiary_name] = {
             name: beneficiary_name,

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
@@ -212,6 +212,8 @@ export default {
   created() {
     this.columns = grantedColumns;
     this.showColumns = ['name', 'count', 'sum']
+    this.visualizationsData = this.visualizationsData
+      .map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
   },
   methods: {
     refreshSummaryData(){

--- a/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
@@ -384,8 +384,6 @@ export default {
             } else {
               htmlTreeMap = treeMapTwoDepth(d)
             }
-            const self = this
-            self.injectRouter()
             return htmlTreeMap
           })
           .attr('class', 'treemap-nested-container-text')
@@ -467,6 +465,12 @@ export default {
             transitioning = false;
           });
           labelTotalContracts = self.labelTotalPlural
+
+          const { depth } = d
+          const calculateActualDepth = deepLevel - depth
+          if (calculateActualDepth === 1) {
+            self.injectRouter()
+          }
         }
 
         function treeMapFirsthDepth(d) {
@@ -629,11 +633,12 @@ export default {
 
         function buildLastDepth(d) {
           let title = d.data.name === undefined ? d.data[keyForThirdDepth] : d.data.name;
-          const { data: { assignee_routing_id }, parent: { data: { name } } } = d
-          let heading = assignee_routing_id !== undefined ? `<a href="#" class="title">${name}</a>` : `<p class="title">${name}</p>`
+          const { parent: { data: { name } } } = d
           return `
-            ${heading}
-            <p class="text">${title}</p>
+            <a class="link-last-depth">
+              <p class="title">${name}</p>
+              <p class="text">${title}</p>
+            </a>
             `
         }
 
@@ -714,22 +719,18 @@ export default {
     },
     injectRouter() {
       this.closeTooltips()
-      const contractsLink = document.querySelectorAll('a.title')
+      const contractsLink = document.querySelectorAll(`.treemap-nested-container-${this.treemapId} a.link-last-depth`)
       contractsLink.forEach(contract => contract.addEventListener('click', (e) => {
         const {
           target: {
             parentNode: {
               __data__: {
-                data: {
-                  assignee_routing_id
-                }
+                data
               }
             }
           }
         } = e
-        e.preventDefault()
-        // eslint-disable-next-line no-unused-vars
-        this.$router.push(`${location.pathname}/adjudicatario/${assignee_routing_id}`).catch(err => {})
+        this.$emit('on-treemap-click', data)
       }))
     },
     closeTooltips() {

--- a/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
@@ -721,7 +721,7 @@ export default {
         } = e
         e.preventDefault()
         // eslint-disable-next-line no-unused-vars
-        this.$router.push(`/visualizaciones/contratos/adjudicatario/${assignee_routing_id}`).catch(err => {})
+        this.$router.push(`${location.pathname}/adjudicatario/${assignee_routing_id}`).catch(err => {})
       }))
     },
     closeTooltips() {


### PR DESCRIPTION
## :v: What does this PR do?

- Relative position for tabs, could not be clicked because it was above the block to customize columns.
- Include the link in the subsidies elements. 
- The link occupies the full width and height of the element.
- Replace 'persona' with 'persona fisica.'
- Generate permalink.
- Correct color scale when the treemap has only three levels and is of entities. 
- Only **build the link** when the last level has more than 20 elements, for example, subsidies > "persona física."

## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### After this PR

![Screen Recording 2021-02-19 at 10 47 45 2021-02-19 10_49_41](https://user-images.githubusercontent.com/2649175/108488057-3ab1d980-72a0-11eb-9582-bda282e6d471.gif)