### PR TITLE
3723 fix external id calculation

### DIFF
--- a/app/models/concerns/gobierto_common/has_external_id.rb
+++ b/app/models/concerns/gobierto_common/has_external_id.rb
@@ -27,7 +27,7 @@ module GobiertoCommon
     def new_external_id
       table_name = self.class.table_name
 
-      base_id = id || self.class.maximum(:id) + 1
+      base_id = id || self.class.maximum(:id).to_i + 1
       if (related_external_ids = self.class.where("#{table_name}.external_id ~* ?", "#{base_id}-\\d+$")).exists?
         max_count = related_external_ids.pluck(:external_id).map { |related_id| related_id.scan(/\d+$/).first.to_i }.max
         "#{base_id}-#{max_count + 1}"

--- a/test/models/gobierto_people/charge_test.rb
+++ b/test/models/gobierto_people/charge_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/concerns/gobierto_common/has_external_id_test"
+
+module GobiertoPeople
+  class ChargeTest < ActiveSupport::TestCase
+    include GobiertoCommon::HasExternalIdTest
+
+    def subject
+      ::GobiertoPeople::Charge
+    end
+
+    def charge
+      @charge ||= gobierto_people_charges(:richard_avenger)
+    end
+
+    def test_valid
+      assert charge.valid?
+    end
+  end
+end

--- a/test/models/gobierto_plans/node_test.rb
+++ b/test/models/gobierto_plans/node_test.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "support/concerns/gobierto_common/has_external_id_test"
 
 module GobiertoPlans
   class NodeTest < ActiveSupport::TestCase
+    include GobiertoCommon::HasExternalIdTest
 
     def setup
       super
@@ -15,6 +17,10 @@ module GobiertoPlans
 
       @instance_custom_field = gobierto_common_custom_fields(:madrid_economic_plan_node_instance_level)
       @instance_custom_field_record = gobierto_common_custom_field_records(:scholarships_in_school_cateens_custom_field_instance_level)
+    end
+
+    def subject
+      ::GobiertoPlans::Node
     end
 
     def node_custom_fields

--- a/test/support/concerns/gobierto_common/has_external_id_test.rb
+++ b/test/support/concerns/gobierto_common/has_external_id_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GobiertoCommon::HasExternalIdTest
+
+  def test_automatic_generation_of_external_id_when_table_is_empty
+    subject.destroy_all
+
+    new_item = subject.new
+    new_item.valid?
+
+    assert_equal "1", new_item.external_id
+  end
+
+  def test_automatic_generation_of_external_id_when_there_are_items
+    existing_item = subject.first
+    subject.where.not(id: existing_item.id).destroy_all
+
+    new_item = subject.new
+    new_item.valid?
+
+    refute_equal existing_item.external_id, new_item.external_id
+  end
+end


### PR DESCRIPTION
Closes #3723


## :v: What does this PR do?

* Fixes errors calculating external ids when the table is empty and maximum query returns nil
* Add some tests

## :mag: How should this be manually tested?

The concern is used in `GobiertoPeople::Charge` and `GobiertoPlans::Node` models. Delete all projects of plans of all sites. Create a project in a plan and save it. Nothing should raise


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
