### PR TITLE
reset_passwords rake task

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -69,4 +69,32 @@ namespace :dev do
     end
   end
 
+  # bin/rails dev:reset_passwords[user]
+  # bin/rails dev:reset_passwords[admin]
+  # bin/rails dev:reset_passwords
+  desc "Reset passwords"
+  task :reset_passwords, [:category] do |_t, args|
+    raise "Can't run this task in the #{Rails.env} environment" if Rails.env.staging? || Rails.env.production?
+    
+    category = args.category
+
+    if category.nil? || category == "user"
+      puts "Resetting user passwords..."
+
+      User.all.each do |user|
+        user.password = user.password_confirmation = "gobierto"
+        user.save
+      end
+    end
+
+    if category.nil? || category == "admin"
+      puts "Resetting admin passwords..."
+
+      GobiertoAdmin::Admin.all.each do |admin|
+        admin.password = admin.password_confirmation = "gobierto"
+        admin.save
+      end
+    end
+  end
+
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -71,9 +71,9 @@ namespace :dev do
     end
   end
 
+  # bin/rails dev:reset_passwords
   # bin/rails dev:reset_passwords[user]
   # bin/rails dev:reset_passwords[admin]
-  # bin/rails dev:reset_passwords
   desc "Reset passwords"
   task :reset_passwords, [:category] => :environment do |_t, args|
     raise "Can't run this task in the #{Rails.env} environment" if Rails.env.staging? || Rails.env.production?
@@ -81,7 +81,7 @@ namespace :dev do
     category = args.category
 
     if category.nil? || category == "user"
-      puts "Resetting user passwords..."
+      puts "Setting all user passwords as \"gobierto\"..."
 
       User.all.each do |user|
         user.password = user.password_confirmation = "gobierto"
@@ -90,7 +90,7 @@ namespace :dev do
     end
 
     if category.nil? || category == "admin"
-      puts "Resetting admin passwords..."
+      puts "Setting all admin passwords as \"gobierto\"..."
 
       GobiertoAdmin::Admin.all.each do |admin|
         admin.password = admin.password_confirmation = "gobierto"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :dev do
 
   # bin/rails dev:load_data[staging]
@@ -73,9 +75,9 @@ namespace :dev do
   # bin/rails dev:reset_passwords[admin]
   # bin/rails dev:reset_passwords
   desc "Reset passwords"
-  task :reset_passwords, [:category] do |_t, args|
+  task :reset_passwords, [:category] => :environment do |_t, args|
     raise "Can't run this task in the #{Rails.env} environment" if Rails.env.staging? || Rails.env.production?
-    
+
     category = args.category
 
     if category.nil? || category == "user"


### PR DESCRIPTION
## :v: What does this PR do?
For development purposes, a task to reset all passwords in gobierto. They will set as _gobierto_
It can be run as:
```sh
  # bin/rails dev:reset_passwords
  # bin/rails dev:reset_passwords[user]
  # bin/rails dev:reset_passwords[admin]
```
If you provide parameters, it will reset only those pointed out.