### PR TITLE
Add unit type options to numeric custom field form

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/custom_fields_controller.rb
@@ -133,6 +133,7 @@ module GobiertoAdmin
             :vocabulary_type,
             :plugin_type,
             :date_type,
+            :unit_type,
             :instance_class_name,
             :instance_id,
             :plugin_configuration,

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -24,6 +24,7 @@ module GobiertoAdmin
         :vocabulary_type,
         :plugin_type,
         :date_type,
+        :unit_type,
         :plugin_configuration,
         :multiple
       )
@@ -91,6 +92,10 @@ module GobiertoAdmin
         ::GobiertoCommon::CustomField.date_options
       end
 
+      def available_unit_options
+        ::GobiertoCommon::CustomField.unit_options
+      end
+
       def options
         @options ||= {}.tap do |opts|
           opts[:configuration] ||= {}
@@ -101,6 +106,9 @@ module GobiertoAdmin
           end
           if custom_field.date?
             opts[:configuration][:date_type] = date_type
+          end
+          if custom_field.numeric?
+            opts[:configuration][:unit_type] = unit_type
           end
           if custom_field.plugin?
             opts[:configuration][:plugin_type] = plugin_type
@@ -166,6 +174,10 @@ module GobiertoAdmin
 
       def plugin
         ::GobiertoCommon::CustomFieldPlugin.find(plugin_type)
+      end
+
+      def unit_type
+        @unit_type ||= custom_field.configuration.unit_type || :generic
       end
 
       def date_type

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -76,6 +76,10 @@ module GobiertoCommon
       [:date, :datetime]
     end
 
+    def self.unit_options
+      [:generic, :currency]
+    end
+
     def allow_multiple?
       self.class.field_types_with_multiple_setting.include? field_type
     end

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_form.html.erb
@@ -93,6 +93,11 @@
           <% end %>
         <% end %>
         <%= content_tag :div, class: "form_block" do %>
+          <%= content_tag :div, id: "numeric", class: "form_item", style: @custom_field_form.custom_field.numeric? ? nil : "display: none;" do %>
+            <%= render partial: "numeric_options", locals: { f: f } %>
+          <% end %>
+        <% end %>
+        <%= content_tag :div, class: "form_block" do %>
           <%= content_tag :div, id: "configuration", class: "form_item", style: @custom_field_form.plugin&.has_configuration? ? nil : "display: none;", data: {
                 defaults: @custom_field_form.plugin_configuration_defaults,
                 type: @custom_field_form.plugin_type,

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_numeric_options.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/custom_fields/_numeric_options.html.erb
@@ -1,0 +1,15 @@
+<h4 class="options compact"><%= t(".unit_type") %></h4>
+<%= f.collection_radio_buttons(
+      "unit_type",
+      @custom_field_form.available_unit_options,
+      :itself,
+      :itself
+    ) do |b| %>
+  <div class="option">
+    <%= b.radio_button %>
+    <%= b.label do %>
+      <span></span>
+      <%= t(".#{b.text}") %>
+    <% end %>
+  </div>
+<% end %>

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -15,7 +15,7 @@ ca:
     - dv
     - ds
     abbr_month_names:
-    - 
+    -
     - gen
     - feb
     - mar
@@ -43,7 +43,7 @@ ca:
       short: "%d %b"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - gener
     - febrer
     - març

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -15,7 +15,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       short: "%b %d %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - January
     - February
     - March

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -15,7 +15,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       short: "%d %b %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/ca.yml
@@ -29,6 +29,10 @@ ca:
             cancel_new_option: Cancel·lar
             create: Crear opció
             new: Nova opció
+          numeric_options:
+            currency: Monetària
+            generic: Genèrica
+            unit_type: Tipus d'unitat
           options_form:
             add_option: Afegir opció
           plugin:

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/en.yml
@@ -29,6 +29,10 @@ en:
             cancel_new_option: Cancel
             create: Create option
             new: New option
+          numeric_options:
+            currency: Currency
+            generic: Generic
+            unit_type: Unit type
           options_form:
             add_option: Add option
           plugin:

--- a/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_common/custom_fields/views/es.yml
@@ -29,6 +29,10 @@ es:
             cancel_new_option: Cancelar
             create: Crear opción
             new: Nueva opción
+          numeric_options:
+            currency: Monetaria
+            generic: Genérica
+            unit_type: Tipo de unidad
           options_form:
             add_option: Añadir opción
           plugin:


### PR DESCRIPTION
## :v: What does this PR do?

* Adds options to numeric custom field type to set the unit type. For the moment only `generic` (default) and `currency`
* Note:  The i18n-task hook has automatically added changes in config/locales/defaults/ translations removing some trailing spaces

## :mag: How should this be manually tested?

From admin edit/create a custom field of numeric type. A unit type section should appear

## :eyes: Screenshots

### Before this PR

<img width="800" alt="Screen Shot 2021-02-23 at 22 47 47" src="https://user-images.githubusercontent.com/446459/108912866-7f839a80-7629-11eb-83a1-4b6235d630c8.png">


### After this PR

<img width="748" alt="Screen Shot 2021-02-23 at 22 48 28" src="https://user-images.githubusercontent.com/446459/108912894-87dbd580-7629-11eb-9e68-8ecb5ae69026.png">


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

* [Suggestion added](https://dash.readme.com/project/gobierto/v0.1/suggested/update/60357a99eedb840038f074e8) 
