### PR TITLE
Gobierto Visualizations / Use gobierto_start_date instead of award_date

### DIFF
--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -172,14 +172,14 @@ export class ContractsController {
       .domain(this._amountRange.domain)
       .range(this._amountRange.range);
 
-    const contractsDataMap = contractsData.map(({ final_amount_no_taxes = 0, initial_amount_no_taxes = 0, award_date, assignee_id, ...rest }) => {
+    const contractsDataMap = contractsData.map(({ final_amount_no_taxes = 0, initial_amount_no_taxes = 0, gobierto_start_date, assignee_id, ...rest }) => {
       return {
         final_amount_no_taxes: (final_amount_no_taxes && !Number.isNaN(final_amount_no_taxes)) ? parseFloat(final_amount_no_taxes): 0.0,
         initial_amount_no_taxes: (initial_amount_no_taxes && !Number.isNaN(initial_amount_no_taxes)) ? parseFloat(initial_amount_no_taxes): 0.0,
         range: rangeFormat(+final_amount_no_taxes),
         assignee_routing_id: assignee_id,
-        award_date_year: award_date ? new Date(award_date).getFullYear().toString() : '',
-        award_date: new Date(award_date),
+        gobierto_start_date_year: gobierto_start_date ? new Date(gobierto_start_date).getFullYear().toString() : '',
+        gobierto_start_date: new Date(gobierto_start_date),
         ...rest
       }
 
@@ -201,7 +201,7 @@ export class ContractsController {
 
     this.data = {
       contractsData: this._formalizedContractsData(contractsDataMap).sort(
-        sortByField("award_date")
+        sortByField("gobierto_start_date")
       ),
       tendersData: this.unfilteredTendersData
     };
@@ -385,7 +385,7 @@ export class ContractsController {
   }
 
   _renderDateChart() {
-    const dimension = this.ndx.dimension(contract => contract.award_date_year);
+    const dimension = this.ndx.dimension(contract => contract.gobierto_start_date_year);
 
     const renderOptions = {
       containerSelector: "#date-bars",

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Aside.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Aside.vue
@@ -109,7 +109,7 @@ export default {
       const dateOptions = [];
       const categoryTypesOptions = [];
       const contractorTypesOptions = [];
-      const years = new Set(this.contractsData.map(({ award_date_year }) => award_date_year));
+      const years = new Set(this.contractsData.map(({ gobierto_start_date_year }) => gobierto_start_date_year));
       const contractTypes = new Set(this.contractsData.map(({ contract_type }) => contract_type));
       const processTypes = new Set(this.contractsData.map(({ process_type }) => process_type));
       const categoryTypes = new Set(this.contractsData.map(({ category_title }) => category_title));
@@ -178,15 +178,15 @@ export default {
       // It iterates over the contracts to get the number of items for each year, process type and contract type
       // In the end, it populates counter with something like:
       // {process_types: {'Abierto': 12, 'Abierto Simplificado': 43,...}, dates: {2020: '12'...}}
-      this.contractsData.forEach(({ process_type, contract_type, award_date_year, category_title, contractor }) => {
+      this.contractsData.forEach(({ process_type, contract_type, gobierto_start_date_year, category_title, contractor }) => {
         counter.process_types[process_type] = counter.process_types[process_type] || 0
         counter.process_types[process_type]++
 
         counter.contract_types[contract_type] = counter.contract_types[contract_type] || 0
         counter.contract_types[contract_type]++
 
-        counter.dates[award_date_year] = counter.dates[award_date_year] || 0
-        counter.dates[award_date_year]++
+        counter.dates[gobierto_start_date_year] = counter.dates[gobierto_start_date_year] || 0
+        counter.dates[gobierto_start_date_year]++
 
         counter.category_title[category_title] = counter.category_title[category_title] || 0
         counter.category_title[category_title]++

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/AssigneesShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/AssigneesShow.vue
@@ -56,7 +56,7 @@ export default {
     EventBus.$emit("refresh-active-tab");
 
     this.buildItems();
-    this.showColumns = ['title', 'final_amount_no_taxes', 'award_date',]
+    this.showColumns = ['title', 'final_amount_no_taxes', 'gobierto_start_date',]
   },
   methods: {
     buildItems(){

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsIndex.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsIndex.vue
@@ -47,7 +47,7 @@ export default {
 
     this.items = this.contractsData.map(d => ({ ...d, href: `${location.origin}${location.pathname}/${d.id}` } ))
     this.columns = contractsColumns;
-    this.showColumns = ['assignee', 'title', 'award_date', 'final_amount_no_taxes']
+    this.showColumns = ['assignee', 'title', 'gobierto_start_date', 'final_amount_no_taxes']
   },
   beforeDestroy(){
     EventBus.$off('refresh-summary-data');

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
@@ -68,7 +68,7 @@
         <div class="pure-u-1 pure-u-lg-1-2 pure-u-md-1-2">
           <ContractsShowLabelGroup
             :label="labelAwarding"
-            :value="award_date | formatDate"
+            :value="gobierto_start_date | formatDate"
           />
           <ContractsShowLabelGroup
             :label="labelContractAmount"
@@ -137,7 +137,7 @@ export default {
       contract_type: '',
       start_date: '',
       end_date: '',
-      award_date: '',
+      gobierto_start_date: '',
       batch_number: '',
       minor_contract: '',
       open_proposals_date: '',
@@ -204,7 +204,7 @@ export default {
         assignee_routing_id,
         start_date,
         end_date,
-        award_date,
+        gobierto_start_date,
         minor_contract,
         open_proposals_date,
         submission_date,
@@ -226,7 +226,7 @@ export default {
       this.contract_type = contract_type
       this.start_date = start_date
       this.end_date = end_date
-      this.award_date = award_date
+      this.gobierto_start_date = gobierto_start_date
       this.batch_number = +batch_number
       this.minor_contract = minor_contract
       this.open_proposals_date = open_proposals_date || null

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -16,7 +16,7 @@
       v-if="activeTab === 0"
       :data="visualizationsDataExcludeMinorContract"
       :radius-property="'final_amount_no_taxes'"
-      :x-axis-prop="'award_date'"
+      :x-axis-prop="'gobierto_start_date'"
       :y-axis-prop="'contract_type'"
       @showTooltip="showTooltipBeesWarm"
       @goesToItem="goesToItem"

--- a/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
@@ -3,7 +3,7 @@ export const contractsColumns = [
   { field: 'assignee', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
   { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.contractor'), cssClass: 'largest-width-td ellipsis' },
   { field: 'final_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.contract_amount'), cssClass: 'right nowrap pr1', type: 'money' },
-  { field: 'award_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding'), cssClass: 'nowrap pl1 right', type: 'date' },
+  { field: 'gobierto_start_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding'), cssClass: 'nowrap pl1 right', type: 'date' },
   { field: 'contractor', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding_entity'), cssClass: 'nowrap pl1' },
   { field: 'status', name: I18n.t('gobierto_visualizations.visualizations.contracts.status'), cssClass: 'nowrap pl1' },
   { field: 'contract_type', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.type'), cssClass: 'nowrap pl1' },
@@ -29,7 +29,7 @@ export const assigneesColumns = [
 export const assigneesShowColumns = [
   { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
   { field: 'final_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.final_amount_no_taxes'), cssClass: 'nowrap pr1 right', type: 'money' },
-  { field: 'award_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.date'), cssClass: 'nowrap pl1 right', type: 'date' },
+  { field: 'gobierto_start_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.date'), cssClass: 'nowrap pl1 right', type: 'date' },
 ];
 
 // filters config


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1216


## :v: What does this PR do?

Use `gobierto_start_date` instead of `award_date` for tables, visualizations, and contracts page.

## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-02-24 at 15 29 28](https://user-images.githubusercontent.com/2649175/109015184-28c3a280-76b5-11eb-8dd7-93677f969606.png)


### After this PR

![Screenshot 2021-02-24 at 15 29 37](https://user-images.githubusercontent.com/2649175/109015175-26614880-76b5-11eb-960a-e1ccaaa5c7ec.png)

