### PR TITLE
Fix budgets-total card parameters

### DIFF
--- a/app/javascript/gobierto_observatory/modules/classes/budget_by_inhabitant.js
+++ b/app/javascript/gobierto_observatory/modules/classes/budget_by_inhabitant.js
@@ -7,7 +7,7 @@ export class BudgetByInhabitantCard extends Card {
 
     this.url =
       window.populateData.endpoint +
-      "/datasets/ds-presupuestos-municipales-total.json?sort_desc_by=date&with_metadata=true&limit=5&filter_by_municipality_id=" +
+      "/datasets/ds-presupuestos-municipales-total.json?sort_desc_by=year&with_metadata=true&limit=5&filter_by_organization_id=" +
       city_id;
   }
 

--- a/app/javascript/gobierto_observatory/modules/classes/budget_by_inhabitant.js
+++ b/app/javascript/gobierto_observatory/modules/classes/budget_by_inhabitant.js
@@ -15,14 +15,14 @@ export class BudgetByInhabitantCard extends Card {
     var data = this.handlePromise(this.url);
 
     data.then(jsonData => {
-      var value = jsonData.data[0].value_per_inhabitant;
+      var value = jsonData.data[0].total_budget_per_inhabitant;
 
       new SimpleCard(
         this.container,
         jsonData,
         value,
         "budget_by_inhabitant",
-        "value_per_inhabitant"
+        "total_budget_per_inhabitant"
       );
     });
   }

--- a/app/javascript/gobierto_observatory/modules/classes/budget_by_inhabitant.js
+++ b/app/javascript/gobierto_observatory/modules/classes/budget_by_inhabitant.js
@@ -7,7 +7,7 @@ export class BudgetByInhabitantCard extends Card {
 
     this.url =
       window.populateData.endpoint +
-      "/datasets/ds-presupuestos-municipales-total.json?sort_desc_by=year&with_metadata=true&limit=5&filter_by_organization_id=" +
+      "/datasets/ds-presupuestos-municipales-total.json?filter_by_kind=G&sort_desc_by=year&with_metadata=true&limit=5&filter_by_organization_id=" +
       city_id;
   }
 
@@ -16,6 +16,11 @@ export class BudgetByInhabitantCard extends Card {
 
     data.then(jsonData => {
       var value = jsonData.data[0].total_budget_per_inhabitant;
+
+      jsonData.data.forEach(function(d) {
+        d.date = `${d.year}-01-01`
+        d.value = d.total_budget_per_inhabitant
+      });
 
       new SimpleCard(
         this.container,

--- a/app/javascript/gobierto_observatory/modules/classes/get_unemployment_age_data.js
+++ b/app/javascript/gobierto_observatory/modules/classes/get_unemployment_age_data.js
@@ -91,10 +91,18 @@ export class GetUnemploymentAgeData extends Card {
         var year = d.date.slice(0, 4);
 
         if (nested.hasOwnProperty(year)) {
-          d.pct = d.value / nested[year][d.age_range];
-        } else if (year === lastYear) {
+          if(nested[year] === undefined) {
+            d.pct = d.value / nested[year1][d.age_range];
+          } else {
+            d.pct = d.value / nested[year][d.age_range];
+          }
+        } else if (year >= lastYear - 2){
           // If we are in the last year, divide the unemployment by last year's population
-          d.pct = d.value / nested[year - 1][d.age_range];
+          if(nested[year - 1] === undefined) {
+            d.pct = d.value / nested[year - 2][d.age_range];
+          } else {
+            d.pct = d.value / nested[year - 1][d.age_range];
+          }
         } else {
           d.pct = null;
         }

--- a/app/javascript/gobierto_observatory/modules/classes/unemployed_sector.js
+++ b/app/javascript/gobierto_observatory/modules/classes/unemployed_sector.js
@@ -32,6 +32,12 @@ export class UnemplBySectorCard extends Card {
         })
         .entries(this.data);
 
+      this.nest.forEach(function(d) {
+          d.diff = d.value.diff;
+          d.value = d.value.value;
+        }.bind(this)
+      );
+
       // d3v6
       //
       // this.nest = rollup(
@@ -52,6 +58,7 @@ export class UnemplBySectorCard extends Card {
 
       this.nest = this.nest.filter(d => d.key !== "Sin empleo anterior");
 
+      console.log(this.nest)
       new SparklineTableCard(
         this.container,
         jsonData,

--- a/app/javascript/gobierto_observatory/modules/classes/unemployed_sector.js
+++ b/app/javascript/gobierto_observatory/modules/classes/unemployed_sector.js
@@ -58,7 +58,6 @@ export class UnemplBySectorCard extends Card {
 
       this.nest = this.nest.filter(d => d.key !== "Sin empleo anterior");
 
-      console.log(this.nest)
       new SparklineTableCard(
         this.container,
         jsonData,

--- a/app/javascript/lib/visualizations/modules/card_simple.js
+++ b/app/javascript/lib/visualizations/modules/card_simple.js
@@ -13,7 +13,6 @@ export class SimpleCard extends Card {
 
     var trend = this.div.attr("data-trend");
     var freq = this.div.attr("data-freq");
-    var parsedDate
 
     var parseDate =
       freq === "daily"
@@ -22,14 +21,7 @@ export class SimpleCard extends Card {
         ? d3.timeParse("%Y-%m")
         : d3.timeParse("%Y");
     var date = json.data[0].date;
-    if (date === undefined) {
-      // There are some datasets where the date comes as year
-      if ('year' in json.data[0]) {
-        parseDate = new Date(json.data[0].year, 0, 1);
-      }
-    } else {
-      parsedDate = parseDate(date);
-    }
+    var parsedDate = parseDate(date);
     var formatDate = d3.timeFormat("%b %Y");
 
     var divCard = $('div[class*="' + divClass.replace(".", "") + '"]');

--- a/app/javascript/lib/visualizations/modules/card_simple.js
+++ b/app/javascript/lib/visualizations/modules/card_simple.js
@@ -13,6 +13,7 @@ export class SimpleCard extends Card {
 
     var trend = this.div.attr("data-trend");
     var freq = this.div.attr("data-freq");
+    var parsedDate
 
     var parseDate =
       freq === "daily"
@@ -21,13 +22,14 @@ export class SimpleCard extends Card {
         ? d3.timeParse("%Y-%m")
         : d3.timeParse("%Y");
     var date = json.data[0].date;
-    // There are some datasets where the date comes as year
     if (date === undefined) {
+      // There are some datasets where the date comes as year
       if ('year' in json.data[0]) {
-        date = json.data[0].year;
+        parseDate = new Date(json.data[0].year, 0, 1);
       }
+    } else {
+      parsedDate = parseDate(date);
     }
-    var parsedDate = parseDate(date);
     var formatDate = d3.timeFormat("%b %Y");
 
     var divCard = $('div[class*="' + divClass.replace(".", "") + '"]');

--- a/app/javascript/lib/visualizations/modules/card_simple.js
+++ b/app/javascript/lib/visualizations/modules/card_simple.js
@@ -20,7 +20,14 @@ export class SimpleCard extends Card {
         : freq === "monthly"
         ? d3.timeParse("%Y-%m")
         : d3.timeParse("%Y");
-    var parsedDate = parseDate(json.data[0].date);
+    var date = json.data[0].date;
+    // There are some datasets where the date comes as year
+    if (date === undefined) {
+      if ('year' in json.data[0]) {
+        date = json.data[0].year;
+      }
+    }
+    var parsedDate = parseDate(date);
     var formatDate = d3.timeFormat("%b %Y");
 
     var divCard = $('div[class*="' + divClass.replace(".", "") + '"]');

--- a/app/javascript/lib/visualizations/modules/unemployment_sex.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_sex.js
@@ -149,9 +149,13 @@ export class VisUnemploymentSex {
 
         if (Object.prototype.hasOwnProperty.call(nested, year)) {
           d.pct = d.value / nested[year];
-        } else if (year === lastYear) {
+        } else if (year >= lastYear - 2) {
           // If we are in the last year, divide the unemployment by last year's population
-          d.pct = d.value / nested[year - 1];
+          if (nested[year - 1] === undefined) {
+            d.pct = d.value / nested[year - 2];
+          } else {
+            d.pct = d.value / nested[year - 1];
+          }
         } else {
           d.pct = null;
         }


### PR DESCRIPTION
## :v: What does this PR do?

Due to a change in the populate-data dataset for the budget total, the parameters of the search have changed. Now we are using the same index for both sites, so we don't need to load the data twice.

## :mag: How should this be manually tested?

The card should stop returning a 400 error and should work.
