### PR TITLE
User local elastic search for providers data

### DIFF
--- a/app/controllers/gobierto_budgets/providers_controller.rb
+++ b/app/controllers/gobierto_budgets/providers_controller.rb
@@ -13,14 +13,10 @@ class GobiertoBudgets::ProvidersController < GobiertoBudgets::ApplicationControl
         @budgets_data_updated_at = site_stats.providers_data_updated_at
       end
       format.csv do
-        render csv: GobiertoBudgets::Data::Invoices.dump_csv({
-          location_id: current_site.organization_id,
-          limit: params[:limit],
-          sort_desc_by: params[:sort_desc_by],
-          sort_asc_by: params[:sort_asc_by],
-          date_date_range: params[:date_date_range],
-          except_columns: params[:except_columns]
-        }), filename: 'invoices.csv'
+        render csv: csv, filename: 'invoices.csv'
+      end
+      format.json do
+        render json: json
       end
     end
   end
@@ -29,6 +25,23 @@ class GobiertoBudgets::ProvidersController < GobiertoBudgets::ApplicationControl
 
   def check_setting_enabled
     render_404 unless budgets_providers_active?
+  end
+
+  def csv
+    GobiertoBudgets::Data::Invoices.dump_csv({
+      location_id: current_site.organization_id,
+      limit: params[:limit],
+      sort_desc_by: params[:sort_desc_by],
+      sort_asc_by: params[:sort_asc_by],
+      date_date_range: params[:date_date_range],
+      except_columns: params[:except_columns]
+    })
+  end
+
+  def json
+    rows = []
+    CSV.parse(csv, headers: true){|row| rows << row.to_hash }
+    rows.to_json
   end
 
 end

--- a/app/models/gobierto_budgets/data/providers.rb
+++ b/app/models/gobierto_budgets/data/providers.rb
@@ -66,20 +66,12 @@ module GobiertoBudgets
 
       private
 
-      def token
-        @token ||= site.configuration.populate_data_api_token
-      end
-
-      def endpoint
-        @endpoint ||= APP_CONFIG[:populate_data][:endpoint]
-      end
-
       def date_range
         @date_range ||= "#{ year }0101-#{ year }1231"
       end
 
       def format_uri(format)
-        URI("#{ endpoint }/datasets/ds-facturas-municipio.#{ format }?filter_by_location_id=#{ site.organization_id }&date_date_range=#{ date_range }&sort_asc_by=date")
+        URI("https://#{site.domain}/presupuestos/proveedores-facturas.#{ format }?filter_by_location_id=#{ site.organization_id }&date_date_range=#{ date_range }&sort_asc_by=date")
       end
 
       def request_response(format)
@@ -87,8 +79,6 @@ module GobiertoBudgets
 
         res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
           req = Net::HTTP::Get.new uri
-          req["authorization"] = "Bearer #{ token }"
-          req["Origin"] = site.domain
           http.request req
         end
 


### PR DESCRIPTION
Closes #3377

## :v: What does this PR do?

- `GobiertoBudgets::Data::Providers` now uses local ElasticSearch to generate the csv/json with providers and invoices data
- `GobiertoBudgets::ProvidersController` now supports json format 

## :mag: How should this be manually tested?

Data is filled after running the rake task: https://esplugues.gobify.net/descarga-datos

Also, json url is accessible: https://esplugues.gobify.net/presupuestos/proveedores-facturas.json?filter_by_location_id=8077&sort_asc_by=date

