### PR TITLE
Embed visualizations

### DIFF
--- a/app/assets/stylesheets/comp-perspective-viewer.scss
+++ b/app/assets/stylesheets/comp-perspective-viewer.scss
@@ -1,0 +1,46 @@
+perspective-viewer {
+  --plugin--background: transparent;
+
+  overflow: hidden;
+  width: 95%;
+  height: 100%;
+  background-color: transparent;
+
+  table {
+    width: auto;
+  }
+
+  ::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+  }
+
+  regular-table {
+    overflow: scroll;
+    -ms-overflow-style: none;
+  
+    ::-webkit-scrollbar {
+      width: 0;
+      background: transparent;
+    }
+  
+    th {
+      width: auto !important;
+  
+      span {
+        font-weight: bold;
+      }
+    }
+  
+    td,
+    th {
+      padding: .25rem;
+    }
+  }
+}

--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -2,6 +2,7 @@
 @import "mixins";
 @import "comp-block-checkbox";
 @import "comp-block-header";
+@import "comp-perspective-viewer";
 @import "comp-vue-dropdown";
 @import "comp-vue-skeleton-spinner";
 
@@ -1150,31 +1151,6 @@
     margin: 0 0 1rem;
   }
 
-  perspective-viewer {
-    --plugin--background: transparent;
-
-    overflow: hidden;
-    width: 95%;
-    height: 100%;
-    background-color: transparent;
-
-    table {
-      width: auto;
-    }
-
-    ::-webkit-scrollbar {
-      -webkit-appearance: none;
-      width: 7px;
-    }
-
-    ::-webkit-scrollbar-thumb {
-      border-radius: 4px;
-      background-color: rgba(0, 0, 0, .5);
-      -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
-    }
-
-  }
-
   &-description {
     height: auto;
     columns: 3;
@@ -1291,27 +1267,4 @@
     padding: 0 1rem 1rem 1rem;
   }
 
-}
-
-perspective-viewer regular-table {
-  overflow: scroll;
-  -ms-overflow-style: none;
-
-  ::-webkit-scrollbar {
-    width: 0;
-    background: transparent;
-  }
-
-  th {
-    width: auto !important;
-
-    span {
-      font-weight: bold;
-    }
-  }
-
-  td,
-  th {
-    padding: .25rem;
-  }
 }

--- a/app/javascript/gobierto_embeds/index.js
+++ b/app/javascript/gobierto_embeds/index.js
@@ -3,37 +3,49 @@ import "@finos/perspective-viewer";
 import "@finos/perspective-viewer-datagrid";
 import "@finos/perspective-viewer-d3fc";
 import "@finos/perspective-viewer/themes/all-themes.css";
+import "../../assets/stylesheets/comp-perspective-viewer.scss";
 
 // Look for all possible vizzs in the site
-document.querySelectorAll("[data-gobierto-vizz-id]").forEach(container => {
+document.querySelectorAll("[data-gobierto-visualization]").forEach(async container => {
+  const { gobiertoVisualization: id, site } = container.dataset
+  const { "embeds.css": cssUrl } = await fetch(`${site}/packs/manifest.json`).then(r => r.json())
+  const cssHref = `${site}${cssUrl}`
 
-  const data = {
-    Sales: [500, 1000, 1500],
-    Profit: [100.25, 200.5, 300.75]
-  };
-
-  function load() {
-    const data = {
-      Sales: [500, 1000, 1500],
-      Profit: [100.25, 200.5, 300.75]
-    };
-
-    // The `<perspective-viewer>` HTML element exposes the viewer API
-    const el = document.getElementsByTagName("perspective-viewer")[0];
-    el.load(data);
+  // Include the styles if they're not included yet
+  if (!([...document.getElementsByTagName("link")].some(({ href }) => href === cssHref))) {
+    const link = document.createElement("link");
+    link.href = cssHref;
+    link.type = "text/css";
+    link.rel = "stylesheet";
+    link.media = "screen,print";
+    document.getElementsByTagName("head")[0].appendChild(link);
   }
 
-  // Append required elements to the DOM
-  const viewer = document.createElement("perspective-viewer")
-  viewer.setAttribute("columns", JSON.stringify(Object.keys(data)))
-  viewer.style.width = "100%"
-  container.appendChild(viewer)
+  const response = await fetch(`${site}/api/v1/data/visualizations/${id}`).then(r => r.json())
+  const { attributes: { query_id, sql, spec } } = response?.data
 
-  const script = document.createElement("script")
-  script.innerHTML = `document.addEventListener("WebComponentsReady", ${load})`
-  container.appendChild(script)
+  let url = null
+  if (query_id) {
+    url = `${site}/api/v1/data/queries/${query_id}.csv`
+  } else if (sql) {
+    url = `${site}/api/v1/data/data.csv?sql=${encodeURIComponent(sql)}`
+  }
 
-  // Run perspective
-  // viewer.clear();
-  // viewer.load(data);
+  if (url) {
+    const responseQuery = await fetch(url).then(r => r.text())
+
+    const viewer = document.createElement("perspective-viewer")
+    viewer.setAttribute("columns", spec.columns)
+    viewer.setAttribute("plugin", spec.plugin)
+    container.appendChild(viewer)
+
+    // run perspective
+    viewer.clear();
+    viewer.restore(spec);
+    viewer.load(responseQuery);
+
+    // hide configuration
+    const configButtonPerspective = viewer.shadowRoot.getElementById('config_button')
+    configButtonPerspective.style.display = "none"
+  }
 })

--- a/app/javascript/gobierto_embeds/index.js
+++ b/app/javascript/gobierto_embeds/index.js
@@ -52,7 +52,7 @@ document.querySelectorAll("[data-gobierto-visualization]").forEach(async contain
           viewer.setAttribute("computed-columns", JSON.stringify(spec.computed_columns))
         }
 
-        container.appendChild(viewer)
+        container.parentNode.replaceChild(viewer, container)
 
         // hide configuration
         const configButtonPerspective = viewer.shadowRoot.getElementById('config_button')

--- a/app/javascript/gobierto_embeds/index.js
+++ b/app/javascript/gobierto_embeds/index.js
@@ -1,1 +1,39 @@
-console.log('Hola embed');
+import "@finos/perspective";
+import "@finos/perspective-viewer";
+import "@finos/perspective-viewer-datagrid";
+import "@finos/perspective-viewer-d3fc";
+import "@finos/perspective-viewer/themes/all-themes.css";
+
+// Look for all possible vizzs in the site
+document.querySelectorAll("[data-gobierto-vizz-id]").forEach(container => {
+
+  const data = {
+    Sales: [500, 1000, 1500],
+    Profit: [100.25, 200.5, 300.75]
+  };
+
+  function load() {
+    const data = {
+      Sales: [500, 1000, 1500],
+      Profit: [100.25, 200.5, 300.75]
+    };
+
+    // The `<perspective-viewer>` HTML element exposes the viewer API
+    const el = document.getElementsByTagName("perspective-viewer")[0];
+    el.load(data);
+  }
+
+  // Append required elements to the DOM
+  const viewer = document.createElement("perspective-viewer")
+  viewer.setAttribute("columns", JSON.stringify(Object.keys(data)))
+  viewer.style.width = "100%"
+  container.appendChild(viewer)
+
+  const script = document.createElement("script")
+  script.innerHTML = `document.addEventListener("WebComponentsReady", ${load})`
+  container.appendChild(script)
+
+  // Run perspective
+  // viewer.clear();
+  // viewer.load(data);
+})

--- a/app/javascript/gobierto_embeds/index.js
+++ b/app/javascript/gobierto_embeds/index.js
@@ -9,7 +9,7 @@ import "../../assets/stylesheets/comp-perspective-viewer.scss";
 document.querySelectorAll("[data-gobierto-visualization]").forEach(async container => {
   const { gobiertoVisualization: id, site, token } = container.dataset
   const { "embeds.css": cssUrl } = await fetch(`${site}/packs/manifest.json`).then(r => r.json())
-  const headers = { Authorization: `Bearer ${token}` }
+  const headers = token ? { Authorization: `Bearer ${token}` } : {}
 
   // Include the styles if they're not included yet
   if (!([...document.getElementsByTagName("link")].some(({ href }) => href.match(cssUrl)))) {
@@ -39,18 +39,29 @@ document.querySelectorAll("[data-gobierto-visualization]").forEach(async contain
         const viewer = document.createElement("perspective-viewer")
         viewer.setAttribute("columns", spec.columns)
         viewer.setAttribute("plugin", spec.plugin)
+
+        if (spec.column_pivots) {
+          viewer.setAttribute("column-pivots", JSON.stringify(spec.column_pivots))
+        }
+
+        if (spec.row_pivots) {
+          viewer.setAttribute("row-pivots", JSON.stringify(spec.row_pivots))
+        }
+
+        if (spec.computed_columns) {
+          viewer.setAttribute("computed-columns", JSON.stringify(spec.computed_columns))
+        }
+
         container.appendChild(viewer)
 
-        // TODO: el tema de parsear los datos
+        // hide configuration
+        const configButtonPerspective = viewer.shadowRoot.getElementById('config_button')
+        configButtonPerspective.style.display = "none"
 
         // run perspective
         viewer.clear();
         viewer.restore(spec);
         viewer.load(data);
-
-        // hide configuration
-        const configButtonPerspective = viewer.shadowRoot.getElementById('config_button')
-        configButtonPerspective.style.display = "none"
       }
     }
   }

--- a/app/javascript/gobierto_embeds/index.js
+++ b/app/javascript/gobierto_embeds/index.js
@@ -1,0 +1,1 @@
+console.log('Hola embed');

--- a/app/javascript/packs/embeds.js
+++ b/app/javascript/packs/embeds.js
@@ -1,6 +1,1 @@
-import "@finos/perspective";
-import "@finos/perspective-viewer";
-import "@finos/perspective-viewer-datagrid";
-import "@finos/perspective-viewer-d3fc";
-import "@finos/perspective-viewer/themes/all-themes.css";
 import "gobierto_embeds"

--- a/app/javascript/packs/embeds.js
+++ b/app/javascript/packs/embeds.js
@@ -1,0 +1,6 @@
+import "@finos/perspective";
+import "@finos/perspective-viewer";
+import "@finos/perspective-viewer-datagrid";
+import "@finos/perspective-viewer-d3fc";
+import "@finos/perspective-viewer/themes/all-themes.css";
+import "gobierto_embeds"

--- a/config/webpack/config/output.js
+++ b/config/webpack/config/output.js
@@ -1,0 +1,7 @@
+module.exports = {
+  output: {
+    filename: (pathData) => {
+      return pathData.chunk.name === 'embeds' ? "js/[name].js" : "js/[name]-[contenthash].js";
+    },
+  },
+};

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -38,8 +38,8 @@ environment.plugins.append(
 environment.loaders.delete("nodeModules");
 
 // Persperctive webpack
-const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
-environment.plugins.append("Perspective", new PerspectivePlugin());
+// const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
+// environment.plugins.append("Perspective", new PerspectivePlugin());
 
 // const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 // environment.plugins.insert("BundleAnalyzerPlugin", new BundleAnalyzerPlugin());
@@ -53,7 +53,5 @@ const aliasConfig = (module.exports = {
     }
   }
 });
-
-console.log(JSON.stringify(environment.config, null, 2));
 
 module.exports = merge(envConfig.toWebpackConfig(), aliasConfig);

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,56 +1,59 @@
-const { environment } = require('@rails/webpacker')
-const webpack = require('webpack')
-const merge = require('webpack-merge')
-const { VueLoaderPlugin } = require('vue-loader')
-const vue = require('./loaders/vue')
-const less = require('./loaders/less')
-const terser = require('./optimization/terser')
+const { environment } = require("@rails/webpacker");
+const webpack = require("webpack");
+const merge = require("webpack-merge");
+const { VueLoaderPlugin } = require("vue-loader");
+const vue = require("./loaders/vue");
+const less = require("./loaders/less");
+const terser = require("./optimization/terser");
+const splitChunks = require("./optimization/splitChunks");
+const output = require('./config/output')
 
-environment.loaders.append('less', less)
-environment.loaders.append('vue', vue)
-environment.config.merge(terser)
-environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
+environment.loaders.append("less", less);
+environment.loaders.append("vue", vue);
+environment.config.merge(terser);
+environment.config.merge(splitChunks);
+environment.config.merge(output)
+
+environment.plugins.prepend("VueLoaderPlugin", new VueLoaderPlugin());
 environment.plugins.append(
-  'Provide',
+  "Provide",
   new webpack.ProvidePlugin({
-    $: 'jquery',
-    'window.$': 'jquery',
-    jQuery: 'jquery',
-    'window.jQuery': 'jquery',
-    _: 'lodash'
+    $: "jquery",
+    "window.$": "jquery",
+    jQuery: "jquery",
+    "window.jQuery": "jquery",
+    _: "lodash"
   })
-)
+);
 
 // NOTE: Must be updated if add a new locale files - https://yarnpkg.com/es-ES/package/moment-locales-webpack-plugin
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 environment.plugins.append(
-  'MomentLocales',
+  "MomentLocales",
   new MomentLocalesPlugin({
-    localesToKeep: ['es', 'ca']
+    localesToKeep: ["es", "ca"]
   })
-)
+);
+
+environment.loaders.delete("nodeModules");
 
 // Persperctive webpack
-const PerspectivePlugin = require('@finos/perspective-webpack-plugin')
-environment.plugins.append(
-  'Perspective',
-  new PerspectivePlugin()
-)
+const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
+environment.plugins.append("Perspective", new PerspectivePlugin());
 
-environment.splitChunks((config) => Object.assign({}, config, { optimization: { splitChunks: { name: "commons", minChunks: 5 } } }))
-environment.loaders.delete('nodeModules')
+// const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+// environment.plugins.insert("BundleAnalyzerPlugin", new BundleAnalyzerPlugin());
 
-// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-// environment.plugins.insert('BundleAnalyzerPlugin', new BundleAnalyzerPlugin())
-
-const envConfig = module.exports = environment
-const aliasConfig = module.exports = {
+const envConfig = (module.exports = environment);
+const aliasConfig = (module.exports = {
   resolve: {
     symlinks: false,
     alias: {
-      vue: 'vue/dist/vue.esm.js'
+      vue: "vue/dist/vue.esm.js"
     }
   }
-}
+});
 
-module.exports = merge(envConfig.toWebpackConfig(), aliasConfig)
+console.log(JSON.stringify(environment.config, null, 2));
+
+module.exports = merge(envConfig.toWebpackConfig(), aliasConfig);

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,4 +1,5 @@
 const { environment } = require("@rails/webpacker");
+
 const webpack = require("webpack");
 const merge = require("webpack-merge");
 const { VueLoaderPlugin } = require("vue-loader");
@@ -36,10 +37,6 @@ environment.plugins.append(
 );
 
 environment.loaders.delete("nodeModules");
-
-// Persperctive webpack
-// const PerspectivePlugin = require("@finos/perspective-webpack-plugin");
-// environment.plugins.append("Perspective", new PerspectivePlugin());
 
 // const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 // environment.plugins.insert("BundleAnalyzerPlugin", new BundleAnalyzerPlugin());

--- a/config/webpack/optimization/splitChunks.js
+++ b/config/webpack/optimization/splitChunks.js
@@ -1,0 +1,10 @@
+module.exports = {
+  optimization: {
+    runtimeChunk: false,
+    splitChunks: {
+      name: "commons",
+      minChunks: 5,
+      chunks: chunk => chunk.name !== "embeds"
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "@finos/perspective-viewer": "0.5.1",
     "@finos/perspective-viewer-d3fc": "0.5.1",
     "@finos/perspective-viewer-datagrid": "0.5.1",
-    "@finos/perspective-webpack-plugin": "0.5.0",
     "@rails/webpacker": "^5.2.1",
     "accounting": "^0.4.1",
     "air-datepicker": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,18 +1167,6 @@
     lodash "^4.17.4"
     mobile-drag-drop "^2.3.0-rc.2"
 
-"@finos/perspective-webpack-plugin@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@finos/perspective-webpack-plugin/-/perspective-webpack-plugin-0.5.0.tgz#424478894dd343e9f728687006391c316cc8d167"
-  integrity sha512-LCQ+x1nps2UZDB5LaiFov+zV/RsTsE20qYA3tQ01Trlwgnj2WVmwjodkkuGJgCEqiZa47fzaVxO9zodwHMWPAQ==
-  dependencies:
-    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
-    acorn "^6.1.1"
-    source-map-loader "^0.2.4"
-    string-replace-loader "^2.1.1"
-    tslib "^1.9.3"
-    worker-loader "^2.0.0"
-
 "@finos/perspective@^0.5.1", "@finos/perspective@^0.5.6":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/@finos/perspective/-/perspective-0.5.6.tgz#04bbd3454db7953d26492b1fb2c27774db3a8c6e"
@@ -1737,18 +1725,6 @@
   resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.4.tgz#fe18c288f99b7103e9ae7a766020f9702cedcc08"
   integrity sha512-wzPSTmwjAd/0oKW36Yi+cB/BmDrHhcHqGlbqqMjrbPIFkt5Mw7wtvEZQouCrQyBNnRquUhRnSWIBrRijHNBBKg==
 
-"@webpack-contrib/schema-utils@^1.0.0-beta.0":
-  version "1.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
-  integrity sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-    chalk "^2.3.2"
-    strip-ansi "^4.0.0"
-    text-table "^0.2.0"
-    webpack-log "^1.1.2"
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -1800,7 +1776,7 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^6.0.2, acorn@^6.1.1, acorn@^6.4.1:
+acorn@^6.0.2, acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
@@ -2069,7 +2045,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@^2.5.0, async@^2.6.2:
+async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -2620,7 +2596,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4277,14 +4253,6 @@ d3fc@14.0.40:
     "@d3fc/d3fc-shape" "^5.0.7"
     "@d3fc/d3fc-technical-indicator" "^7.0.23"
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -4804,32 +4772,6 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
-
-es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -5107,13 +5049,6 @@ express@^4.16.3, express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-ext@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
-  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
-  dependencies:
-    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -7003,7 +6938,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -7091,13 +7026,6 @@ lodash@^4.0.0, lodash@^4.16.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-log-symbols@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
-  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
-  dependencies:
-    chalk "^2.0.1"
-
 log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -7119,14 +7047,6 @@ loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
   integrity sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==
-
-loglevelnext@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
-  integrity sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==
-  dependencies:
-    es6-symbol "^3.1.1"
-    object.assign "^4.1.0"
 
 longest-streak@^2.0.0:
   version "2.0.4"
@@ -7688,11 +7608,6 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -9796,7 +9711,7 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-schema-utils@^0.4.0, schema-utils@^0.4.5:
+schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -10147,14 +10062,6 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-loader@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.4.tgz#c18b0dc6e23bf66f6792437557c569a11e072271"
-  integrity sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==
-  dependencies:
-    async "^2.5.0"
-    loader-utils "^1.1.0"
-
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -10379,14 +10286,6 @@ string-argv@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
-
-string-replace-loader@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-2.3.0.tgz#7f29be7d73c94dd92eccd5c5a15651181d7ecd3d"
-  integrity sha512-HYBIHStViMKLZC/Lehxy42OuwsBaPzX/LjcF5mkJlE2SnHXmW6SW6eiHABTXnY8ZCm/REbdJ8qnA0ptmIzN0Ng==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^2.6.5"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -11012,16 +10911,6 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz#9bdc22c648cf8cf86dd23d32336a41cfb6475e3f"
-  integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
-
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -11242,7 +11131,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.1.0, uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -11580,16 +11469,6 @@ webpack-jquery-ui@^2.0.1:
     jquery-ui "^1.12.1"
     style-loader "^0.21.0"
 
-webpack-log@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
-  integrity sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==
-  dependencies:
-    chalk "^2.1.0"
-    log-symbols "^2.1.0"
-    loglevelnext "^1.0.1"
-    uuid "^3.1.0"
-
 webpack-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f"
@@ -11731,14 +11610,6 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
-
-worker-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
-  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
-  dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1218

## :v: What does this PR do?
Allow embed data visualizations from GobiertoAPI in external sites. [Further reference](https://populate.getoutline.com/doc/gobierto-data-visualizations-embed-PluB5kUNBA)

Just add the following somewhere else:

```html
<div 
  data-gobierto-visualization="<!-- vizz_id -->"
  data-site="<!-- vizz site, i.e. https://datos.gobierto.es -->" 
  data-token="<!-- TOKEN -->" 
></div>

<!-- example -->
<div
  data-gobierto-visualization="158"
  data-site="https://demo-datos.gobify.net"
  data-token="---------------" 
></div>

<script src="https://gobify.net/packs/js/embeds.js"></script>
```

Showcase: https://data-visualizer.populate.tools/public/staging/embed.html