### PR TITLE
Gobierto Visualizations | Missing translations

### DIFF
--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -245,6 +245,16 @@ export class ContractsController {
         d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.restricted')
       }
 
+      if (d.status === 'Adjudicado') {
+        d.status = I18n.t('gobierto_visualizations.visualizations.status_types.awarded')
+      } else if (d.status === 'Rechazado') {
+        d.status = I18n.t('gobierto_visualizations.visualizations.status_types.renunciation')
+      } else if (d.status === 'Formalizado') {
+        d.status = I18n.t('gobierto_visualizations.visualizations.status_types.formalized')
+      } else if (d.status === 'Desierto') {
+        d.status = I18n.t('gobierto_visualizations.visualizations.status_types.deserted')
+      }
+
     })
     return contractsData
   }
@@ -528,7 +538,7 @@ export class ContractsController {
 
   _formalizedContractsData(contractsData) {
     return contractsData.filter(
-      ({ status }) => status === "Formalizado" || status === "Adjudicado"
+      ({ status }) => status === I18n.t('gobierto_visualizations.visualizations.status_types.formalized') || status === I18n.t('gobierto_visualizations.visualizations.status_types.awarded')
     );
   }
 }

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -140,6 +140,7 @@ export class ContractsController {
 
   setGlobalVariables([contractsData, tendersData]) {
     let contractsDataMap = this._translateCategoriesTitle(contractsData)
+    let tendersDataMap = this._translateCategoriesTitle(tendersData)
     const sortByField = dateField => {
       return function(a, b) {
         const aDate = a[dateField],
@@ -185,7 +186,7 @@ export class ContractsController {
       }
     })
 
-    const tendersDataMap = tendersData.map(({ initial_amount_no_taxes = 0, submission_date, ...rest }) => {
+    tendersDataMap = tendersData.map(({ initial_amount_no_taxes = 0, submission_date, ...rest }) => {
 
       return {
         initial_amount_no_taxes: initial_amount_no_taxes ? parseFloat(initial_amount_no_taxes) : 0.0,
@@ -207,15 +208,45 @@ export class ContractsController {
     };
   }
 
-  _translateCategoriesTitle(contractsDataMap) {
+  _translateCategoriesTitle(contractsData) {
 
-    contractsDataMap.map(d => {
+    contractsData.map(d => {
       const { category_title } = d
 
       d.category_title = I18n.t(`gobierto_visualizations.visualizations.categories.${category_title}`)
 
+      if (d.contract_type === 'Servicios') {
+        d.contract_type = I18n.t('gobierto_visualizations.visualizations.contracts_types.services')
+      } else if (d.contract_type === 'Suministros') {
+        d.contract_type = I18n.t('gobierto_visualizations.visualizations.contracts_types.supplies')
+      } else if (d.contract_type === 'Obras') {
+        d.contract_type = I18n.t('gobierto_visualizations.visualizations.contracts_types.works')
+      } else if (d.contract_type === 'Otros') {
+        d.contract_type = I18n.t('gobierto_visualizations.visualizations.contracts_types.others')
+      } else if (d.contract_type === 'Privado') {
+        d.contract_type = I18n.t('gobierto_visualizations.visualizations.contracts_types.private')
+      } else if (d.contract_type === 'Gestión de servicios públicos') {
+        d.contract_type = I18n.t('gobierto_visualizations.visualizations.contracts_types.public_services')
+      }
+
+      if (d.process_type === 'Contrato menor') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.minor_contract')
+      } else if (d.process_type === 'Abierto') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.open')
+      } else if (d.process_type === 'Negociado sin publicidad') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.negotiated_publicity')
+      } else if (d.process_type === 'Basado en Acuerdo Marco') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.based_marco')
+      } else if (d.process_type === 'Otros') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.others')
+      } else if (d.process_type === 'Licitación con negociación') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.tender')
+      } else if (d.process_type === 'Restringido') {
+        d.process_type = I18n.t('gobierto_visualizations.visualizations.process_type.restricted')
+      }
+
     })
-    return contractsDataMap
+    return contractsData
   }
 
   _renderSummary() {

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -80,8 +80,8 @@ export class ContractsController {
             }
           ],
           scrollBehavior(to) {
-            const scrollRoutes = ['contracts_show', 'assignees_show']
-            if (scrollRoutes.includes(to.name)) {
+            const components = ['contracts_show', 'assignees_show']
+            if (components.includes(to.name)) {
               const element = document.getElementById(selector);
               window.scrollTo({ top: element.offsetTop, behavior: "smooth" });
             }

--- a/app/javascript/lib/vue/components/modules/BeesWarmChart.vue
+++ b/app/javascript/lib/vue/components/modules/BeesWarmChart.vue
@@ -210,12 +210,14 @@ export default {
 
       g.selectAll('.label-y').call(this.wrapTextLabel, 120);
 
+      const ticksLength = filterData.length > 100 ? filterData.length : 100
+
       d3
         .forceSimulation(filterData)
         .force('x', d3.forceX(d => scaleX(d[this.xAxisProp])))
         .force('y', d3.forceY(d => scaleY(d[this.yAxisProp])))
         .force('collide', d3.forceCollide().radius(d => d.radius + this.padding))
-        .tick(filterData.length * 0.25)
+        .tick(ticksLength)
 
       let circlesBees = g
         .selectAll('.beeswarm-circle')

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -75,7 +75,7 @@ ca:
           contracts: Contractes
           summary: Resum
           tenders: Licitacions
-        process_type: Tipus de procés
+        process_type: Tipus de procediment
         search_placeholder: Cerqueu per adjudicatari o per títol del contracte
         status: Estat
         submission_date: Data

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -98,7 +98,7 @@ ca:
         title: Contractes i licitacions
       contracts_types:
         others: Altres
-        private: Privadot
+        private: Privat
         public_services: Gestió de serveis públics
         services: Serveis
         supplies: Subministraments

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -96,6 +96,13 @@ ca:
           tenders_for: licitacions per un import de
         tender_amount: Imp. licitació
         title: Contractes i licitacions
+      contracts_types:
+        others: Altres
+        private: Privadot
+        public_services: Gestió de serveis públics
+        services: Serveis
+        supplies: Subministraments
+        works: Obres
       costs:
         activities: activitats
         cost_direct: Cost directe
@@ -174,6 +181,14 @@ ca:
             en concepte de subvenció prèviament concedida.
         total: Total
         total_cost: Cost total
+      process_type:
+        based_marco: Basat en Acord Marco
+        minor_contract: Contracte menor
+        negotiated_publicity: Negociat sense publicitat
+        open: Obert
+        others: Altres
+        restricted: Restringit
+        tender: Licitació amb negociació
       subsidies:
         amount: Import
         amount_distribution: Distribució per imports

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -57,7 +57,7 @@ ca:
           estimated_value: Valor estimat
           external_source: Font
           open_proposals_date: Data de licitació
-          process: Procés
+          process: Procediment
           question_description: Què % del pressupost suposa aquest contracte?
           submission_date: Data de lliurament
           tender: Licitació
@@ -189,6 +189,11 @@ ca:
         others: Altres
         restricted: Restringit
         tender: Licitació amb negociació
+      status_types:
+        awarded: Adjudicat
+        deserted: Desert
+        formalized: Formalizat
+        renunciation: Rebutjat
       subsidies:
         amount: Import
         amount_distribution: Distribució per imports

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -76,7 +76,7 @@ en:
           contracts: Contracts
           summary: Summary
           tenders: Tenders
-        process_type: Type of process
+        process_type: Type of procedure
         search_placeholder: Search by assignee or by contract title
         status: Status
         submission_date: Date

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -97,6 +97,13 @@ en:
           tenders_for: tenders for a total amount of
         tender_amount: Tender Amount
         title: Contracts and tenders
+      contracts_types:
+        others: Others
+        private: Private
+        public_services: Management of public services
+        services: Services
+        supplies: Supplies
+        works: Works
       costs:
         activities: Activities
         cost_direct: Direct cost
@@ -175,6 +182,14 @@ en:
             as a previously granted subsidy.
         total: Total cost
         total_cost: Total cost
+      process_type:
+        based_marco: Based on Marco agreement
+        minor_contract: Minor contract
+        negotiated_publicity: Negotiated without advertising
+        open: Open
+        others: Other
+        restricted: Restricted
+        tender: Tender with negotiation
       subsidies:
         amount: Amount
         amount_distribution: Amount distribution

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -58,7 +58,7 @@ en:
           estimated_value: Estimated value
           external_source: Source
           open_proposals_date: Open proposals
-          process: Process
+          process: Procedure
           question_description: What % of the budget is this contract?
           submission_date: Submission date
           tender: Tender
@@ -190,6 +190,11 @@ en:
         others: Other
         restricted: Restricted
         tender: Tender with negotiation
+      status_types:
+        awarded: Awarded
+        deserted: Deserted
+        formalized: Formalized
+        renunciation: Renunciation
       subsidies:
         amount: Amount
         amount_distribution: Amount distribution

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -58,7 +58,7 @@ es:
           estimated_value: Valor estimado
           external_source: Fuente
           open_proposals_date: Fecha de licitación
-          process: Proceso
+          process: Procedimiento
           question_description: "¿Qué % del presupuesto supone este contrato?"
           submission_date: Fecha de entrega
           tender: Licitación
@@ -193,6 +193,11 @@ es:
         others: Otros
         restricted: Restringido
         tender: Licitación con negociación
+      status_types:
+        awarded: Adjudicado
+        deserted: Desierto
+        formalized: Formalizado
+        renunciation: Rechazado
       subsidies:
         amount: Importe
         amount_distribution: Distribución por importes

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -76,7 +76,7 @@ es:
           contracts: Contratos
           summary: Resumen
           tenders: Licitaciones
-        process_type: Tipo de proceso
+        process_type: Tipo de procedimiento
         search_placeholder: Busca por adjudicatario o por título del contrato
         status: Estado
         submission_date: Fecha

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -97,6 +97,13 @@ es:
           tenders_for: licitaciones por importe de
         tender_amount: Imp. licitación
         title: Contratos y licitaciones
+      contracts_types:
+        others: Otros
+        private: Privado
+        public_services: Gestión de servicios públicos
+        services: Servicios
+        supplies: Suministros
+        works: Obras
       costs:
         activities: Actividades
         cost_direct: Coste directo
@@ -178,6 +185,14 @@ es:
             en concepto de subvención previamente concedida.
         total: Total
         total_cost: Coste total
+      process_type:
+        based_marco: Basado en Acuerdo Marco
+        minor_contract: Contrato menor
+        negotiated_publicity: Negociado sin publicidad
+        open: Abierto
+        others: Otros
+        restricted: Restringido
+        tender: Licitación con negociación
       subsidies:
         amount: Importe
         amount_distribution: Distribución por importes

--- a/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
@@ -152,10 +152,10 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
       assert page.has_content?('€12,207,444.40')
 
       # Status
-      assert page.has_content?('Formalizado')
+      assert page.has_content? I18n.t('gobierto_visualizations.visualizations.status_types.formalized')
 
       # Type
-      assert page.has_content?('Abierto')
+      assert page.has_content? I18n.t('gobierto_visualizations.visualizations.process_type.open')
 
       # Assignees Show
       ################

--- a/test/reports/TEST-GobiertoVisualizations_VisualizationsContractsTest.xml
+++ b/test/reports/TEST-GobiertoVisualizations_VisualizationsContractsTest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite time='36.475137' skipped='0' failures='0' errors='0' name="GobiertoVisualizations::VisualizationsContractsTest" assertions='38' tests='2' timestamp="2021-03-08T16:15:45+01:00">
+  <testcase time='34.215846' file="test/integration/gobierto_visualizations/visualizations_contracts_test.rb" name="test_contracts" assertions='20'>
+  </testcase>
+  <testcase time='2.259291' file="test/integration/gobierto_visualizations/visualizations_contracts_test.rb" name="test_summary" assertions='18'>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1228
Closes https://github.com/PopulateTools/issues/issues/1229


## :v: What does this PR do?

- Adds translations for tenders, contracts types, process types and status.
- More iterations for beeswarm-circles

## :mag: How should this be manually tested?

[Staging](https://santfeliu.gobify.net/visualizaciones/contratos)

## :eyes: Screenshots

### Before this PR

![before-contracts](https://user-images.githubusercontent.com/2649175/110294653-6ba84300-7ff0-11eb-81dc-c7ff523f6149.gif)

### After this PR

![after-contracts](https://user-images.githubusercontent.com/2649175/110295519-7e6f4780-7ff1-11eb-887e-1504582d0c35.gif)

