### PR TITLE
Gobierto Visualizations / Fix the translations of the median and mean in Catalan

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
@@ -1,7 +1,7 @@
 // table columns
 export const contractsColumns = [
   { field: 'assignee', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
-  { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.contractor'), cssClass: 'largest-width-td ellipsis' },
+  { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.contract'), cssClass: 'largest-width-td ellipsis' },
   { field: 'final_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.contract_amount'), cssClass: 'right nowrap pr1', type: 'money' },
   { field: 'gobierto_start_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding'), cssClass: 'nowrap pl1 right', type: 'date' },
   { field: 'contractor', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding_entity'), cssClass: 'nowrap pl1' },

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -89,9 +89,9 @@ ca:
           label_larger_contract_amount_2: " de tota la despesa en contractes"
           label_less_than_1000_1: 'El '
           label_less_than_1000_2: " dels contractes són menors de "
-          mean_amount: Import mitjà
+          mean_amount: Import mig
           mean_savings: Estalvi mitjà de licitació a adjudicació
-          median_amount: Import mitjana
+          median_amount: Mediana dels imports
           tenders: Licitacions
           tenders_for: licitacions per un import de
         tender_amount: Imp. licitació
@@ -223,8 +223,8 @@ ca:
           label_larger_subsidy_amount_2: " de tota la despesa en subvencions"
           label_less_than_1000_1: 'El '
           label_less_than_1000_2: " de les subvencions són menors de "
-          mean_amount: Import mitjà
-          median_amount: Import mitjana
+          mean_amount: Import mig
+          median_amount: Mediana dels imports
           subsidies: Subvencions
           subsidies_for: subvencions per import de
         title: Subvencions

--- a/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
@@ -109,7 +109,7 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
       visit @contracts_path
 
       assert page.has_content?('ASSIGNEE')
-      assert page.has_content?('CONTRACTOR')
+      assert page.has_content?('CONTRACT')
       assert page.has_content?('AMOUNT')
 
       # Active tab is Contracts


### PR DESCRIPTION
## :v: What does this PR do?

Correctly translate mean and median into Catalan .

Show contracte instead of the contractor at the table of contracts.

## :mag: How should this be manually tested?
Staging

## :eyes: Screenshots

### Before this PR
![Screenshot 2021-03-09 at 13 07 19](https://user-images.githubusercontent.com/2649175/110468322-69b9af00-80d8-11eb-81f2-1e6ff202d74a.png)
![Screenshot 2021-03-09 at 13 07 14](https://user-images.githubusercontent.com/2649175/110468324-6a524580-80d8-11eb-9b48-2fab66a7f249.png)


### After this PR

![Screenshot 2021-03-09 at 13 06 41](https://user-images.githubusercontent.com/2649175/110468271-5ad2fc80-80d8-11eb-87f9-fa4f5c2fb270.png)
![Screenshot 2021-03-09 at 13 06 48](https://user-images.githubusercontent.com/2649175/110468268-59a1cf80-80d8-11eb-9d39-f94f722b3ebf.png)

