### PR TITLE
Gobierto Visualizations / Replaces the text for award and tenders date

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsShow.vue
@@ -150,7 +150,7 @@ export default {
       labelAssigneeDescription: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.assignee_description') || '',
       labelContractAmount: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.contract_amount') || '',
       labelTender: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.tender') || '',
-      labelAwarding: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding') || '',
+      labelAwarding: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.formalization') || '',
       labelBidDescription: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.bid_description') || '',
       labelBiddersDescription: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.bidders_description') || '',
       labelStatus: I18n.t('gobierto_visualizations.visualizations.contracts.status') || '',

--- a/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
@@ -3,14 +3,13 @@ export const contractsColumns = [
   { field: 'assignee', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
   { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.contract'), cssClass: 'largest-width-td ellipsis' },
   { field: 'final_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.contract_amount'), cssClass: 'right nowrap pr1', type: 'money' },
-  { field: 'gobierto_start_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding'), cssClass: 'nowrap pl1 right', type: 'date' },
+  { field: 'gobierto_start_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.formalization_date'), cssClass: 'nowrap pl1 right', type: 'date' },
   { field: 'contractor', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.awarding_entity'), cssClass: 'nowrap pl1' },
   { field: 'status', name: I18n.t('gobierto_visualizations.visualizations.contracts.status'), cssClass: 'nowrap pl1' },
   { field: 'contract_type', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.type'), cssClass: 'nowrap pl1' },
   { field: 'process_type', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.process'), cssClass: 'nowrap pl1' },
   { field: 'category_title', name: I18n.t('gobierto_visualizations.visualizations.subsidies.category'), cssClass: 'nowrap pl1' },
-  { field: 'open_proposals_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.open_proposals_date'), cssClass: 'nowrap pl1', type: 'date' },
-  { field: 'submission_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.submission_date'), cssClass: 'nowrap pl1', type: 'date' },
+  { field: 'open_proposals_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.tender_date'), cssClass: 'nowrap pl1 right', type: 'date' },
   { field: 'initial_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.bid_description'), cssClass: 'nowrap pl1 right', type: 'money' }
 ];
 

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -47,7 +47,6 @@ ca:
         contracts_show:
           assignee_description: Empresa que ha guanyat el contracte (Adjudicatari)
           assignees_description: Empreses que han guanyat el contracte (Adjudicataris)
-          awarding: Adjudicació
           awarding_entity: Entitat adjudicadora
           batch: Lot
           bid_description: Pressupost base de licitació sense impostos
@@ -56,10 +55,9 @@ ca:
           entity: Entitat
           estimated_value: Valor estimat
           external_source: Font
-          open_proposals_date: Data de licitació
+          formalization: Formalització
           process: Procediment
           question_description: Què % del pressupost suposa aquest contracte?
-          submission_date: Data de lliurament
           tender: Licitació
           type: Tipus
         date: Data
@@ -68,6 +66,7 @@ ca:
           del %{entity_name}
         entities: Entitats
         final_amount_no_taxes: Import
+        formalization_date: Data de formalització
         fromto: De a Nº Contr.
         main_assignees: Principals adjudicataris
         more: Més de
@@ -95,6 +94,7 @@ ca:
           tenders: Licitacions
           tenders_for: licitacions per un import de
         tender_amount: Imp. licitació
+        tender_date: Data de licitació
         title: Contractes i licitacions
       contracts_types:
         others: Altres

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -47,7 +47,6 @@ en:
         contracts_show:
           assignee_description: Company that has won the contract (Assignee)
           assignees_description: Companies that have won the contract (Assignees)
-          awarding: Awarding
           awarding_entity: Awarding entity
           batch: Batch
           bid_description: Bid base budget without taxes
@@ -57,10 +56,9 @@ en:
           entity: Entity
           estimated_value: Estimated value
           external_source: Source
-          open_proposals_date: Open proposals
+          formalization: Formalization
           process: Procedure
           question_description: What % of the budget is this contract?
-          submission_date: Submission date
           tender: Tender
           type: Type
         date: Date
@@ -69,6 +67,7 @@ en:
           to %{entity_name}
         entities: Entities
         final_amount_no_taxes: Amount
+        formalization_date: Date of formalization
         fromto: From To No Contr.
         main_assignees: Main assignees
         more: More than
@@ -96,6 +95,7 @@ en:
           tenders: Tenders
           tenders_for: tenders for a total amount of
         tender_amount: Tender Amount
+        tender_date: Date of tender
         title: Contracts and tenders
       contracts_types:
         others: Others

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -47,7 +47,6 @@ es:
         contracts_show:
           assignee_description: Empresa que ha ganado el contrato (Adjudicatario)
           assignees_description: Empresas que han ganado el contrato (Adjudicatarios)
-          awarding: Adjudicación
           awarding_entity: Entidad adjudicadora
           batch: Lote
           bid_description: Presupuesto base de licitación sin impuestos
@@ -57,10 +56,9 @@ es:
           entity: Entidad
           estimated_value: Valor estimado
           external_source: Fuente
-          open_proposals_date: Fecha de licitación
+          formalization: Formalización
           process: Procedimiento
           question_description: "¿Qué % del presupuesto supone este contrato?"
-          submission_date: Fecha de entrega
           tender: Licitación
           type: Tipo
         date: Fecha
@@ -69,6 +67,7 @@ es:
           del %{entity_name}
         entities: Entidades
         final_amount_no_taxes: Importe
+        formalization_date: Fecha de formalización
         fromto: Desde A Nº. Contr.
         main_assignees: Principales adjudicatarios
         more: Más de
@@ -96,6 +95,7 @@ es:
           tenders: Licitaciones
           tenders_for: licitaciones por importe de
         tender_amount: Imp. licitación
+        tender_date: Fecha de licitación
         title: Contratos y licitaciones
       contracts_types:
         others: Otros


### PR DESCRIPTION
## :v: What does this PR do?

Replaces the text in the contracts table:
  - "Adjudicación" for "Fecha de formalización"
  - "Licitación" for "Fecha de licitación"
  
Replaces the text in the contracts shows:
 - "Adjudicación " for "Formalización"

## :mag: How should this be manually tested?

Staging


## :eyes: Screenshots
![Screenshot 2021-03-10 at 11 15 50](https://user-images.githubusercontent.com/2649175/110613898-0f7d2480-8192-11eb-9021-d05931fa5ad3.png)
![Screenshot 2021-03-10 at 11 15 56](https://user-images.githubusercontent.com/2649175/110613905-1146e800-8192-11eb-8c09-ae3a544557ae.png)



### After this PR

