### PR TITLE
Gobierto Data / Show the block with the query associated with the visualizations, and hide the fork button

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -356,7 +356,7 @@ export default {
       this.updateBaseTitle();
       this.handleDatasetTabs(this.$route);
     }
-
+    this.queryOrVizIsNotMine();
     this.displayVizSavingPrompt();
   },
   mounted() {
@@ -555,13 +555,16 @@ export default {
         const {
           attributes: { sql, name, user_id, privacy_status }
         } = this.publicQueries.find(({ id }) => id === queryId);
-
         this.queryName = name;
         this.queryUserId = user_id;
         this.showPrivate = (privacy_status === "closed");
 
         this.setCurrentQuery(sql);
       } else if (queryText) {
+        const {
+          attributes: { name }
+        } = this.publicQueries.find(({ id }) => id === queryId);
+        this.queryName = name;
         this.setCurrentQuery(decodeURIComponent(queryText));
       }
     },

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -508,7 +508,7 @@ export default {
             this.setVisualizations();
           }
           // Request for the queries because we need them to show in visualization
-          if (!this.publicQueries || !this.privateQueries) {
+          if (!this.publicQueries) {
             this.setQueries();
           }
           break;
@@ -979,7 +979,7 @@ export default {
       } else if (userId !== 0 && nameComponent === ROUTE_NAMES.Visualization) {
         this.showLabelEdit = true;
 
-        if (!this.privateVisualizations || !this.publicVisualizations) {
+        if (!this.publicVisualizations) {
           await this.setVisualizations();
         }
 

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -594,6 +594,7 @@ export default {
       }
 
       this.currentQuery = sql;
+      this.runCurrentQuery();
     },
     storeRecentQuery() {
       // if the currentQuery does not exist, nor recent, nor in stored queries neither
@@ -748,6 +749,7 @@ export default {
       }
     },
     async runCurrentQuery() {
+      console.log("runCurrentQuery");
       this.isQueryRunning = true;
 
       // save the query executed

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -560,11 +560,13 @@ export default {
         this.showPrivate = (privacy_status === "closed");
 
         this.setCurrentQuery(sql);
-      } else if (queryText) {
+      } else if (queryId && queryText) {
         const {
           attributes: { name }
         } = this.publicQueries.find(({ id }) => id === queryId);
         this.queryName = name;
+        this.setCurrentQuery(decodeURIComponent(queryText));
+      } else if (!queryId && queryText) {
         this.setCurrentQuery(decodeURIComponent(queryText));
       }
     },
@@ -749,7 +751,6 @@ export default {
       }
     },
     async runCurrentQuery() {
-      console.log("runCurrentQuery");
       this.isQueryRunning = true;
 
       // save the query executed

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -760,7 +760,7 @@ export default {
       // update url with a temporal parameter
       this.$router.push({
         ...this.$route,
-        query: { ...this.$route.query }
+        query: { ...this.$route.query, sql: encodeURIComponent(this.currentQuery) }
       }).catch(()=>{})
 
       const startTime = new Date().getTime();
@@ -946,7 +946,7 @@ export default {
     isSavingPromptVisibleHandler(value) {
       this.isSavingPromptVisible = value;
     },
-    queryOrVizIsNotMine() {
+    async queryOrVizIsNotMine() {
       const userId = Number(getUserId());
       const {
         params: { queryId },
@@ -972,6 +972,10 @@ export default {
         }
       } else if (userId !== 0 && nameComponent === ROUTE_NAMES.Visualization) {
         this.showLabelEdit = true;
+
+        if (!this.privateVisualizations || !this.publicVisualizations) {
+          await this.setVisualizations();
+        }
 
         const objectViz =
           this.privateVisualizations?.find(({ id }) => id === queryId) || {};

--- a/app/javascript/gobierto_data/webapp/components/Dataset.vue
+++ b/app/javascript/gobierto_data/webapp/components/Dataset.vue
@@ -357,7 +357,6 @@ export default {
       this.handleDatasetTabs(this.$route);
     }
 
-    this.queryOrVizIsNotMine();
     this.displayVizSavingPrompt();
   },
   mounted() {
@@ -508,6 +507,10 @@ export default {
           if (!this.publicVisualizations) {
             this.setVisualizations();
           }
+          // Request for the queries because we need them to show in visualization
+          if (!this.publicQueries || !this.privateQueries) {
+            this.setQueries();
+          }
           break;
         }
 
@@ -610,6 +613,7 @@ export default {
       this.publicQueries = data
       // privateQueries is always a subset of the publicQueries
       this.privateQueries = data.filter(({ attributes }) => +attributes?.user_id === +getUserId())
+      this.queryOrVizIsNotMine();
     },
     async setVisualizations() {
       this.isPublicVizLoading = true;
@@ -756,7 +760,7 @@ export default {
       // update url with a temporal parameter
       this.$router.push({
         ...this.$route,
-        query: { ...this.$route.query, sql: encodeURIComponent(this.currentQuery) }
+        query: { ...this.$route.query }
       }).catch(()=>{})
 
       const startTime = new Date().getTime();

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
@@ -216,6 +216,9 @@ export default {
       this.getDataVisualization(this.privateVisualizations);
     }
   },
+  mounted() {
+    this.currentConfigChart = this.$refs.viewer.getConfig()
+  },
   beforeDestroy() {
     //Hide the string, and the buttons return to their initial state.
     this.$root.$emit("isVizModified", false);
@@ -235,6 +238,16 @@ export default {
       const config = this.$refs.viewer.getConfig()
       this.$root.$emit("storeCurrentVisualization", config, opts);
       this.hidePromptSaveViz()
+
+      const { plugin: updateConfigPlugin } = config
+      const { plugin: currentConfigPlugin } = this.currentConfigChart
+      /* When saving a query, checks if the type of chart is changed.
+        If the chart change, we need to reload the visualization to
+        show the new type of chart.*/
+      if (updateConfigPlugin !== currentConfigPlugin) {
+        this.$root.$emit("reloadVisualizations")
+        this.saveLoader = false
+      }
     },
     updateVizName(value) {
       const {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1231


## :v: What does this PR do?

- Show the block with the query associated with the visualizations.
- When loads a visualization or query that is yours, the fork button should not be shown. 
- When you load a query, yours or someone else's, that contains `sql=? ` the input with the name must be seen.
- If the type of chart is changes, the visualization must be reloaded to show the difference.


## :mag: How should this be manually tested?
Staging

## :eyes: Screenshots

### Before this PR

**Show the block with the query associated with the visualizations**
![before](https://user-images.githubusercontent.com/2649175/110779903-63583e00-8264-11eb-9659-284d40431297.gif)

**Save viz.**
![Screen Recording 2021-03-11 at 12 10 08 2021-03-11 12_16_40](https://user-images.githubusercontent.com/2649175/110779890-5e938a00-8264-11eb-9a02-dddf571419a4.gif)

**Show the name of the query**
![Screen Recording 2021-03-11 at 13 42 28 2021-03-11 13_45_04](https://user-images.githubusercontent.com/2649175/110789813-943e7000-8270-11eb-891d-eed98f1a57e2.gif)

### After this PR

[Loom](https://www.loom.com/share/73c6eb6a49044b628649bfdf5815ab4e)
