### PR TITLE
Gobierto Observatory / Fix unemployment age module

### DIFF
--- a/app/javascript/gobierto_observatory/modules/classes/get_unemployment_age_data.js
+++ b/app/javascript/gobierto_observatory/modules/classes/get_unemployment_age_data.js
@@ -26,6 +26,9 @@ export class GetUnemploymentAgeData extends Card {
     Promise.all([pop, unemployed]).then(([jsonData, unemployed]) => {
       // d3v5
       //
+      jsonData.forEach(function(d) {
+        d.age = parseInt(d.age)
+      })
       var nested = nest()
         .key(function(d) {
           return d.date;
@@ -90,15 +93,15 @@ export class GetUnemploymentAgeData extends Card {
       unemployed.forEach(d => {
         var year = d.date.slice(0, 4);
 
-        if (nested.hasOwnProperty(year)) {
-          if(nested[year] === undefined) {
-            d.pct = d.value / nested[year1][d.age_range];
+        if (Object.prototype.hasOwnProperty.call(nested, year)) {
+          if (nested[year] === undefined) {
+            d.pct = d.value / nested[year - 1][d.age_range];
           } else {
             d.pct = d.value / nested[year][d.age_range];
           }
         } else if (year >= lastYear - 2){
           // If we are in the last year, divide the unemployment by last year's population
-          if(nested[year - 1] === undefined) {
+          if (nested[year - 1] === undefined) {
             d.pct = d.value / nested[year - 2][d.age_range];
           } else {
             d.pct = d.value / nested[year - 1][d.age_range];

--- a/app/javascript/lib/visualizations/modules/unemployment_age.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_age.js
@@ -28,7 +28,7 @@ const d3 = {
 
 export class VisUnemploymentAge {
   constructor(divId, city_id, unemplAgeData) {
-    this.data = unemplAgeData;
+    this.data = unemplAgeData.filter(function(d) { return d.pct !== Infinity});
     this.container = divId;
     this.parseTime = d3.timeParse("%Y-%m");
     this.pctFormat = d3.format(".1%");

--- a/app/javascript/lib/visualizations/modules/unemployment_sex.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_sex.js
@@ -44,7 +44,7 @@ export class VisUnemploymentSex {
       "/datasets/ds-personas-paradas-municipio-sexo.json?sort_asc_by=date&filter_by_location_id=" +
       city_id;
     this.parseTime = d3.timeParse("%Y-%m");
-    this.pctFormat = d3.format(".1%");
+    this.pctFormat = d3.format(".3n");
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
@@ -160,6 +160,7 @@ export class VisUnemploymentSex {
           d.pct = null;
         }
         d.date = this.parseTime(d.date);
+        d.pct = d.pct * 100
       });
 
       // Filtering values to start from the first data points
@@ -208,7 +209,7 @@ export class VisUnemploymentSex {
 
     this.yScale.rangeRound([this.height, 0]).domain([
       0.0,
-      d3.max(this.unemplAgeData, function(d) {
+      d3.max(this.data, function(d) {
         return d.pct;
       })
     ]);
@@ -404,7 +405,7 @@ export class VisUnemploymentSex {
     this.focus.select("tspan").text(
       `${this._getLabel(d.data.sex)}: ${this.pctFormat(
         d.data.pct
-      )} (${d.data.date.toLocaleString(I18n.locale, {
+      )}% (${d.data.date.toLocaleString(I18n.locale, {
         month: "short"
       })} ${d.data.date.getFullYear()})`
     );
@@ -441,7 +442,10 @@ export class VisUnemploymentSex {
     this.yAxis
       .tickSize(-this.width)
       .scale(this.yScale)
-      .ticks(3, "%");
+      .tickFormat(function(d) {
+        return d + '%';
+      })
+      .ticks(3);
 
     this.svg.select(".y.axis").call(this.yAxis);
 

--- a/app/javascript/lib/visualizations/modules/unemployment_sex.js
+++ b/app/javascript/lib/visualizations/modules/unemployment_sex.js
@@ -44,7 +44,7 @@ export class VisUnemploymentSex {
       "/datasets/ds-personas-paradas-municipio-sexo.json?sort_asc_by=date&filter_by_location_id=" +
       city_id;
     this.parseTime = d3.timeParse("%Y-%m");
-    this.pctFormat = d3.format(".3n");
+    this.pctFormat = d3.format(".1%");
     this.isMobile = window.innerWidth <= 768;
 
     // Chart dimensions
@@ -160,7 +160,6 @@ export class VisUnemploymentSex {
           d.pct = null;
         }
         d.date = this.parseTime(d.date);
-        d.pct = d.pct * 100
       });
 
       // Filtering values to start from the first data points
@@ -209,7 +208,7 @@ export class VisUnemploymentSex {
 
     this.yScale.rangeRound([this.height, 0]).domain([
       0.0,
-      d3.max(this.data, function(d) {
+      d3.max(this.unemplAgeData, function(d) {
         return d.pct;
       })
     ]);
@@ -442,10 +441,7 @@ export class VisUnemploymentSex {
     this.yAxis
       .tickSize(-this.width)
       .scale(this.yScale)
-      .tickFormat(function(d) {
-        return d + '%';
-      })
-      .ticks(3);
+      .ticks(3, "%")
 
     this.svg.select(".y.axis").call(this.yAxis);
 


### PR DESCRIPTION
Closes #3756


## :v: What does this PR do?

In last year's data (2020), `d.age` comes as a string. Add an exception to convert text strings to numbers.

## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### Before this PR
![Screenshot 2021-03-15 at 07 58 21](https://user-images.githubusercontent.com/2649175/111115023-59845280-8564-11eb-846d-d4bed154ff34.png)

### After this PR
![Screenshot 2021-03-15 at 08 09 10](https://user-images.githubusercontent.com/2649175/111116159-e5e34500-8565-11eb-8240-17351152a7e0.png)