### PR TITLE
Fix app signal version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,8 @@ gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
 gem "rubyXL"
 
 # Performance
-gem "appsignal", "~> 3.0.1"
+# TODO: v3 raises a middleware error
+gem "appsignal", "= 2.11.9"
 
 # Auth strategies
 gem "net-ldap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     ansi (1.5.0)
-    appsignal (3.0.1)
+    appsignal (2.11.9)
       rack
     ast (2.4.2)
     aws-eventstream (1.1.1)
@@ -550,7 +550,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack-action_caching
   active_model_serializers
-  appsignal (~> 3.0.1)
+  appsignal (= 2.11.9)
   aws-sdk-s3 (~> 1)
   aws-ses (= 0.7.0)
   bcrypt (~> 3.1.0)


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR forces v2.9 version of app signal, because version 3 brokes some middlware

I've added a comment in the Gemfile, and this should be investigated

