### PR TITLE
Gobierto Visualizations / Get the treemaps width with its container

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
@@ -194,7 +194,7 @@ export default {
     }
   },
   mounted() {
-    this.containerChart = document.querySelector('.treemap-nested-container');
+    this.containerChart = document.querySelector(`.treemap-nested-container-${this.treemapId}`);
     this.svgWidth = this.containerChart.offsetWidth;
     /*To avoid add/remove colors in every update use Object.freeze(this.data)
     to create a scale/domain color persistent with the original keys*/

--- a/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
@@ -179,7 +179,7 @@ export default {
     },
     $route(to, from) {
       if (to !== from) {
-        this.containerChart = document.querySelector('.treemap-nested-container');
+        this.containerChart = document.querySelector(`.treemap-nested-container-${this.treemapId}`);
         this.svgWidth = this.containerChart.offsetWidth;
         this.transformDataTreemap(this.data)
       }
@@ -727,8 +727,7 @@ export default {
       }
     },
     resizeListener() {
-      const containerChart = document.querySelector('.treemap-nested-container');
-      this.svgWidth = containerChart.offsetWidth
+      this.svgWidth = this.containerChart.offsetWidth
       this.transformDataTreemap(this.data)
     },
     injectRouter() {


### PR DESCRIPTION
## :v: What does this PR do?

Get the treemap's width with its own container instead of the parent container to avoid that if the first treemap is hidden, the second cannot calculate its width.

## :mag: How should this be manually tested?

[Staging](https://alcobendas.gobify.net/visualizaciones/contratos)

## Screenshots

### After

![Screenshot 2021-03-16 at 11 03 20](https://user-images.githubusercontent.com/2649175/111291243-49916f00-8647-11eb-8b8e-ee6c9d1892d4.png)
