### PR TITLE
Gobierto Visualilzations / Check if contracts comes with gobierto_start_date

### DIFF
--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -174,7 +174,15 @@ export class ContractsController {
       .domain(this._amountRange.domain)
       .range(this._amountRange.range);
 
-    contractsDataMap = contractsData.map(({ final_amount_no_taxes = 0, initial_amount_no_taxes = 0, gobierto_start_date, assignee_id, ...rest }) => {
+    contractsDataMap = contractsData.map(({ final_amount_no_taxes = 0, initial_amount_no_taxes = 0, gobierto_start_date, assignee_id, award_date, formalized_date, ...rest }) => {
+      if (!gobierto_start_date && formalized_date) {
+        gobierto_start_date = formalized_date
+      }
+
+      if (!gobierto_start_date && !formalized_date) {
+        gobierto_start_date = award_date
+      }
+
       return {
         final_amount_no_taxes: (final_amount_no_taxes && !Number.isNaN(final_amount_no_taxes)) ? parseFloat(final_amount_no_taxes): 0.0,
         initial_amount_no_taxes: (initial_amount_no_taxes && !Number.isNaN(initial_amount_no_taxes)) ? parseFloat(initial_amount_no_taxes): 0.0,
@@ -182,6 +190,8 @@ export class ContractsController {
         assignee_routing_id: assignee_id,
         gobierto_start_date_year: gobierto_start_date ? new Date(gobierto_start_date).getFullYear().toString() : '',
         gobierto_start_date: new Date(gobierto_start_date),
+        award_date,
+        formalized_date,
         ...rest
       }
     })


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1237


## :v: What does this PR do?

In some contracts, `gobierto_start_date` is `undefined`. We add an exception, if `gobierto_start_date` is `undefined`, it will be `formalized_date`. In case `gobierto_start_date` and `formalized_date` come `undefined`, we use `award_date`.

## :mag: How should this be manually tested?

[Staging](https://alcobendas.gobify.net/visualizaciones/contratos/adjudicaciones)

## :eyes: Screenshots

### Before this PR

### After this PR

![Screenshot 2021-03-17 at 11 37 43](https://user-images.githubusercontent.com/2649175/111454747-4a90d200-8715-11eb-8247-44d23a8f472c.png)
