### PR TITLE
Upgrade Amazon SES delivery to v4 signature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem "sidekiq-monitor-stats"
 gem "aws-sdk-s3", "~> 1"
 
 # AWS SES client
-gem "aws-ses", "= 0.7.0"
+gem "aws-ses", git: "https://github.com/zebitex/aws-ses.git", ref: "78-sigv4-problem"
 
 # Calendar view component
 gem "simple_calendar", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,17 @@ GIT
       liquid (~> 4.0.0)
       rails (>= 5.0.6)
 
+GIT
+  remote: https://github.com/zebitex/aws-ses.git
+  revision: 65e1ff1c3c2031b243f773cb9e61df6e49db71dd
+  ref: 78-sigv4-problem
+  specs:
+    aws-ses (0.7.1)
+      builder
+      mail (> 2.2.5)
+      mime-types
+      xml-simple
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -109,11 +120,6 @@ GEM
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-ses (0.7.0)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
     aws_cf_signer (0.1.3)
@@ -539,7 +545,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xml-simple (1.1.5)
+    xml-simple (1.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -552,7 +558,7 @@ DEPENDENCIES
   active_model_serializers
   appsignal (= 2.11.9)
   aws-sdk-s3 (~> 1)
-  aws-ses (= 0.7.0)
+  aws-ses!
   bcrypt (~> 3.1.0)
   before_renders
   bootsnap

--- a/config/initializers/action_mailer_settings.rb
+++ b/config/initializers/action_mailer_settings.rb
@@ -7,6 +7,7 @@ if Rails.application.secrets.mailer_delivery_method == "ses"
                                          access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID") { "" },
                                          secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY") { "" },
                                          server: "email.eu-west-1.amazonaws.com",
+                                         region: 'eu-west-1',
                                          signature_version: 4
 
 elsif Rails.application.secrets.mailer_delivery_method == "smtp"


### PR DESCRIPTION
Closes #3727 

## :v: What does this PR do?

This PR updates Amazon SES gem version to the fork that supports v4 signature.

## :mag: How should this be manually tested?

Emails should work as usual

