### PR TITLE
Gobierto Contracts / Show or hide contracts depending on permalink content

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/components/ContractsShowTableFooter.vue
+++ b/app/javascript/gobierto_visualizations/webapp/components/ContractsShowTableFooter.vue
@@ -17,7 +17,10 @@
         />
       </table>
     </div>
-    <div class="visualizations-contracts-show__footer_link">
+    <div
+      v-if="showPermalink"
+      class="visualizations-contracts-show__footer_link"
+    >
       <a :href="permalink">
         <i
           class="fas fa-external-link-alt"
@@ -55,6 +58,11 @@ export default {
       labelType: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.type') || '',
       labelQuestionDescription: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.question_description') || '',
       labelLink: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.external_source') || '',
+    }
+  },
+  computed: {
+    showPermalink() {
+      return !this.permalink.includes('.gobierto.es')
     }
   },
   created() {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1241

## :v: What does this PR do?
Some contracts don't have a valid permalink. In this case, hide the block which contains the permalink.

## :mag: How should this be manually tested?
[Staging](https://alcobendas.gobify.net/visualizaciones/contratos/adjudicaciones/1537704)

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-03-22 at 16 20 18](https://user-images.githubusercontent.com/2649175/112013705-89b28f00-8b2a-11eb-988a-61b2a21d619a.png)

### After this PR
![Screenshot 2021-03-22 at 16 22 30](https://user-images.githubusercontent.com/2649175/112014027-d0a08480-8b2a-11eb-86ed-0176b97c8dcb.png)
