### PR TITLE
Gobierto Data / Hide the queries tab from the sidebar.

### DIFF
--- a/app/assets/stylesheets/module-data.scss
+++ b/app/assets/stylesheets/module-data.scss
@@ -61,7 +61,10 @@
   }
 
   &-tabs-sidebar {
-    list-style: none;
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: nowrap;
+    margin-bottom: 1rem;
   }
 
   &-tab-sidebar--tab {
@@ -69,7 +72,7 @@
     font-size: $f7;
     color: #666;
     cursor: pointer;
-    width: 32%;
+    width: 100%;
     display: inline-block;
     text-align: center;
     padding-bottom: .25rem;
@@ -79,6 +82,10 @@
     &.is-active {
       opacity: 1;
       font-weight: bold;
+    }
+
+    &:not(:last-child) {
+      margin-right: .25rem;
     }
 
   }

--- a/app/javascript/gobierto_data/webapp/components/Sidebar.vue
+++ b/app/javascript/gobierto_data/webapp/components/Sidebar.vue
@@ -1,30 +1,28 @@
 <template>
   <div>
     <nav class="gobierto-data-tabs-sidebar">
-      <ul>
-        <li
-          :class="{ 'is-active': activeTab === 0 }"
-          class="gobierto-data-tab-sidebar--tab"
-          @click="activateTab(0)"
-        >
-          <span>{{ labelCategories }}</span>
-        </li>
-        <li
-          :class="{ 'is-active': activeTab === 1 }"
-          class="gobierto-data-tab-sidebar--tab"
-          @click="activateTab(1)"
-        >
-          <span>{{ labelSets }}</span>
-        </li>
+      <div
+        :class="{ 'is-active': activeTab === 0 }"
+        class="gobierto-data-tab-sidebar--tab"
+        @click="activateTab(0)"
+      >
+        <span>{{ labelCategories }}</span>
+      </div>
+      <div
+        :class="{ 'is-active': activeTab === 1 }"
+        class="gobierto-data-tab-sidebar--tab"
+        @click="activateTab(1)"
+      >
+        <span>{{ labelSets }}</span>
+      </div>
 
-        <li
-          :class="{ 'is-active': activeTab === 2 }"
-          class="gobierto-data-tab-sidebar--tab"
-          @click="activateTab(2)"
-        >
-          <span>{{ labelQueries }}</span>
-        </li>
-      </ul>
+      <!-- <div
+        :class="{ 'is-active': activeTab === 2 }"
+        class="gobierto-data-tab-sidebar--tab"
+        @click="activateTab(2)"
+      >
+        <span>{{ labelQueries }}</span>
+      </div> -->
     </nav>
 
     <keep-alive>
@@ -63,7 +61,7 @@ export default {
   data() {
     return {
       labelSets: I18n.t("gobierto_data.projects.sets") || "",
-      labelQueries: I18n.t("gobierto_data.projects.queries") || "",
+      /*labelQueries: I18n.t("gobierto_data.projects.queries") || "",*/
       labelCategories: I18n.t("gobierto_data.projects.categories") || "",
       currentTabComponent: null,
       mutatedFilters: []


### PR DESCRIPTION
Closes #3801


## :v: What does this PR do?

Hide the queries tab from the sidebar.
## :mag: How should this be manually tested?

Staging

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-04-08 at 17 53 52](https://user-images.githubusercontent.com/2649175/114058092-70804100-9893-11eb-9bad-3a71831cdf48.png)

### After this PR
![Screenshot 2021-04-08 at 18 14 47](https://user-images.githubusercontent.com/2649175/114061078-52681000-9896-11eb-95c3-c15b97e75742.png)



