### PR TITLE
Gobierto Visualizations / Replaces the path to avoid redirect to blank page.

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -8,7 +8,7 @@
     <EntityTreeMapNested
       v-if="activeTab === 0"
       id="gobierto-visualizations-treemap-entity"
-      :data="visualizationsData"
+      :data="visualizationsDataEntity"
       class="mt4"
     />
     <div id="gobierto-visualizations-beeswarm">
@@ -228,6 +228,10 @@ export default {
       return this.visualizationsData
         .filter(({ minor_contract: minor }) => minor === 'f')
         .map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
+    },
+    visualizationsDataEntity() {
+      return this.visualizationsData
+        .map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
     }
   },
   created() {
@@ -269,7 +273,7 @@ export default {
     goesToItem(event) {
       const { id } = event
       // eslint-disable-next-line no-unused-vars
-      this.$router.push(`adjudicaciones/${id}`).catch(err => {})
+      this.$router.push(`/visualizaciones/contratos/adjudicaciones/${id}`).catch(err => {})
     },
     refreshSummaryData() {
       if (!this.value) {

--- a/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
+++ b/app/javascript/gobierto_visualizations/webapp/visualizations/treeMapNested.vue
@@ -640,7 +640,7 @@ export default {
 
         function buildLastDepth(d) {
           let title = d.data.name === undefined ? d.data[keyForThirdDepth] : d.data.name;
-          const { parent: { data: { name, href } } } = d
+          const { parent: { data: { name } }, data: { href } } = d
           return `
             <a href="${href}" class="link-last-depth">
               <p class="title">${name}</p>


### PR DESCRIPTION
## :v: What does this PR do?

If the URL doesn't contain a slash at the end and the user clicks on the beeswarm circle, it redirects to a blank page. Replaces the path to avoid redirect to blank page.
Don't get the HREF data from parent to deal with undefined.

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

![before](https://user-images.githubusercontent.com/2649175/114207366-97567a00-995c-11eb-93a6-451616e5874f.gif)

### After this PR

![after](https://user-images.githubusercontent.com/2649175/114207367-97567a00-995c-11eb-9c49-07d75eb0f493.gif)

