### PR TITLE
Remove participation, citizens charters and budget consultations workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,18 +164,6 @@ jobs:
       - store_test_results:
           path: test/reports
 
-  tests_budget_consultations:
-    <<: *defaults
-    steps:
-      - prepare_workspace
-      - run:
-          name: Run tests
-          command: |
-            TEST_FILES="$(find test -path '*gobierto_budget_consultations*' -name '*_test.rb' | circleci tests split --split-by=timings)"
-            bin/rails test $TEST_FILES
-      - store_test_results:
-          path: test/reports
-
   tests_budgets:
     <<: *defaults
     steps:
@@ -196,18 +184,6 @@ jobs:
           name: Run tests
           command: |
             TEST_FILES="$(find test -path '*gobierto_calendars*' -name '*_test.rb' | circleci tests split --split-by=timings)"
-            bin/rails test $TEST_FILES
-      - store_test_results:
-          path: test/reports
-
-  tests_citizens_charters:
-    <<: *defaults
-    steps:
-      - prepare_workspace
-      - run:
-          name: Run tests
-          command: |
-            TEST_FILES="$(find test -path '*gobierto_citizens_charters*' -name '*_test.rb' | circleci tests split --split-by=timings)"
             bin/rails test $TEST_FILES
       - store_test_results:
           path: test/reports
@@ -320,19 +296,6 @@ jobs:
       - store_test_results:
           path: test/reports
 
-  tests_participation:
-    <<: *defaults
-    parallelism: 2
-    steps:
-      - prepare_workspace
-      - run:
-          name: Run tests
-          command: |
-            TEST_FILES="$(find test -path '*gobierto_participation*' -name '*_test.rb' | circleci tests split --split-by=timings)"
-            bin/rails test $TEST_FILES
-      - store_test_results:
-          path: test/reports
-
   tests_people:
     <<: *defaults
     parallelism: 2
@@ -428,16 +391,10 @@ workflows:
       - tests_attachments:
           requires:
             - bundle_dependencies
-      - tests_budget_consultations:
-          requires:
-            - bundle_dependencies
       - tests_budgets:
           requires:
             - bundle_dependencies
       - tests_calendars:
-          requires:
-            - bundle_dependencies
-      - tests_citizens_charters:
           requires:
             - bundle_dependencies
       - tests_cms:
@@ -467,9 +424,6 @@ workflows:
       - tests_observatory:
           requires:
             - bundle_dependencies
-      - tests_participation:
-          requires:
-            - bundle_dependencies
       - tests_people:
           requires:
             - bundle_dependencies
@@ -490,10 +444,8 @@ workflows:
             - bundle_dependencies
             - tests_admin
             - tests_attachments
-            - tests_budget_consultations
             - tests_budgets
             - tests_calendars
-            - tests_citizens_charters
             - tests_cms
             - tests_common
             - tests_core
@@ -503,7 +455,6 @@ workflows:
             - tests_indicators
             - tests_investments
             - tests_observatory
-            - tests_participation
             - tests_people
             - tests_plans
             - tests_visualizations
@@ -517,10 +468,8 @@ workflows:
             - bundle_dependencies
             - tests_admin
             - tests_attachments
-            - tests_budget_consultations
             - tests_budgets
             - tests_calendars
-            - tests_citizens_charters
             - tests_cms
             - tests_common
             - tests_core
@@ -530,7 +479,6 @@ workflows:
             - tests_indicators
             - tests_investments
             - tests_observatory
-            - tests_participation
             - tests_people
             - tests_plans
             - tests_visualizations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ defaults: &defaults
     - image: elasticsearch:2.4.1
     - image: redis:4.0.9
 
-orbs:
-  bye-github-draft: whyayen/bye-github-draft@0.0.1
-
 commands:
   restore_bundler_cache:
     steps:
@@ -93,7 +90,6 @@ jobs:
     <<: *defaults
     resource_class: medium+
     steps:
-      - bye-github-draft/check-skippable-pr
       - checkout
       - attach_workspace:
           at: *working_directory
@@ -376,11 +372,12 @@ jobs:
 workflows:
   version: 2
   build-and-deploy:
-    branches:
-      ignore:
-        - staging
     jobs:
-      - bundle_dependencies
+      - bundle_dependencies:
+          filters:
+            branches:
+              ignore:
+                - staging
       - tests_admin:
           requires:
             - bundle_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,17 +358,6 @@ jobs:
       - store_test_results:
           path: test/reports
 
-  staging-deploy:
-    working_directory: *working_directory
-    machine:
-      enabled: true
-    steps:
-      # deploy script is in the repository
-      - checkout
-      - run:
-          name: Deploy staging branch
-          command: script/staging_deploy.sh
-
   production-deploy:
     working_directory: *working_directory
     machine:
@@ -383,6 +372,9 @@ jobs:
 workflows:
   version: 2
   build-and-deploy:
+    branches:
+      ignore:
+        - staging
     jobs:
       - bundle_dependencies
       - tests_admin:
@@ -439,30 +431,6 @@ workflows:
       - tests_engines:
           requires:
             - bundle_dependencies
-      - staging-deploy:
-          requires:
-            - bundle_dependencies
-            - tests_admin
-            - tests_attachments
-            - tests_budgets
-            - tests_calendars
-            - tests_cms
-            - tests_common
-            - tests_core
-            - tests_dashboards
-            - tests_data
-            - tests_exports
-            - tests_indicators
-            - tests_investments
-            - tests_observatory
-            - tests_people
-            - tests_plans
-            - tests_visualizations
-            - tests_others
-            - tests_engines
-          filters:
-            branches:
-              only: staging
       - production-deploy:
           requires:
             - bundle_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ defaults: &defaults
     - image: elasticsearch:2.4.1
     - image: redis:4.0.9
 
+orbs:
+  bye-github-draft: whyayen/bye-github-draft@0.0.1
+
 commands:
   restore_bundler_cache:
     steps:
@@ -90,6 +93,7 @@ jobs:
     <<: *defaults
     resource_class: medium+
     steps:
+      - bye-github-draft/check-skippable-pr
       - checkout
       - attach_workspace:
           at: *working_directory


### PR DESCRIPTION
## :v: What does this PR do?

This PR 

1. removes the following jobs from the CircleCI build:

- budgets consultations
- participation
- citizien charts

2. prevents the build to be executed for the staging branch
3. ~prevents to run tests on draft PRs~ (I tried but the existing orbs doesn't work and it's not easy to implement)

## :mag: How should this be manually tested?


- those tests shouldn't be executed
- staging build shouldn't be executed:

![Screenshot from 2021-04-17 06-30-02](https://user-images.githubusercontent.com/17616/115101668-5fe06280-9f46-11eb-8bef-db0b2a14037b.png)
