### PR TITLE
Don't require embed param to set X-FRAME-OPTIONS header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
   #
   # Reads the allowed domain from the site configuration
   def allow_iframe_embed
-    if params.has_key?(:embed) and current_site.configuration.configuration_variables["allowed_iframe_origin"].present?
+    if current_site.configuration.configuration_variables["allowed_iframe_origin"].present?
       # To support IE
       response.headers["X-Frame-Options"] = "ALLOW-FROM #{current_site.configuration.configuration_variables["allowed_iframe_origin"]}"
       # Rest of modern browsers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
   #
   # Reads the allowed domain from the site configuration
   def allow_iframe_embed
-    if current_site.configuration.configuration_variables["allowed_iframe_origin"].present?
+    if current_site && current_site.configuration.configuration_variables["allowed_iframe_origin"].present?
       # To support IE
       response.headers["X-Frame-Options"] = "ALLOW-FROM #{current_site.configuration.configuration_variables["allowed_iframe_origin"]}"
       # Rest of modern browsers

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -24,6 +24,7 @@ madrid:
     "available_locales" => ["en", "es"],
     "home_page" => "GobiertoParticipation",
     "privacy_page_id" => "58988811",
+    "raw_configuration_variables" => "allowed_iframe_origin\: \"https://populate.tools\"",
     "google_analytics_id" => "UA-000000-01" }.to_yaml.inspect %>
   organization_name: Madrid
   organization_id: <%= INE::Places::Place.find_by_slug("madrid").id %>


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

The setting allowed_iframe_origin shouldn't require the embed parameter to be present to set the headers X-FRAME-OPTIONS and allow site embeddings.

## :mag: How should this be manually tested?

Configure a site with this option and check the header X-FRAME-OPTIONS is properly set

