### PR TITLE
3837 add rake tasks to run every module only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,7 @@ group :development, :test do
   gem "i18n-tasks"
   gem "spring"
   gem "puma"
+    gem "open3", "~> 0.1.1"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :development, :test do
   gem "i18n-tasks"
   gem "spring"
   gem "puma"
-    gem "open3", "~> 0.1.1"
+  gem "open3", "~> 0.1.1"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,7 @@ GEM
       racc (~> 1.4)
     nori (2.6.0)
     oj (3.10.16)
+    open3 (0.1.1)
     open4 (1.3.4)
     os (1.1.1)
     paper_trail (12.0.0)
@@ -572,6 +573,7 @@ DEPENDENCIES
   minitest-stub_any_instance
   mocha
   net-ldap
+  open3 (~> 0.1.1)
   paper_trail
   paranoia
   pg (~> 1.1)

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 namespace :test do
   modules = %w{
     gobierto_admin
@@ -26,8 +28,16 @@ namespace :test do
     task "#{mod}".to_sym, [:fail_fast_enable] => :environment do |_t, args|
       files = `find test -path '*#{mod}*' -name '*_test.rb' | grep -v '#{mod}\/gobierto_'`.gsub("\n"," ")
       cmd = "bin/rails test #{files} #{"--fail-fast" if args[:fail_fast_enable]}"
-      puts cmd
-      puts `#{cmd}`
+
+      Open3::popen3(cmd) do |std_in, std_out, std_err|
+        std_err.each_line do |line|
+          puts line
+        end
+        std_out.each_line do |line|
+          puts line
+        end
+      end
+
     end
   end
 end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :test do
+  modules = %w{
+    gobierto_admin
+    gobierto_attachments
+    gobierto_budgets
+    gobierto_calendars
+    gobierto_cms gobierto_common
+    gobierto_core
+    gobierto_dashboards
+    gobierto_data
+    gobierto_exports
+    gobierto_indicators
+    gobierto_investments
+    gobierto_observatory
+    gobierto_people
+    gobierto_plans
+    gobierto_visualizations
+    gobierto_others
+    gobierto_engines
+  }
+
+  modules.each do |mod|
+    desc "run test for module #{mod}.safe_constantize "
+    task "#{mod}".to_sym, [:fail_fast_enable] => :environment do |_t, args|
+      files = `find test -path '*#{mod}*' -name '*_test.rb' | grep -v '#{mod}\/gobierto_'`.gsub("\n"," ")
+      cmd = "bin/rails test #{files} #{"--fail-fast" if args[:fail_fast_enable]}"
+      puts cmd
+      puts `#{cmd}`
+    end
+  end
+end


### PR DESCRIPTION
Closes #3837


## :v: What does this PR do?

add new rake task to run test by every gobierto module

## :mag: How should this be manually tested?


```
bin/rails -T # should show new task like:

bin/rails test:gobierto_admin
...
```

