### PR TITLE
Optional webpack plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,8 @@ APPSIGNAL_PUSH_API_KEY=
 
 # Mapbox token used in tests
 MAPBOX_TOKEN=
+
+# Webpack activate analyzer plugin
+WEBPACK_ANALYZE=
+# Webpack activate speed analyzer plugin
+WEBPACK_SPEED=

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,21 +2,31 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
 const stats = require('./config/stats')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
 
 environment.config.merge(stats)
-
 environment.plugins.delete('CaseSensitivePaths')
-environment.plugins.append('BundleAnalyzerPlugin', new BundleAnalyzerPlugin({
-  openAnalyzer: false
-}))
 
-const smp = new SpeedMeasurePlugin({
-  outputFormat: "human",
-  loaderTopFiles: 5,
-  // compareLoadersBuild: {
-  //   filePath: "./tmp/build-info.json",
-  // },
-});
-module.exports = smp.wrap(environment.toWebpackConfig())
+// How to run: WEBPACK_ANALYZE=true bin/webpack-dev-server
+if (process.env.WEBPACK_ANALYZE === 'true') {
+  const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+  environment.plugins.append('BundleAnalyzerPlugin', new BundleAnalyzerPlugin())
+}
+
+let config;
+// How to run: WEBPACK_SPEED=true bin/webpack-dev-server
+if (process.env.WEBPACK_SPEED === 'true') {
+  const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+  const smp = new SpeedMeasurePlugin({
+    outputFormat: "human",
+    loaderTopFiles: 5,
+    // compareLoadersBuild: {
+    //   filePath: "./tmp/build-info.json",
+    // },
+  });
+
+  config = smp.wrap(environment.toWebpackConfig())
+} else {
+  config = environment.toWebpackConfig()
+}
+
+module.exports = config


### PR DESCRIPTION
## :v: What does this PR do?
Currently, in development mode, webpack runs `webpack-bundle-analyzer` and `speed-measure-webpack-plugin`, which slows down the startup. Turn the webpack plugins into on-demand using environment variables.

```
WEBPACK_ANALYZE=true bin/webpack-dev-server
WEBPACK_SPEED=true bin/webpack-dev-server
```

[Docs](https://gobierto.readme.io/docs/environment-variables-overview-1#webpack-plugins)