### PR TITLE
Fix seed for gobierto people

### DIFF
--- a/db/seeds/gobierto_seeds/gobierto_people/recipe.rb
+++ b/db/seeds/gobierto_seeds/gobierto_people/recipe.rb
@@ -9,7 +9,7 @@ module GobiertoSeeds
         settings = GobiertoModuleSettings.find_by site: site, module_name: "GobiertoPeople"
         if settings.nil?
           settings = GobiertoModuleSettings.new site: site, module_name: "GobiertoPeople"
-          settings.submodules_enabled = GobiertoPeople.module_submodules
+          settings.submodules_enabled = ::GobiertoPeople.module_submodules
           settings.save!
         end
 


### PR DESCRIPTION
Closes #3855


## :v: What does this PR do?

fix below:
```
NoMethodError: undefined method `module_submodules' for GobiertoSeeds::GobiertoPeople:Module
Did you mean?  module_exec
~/gobierto/db/seeds/gobierto_seeds/gobierto_people/recipe.rb:12:in `run'
```

## :mag: How should this be manually tested?
```
bin/rails db:drop
bin/rails db:create
bin/rails db:migrate
bin/rails db:seed
```
