### PR TITLE
add custom field gobierto-default-geometry-data-column

### DIFF
--- a/db/migrate/20210510055424_add_custom_field_geometry_data_colum.rb
+++ b/db/migrate/20210510055424_add_custom_field_geometry_data_colum.rb
@@ -1,0 +1,9 @@
+class AddCustomFieldGeometryDataColum < ActiveRecord::Migration[6.0]
+  def up
+    Site.find_each do |site|
+      GobiertoSeeds::GobiertoData::Recipe.run(site) if site.configuration.gobierto_data_enabled?
+    end
+  end
+  def down
+  end
+end

--- a/db/seeds/gobierto_seeds/gobierto_data/recipe.rb
+++ b/db/seeds/gobierto_seeds/gobierto_data/recipe.rb
@@ -122,6 +122,14 @@ module GobiertoSeeds
           }
           license.save
         end
+
+        dataset_default_geometry = site.custom_fields.string.where(class_name: "GobiertoData::Dataset").find_or_initialize_by(uid: 'gobierto-default-geometry-data-column')
+        if dataset_default_geometry.new_record?
+          dataset_default_geometry.name_translations = { ca: "Columna per llegir dades de geometria", en: "Column to read geometry data", es: "Columna para leer datos de geometría" }
+          dataset_default_geometry.position = 7
+          dataset_default_geometry.options = { configuration: {} }
+          dataset_default_geometry.save
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #3841 


## :v: What does this PR do?
add a custom field with uid `gobierto-default-geometry-data-colum` into GobiertoData::Dataset, this field will be used by the maps visualization to fetch the data to show 

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?
it need to run:

```
bin/rails c
site = Site.find_by(domain: "**********")
GobiertoSeeds::GobiertoData::Recipe.run(site) if site.configuration.gobierto_data_enabled?
```