### PR TITLE
3032 fix source dataset is shown despite to be blank

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/commons/Info.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Info.vue
@@ -157,7 +157,7 @@ export default {
       return this.descriptionDataset.length > 250
     },
     hasDatasetSource() {
-      return this.sourceDataset && this.sourceDataset?.text !== ""
+      return this.sourceDataset && this.sourceDataset?.text !== undefined && this.sourceDataset?.text !== ""
     },
     hasDatasetLicense() {
       return this.licenseDataset?.text !== undefined && this.licenseDataset?.url !== undefined


### PR DESCRIPTION
Closes #3032 


## :v: What does this PR do?

This PR fix for existing Dataset custom fields `source dataset` is shown despite to be blank. 
this problem don't happen for new created datasets.


## :mag: How should this be manually tested?

