### PR TITLE
Gobierto Visualizations / Improvements the perfomance of the table

### DIFF
--- a/app/javascript/lib/vue/components/modules/Table.vue
+++ b/app/javascript/lib/vue/components/modules/Table.vue
@@ -154,6 +154,8 @@ import { VueFiltersMixin } from "lib/vue/filters"
 import TableColumnsSelector from './TableColumnsSelector'
 import SortIcon from './SortIcon'
 
+const collator = new Intl.Collator(I18n.locale)
+
 export default {
   name: 'Table',
   components: {
@@ -222,16 +224,16 @@ export default {
         .sort(({ [id]: termA }, { [id]: termB }) =>
           sort === "asc"
             ? typeof termA === "string"
-              ? termA.localeCompare(termB, undefined, { numeric: true })
+              ? collator.compare(termA, termB)
               : termA > termB ? 1 : -1
             : typeof termA === "string"
-              ? termB.localeCompare(termA, undefined, { numeric: true })
+              ? collator.compare(termB, termA)
               : termA < termB ? 1 : -1
         );
     },
     visibleRows() {
       // if there's pagination, display only such subset, otherwise show everything
-      return this.visiblePaginatedRows || this.rowsSorted
+      return this.showPagination ? this.visiblePaginatedRows : this.rowsSorted
     },
   },
   created() {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1287


## :v: What does this PR do?

Improvements the performance of the table component. The problem was table tried to render all the elements even if the pagination was activated. Now, if the pagination is activated, the table only renders the visible elements.


## :mag: How should this be manually tested?

[Staging](https://getafe.gobify.net/visualizaciones/subvenciones/subvenciones)