### PR TITLE
995 GobiertoData add geometry support for neighbourhood in datasets

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -28,6 +28,7 @@ module GobiertoData
     belongs_to :site
     has_many :queries, dependent: :destroy, class_name: "GobiertoData::Query"
     has_many :visualizations, dependent: :destroy, class_name: "GobiertoData::Visualization"
+    has_one :neighbourhood, dependent: :destroy, class_name: "GobiertoData::Neighbourhood"
 
     scope :sorted, -> { order(data_updated_at: :desc) }
 

--- a/app/models/gobierto_data/neighbourhood.rb
+++ b/app/models/gobierto_data/neighbourhood.rb
@@ -1,0 +1,10 @@
+require_relative "../gobierto_data"
+
+module GobiertoData
+  class Neighbourhood < ApplicationRecord
+    belongs_to :site
+    belongs_to :dataset
+
+    validates :site, :dataset, :name, :geometry, presence: true
+  end
+end

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -7,7 +7,7 @@ module GobiertoData
 
     cache key: "dataset"
 
-    attributes :id, :name, :slug, :table_name, :data_updated_at
+    attributes :id, :name, :slug, :table_name, :geometry, :data_updated_at
 
     attribute :links, unless: :exclude_links? do
       slug = object.slug
@@ -26,6 +26,10 @@ module GobiertoData
           )
         end
       end
+    end
+
+    def geometry
+      object.neighbourhood&.geometry
     end
 
     def current_site

--- a/db/migrate/20210513055001_create_gobierto_data_neighbourhoods.rb
+++ b/db/migrate/20210513055001_create_gobierto_data_neighbourhoods.rb
@@ -1,0 +1,11 @@
+class CreateGobiertoDataNeighbourhoods < ActiveRecord::Migration[6.0]
+  def change
+    create_table :gdata_neighbourhoods do |t|
+      t.belongs_to  :site,    index: true
+      t.belongs_to  :dataset, index: true
+      t.string      :name
+      t.json        :geometry
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Related /PopulateTools/issues#995

## :v: What does this PR do?

This PR give support to datasets for `has_one` Neighbourhood model which have a geojson into geometry attribute. 
However this geometry will show this into the api for request datasets

## :mag: How should this be manually tested?

- this PR don't break existing dataset without Neighbourhood relation
- appear into the API new attributte named geometry
-  until the ETL not ready geometry in all dataset should appear as `null`

## :eyes: Screenshots
![Screenshot from 2021-05-13 10-10-09](https://user-images.githubusercontent.com/288355/118098952-e3219680-b3d4-11eb-95d7-100b840b2a7d.png)

![Screenshot from 2021-05-13 09-42-05](https://user-images.githubusercontent.com/288355/118098980-e9177780-b3d4-11eb-85f0-87fac16535d1.png)
