### PR TITLE
Gobierto Visualizations / Improves the usability of the subsidies table

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/SubsidiesIndex.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/SubsidiesIndex.vue
@@ -1,7 +1,7 @@
 <template>
   <Table
     :data="items"
-    :sort-column="'beneficiary'"
+    :sort-column="'call'"
     :columns="subsidiesColumns"
     :show-columns="showColumns"
     class="gobierto-table-margin-top"
@@ -44,7 +44,7 @@ export default {
 
     this.items = this.subsidiesData.map(d => ({ ...d, href: `${location.origin}${location.pathname}/${d.id}` } ))
     this.columns = subsidiesColumns;
-    this.showColumns = ['beneficiary', 'amount', 'grant_date']
+    this.showColumns = ['beneficiary', 'call','amount', 'grant_date']
   },
   beforeDestroy(){
     EventBus.$off('refresh-summary-data');

--- a/app/javascript/gobierto_visualizations/webapp/lib/config/subsidies.js
+++ b/app/javascript/gobierto_visualizations/webapp/lib/config/subsidies.js
@@ -1,8 +1,9 @@
 // table columns
 export const subsidiesColumns = [
-  { field: 'beneficiary', name: I18n.t('gobierto_visualizations.visualizations.subsidies.beneficiary'), cssClass: 'bold' },
+  { field: 'beneficiary', name: I18n.t('gobierto_visualizations.visualizations.subsidies.beneficiary'), cssClass: 'bold nowrap' },
+  { field: 'call', name: I18n.t('gobierto_visualizations.visualizations.subsidies.call'), cssClass: 'bold' },
   { field: 'amount', name: I18n.t('gobierto_visualizations.visualizations.subsidies.amount'), cssClass: 'right', type: 'money' },
-  { field: 'grant_date', name: I18n.t('gobierto_visualizations.visualizations.subsidies.date'), cssClass: 'nowrap pl1 right' },
+  { field: 'grant_date', name: I18n.t('gobierto_visualizations.visualizations.subsidies.date'), cssClass: 'nowrap pl1 right' }
 ];
 
 export const grantedColumns = [

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -217,6 +217,7 @@ ca:
         amount: Import
         amount_distribution: Distribució per imports
         beneficiary: beneficiari
+        call: Convocatòria
         category: Categoria
         date: Data
         dates: Dates

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -218,6 +218,7 @@ en:
         amount: Amount
         amount_distribution: Amount distribution
         beneficiary: Beneficiary
+        call: Call
         category: Category
         date: Date
         dates: Dates

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -221,6 +221,7 @@ es:
         amount: Importe
         amount_distribution: Distribución por importes
         beneficiary: Beneficiario
+        call: Convocatoria
         category: Categoría
         date: Fecha
         dates: Fechas

--- a/test/integration/gobierto_visualizations/visualizations_subsidies_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_subsidies_test.rb
@@ -105,10 +105,10 @@ class GobiertoVisualizations::VisualizationsSubsidiesTest < ActionDispatch::Inte
       assert first_subsidy.has_content?('1')
 
       # Amount
-      assert first_subsidy.has_content?('€1,305.05')
+      assert first_subsidy.has_content?('€9,500.00')
 
       # Date
-      assert first_subsidy.has_content?('2016-08-02')
+      assert first_subsidy.has_content?('2016-12-01')
 
       # Subsidies Show
       ################
@@ -118,13 +118,13 @@ class GobiertoVisualizations::VisualizationsSubsidiesTest < ActionDispatch::Inte
       assert find(".visualizations-home-nav--tab.is-active").text, 'SUBSIDIES'
 
       # Url is updated
-      assert_equal current_path, "/visualizaciones/subvenciones/subvenciones/2016080213050"
+      assert_equal current_path, "/visualizaciones/subvenciones/subvenciones/2016120195008"
 
       # Title
-      assert page.has_content?('CONVOCATORIA DE SUBVENCIONES DIRIGIDAS A ASOCIACIONES DE VECINOS DE GETAFE PARA LA REALIZACIÓN DE SUS PROGRAMAS DE ACTIVIDADES DURANTE EL AÑO 2016')
+      assert page.has_content?('CONCESIÓN DE SUBVENCIONES PARA INSTALACIÓN DE ASCENSORES PARA 2012')
 
       # Beneficiary
-      assert page.has_content?('AA.VV. CASERIO DE PERALES')
+      assert page.has_content?('COMUNIDAD DE PROPIETARIOS C/RUIZ DE ALARNES')
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1288


## :v: What does this PR do?

Improves the usability of the subsidies table, now shows the column in the table and saves a click to the user. Sort the table by call instead of beneficiary


## :mag: How should this be manually tested?

[Staging](https://getafe.gobify.net/visualizaciones/subvenciones/subvenciones)

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-05-18 at 10 48 12](https://user-images.githubusercontent.com/2649175/118621387-9966f080-b7c6-11eb-83b4-d67d216aec91.png)

### After this PR

![Screenshot 2021-05-18 at 07 56 53](https://user-images.githubusercontent.com/2649175/118598612-a11a9b00-b7ae-11eb-9679-2500431381ee.png)