### PR TITLE
Gobierto Data / Fix embed vizualitions

### DIFF
--- a/app/javascript/gobierto_embeds/index.js
+++ b/app/javascript/gobierto_embeds/index.js
@@ -1,4 +1,4 @@
-import "@finos/perspective";
+import perspective from "@finos/perspective";
 import "@finos/perspective-viewer";
 import "@finos/perspective-viewer-datagrid";
 import "@finos/perspective-viewer-d3fc";
@@ -44,8 +44,6 @@ const getVisualizationList = async container => {
 
       if (data) {
         const viewer = document.createElement("perspective-viewer");
-        viewer.setAttribute("columns", spec.columns);
-        viewer.setAttribute("plugin", spec.plugin);
 
         if (spec.column_pivots) {
           viewer.setAttribute(
@@ -74,9 +72,9 @@ const getVisualizationList = async container => {
         configButtonPerspective.style.display = "none";
 
         // run perspective
-        viewer.clear();
+        const table = perspective.worker().table(data);
         viewer.restore(spec);
-        viewer.load(data);
+        viewer.load(table);
       }
     }
   }


### PR DESCRIPTION
## :v: What does this PR do?
`Perspective@0.6.2` has deprecated the `viewer.clear()`, and now it is necessary to create an instance of the `worker` to load the data.

When adding the columns with `setAttribute()`, and `viewer.restore(spec)` throws an error in the console `too much recursion`, so to avoid errors, just load the configuration of the visualizations with `viewer.restore(spec)`
## :mag: How should this be manually tested?

[Demo](https://data-visualizer.populate.tools/public/staging/embed.html)

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-05-28 at 12 05 07](https://user-images.githubusercontent.com/2649175/119967739-f9bb1680-bfac-11eb-8560-66eeacab1d70.png)

### After this PR
![Screenshot 2021-05-28 at 12 15 25](https://user-images.githubusercontent.com/2649175/119969074-684ca400-bfae-11eb-987d-20f6a227da76.png)
)

## :book: Does this PR require updating the documentation?

[Adds an example to develop the embed in local](https://populate.getoutline.com/doc/gobierto-data-visualizations-embed-PluB5kUNBA)
