### PR TITLE
fix nil option for select

### DIFF
--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -931,6 +931,10 @@ a .global_menu {
   }
 }
 
+ul.select2-results__options li.select2-results__option:first-child {
+  min-height: 16px;
+}
+
 .gobierto_admin .select2-container .select2-selection--single {
   position: relative;
 }


### PR DESCRIPTION
Closes #3827


## :v: What does this PR do?

set the min-height for nil option of custom field select.

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR
![Screenshot from 2021-06-07 16-24-11](https://user-images.githubusercontent.com/288355/121034014-fb56bc80-c7ac-11eb-8cdc-6451697b1053.png)

### After this PR
![Screenshot from 2021-06-07 16-23-49](https://user-images.githubusercontent.com/288355/121034073-04e02480-c7ad-11eb-9b08-58fd95631538.png)

