### PR TITLE
3340 gobierto data delete dataset api action

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -148,6 +148,11 @@ module GobiertoData
           end
         end
 
+        # DELETE /api/v1/data/datasets/:dataset_slug
+        def destroy
+          find_item.destroy
+        end
+
         private
 
         def cached_item_csv

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -47,7 +47,7 @@ module GobiertoData
     validates :slug, :table_name, uniqueness: { scope: :site_id }
 
     before_save :set_schema, if: :will_save_change_to_visibility_level?
-    before_destroy :delete_cached_data
+    before_destroy :delete_cached_data, :delete_dataset_table_gobierto_data
 
     def attributes_for_slug
       [name]
@@ -148,6 +148,10 @@ module GobiertoData
 
     def delete_cached_data
       GobiertoData::Cache.expire_dataset_cache(self)
+    end
+
+    def delete_dataset_table_gobierto_data
+      GobiertoData::Connection.execute_query(site, "drop table #{table_name}")
     end
 
     def refresh_cached_downloads

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -55,6 +55,10 @@ module GobiertoData
           @no_size_dataset ||= gobierto_data_datasets(:no_size_dataset)
         end
 
+        def to_delete_dataset
+          @to_delete_dataset ||= gobierto_data_datasets(:dataset_to_delete)
+        end
+
         def datasets_category
           @datasets_category ||= gobierto_common_custom_fields(:madrid_data_datasets_custom_field_category)
         end
@@ -146,14 +150,14 @@ module GobiertoData
             get gobierto_data_api_v1_datasets_path, as: :json
             response_data = response.parsed_body
             datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
-            assert_equal [no_size_dataset.name, dataset.name, other_dataset.name], datasets_names
+            assert_equal [dataset.name, to_delete_dataset.name, no_size_dataset.name, other_dataset.name], datasets_names
 
             other_dataset.update_attribute(:data_updated_at, 1.second.ago)
 
             get gobierto_data_api_v1_datasets_path, as: :json
             response_data = response.parsed_body
             datasets_names = response_data["data"].map { |item| item.dig("attributes", "name") }
-            assert_equal [no_size_dataset.name, other_dataset.name, dataset.name], datasets_names
+            assert_equal [other_dataset.name, dataset.name, to_delete_dataset.name, no_size_dataset.name], datasets_names
           end
         end
 

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 module GobiertoData
   module Api
     module V1
-      class DatasetsControllerTest < GobiertoControllerTest
+      class DatasetsCreationControllerTest < GobiertoControllerTest
         self.use_transactional_tests = false
 
         def auth_header

--- a/test/controllers/gobierto_data/api/v1/datasets_deletion_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_deletion_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoData
+  module Api
+    module V1
+      class DatasetsDeletionControllerTest < GobiertoControllerTest
+        self.use_transactional_tests = false
+
+        def auth_header
+          @auth_header ||= "Bearer #{admin.primary_api_token}"
+        end
+
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin
+          @admin ||= gobierto_admin_admins(:tony)
+        end
+
+        # DELETE /api/v1/data/datasets/:dataset-slug
+        def test_delete_dataset_remove_also_visualizations_favourites_queries_gobierto_data_table
+          with(site: site) do
+            dataset = gobierto_data_datasets(:dataset_to_delete)
+            query = gobierto_data_queries(:dataset_to_delete_query_to_delete)
+            visualization = gobierto_data_visualizations(:dataset_to_delete_visualization_to_delete)
+            gdata_db_name = gobierto_module_settings(:gobierto_data_settings_madrid).settings["db_config"]["read_db_config"]["database"]
+
+            assert_equal 1, ::GobiertoData::Dataset.where(slug: dataset.slug).count
+            assert_equal 1, ::GobiertoData::Query.where(dataset: dataset.id).count
+            assert_equal 1, ::GobiertoData::Visualization.where(query_id: query.id).count
+            assert_equal 1, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Visualization",favorited_id: visualization.id).count
+            assert_equal 1, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Query",favorited_id: query.id).count
+
+            delete(
+              gobierto_data_api_v1_dataset_path(slug: dataset.slug),
+              headers: { "Authorization" => auth_header }
+            )
+
+            assert_response :no_content
+            assert_equal 0, ::GobiertoData::Dataset.where(slug: dataset.slug).count
+            assert_equal 0, ::GobiertoData::Query.where(dataset: dataset.id).count
+            assert_equal 0, ::GobiertoData::Visualization.where(query_id: query.id).count
+            assert_equal 0, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Visualization",favorited_id: visualization.id).count
+            assert_equal 0, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Query",favorited_id: query.id).count
+
+            refute ::GobiertoData::Connection.execute_query(site, "select exists (select from information_schema.tables where table_schema = '#{gdata_db_name}' and table_name = '#{dataset.table_name}')").first["exists"]
+          end
+        end
+
+        def test_delete_dataset_with_wrong_slug_return_404
+          with(site: site) do
+
+            delete(
+              gobierto_data_api_v1_dataset_path(slug: "this-slug-don't-exist"),
+              headers: { "Authorization" => auth_header }
+            )
+
+            assert_response :not_found
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_data/api/v1/datasets_deletion_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_deletion_test.rb
@@ -42,7 +42,7 @@ module GobiertoData
             assert_equal 1, ::GobiertoData::Visualization.where(query_id: query.id).count
             assert_equal 1, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Visualization",favorited_id: visualization.id).count
             assert_equal 1, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Query",favorited_id: query.id).count
-            assert_equal true, exists_table_for_dataset?
+            assert exists_table_for_dataset?
 
             delete(
               gobierto_data_api_v1_dataset_path(slug: dataset.slug),
@@ -55,7 +55,7 @@ module GobiertoData
             assert_equal 0, ::GobiertoData::Visualization.where(query_id: query.id).count
             assert_equal 0, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Visualization",favorited_id: visualization.id).count
             assert_equal 0, ::GobiertoData::Favorite.where(favorited_type: "GobiertoData::Query",favorited_id: query.id).count
-            assert_equal false, exists_table_for_dataset?
+            refute exists_table_for_dataset?
           end
         end
 

--- a/test/fixtures/gobierto_data/datasets.yml
+++ b/test/fixtures/gobierto_data/datasets.yml
@@ -3,8 +3,9 @@ users_dataset:
   name_translations: <%= { en: "Users", es: "Usuarios" }.to_json %>
   table_name: users
   slug: users-dataset
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  created_at: <%= 10.minutes.ago %>
+  updated_at: <%= 10.minutes.ago %>
+  data_updated_at: <%= 10.minute.ago %>
   visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
   size: <%= { csv: 15.megabytes, json: 25.megabytes }.to_json %>
 
@@ -13,8 +14,9 @@ events_dataset:
   name_translations: <%= { en: "Events", es: "Eventos" }.to_json %>
   table_name: gc_events
   slug: events-dataset
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  created_at: <%= 9.minutes.ago %>
+  updated_at: <%= 9.minutes.ago %>
+  data_updated_at: <%= 9.minute.ago %>
   visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
   size: <%= { csv: 3.megabytes, json: 4.megabytes }.to_json %>
 
@@ -23,8 +25,9 @@ draft_dataset:
   name_translations: <%= { en: "Interest Groups", es: "Grupos de Interés" }.to_json %>
   table_name: gp_interest_groups
   slug: interest-groups-dataset
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  created_at: <%= 8.minutes.ago %>
+  updated_at: <%= 8.minutes.ago %>
+  data_updated_at: <%= 8.minute.ago %>
   visibility_level: <%= GobiertoData::Dataset.visibility_levels["draft"] %>
 
 santander_dataset:
@@ -32,8 +35,9 @@ santander_dataset:
   name_translations: <%= { en: "Santander dataset", es: "Dataset de Santander" }.to_json %>
   table_name: activities
   slug: santander-dataset
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  created_at: <%= 7.minutes.ago %>
+  updated_at: <%= 7.minutes.ago %>
+  data_updated_at: <%= 7.minute.ago %>
   visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
 
 no_size_dataset:
@@ -41,7 +45,18 @@ no_size_dataset:
   name_translations: <%= { en: "No size", es: "No se el size" }.to_json %>
   table_name: sites
   slug: no-size
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  created_at: <%= 6.minutes.ago %>
+  updated_at: <%= 6.minutes.ago %>
+  data_updated_at: <%= 6.minute.ago %>
   visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
 
+dataset_to_delete:
+  site: madrid
+  name_translations: <%= { en: "to delete", es: "para borrar" }.to_json %>
+  table_name: delete_me_table
+  slug: delete-me-dataset
+  created_at: <%= 5.minute.ago %>
+  updated_at: <%= 5.minute.ago %>
+  data_updated_at: <%= 5.minute.ago %>
+  visibility_level: <%= GobiertoData::Dataset.visibility_levels["active"] %>
+  size: <%= { csv: 15.megabytes, json: 25.megabytes }.to_json %>

--- a/test/fixtures/gobierto_data/favorites.yml
+++ b/test/fixtures/gobierto_data/favorites.yml
@@ -75,3 +75,15 @@ draft_visualization_favorite:
   favorited: draft_dataset_visualization (GobiertoData::Visualization)
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+
+dataset_to_delete_favorite_query_to_delete:
+  user: dennis
+  favorited: dataset_to_delete_visualization_to_delete (GobiertoData::Visualization)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+
+dataset_to_delete_favorite_visualization_to_delete:
+  user: dennis
+  favorited: dataset_to_delete_query_to_delete (GobiertoData::Query)
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>

--- a/test/fixtures/gobierto_data/queries.yml
+++ b/test/fixtures/gobierto_data/queries.yml
@@ -25,3 +25,10 @@ draft_dataset_query:
   name_translations: <%= { en: "Interest Groups by domain", es: "Grupos de interés por dominio" }.to_json %>
   privacy_status: <%= GobiertoData::Query.privacy_statuses["open"] %>
   sql: "select sites.domain, count(*) from gp_interest_groups join sites on gp_interest_groups.site_id = sites.id group by sites.domain"
+
+dataset_to_delete_query_to_delete:
+  dataset: dataset_to_delete
+  user: dennis
+  name_translations: <%= { en: "Query to delete", es: "Consulta para borrar" }.to_json %>
+  privacy_status: <%= GobiertoData::Query.privacy_statuses["open"] %>
+  sql: "select count(*) from delete_me_table "

--- a/test/fixtures/gobierto_data/visualizations.yml
+++ b/test/fixtures/gobierto_data/visualizations.yml
@@ -96,3 +96,11 @@ draft_dataset_visualization:
   name_translations: <%= { en: "Interest Groups by domain visualization", es: "Visualización de grupos de interés por dominio" }.to_json %>
   privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
   spec: "{}"
+
+dataset_to_delete_visualization_to_delete:
+  query: dataset_to_delete_query_to_delete
+  dataset: dataset_to_delete
+  user: dennis
+  name_translations: <%= { en: "a fake visualization", es: "una visualization falsa" }.to_json %>
+  privacy_status: <%= GobiertoData::Visualization.privacy_statuses["open"] %>
+  spec: "{}"


### PR DESCRIPTION
Closes #3340 


## :v: What does this PR do?

add to gobierto data api action: remove dataset

the action of remove dataset also involve:
- remove all favorites asociated to dataset
- remove all visualization asociated to dataset
- remove all queries asociated to dataset
- remove table from gobierto_data database with `dataset.table_name` name
- remove dataset

- [x] update API documentation




## :mag: How should this be manually tested?

- create a new dataset
- change its state from draft to published
- get admin token
- execute curl spell
```
TOKEN=...
DOMAIN=madrid.gobierto.test
curl --location --request DELETE 'https://$DOMAIN/api/v1/data/datasets/calidad-aire' \
--header 'Authorization: Bearer $TOKEN'
```
