### PR TITLE
3906 sanitizer from html event description

### DIFF
--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -143,8 +143,8 @@ module GobiertoCalendars
         event_attributes.site_id = site_id
         event_attributes.state = state
         event_attributes.title_translations = title_translations
-        event_attributes.description_translations = description_translations
-        event_attributes.description_source_translations = description_source_translations
+        event_attributes.description_translations = description_translations.transform_values { |value| sanitize(value) }
+        event_attributes.description_source_translations = description_translations.transform_values { |value| sanitize(value) }
         event_attributes.starts_at = starts_at
         event_attributes.ends_at = ends_at
         event_attributes.meta = meta
@@ -170,6 +170,16 @@ module GobiertoCalendars
 
         false
       end
+    end
+
+    private
+
+    def sanitizer
+      @sanitizer ||= Rails::Html::FullSanitizer.new
+    end
+
+    def sanitize(value)
+      sanitizer.sanitize(value)
     end
   end
 end

--- a/test/forms/gobierto_calendars/event_form_test.rb
+++ b/test/forms/gobierto_calendars/event_form_test.rb
@@ -31,8 +31,8 @@ module GobiertoCalendars
         site_id: site.id,
         person_id: person.id,
         title_translations: { es: "Nuevo evento", en: "New event" },
-        description_translations: { es: "Descripción de nuevo evento", en: "New event description" },
-        description_source_translations: { es: "Descripción de nuevo evento", en: "New event description" },
+        description_translations: { es: "<span>Descripción de <b>nuevo evento</b></span>", en: "<span><b>New event</b> description</span>" },
+        description_source_translations: { es: "<span>Descripción de <b>nuevo evento</b></span>", en: "<span><b>New event</b> description</span>" },
         starts_at: 1.day.from_now,
         ends_at: 2.days.from_now,
         notify: false,
@@ -51,6 +51,12 @@ module GobiertoCalendars
       attendees.each do |attendee|
         assert event_attendees.include? attendee.person
       end
+
+      expected = {
+        "es" => "Descripción de nuevo evento",
+        "en" => "New event description"
+      }
+      assert_equal expected, event.description_translations
     end
 
     def test_update_with_valid_attributes


### PR DESCRIPTION
Closes #3906 


## :v: What does this PR do?

when an event is imported its attributte description can have html we need sanitize it

## :mag: How should this be manually tested?

- create a new event with html into description attributte
- import it using task ~/gobierto/lib/tasks/gobierto_people/sync_agendas.rake


