### PR TITLE
check nil for description and descriptions source

### DIFF
--- a/app/forms/gobierto_calendars/event_form.rb
+++ b/app/forms/gobierto_calendars/event_form.rb
@@ -143,8 +143,8 @@ module GobiertoCalendars
         event_attributes.site_id = site_id
         event_attributes.state = state
         event_attributes.title_translations = title_translations
-        event_attributes.description_translations = description_translations.transform_values { |value| sanitize(value) }
-        event_attributes.description_source_translations = description_translations.transform_values { |value| sanitize(value) }
+        event_attributes.description_translations = description_translations&.transform_values { |value| sanitize(value) }
+        event_attributes.description_source_translations = description_source_translations&.transform_values { |value| sanitize(value) }
         event_attributes.starts_at = starts_at
         event_attributes.ends_at = ends_at
         event_attributes.meta = meta

--- a/test/forms/gobierto_calendars/event_form_test.rb
+++ b/test/forms/gobierto_calendars/event_form_test.rb
@@ -90,5 +90,17 @@ module GobiertoCalendars
         assert_equal initial_slug, event.slug
       end
     end
+
+    def test_update_with_nil_descriptions
+      initial_slug = existing_event.slug
+
+      form = EventForm.new(valid_attributes.merge(id: existing_event.id, description_translations: nil , description_source_translations: nil))
+      assert form.save
+
+      event = form.event
+      assert event.persisted?
+      assert_equal initial_slug, event.slug
+
+    end
   end
 end


### PR DESCRIPTION
Closes #3906


## :v: What does this PR do?

1. fix `undefined method `transform_values' for nil:NilClass`
2. restore bad attributte set up 
```
from:
event_attributes.description_source_translations = description_translations&.transform_values { |value| sanitize(value) }

to:
event_attributes.description_source_translations = description_source_translations&.transform_values { |value| sanitize(value) }
```

