### PR TITLE
WIP enable parallelize test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,8 @@ end
 ActiveRecord::Migration.maintain_test_schema!
 
 class ActiveSupport::TestCase
+  parallelize
+
   include CommonHelpers
   include SessionHelpers
   include AppHostHelpers


### PR DESCRIPTION
before parallelize:
```
time bin/rails test test/models
real	0m12.553s
user	0m0.143s
sys	0m0.040s
```

after parallelize:
```
time bin/rails test test/models
real	0m7.374s
user	0m0.140s
sys	0m0.036s


time bin/rails test
1932 tests, 5896 assertions, 126 failures, 234 errors, 11 skips
real	5m36.541s
user	0m0.197s
sys	0m0.050s
```

UPDATE:
I need review some test which fails only when parallelize is enabled:

- bin/rails test test/models/gobierto_budgets/budget_line_stats_test.rb 
