### PR TITLE
replace link for "view item" into backoffice project

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -185,9 +185,9 @@ module GobiertoAdmin
       def find_versioned_project
         @project = base_relation.find params[:id]
         if @project.published?
-          @preview_item_url = gobierto_plans_project_path(slug: params[:plan_id], id: params[:id])
+          @preview_item_url = gobierto_plans_project_path(slug: @plan.slug, year: @plan.year, id: @project.id)
         else
-          @preview_item_url = gobierto_plans_project_path(slug: params[:plan_id], id: params[:id], preview_token: current_admin.preview_token )
+          @preview_item_url = gobierto_plans_project_path(slug: @plan.slug, year: @plan.year, id: @project.id, preview_token: current_admin.preview_token)
         end
 
         return if params[:version].blank?

--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -185,9 +185,9 @@ module GobiertoAdmin
       def find_versioned_project
         @project = base_relation.find params[:id]
         if @project.published?
-          @preview_item_url = gobierto_plans_project_path(slug: @plan.slug, year: @plan.year, id: @project.id)
+          @preview_item_url = gobierto_plans_project_path(slug: @plan.plan_type.slug, year: @plan.year, id: @project.id)
         else
-          @preview_item_url = gobierto_plans_project_path(slug: @plan.slug, year: @plan.year, id: @project.id, preview_token: current_admin.preview_token)
+          @preview_item_url = gobierto_plans_project_path(slug: @plan.plan_type.slug, year: @plan.year, id: @project.id, preview_token: current_admin.preview_token)
         end
 
         return if params[:version].blank?

--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -187,7 +187,7 @@ module GobiertoAdmin
         if @project.published?
           @preview_item_url = gobierto_plans_project_path(slug: params[:plan_id], id: params[:id])
         else
-          @preview_item_url = nil
+          @preview_item_url = gobierto_plans_project_path(slug: params[:plan_id], id: params[:id], preview_token: current_admin.preview_token )
         end
 
         return if params[:version].blank?

--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -184,6 +184,11 @@ module GobiertoAdmin
 
       def find_versioned_project
         @project = base_relation.find params[:id]
+        if @project.published?
+          @preview_item_url = gobierto_plans_project_path(slug: params[:plan_id], id: params[:id])
+        else
+          @preview_item_url = nil
+        end
 
         return if params[:version].blank?
 

--- a/app/views/gobierto_admin/gobierto_plans/projects/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_plans/projects/index.html.erb
@@ -46,9 +46,16 @@
       <td><%= project.status&.name %></td>
       <td><%= time_ago_in_words(project.updated_at) %></td>
       <td>
-        <%= link_to gobierto_plans_plan_type_preview_url(@plan, host: current_site.domain), class: 'view_item' do %>
-          <i class="fas fa-eye"></i>
-          <%= t(".view") %>
+        <% if project.published? %>
+          <%= link_to gobierto_plans_project_path(slug: @plan.plan_type.slug, year: @plan.year, id: project.id), class: 'view_item' do %>
+            <i class="fas fa-eye"></i>
+            <%= t(".view") %>
+          <% end %>
+        <% else %>
+          <%= link_to gobierto_plans_project_path(slug: @plan.plan_type.slug, year: @plan.year, id: project.id, preview_token: current_admin.preview_token), class: 'view_item' do %>
+            <i class="fas fa-eye"></i>
+            <%= t(".view") %>
+          <% end %>
         <% end %>
       </td>
       <td>

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -72,7 +72,7 @@ module GobiertoAdmin
         def preview_test_conf
           {
             item_admin_path: @path,
-            item_public_url: gobierto_plans_project_path(slug: @plan.slug, year: @plan.year, id: @published_project.id, host: site.domain),
+            item_public_url: gobierto_plans_project_path(slug: @plan.plan_type.slug, year: @plan.year, id: @published_project.id, host: site.domain),
             publish_proc: -> { @published_project.published! },
             unpublish_proc: -> { @published_project.draft! }
           }

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -72,9 +72,9 @@ module GobiertoAdmin
         def preview_test_conf
           {
             item_admin_path: @path,
-            item_public_url: gobierto_plans_plan_url(plan.plan_type.slug, plan.year, host: site.domain),
-            publish_proc: -> { plan.published! },
-            unpublish_proc: -> { plan.draft! }
+            item_public_url: gobierto_plans_project_path(slug: @plan.slug, year: @plan.year, id: @published_project.id, host: site.domain),
+            publish_proc: -> { @published_project.published! },
+            unpublish_proc: -> { @published_project.draft! }
           }
         end
 

--- a/test/support/concerns/gobierto_admin/previewable_item_test_module.rb
+++ b/test/support/concerns/gobierto_admin/previewable_item_test_module.rb
@@ -51,7 +51,7 @@ module GobiertoAdmin
 
           within("header") { click_link "View item" }
 
-          assert_equal "#{preview_test_conf[:item_public_url]}?preview_token=#{admin.preview_token}", current_url
+          assert current_url.include? "#{preview_test_conf[:item_public_url]}?preview_token=#{admin.preview_token}"
         end
       end
     end


### PR DESCRIPTION
Closes #1314


## :v: What does this PR do?

replace the bad link to the project into front office in two places: 


- available into: > GobiertoAdmin > Plans > Select Plan > Select proyect (top bar `View Item`)
![Screenshot from 2021-07-16 16-21-20](https://user-images.githubusercontent.com/288355/125971532-afeb8450-2fb4-45eb-a4ca-ffa3912d3260.png)
[https://madrid.gobify.net/admin/plans/6/projects/4078/edit](https://madrid.gobify.net/admin/plans/6/projects/4078/edit)


- available into: > GobiertoAdmin > Plans > Select Plan > link at the end of every line
![Screenshot from 2021-07-16 16-16-15](https://user-images.githubusercontent.com/288355/125971543-b0b0a7d3-4ab6-4b96-a8f4-bdc16339bd37.png)
[https://madrid.gobify.net/admin/plans/6/projects](https://madrid.gobify.net/admin/plans/6/projects)

previously link point to public plan into front office
after this link point to public project into front office

## :mag: How should this be manually tested?

- visit plans module
- visit a plan with project 
- click into project tab 
- the link "View Item" should redirect to project view

