### PR TITLE
Accessibility / Disable console.clear()

### DIFF
--- a/app/javascript/lib/shared/modules/accessibility.js
+++ b/app/javascript/lib/shared/modules/accessibility.js
@@ -17,10 +17,6 @@ export function checkAndReportAccessibility (node, label) {
     if (results && !results.violations.length) return
     if (JSON.stringify(results.violations) === lastNotification) return
 
-    if (defaultOptions.clearConsoleOnUpdate) {
-      console.clear()
-    }
-
     defaultOptions.customResultHandler ? defaultOptions.customResultHandler(error, results) : standardResultHandler(error, results, label)
     deferred.resolve()
     lastNotification = JSON.stringify(results.violations)

--- a/app/javascript/lib/vue/accesibility/index.js
+++ b/app/javascript/lib/vue/accesibility/index.js
@@ -4,6 +4,8 @@ import "../../../../assets/stylesheets/accessibility.css";
 export function checkAndReportAccessibility() {
   if (process.env.NODE_ENV === 'development') {
     const VueAxe = require('vue-axe').default
-    Vue.use(VueAxe)
+    Vue.use(VueAxe, {
+      allowConsoleClears: false
+    })
   }
 }


### PR DESCRIPTION
## :v: What does this PR do?

`Vue-axe` for modules with `vue` and `axe-core` for modules without `vue` clear the `console` on every update to show their messages with accessibility issues. But with this option, the console is impossible to use for debugging.

## :mag: How should this be manually tested?
In your local, uses a simple `console.log()`
