### PR TITLE
Replace progress column with percentage out of total

### DIFF
--- a/app/javascript/gobierto_plans/webapp/components/GroupsByTermTableRow.vue
+++ b/app/javascript/gobierto_plans/webapp/components/GroupsByTermTableRow.vue
@@ -16,9 +16,16 @@
         </router-link>
       </div>
     </div>
-    <div class="planification-table__td">
-      {{ percentOutOfTotal | percent }}
-    </div>
+    <template v-if="isStatus">
+      <div class="planification-table__td">
+        {{ percentOutOfTotal | percent }}
+      </div>
+    </template>
+    <template v-else>
+      <div class="planification-table__td">
+        {{ progress | percent }}
+      </div>
+    </template>
     <div class="planification-table__td">
       {{ length }}
     </div>
@@ -61,6 +68,10 @@ export default {
     },
     params() {
       return this.$route.params;
+    },
+    isStatus() {
+      const { id } = this.$route.params;
+      return id === "status"
     },
     tdFirstChildWidth() {
       return `flex: 0 0 calc(50% - ${this.level / 2}rem)`

--- a/app/javascript/gobierto_plans/webapp/components/GroupsByTermTableRow.vue
+++ b/app/javascript/gobierto_plans/webapp/components/GroupsByTermTableRow.vue
@@ -17,7 +17,7 @@
       </div>
     </div>
     <div class="planification-table__td">
-      {{ progress | percent }}
+      {{ percentOutOfTotal | percent }}
     </div>
     <div class="planification-table__td">
       {{ length }}
@@ -51,7 +51,8 @@ export default {
       progress: 0,
       length: 0,
       level: 0,
-      nestedGroups: []
+      nestedGroups: [],
+      percentOutOfTotal: 0
     }
   },
   computed: {
@@ -66,7 +67,7 @@ export default {
     }
   },
   created() {
-    const { key, name, slug, progress, length, level, nestedGroups } = this.term
+    const { key, name, slug, progress, length, level, nestedGroups, percentOutOfTotal } = this.term
     this.key = key
     this.name = name
     this.slug = slug
@@ -74,6 +75,7 @@ export default {
     this.length = length
     this.level = level
     this.nestedGroups = nestedGroups
+    this.percentOutOfTotal = percentOutOfTotal
   },
   methods: {
     showNestedGroups() {

--- a/app/javascript/gobierto_plans/webapp/pages/Groups.vue
+++ b/app/javascript/gobierto_plans/webapp/pages/Groups.vue
@@ -103,7 +103,10 @@ export default {
             return acc
           }, []);
 
-        return { key, name, slug, length, children, progress, level, nestedGroups };
+        // percent out of total
+        const percentOutOfTotal = 100 * (length / projectsWithUid.length)
+
+        return { key, name, slug, length, children, progress, level, nestedGroups, percentOutOfTotal };
       })
 
       this.groups = parseProjects(Object.keys(groupedProjects));

--- a/app/javascript/gobierto_plans/webapp/pages/GroupsByTerm.vue
+++ b/app/javascript/gobierto_plans/webapp/pages/GroupsByTerm.vue
@@ -105,8 +105,13 @@ export default {
 
     // set table columns
     this.map.set("name", { name: this.getName(id), sort: this.currentSort });
-    this.map.set("percentOutOfTotal", { name: this.labelPercentOutOfTotal, sort: this.currentSort });
-    // this.map.set("progress", { name: this.labelProgress, sort:this.currentSort });
+
+    if (id === "status") {
+      this.map.set("percentOutOfTotal", { name: this.labelPercentOutOfTotal, sort: this.currentSort });
+    } else {
+      this.map.set("progress", { name: this.labelProgress, sort:this.currentSort });
+    }
+
     this.map.set("length", { name: null, sort:this.currentSort });
 
     this.columns = Array.from(this.map);

--- a/app/javascript/gobierto_plans/webapp/pages/GroupsByTerm.vue
+++ b/app/javascript/gobierto_plans/webapp/pages/GroupsByTerm.vue
@@ -65,6 +65,7 @@ export default {
   data() {
     return {
       labelProgress: I18n.t("gobierto_plans.plan_types.show.progress") || "",
+      labelPercentOutOfTotal: I18n.t("gobierto_plans.plan_types.show.percent_out_of_total") || "",
       columns: [],
       lastLevel: 0
     };
@@ -104,7 +105,8 @@ export default {
 
     // set table columns
     this.map.set("name", { name: this.getName(id), sort: this.currentSort });
-    this.map.set("progress", { name: this.labelProgress, sort:this.currentSort });
+    this.map.set("percentOutOfTotal", { name: this.labelPercentOutOfTotal, sort: this.currentSort });
+    // this.map.set("progress", { name: this.labelProgress, sort:this.currentSort });
     this.map.set("length", { name: null, sort:this.currentSort });
 
     this.columns = Array.from(this.map);

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -15,7 +15,7 @@ ca:
     - dv
     - ds
     abbr_month_names:
-    - 
+    -
     - gen
     - feb
     - mar
@@ -43,7 +43,7 @@ ca:
       short: "%d %b"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - gener
     - febrer
     - març

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -15,7 +15,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       short: "%b %d %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - January
     - February
     - March

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -15,7 +15,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       short: "%d %b %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo

--- a/config/locales/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_plans/views/ca.yml
@@ -36,6 +36,7 @@ ca:
         global_execution: Estat d'execució global
         latest_update_html: "<strong>Darrera actualització:</strong> %{date}"
         loading: Carregant...
+        percent_out_of_total: "% sobre total"
         plan: Plan
         progress: Progrés
         read_less: Llegiu menys

--- a/config/locales/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_plans/views/en.yml
@@ -34,6 +34,7 @@ en:
         global_execution: State of global execution
         latest_update_html: "<strong>Latest update:</strong> %{date}"
         loading: Loading...
+        percent_out_of_total: "% out of total"
         plan: Plan
         progress: Progress
         read_less: Read more

--- a/config/locales/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_plans/views/es.yml
@@ -36,6 +36,7 @@ es:
         global_execution: Estado de ejecución global
         latest_update_html: "<strong>Última actualización:</strong> %{date}"
         loading: Cargando...
+        percent_out_of_total: "% sobre total"
         plan: Plan
         progress: Progreso
         read_less: Leer menos


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1326

## :v: What does this PR do?
Replace the progress column with a percentage of group items out of total of projects

Url: https://diba-esparreguera.gobify.net/planes/pam/2019/tabla/sdgs/

## :eyes: Screenshots
![imagen](https://user-images.githubusercontent.com/817526/127180516-d8a1b9b4-6f3a-4591-a5e8-aaaece23b39e.png)
