### PR TITLE
1319 cms custom fields

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -19,6 +19,7 @@ module GobiertoAdmin
         @page_visibility_levels = get_page_visibility_levels
         @section_id = nil
         @parent_id = nil
+        @page = @page_form.page
         initialize_custom_field_form
       end
 
@@ -37,6 +38,7 @@ module GobiertoAdmin
 
       def create
         @page_form = PageForm.new(page_params.merge(site_id: current_site.id, admin_id: current_admin.id, collection_id: @collection))
+        @page = @page_form.page
         initialize_custom_field_form
 
         if @page_form.save

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -140,7 +140,7 @@ module GobiertoAdmin
           :parent,
           :published_on,
           title_translations: [*I18n.available_locales],
-          body_translations:  [*I18n.available_locales],
+          body_translations: [*I18n.available_locales],
           body_source_translations: [*I18n.available_locales]
         )
       end

--- a/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_cms/pages_controller.rb
@@ -3,6 +3,8 @@
 module GobiertoAdmin
   module GobiertoCms
     class PagesController < BaseController
+      include CustomFieldsHelper
+
       before_action :load_collection, only: [:new, :edit, :create, :update]
       before_action :load_site_attachments_collection, only: [:new, :edit, :create, :update]
 
@@ -17,6 +19,7 @@ module GobiertoAdmin
         @page_visibility_levels = get_page_visibility_levels
         @section_id = nil
         @parent_id = nil
+        initialize_custom_field_form
       end
 
       def edit
@@ -29,12 +32,15 @@ module GobiertoAdmin
         @page_form = PageForm.new(
           @page.attributes.except(*ignored_page_attributes).merge(collection_id: @collection)
         )
+        initialize_custom_field_form
       end
 
       def create
         @page_form = PageForm.new(page_params.merge(site_id: current_site.id, admin_id: current_admin.id, collection_id: @collection))
+        initialize_custom_field_form
 
         if @page_form.save
+          custom_fields_save
           track_create_activity
 
           redirect_to(
@@ -50,8 +56,9 @@ module GobiertoAdmin
       def update
         load_page(preview: true)
         @page_form = PageForm.new(page_params.merge(id: @page.id, admin_id: current_admin.id, site_id: current_site.id, collection_id: @collection.id))
+        initialize_custom_field_form
 
-        if @page_form.save
+        if @page_form.save && custom_fields_save
           track_update_activity
 
           redirect_to(
@@ -174,6 +181,17 @@ module GobiertoAdmin
         t("gobierto_admin.gobierto_cms.pages.destroy.error_associated_items", links: associated_items_html).html_safe
       end
 
+      def initialize_custom_field_form
+        @custom_fields_form = ::GobiertoAdmin::GobiertoCommon::CustomFieldRecordsForm.new(
+          site_id: current_site.id,
+          item: @page,
+          instance: @collection
+        )
+        custom_params_key = self.class.name.demodulize.gsub("Controller", "").underscore.singularize
+        return if request.get? || !params.has_key?(custom_params_key)
+
+        @custom_fields_form.custom_field_records = params.require(custom_params_key).permit(custom_records: {})
+      end
     end
   end
 end

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
@@ -22,17 +22,21 @@ module GobiertoAdmin
         private
 
         def models_with_custom_fields_at_instance_level
-          @models_with_custom_fields_at_instance_level ||= current_site.configuration.modules.map do |module_name|
+          @models_with_custom_fields_at_instance_level ||= enabled_modules.map do |module_name|
             [module_name, module_name.constantize.try(:classes_with_custom_fields_at_instance_level)]
           end.to_h
         end
 
         def modules_with_custom_fields
-          @modules_with_custom_fields ||= current_site.configuration.modules.inject("global" => ::GobiertoCore.classes_with_custom_fields) do |modules, module_name|
+          @modules_with_custom_fields ||= enabled_modules.inject("global" => ::GobiertoCore.classes_with_custom_fields) do |modules, module_name|
             modules.update(
               module_name => module_name.constantize.try(:classes_with_custom_fields)
             )
           end
+        end
+
+        def enabled_modules
+          current_site.configuration.modules.union(%w(GobiertoCms))
         end
 
         def clean_modules_hash(modules_hash)

--- a/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_common/custom_fields/module_resources_controller.rb
@@ -6,6 +6,8 @@ module GobiertoAdmin
       class ModuleResourcesController < GobiertoCommon::CustomFields::BaseController
         before_action :check_permissions!
 
+        helper_method :single_class_with_custom_fields
+
         def index
           @available_resources = clean_modules_hash modules_with_custom_fields
           @available_instances = clean_modules_hash(models_with_custom_fields_at_instance_level).transform_values do |classes|
@@ -17,6 +19,16 @@ module GobiertoAdmin
 
         def check_permissions!
           raise_module_not_allowed unless current_admin.can_edit_custom_fields?
+        end
+
+        def single_class_with_custom_fields(module_name)
+          return if module_name == "global"
+
+          classes_with_custom_fields = module_name.constantize.try(:classes_with_custom_fields)
+
+          return unless classes_with_custom_fields&.count == 1
+
+          classes_with_custom_fields.first
         end
 
         private

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -254,7 +254,7 @@ module GobiertoAdmin
         if module_name.blank?
           ::GobiertoCore.classes_with_custom_fields.include?(klass)
         else
-          site.configuration.modules.include?(module_name) && module_name.constantize.try(:classes_with_custom_fields)&.include?(klass)
+          enabled_modules.include?(module_name) && module_name.constantize.try(:classes_with_custom_fields)&.include?(klass)
         end
       end
 
@@ -264,6 +264,10 @@ module GobiertoAdmin
 
       def classes_with_custom_fields_at_instance_level
         @classes_with_custom_fields_at_instance_level ||= class_name.deconstantize.constantize.try(:classes_with_custom_fields_at_instance_level) || []
+      end
+
+      def enabled_modules
+        site.configuration.modules.union(%w(GobiertoCms))
       end
 
       def plugin_configuration_format

--- a/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/custom_field_form.rb
@@ -199,7 +199,7 @@ module GobiertoAdmin
       private
 
       def instance_type_is_enabled
-        return if instance.blank? || classes_with_custom_fields_at_instance_level.include?(instance_class)
+        return if instance.blank? || classes_with_custom_fields_at_instance_level.any? { |k| k <= instance_class }
 
         errors.add(:instance_class_name, I18n.t("errors.messages.invalid"))
       end
@@ -242,7 +242,7 @@ module GobiertoAdmin
                               return unless instance_type
 
                               klass = instance_type.constantize
-                              return unless classes_with_custom_fields_at_instance_level.include? klass
+                              return unless classes_with_custom_fields_at_instance_level.any? { |k| k <= klass }
 
                               klass
                             rescue NameError

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -94,13 +94,13 @@ module GobiertoCommon
     def instance_type_options
       return [nil] unless instance
 
-      [nil, instance.class.name]
+      [instance.class.name]
     end
 
     def instance_id_options
       return [nil] unless instance
 
-      [nil, instance.id]
+      [instance.id]
     end
 
     def site

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -17,7 +17,7 @@ module GobiertoCommon
     validates :site, presence: true
 
     def available_custom_fields
-      if instance # GobiertoPlans
+      if instance.is_a?(GobiertoPlans::Plan) # GobiertoPlans
         ::GobiertoPlans::Node.node_custom_fields(instance, item).sorted
       else
         site.custom_fields.sorted.where(class_name: item.class.name, instance_type: instance_type_options, instance_id: instance_id_options)

--- a/app/models/gobierto_cms.rb
+++ b/app/models/gobierto_cms.rb
@@ -9,6 +9,14 @@ module GobiertoCms
     [ GobiertoCms::Page ]
   end
 
+  def self.classes_with_custom_fields
+    [GobiertoCms::Page]
+  end
+
+  def self.classes_with_custom_fields_at_instance_level
+    [GobiertoCms::PagesCollection]
+  end
+
   def self.doc_url
     "https://gobierto.readme.io/docs/cms"
   end

--- a/app/models/gobierto_cms.rb
+++ b/app/models/gobierto_cms.rb
@@ -2,11 +2,11 @@
 
 module GobiertoCms
   def self.table_name_prefix
-    'gcms_'
+    "gcms_"
   end
 
   def self.searchable_models
-    [ GobiertoCms::Page ]
+    [GobiertoCms::Page]
   end
 
   def self.classes_with_custom_fields

--- a/app/models/gobierto_cms.rb
+++ b/app/models/gobierto_cms.rb
@@ -17,6 +17,10 @@ module GobiertoCms
     [GobiertoCms::PagesCollection]
   end
 
+  def self.custom_fields_at_instance_level_only?
+    true
+  end
+
   def self.doc_url
     "https://gobierto.readme.io/docs/cms"
   end

--- a/app/models/gobierto_cms/pages_collection.rb
+++ b/app/models/gobierto_cms/pages_collection.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoCms
+  class PagesCollection < GobiertoCommon::Collection
+    default_scope -> { where(item_type: "GobiertoCms::Page") }
+  end
+end

--- a/app/models/gobierto_common.rb
+++ b/app/models/gobierto_common.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  def self.classes_with_custom_fields
+    [GobiertoCms::Page]
+  end
+end

--- a/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
+++ b/app/views/gobierto_admin/gobierto_cms/pages/_form.html.erb
@@ -47,6 +47,14 @@
         %>
       </div>
 
+      <%= render(
+        partial: "gobierto_admin/gobierto_common/custom_fields/forms/custom_fields",
+        locals: {
+          f: f,
+          item: @custom_fields_form,
+          form_name: "page"
+        }
+      ) %>
     </div>
 
     <div class="pure-u-1 pure-u-md-2-24"></div>

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
@@ -9,6 +9,7 @@
   <%= t(".empty") %>
 <% else %>
   <% @available_resources.each do |module_name, resources| %>
+    <% direct_link_resource = single_class_with_custom_fields(module_name) %>
     <div class="m_b_4">
       <h3><%= t("gobierto_admin.layouts.application.#{ module_name.underscore.gsub("gobierto_", "") }") %></h3>
       <% if module_name == "global" || !module_name.constantize.try(:custom_fields_at_instance_level_only?) %>
@@ -23,7 +24,17 @@
           <h4><%= t(".custom_fields_for_instances_of", name: klass.model_name.human) %></h4>
           <% instances.each do |instance| %>
             <div class="list_item">
-              <%= link_to instance.name, admin_common_custom_fields_module_resource_instance_level_resource_path(instance.model_param, instance.id) %> &nbsp;(<%= GobiertoCommon::CustomField.where(instance: instance).count %>)
+              <%= link_to(
+                instance.name,
+                direct_link_resource ? admin_common_custom_fields_module_resource_custom_fields_path(
+                  module_resource_name: direct_link_resource.name.underscore.gsub("/", "-"),
+                  instance_type: instance.model_param,
+                  instance_id: instance.id
+                ) : admin_common_custom_fields_module_resource_instance_level_resource_path(
+                  instance.model_param,
+                  instance.id
+                )
+              ) %> &nbsp;(<%= GobiertoCommon::CustomField.where(instance: instance).count %>)
             </div>
           <% end %>
 
@@ -32,4 +43,3 @@
     </div>
   <% end %>
 <% end %>
-

--- a/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
+++ b/app/views/gobierto_admin/gobierto_common/custom_fields/module_resources/index.html.erb
@@ -11,10 +11,12 @@
   <% @available_resources.each do |module_name, resources| %>
     <div class="m_b_4">
       <h3><%= t("gobierto_admin.layouts.application.#{ module_name.underscore.gsub("gobierto_", "") }") %></h3>
-      <% resources.each do |resource| %>
-        <div class="list_item">
-          <%= link_to resource.model_name.human, admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: resource.name.underscore.gsub("/", "-")) %>
-        </div>
+      <% if module_name == "global" || !module_name.constantize.try(:custom_fields_at_instance_level_only?) %>
+        <% resources.each do |resource| %>
+          <div class="list_item">
+            <%= link_to resource.model_name.human, admin_common_custom_fields_module_resource_custom_fields_path(module_resource_name: resource.name.underscore.gsub("/", "-")) %>
+          </div>
+        <% end %>
       <% end %>
       <% if @available_instances.has_key?(module_name) %>
         <% @available_instances[module_name].each do |klass, instances| %>

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -15,7 +15,7 @@ ca:
     - dv
     - ds
     abbr_month_names:
-    -
+    - 
     - gen
     - feb
     - mar
@@ -43,7 +43,7 @@ ca:
       short: "%d %b"
       shortest: "%d %b %y"
     month_names:
-    -
+    - 
     - gener
     - febrer
     - març

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -15,7 +15,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       short: "%b %d %Y"
       shortest: "%d %b %y"
     month_names:
-    -
+    - 
     - January
     - February
     - March

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -15,7 +15,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       short: "%d %b %Y"
       shortest: "%d %b %y"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo

--- a/config/locales/gobierto_cms/models/ca.yml
+++ b/config/locales/gobierto_cms/models/ca.yml
@@ -10,3 +10,4 @@ ca:
       gobierto_cms/news: Noticia
       gobierto_cms/news_plural: Noticies
       gobierto_cms/page: Pàgina
+      gobierto_cms/pages_collection: Col·lecció de Pàgines

--- a/config/locales/gobierto_cms/models/en.yml
+++ b/config/locales/gobierto_cms/models/en.yml
@@ -10,3 +10,4 @@ en:
       gobierto_cms/news: News
       gobierto_cms/news_plural: News
       gobierto_cms/page: Page
+      gobierto_cms/pages_collection: Pages Collection

--- a/config/locales/gobierto_cms/models/es.yml
+++ b/config/locales/gobierto_cms/models/es.yml
@@ -10,3 +10,4 @@ es:
       gobierto_cms/news: Noticia
       gobierto_cms/news_plural: Noticias
       gobierto_cms/page: Página
+      gobierto_cms/pages_collection: Colección de Páginas


### PR DESCRIPTION
Closes  PopulateTools/issues#1319

## :v: What does this PR do?
* Creates a model inherited from `GobiertoCommon::Collection` in GobiertoCms for pages collection
* Allows the definition of custom fields for pages of CMS collections
* Adds the management of custom fields of CMS pages using the definition at collection level
* Adds a configuration to avoid the definition of custom fields on CMS page at global module level

## :mag: How should this be manually tested?
Visit a site with at least one CMS collection and define custom fields on them. The admin of pages belonging to the collection should display the custom fields and they should be editable

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
