### PR TITLE
Include path in attachments serialization

### DIFF
--- a/app/serializers/gobierto_admin/gobierto_attachments/attachment_serializer.rb
+++ b/app/serializers/gobierto_admin/gobierto_attachments/attachment_serializer.rb
@@ -10,6 +10,7 @@ module GobiertoAdmin
         :file_digest,
         :url,
         :human_readable_url,
+        :human_readable_path,
         :file_size,
         :current_version,
         :created_at

--- a/app/serializers/gobierto_attachments/attachment_serializer.rb
+++ b/app/serializers/gobierto_attachments/attachment_serializer.rb
@@ -9,6 +9,7 @@ module GobiertoAttachments
       :file_digest,
       :url,
       :human_readable_url,
+      :human_readable_path,
       :file_size,
       :current_version,
       :created_at,

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachings_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachings_test.rb
@@ -30,7 +30,7 @@ module GobiertoAdmin
       end
 
       def attachment_attributes
-        @attachment_attributes ||= %w(id site_id name description file_name file_digest url human_readable_url file_size current_version created_at)
+        @attachment_attributes ||= %w(id site_id name description file_name file_digest url human_readable_url human_readable_path file_size current_version created_at)
       end
 
       def test_attachings_create_success

--- a/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
+++ b/test/integration/gobierto_admin/gobierto_attachments/api/attachments_test.rb
@@ -19,7 +19,7 @@ module GobiertoAdmin
       end
 
       def attachment_attributes
-        @attachment_attributes ||= %w(id site_id name description file_name file_digest url human_readable_url file_size current_version created_at)
+        @attachment_attributes ||= %w(id site_id name description file_name file_digest url human_readable_url human_readable_path file_size current_version created_at)
       end
 
       def pdf_file


### PR DESCRIPTION
## :v: What does this PR do?

Includes a new `human_readable_path` attribute in attachments serialization, required by some front applications instead of absolute url

## :mag: How should this be manually tested?

Make a request for a resource with attachments, a `human_readable_path` attribute should be included with each attacment

## :shipit: Does this PR changes any configuration file?

No 
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
