### PR TITLE
Gobierto Visualizations / Costs: refactor and update data

### DIFF
--- a/app/assets/stylesheets/module-visualizations.scss
+++ b/app/assets/stylesheets/module-visualizations.scss
@@ -1200,7 +1200,7 @@
   }
 
   &-container-title {
-    margin-bottom: 1rem;
+    margin: 2rem 0 1rem;
     display: inline-block;
     vertical-align: middle;
     width: 100%;

--- a/app/assets/stylesheets/module-visualizations.scss
+++ b/app/assets/stylesheets/module-visualizations.scss
@@ -1120,6 +1120,10 @@
     margin-top: 0;
   }
 
+  &-description-color-base {
+    color: var(--color-base);
+  }
+
   .vis-costs {
     position: relative;
     background-color: #f0f0f0;

--- a/app/javascript/gobierto_visualizations/modules/costs_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/costs_controller.js
@@ -150,15 +150,14 @@ export class CostsController {
       "costdirfin"
     ];
 
-    const population = ["126988"];
+    const population = ["128291", "129661"];
+
+    let yearsCosts = [...new Set(rawData.map(item => item.any_))];
 
     for (let index = 0; index < rawData.length; index++) {
       let d = rawData[index];
 
-      if (d["any_"] === "2019") {
-        d["population"] = population[0];
-      }
-
+      d["population"] = getPopulation(d["any_"]);
       for (let amounts = 0; amounts < amountStrings.length; amounts++) {
         d[amountStrings[amounts]] = convertStringToNumbers(
           d[amountStrings[amounts]]
@@ -166,7 +165,13 @@ export class CostsController {
       }
     }
 
-    let yearsCosts = [...new Set(rawData.map(item => item.any_))];
+    function getPopulation(year) {
+      for (let index = 0; index < yearsCosts.length; index++) {
+        if (year === yearsCosts[index]) {
+          return population[index];
+        }
+      }
+    }
 
     let groupDataByYears = [];
 

--- a/app/javascript/gobierto_visualizations/modules/costs_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/costs_controller.js
@@ -153,23 +153,18 @@ export class CostsController {
     const population = ["128291", "129661"];
 
     let yearsCosts = [...new Set(rawData.map(item => item.any_))];
+    console.log("yearsCosts", yearsCosts);
 
     for (let index = 0; index < rawData.length; index++) {
       let d = rawData[index];
 
-      d["population"] = getPopulation(d["any_"]);
+      const ix = yearsCosts.findIndex(x => x === d["any_"])
+      d.population = population[ix]
+
       for (let amounts = 0; amounts < amountStrings.length; amounts++) {
         d[amountStrings[amounts]] = convertStringToNumbers(
           d[amountStrings[amounts]]
         );
-      }
-    }
-
-    function getPopulation(year) {
-      for (let index = 0; index < yearsCosts.length; index++) {
-        if (year === yearsCosts[index]) {
-          return population[index];
-        }
       }
     }
 

--- a/app/javascript/gobierto_visualizations/modules/costs_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/costs_controller.js
@@ -153,7 +153,6 @@ export class CostsController {
     const population = ["128291", "129661"];
 
     let yearsCosts = [...new Set(rawData.map(item => item.any_))];
-    console.log("yearsCosts", yearsCosts);
 
     for (let index = 0; index < rawData.length; index++) {
       let d = rawData[index];

--- a/app/javascript/gobierto_visualizations/webapp/containers/costs/Distribution.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/costs/Distribution.vue
@@ -108,7 +108,7 @@ export default {
       if (newValue !== oldValue) {
         this.updateYear(newValue)
         this.updateBubbles()
-        this.selectYearHandler(newValue)
+        this.activeYear = newValue
       }
     },
     activeYear(newValue, oldValue) {
@@ -122,14 +122,12 @@ export default {
   },
   mounted() {
     this.createBubbleViz()
-    this.selectYearHandler(this.year)
   },
   methods: {
-    updateYear(value) {
-      this.dataFilter = this.data.filter(element => element.any_ === value)
-      const [{
-        population: population
-      }] = this.dataFilter
+    updateYear(year) {
+      this.activeYear = year
+      this.dataFilter = this.data.filter(({ any_ }) => any_ === year)
+      const [{ population: population }] = this.dataFilter
       this.population = population
       this.populationNumber = Number(population).toLocaleString(I18n.locale)
     },
@@ -144,9 +142,10 @@ export default {
       this.visBubblesCosts.resize(this.year)
       this.$emit('preventReload')
     },
-    selectYearHandler(item) {
-      this.activeYear = item
-      this.visBubblesCosts.resize(item)
+    selectYearHandler(year) {
+      this.activeYear = year
+      this.visBubblesCosts.resize(year)
+      this.$emit('updateYear', year)
       this.$emit('preventReload')
     },
   }

--- a/app/javascript/gobierto_visualizations/webapp/containers/costs/Home.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/costs/Home.vue
@@ -33,6 +33,9 @@
         <p class="gobierto-visualizations-description">
           {{ labelDescription3 }}
         </p>
+        <p class="gobierto-visualizations-description">
+          {{ labelDescriptionCovid }}
+        </p>
       </div>
       <Distribution
         :data="groupData"
@@ -40,6 +43,7 @@
         :years="years"
         :years-multiple="yearsMultiple"
         @preventReload="injectRouter"
+        @updateYear="updateData"
       />
       <Table
         :items-filter="groupDataFilter"
@@ -89,21 +93,15 @@ export default {
     }
   },
   created() {
-      this.labelDescription = I18n.t("gobierto_visualizations.visualizations.costs.description", { entity_name: this.getSiteName }) || "";
+    this.labelDescription = I18n.t("gobierto_visualizations.visualizations.costs.description", { entity_name: this.getSiteName }) || "";
     const {
       params: {
         year: year
       }
     } = this.$route
-    let yearFiltered = year
-    if (!year) yearFiltered = '2019'
-    this.yearFiltered = yearFiltered
-
-    const costDataFilter = this.costData.filter(element => element.any_ === yearFiltered).sort((a, b) => (a.costtotal > b.costtotal) ? -1 : 1)
-    const groupDataFilter = this.groupData.filter(element => element.any_ === yearFiltered).sort((a, b) => (a.costtotal > b.costtotal) ? -1 : 1)
-
-    this.costDataFilter = costDataFilter
-    this.groupDataFilter = groupDataFilter
+    this.yearFiltered = year ? year : this.yearFiltered
+    this.costDataFilter = this.costData.filter(({ any_ }) => any_ === this.yearFiltered).sort(({ costtotal: a }, { costtotal: b }) => (a > b ? -1 : 1))
+    this.groupDataFilter = this.groupData.filter(({ any_ }) => any_ === this.yearFiltered).sort(({ costtotal: a }, { costtotal: b }) => (a > b ? -1 : 1))
 
     this.baseTitle = document.title;
   },
@@ -113,22 +111,22 @@ export default {
   },
   methods: {
     onChangeFilterYear(value) {
-      this.injectRouter()
-      let year
-      if (value === '2019') {
-        year = value
-      } else {
-        year = value.target.value
-        this.yearFiltered = value.target.value
-      }
-      const costDataFilter = this.costData.filter(element => element.any_ === year)
-      const groupDataFilter = this.groupData.filter(element => element.any_ === year)
+      const {
+        params: {
+          year: year
+        }
+      } = this.$route
+      this.yearFiltered = value.target ? value.target.value : year
 
-      this.costDataFilter = costDataFilter
-      this.groupDataFilter = groupDataFilter
+      this.updateData(this.yearFiltered)
+    },
+    updateData(year) {
+      this.yearFiltered = year
+      this.costDataFilter = this.costData.filter(({ any_ }) => any_ === this.yearFiltered)
+      this.groupDataFilter = this.groupData.filter(({ any_ }) => any_ === this.yearFiltered)
 
       // eslint-disable-next-line no-unused-vars
-      this.$router.push(`/visualizaciones/costes/${year}`).catch(err => {})
+      this.$router.push(`/visualizaciones/costes/${this.yearFiltered}`).catch(err => {})
     },
     injectRouter() {
       const bubbleLinks = document.querySelectorAll('.bubbles-links')

--- a/app/javascript/gobierto_visualizations/webapp/containers/costs/Home.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/costs/Home.vue
@@ -33,7 +33,7 @@
         <p class="gobierto-visualizations-description">
           {{ labelDescription3 }}
         </p>
-        <p class="gobierto-visualizations-description">
+        <p class="gobierto-visualizations-description-color-base">
           {{ labelDescriptionCovid }}
         </p>
       </div>
@@ -74,6 +74,7 @@ export default {
       labelDescription: '',
       labelDescription2: I18n.t("gobierto_visualizations.visualizations.costs.description_2") || "",
       labelDescription3: I18n.t("gobierto_visualizations.visualizations.costs.description_3") || "",
+      labelDescriptionCovid: I18n.t("gobierto_visualizations.visualizations.costs.description_covid") || "",
       yearFiltered: this.$root.$data.yearsCosts[0],
       years: this.$root.$data.yearsCosts,
       costDataFilter: [],

--- a/app/javascript/lib/visualizations/modules/bubble_cost.js
+++ b/app/javascript/lib/visualizations/modules/bubble_cost.js
@@ -251,7 +251,7 @@ export class VisBubble {
       .attr(
         "xlink:href",
         function(d) {
-          return `/visualizations/costes/${d.year}/${d.ordreagrup}`;
+          return `/visualizaciones/costes/${d.year}/${d.ordreagrup}`;
         }.bind(this)
       )
       .attr("class", "bubbles-links")

--- a/config/locales/defaults/ca.yml
+++ b/config/locales/defaults/ca.yml
@@ -15,7 +15,7 @@ ca:
     - dv
     - ds
     abbr_month_names:
-    - 
+    -
     - gen
     - feb
     - mar
@@ -43,7 +43,7 @@ ca:
       short: "%d %b"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - gener
     - febrer
     - març

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -15,7 +15,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       short: "%b %d %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - January
     - February
     - March

--- a/config/locales/defaults/es.yml
+++ b/config/locales/defaults/es.yml
@@ -15,7 +15,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       short: "%d %b %Y"
       shortest: "%d %b %y"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -137,7 +137,12 @@ ca:
           anàlisi s’amplia i es concreta el cost real d’un servei ja que podem trobar
           relacionat el cost indirecte (de suport) necessari per a la prestació d’un
           servei.
-        description_covid: Les dades del 2020 que presentem, recullen els efectes derivats de l’adaptació a la nova realitat derivada de la pandemia de la COVID 19, adequant els serveis a les necessitats específiques així com la variació en la prestació d’aquests serveis. També es va procedir a l’actualització del catàleg d’activitats i serveis i per tant, hi ha algunes diferències respecte els exercicis anteriors en aquesta relació.
+        description_covid: Les dades del 2020 que presentem, recullen els efectes
+          derivats de l’adaptació a la nova realitat derivada de la pandemia de la
+          COVID 19, adequant els serveis a les necessitats específiques així com la
+          variació en la prestació d’aquests serveis. També es va procedir a l’actualització
+          del catàleg d’activitats i serveis i per tant, hi ha algunes diferències
+          respecte els exercicis anteriors en aquesta relació.
         detail: Detall
         distribution: Distribució de costos per àrea
         home: Inici

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -137,6 +137,7 @@ ca:
           anàlisi s’amplia i es concreta el cost real d’un servei ja que podem trobar
           relacionat el cost indirecte (de suport) necessari per a la prestació d’un
           servei.
+        description_covid: Les dades del 2020 que presentem, recullen els efectes derivats de l’adaptació a la nova realitat derivada de la pandemia de la COVID 19, adequant els serveis a les necessitats específiques així com la variació en la prestació d’aquests serveis. També es va procedir a l’actualització del catàleg d’activitats i serveis i per tant, hi ha algunes diferències respecte els exercicis anteriors en aquesta relació.
         detail: Detall
         distribution: Distribució de costos per àrea
         home: Inici

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -137,6 +137,12 @@ en:
         description_3: The starting point is the municipal budget, but with this analysis
           the real cost of a service is expanded and specified as we can find related
           the indirect (support) cost required to provide a service.
+        description_covid: The 2020 data presented here reflect the effects derived
+          from the adaptation to the new reality derived from the COVID 19 pandemic,
+          adapting the services to the specific needs and the variation in the provision
+          of these services. We also proceeded to update the catalog of activities
+          and services and therefore, there are some differences concerning previous
+          years in this list.
         detail: Detail
         distribution: Distribution of costs by area
         home: Home

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -138,7 +138,12 @@ es:
           análisis se amplía y se concreta el coste real de un servicio ya que podemos
           encontrar relacionado el coste indirecto (de apoyo) necesario para la prestación
           de un servicio.
-        description_covid: Los datos del 2020 que presentamos, recogen los efectos derivados de la adaptación a la nueva realidad derivada de la pandemia de la COVID 19, adecuando los servicios a las necesidades específicas así como la variación en la prestación de estos servicios. También se procedió a la actualización del catálogo de actividades y servicios y por lo tanto, hay algunas diferencias respecto a los ejercicios anteriores en esta relación.
+        description_covid: Los datos del 2020 que presentamos, recogen los efectos
+          derivados de la adaptación a la nueva realidad derivada de la pandemia de
+          la COVID 19, adecuando los servicios a las necesidades específicas así como
+          la variación en la prestación de estos servicios. También se procedió a
+          la actualización del catálogo de actividades y servicios y por lo tanto,
+          hay algunas diferencias respecto a los ejercicios anteriores en esta relación.
         detail: Detalle
         distribution: Distribución de costes por área
         home: Inicio

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -138,6 +138,7 @@ es:
           análisis se amplía y se concreta el coste real de un servicio ya que podemos
           encontrar relacionado el coste indirecto (de apoyo) necesario para la prestación
           de un servicio.
+        description_covid: Los datos del 2020 que presentamos, recogen los efectos derivados de la adaptación a la nueva realidad derivada de la pandemia de la COVID 19, adecuando los servicios a las necesidades específicas así como la variación en la prestación de estos servicios. También se procedió a la actualización del catálogo de actividades y servicios y por lo tanto, hay algunas diferencias respecto a los ejercicios anteriores en esta relación.
         detail: Detalle
         distribution: Distribución de costes por área
         home: Inicio


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1335


## :v: What does this PR do?

- Refactor the code to remove references to the year 2019.
- Add new text about covid19
- Update 2019 and 2020 population data.


## :mag: How should this be manually tested?

[Staging](https://mataro.gobify.net/visualizaciones/costes/)