### PR TITLE
3935 visualizations homepage

### DIFF
--- a/app/controllers/gobierto_visualizations/visualizations_controller.rb
+++ b/app/controllers/gobierto_visualizations/visualizations_controller.rb
@@ -11,7 +11,7 @@ module GobiertoVisualizations
     private
 
     def visualization_enabled!
-      render_404 unless visualizations_config.fetch('enabled', false)
+      render_404 unless visualizations_config&.fetch("enabled", false)
     end
 
     def visualizations_config

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -59,6 +59,7 @@ export class ContractsController {
           routes: [
             {
               path: "/visualizaciones/contratos",
+              alias: "/",
               component: Home,
               props: { dataDownloadEndpoint: options.dataDownloadEndpoint },
               children: [

--- a/app/javascript/gobierto_visualizations/modules/subsidies_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/subsidies_controller.js
@@ -50,6 +50,7 @@ export class SubsidiesController {
           routes: [
             {
               path: "/visualizaciones/subvenciones",
+              alias: "/",
               component: Home,
               props: { dataDownloadEndpoint: options.dataDownloadEndpoint },
               children: [

--- a/app/models/gobierto_visualizations.rb
+++ b/app/models/gobierto_visualizations.rb
@@ -2,7 +2,11 @@
 
 module GobiertoVisualizations
   def self.root_path(current_site)
-    Rails.application.routes.url_helpers.gobierto_visualizations_root_path
+    return unless (module_settings = current_site.gobierto_visualizations_settings)
+
+    home_key = find_home_key(module_settings.settings&.dig("visualizations_config", "visualizations"))
+
+    Rails.application.routes.url_helpers.send("gobierto_visualizations_#{home_key}_path")
   end
 
   def self.default_visualizations_configuration_settings
@@ -25,5 +29,11 @@ module GobiertoVisualizations
       }
     }
 JSON
+  end
+
+  def self.find_home_key(settings)
+    return unless settings.present?
+
+    settings.find { |_key, config| config["home"] }[0]
   end
 end

--- a/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
@@ -43,7 +43,6 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
         "visualizations" => {
           "contracts" => {
             "enabled" => true,
-            "home" => true,
             "data_urls" => {
               "tenders" => "/tenders.csv",
               "contracts" => "/contracts.csv"
@@ -52,18 +51,6 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
         }
       }
     }
-  end
-
-  def test_root_path
-    site.configuration.home_page = "GobiertoVisualizations"
-
-    with(site: site, js: true) do
-      visit @root_path
-
-      assert page.has_content?("ASSIGNEE")
-      assert page.has_content?("CONTRACT")
-      assert page.has_content?("AMOUNT")
-    end
   end
 
   def test_summary

--- a/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
+++ b/test/integration/gobierto_visualizations/visualizations_contracts_test.rb
@@ -43,6 +43,7 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
         "visualizations" => {
           "contracts" => {
             "enabled" => true,
+            "home" => true,
             "data_urls" => {
               "tenders" => "/tenders.csv",
               "contracts" => "/contracts.csv"
@@ -51,6 +52,18 @@ class GobiertoVisualizations::VisualizationsContractsTest < ActionDispatch::Inte
         }
       }
     }
+  end
+
+  def test_root_path
+    site.configuration.home_page = "GobiertoVisualizations"
+
+    with(site: site, js: true) do
+      visit @root_path
+
+      assert page.has_content?("ASSIGNEE")
+      assert page.has_content?("CONTRACT")
+      assert page.has_content?("AMOUNT")
+    end
   end
 
   def test_summary

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -10,6 +10,23 @@ class SiteTest < ActiveSupport::TestCase
 
   attr_reader :module_seeder_spy
 
+  def visualizations_settings
+    {
+      "visualizations_config" => {
+        "visualizations" => {
+          "contracts" => {
+            "enabled" => true,
+            "home" => true,
+            "data_urls" => {
+              "tenders" => "/tenders.csv",
+              "contracts" => "/contracts.csv"
+            }
+          }
+        }
+      }
+    }
+  end
+
   def first_call_arguments
     recipe_spy.calls.first.args
   end
@@ -37,6 +54,17 @@ class SiteTest < ActiveSupport::TestCase
 
   def test_root_path
     assert_equal "/participacion", site.root_path
+  end
+
+  def test_visualizations_root_path
+    ::GobiertoModuleSettings.create!({
+      site_id: site.id,
+      module_name: "GobiertoVisualizations",
+      settings: visualizations_settings
+    })
+    site.configuration.home_page = "GobiertoVisualizations"
+
+    assert_equal Rails.application.routes.url_helpers.gobierto_visualizations_contracts_path, site.root_path
   end
 
   # -- Initialization


### PR DESCRIPTION
Closes #3935


## :v: What does this PR do?

* Changes the visualizations module to take the module root path from the module configuration. To set a visualization as the home include a `"home": true` option in its configuration. Note that if several visualizations are configured as home, only the first one will be taken into account.
* Adds an integration test
* Adds a fix to avoid exceptions if a path is requested for a visualization not configured in the module settings  
* Adds the route `'/' `to visualizations homepage. [front]

## :mag: How should this be manually tested?

Configure GobiertoVisualizations as the home module in the site.
Change the module settings and include in a visualization the `"home": true` setting 
[staging](https://terrassa.gobify.net/)

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Suggestion added to gobierto.readme.io
