### PR TITLE
Ignore some actions from AppSignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -10,6 +10,13 @@ default: &defaults
     - ActionController::UnknownFormat
   enable_frontend_error_catching: true
   enable_gc_instrumentation: true
+  ignore_actions:
+    - "GobiertoPeople::People::PersonEventsController#index"
+    - "GobiertoPeople::PersonEventsController#index"
+    - "GobiertoPeople::PastPersonEventsController#index"
+    - "GobiertoPeople::People::PastPersonEventsController#index"
+    - "GobiertoPeople::People::PersonEventsController#show"
+    - "GobiertoPeople::GovernmentPartyPastPersonEventsController#index"
 
 development:
   <<: *defaults


### PR DESCRIPTION
## :v: What does this PR do?

This PR removes some actions to being tracked in AppSignal. These are actions mainly used by search bots which are using all our monthly requests in the tool.

## :mag: How should this be manually tested?

Review tracked actions, none of the ignored actions should appear in app signal.
