### PR TITLE
Capture error when table_schema method database request fails

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -170,6 +170,8 @@ module GobiertoData
 
     def table_schema
       table_columns = Connection.execute_query(site, "SELECT column_name, data_type FROM information_schema.COLUMNS WHERE table_name='#{table_name}'", write: true)
+      return table_columns if table_columns.is_a?(Hash) && table_columns.has_key?(:errors)
+
       table_columns.inject({}) do |schema, column|
         schema.update(column["column_name"] => { "original_name" => column["column_name"], "type" => column["data_type"] })
       end


### PR DESCRIPTION
Closes #3947


## :v: What does this PR do?

Avoids exceptions when database query used by `table_schema` method, which requires the use of the database user with write permissions fails. When a database error happens the response is a hash with the error message instead of a `PG::Result` instance

## :mag: How should this be manually tested?

Try to upload a dataset using the API when the user of module database with write permissions doesn't have enough permissions to send a select query

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
