### PR TITLE
Don't create draft schema as it should have been created before

### DIFF
--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -10,7 +10,6 @@ module GobiertoData
 
       def execute_query(site, query, include_stats: false, write: false, include_draft: false)
         with_connection(db_config(site), fallback: null_query, connection_key: connection_key_from_options(write, include_draft)) do
-          connection_pool.connection.execute("CREATE SCHEMA IF NOT EXISTS draft") if write
           connection_pool.connection.execute("SET search_path TO draft, public") if write || include_draft
 
           event = nil

--- a/test/controllers/gobierto_data/api/v1/drafts_controllers_test.rb
+++ b/test/controllers/gobierto_data/api/v1/drafts_controllers_test.rb
@@ -51,6 +51,12 @@ module GobiertoData
           ]
         end
 
+        # In testing environment the draft schema doesn't exist
+        def setup
+          ActiveRecord::Base.connection.execute "CREATE SCHEMA IF NOT EXISTS draft"
+          super
+        end
+
         def test_query_draft_dataset_table_without_preview_token
           active_dataset.update_attribute(:visibility_level, "draft")
 


### PR DESCRIPTION
Unexpected


## :v: What does this PR do?

This is a followup of #3948

This PR prevents the creation of the schema draft. This schema is created during the gobierto data database setup because it assigns different permissions to the different users.

## :mag: How should this be manually tested?

You should be able to publish draft datasets
