### PR TITLE
1347 gobierto budgets export

### DIFF
--- a/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
+++ b/app/models/concerns/gobierto_budgets/budget_line_elasticsearch_helpers.rb
@@ -115,18 +115,26 @@ module GobiertoBudgets
         terms.push({term: { code: conditions[:code] }}) if conditions[:code]
         terms.push({term: { level: conditions[:level] }}) if conditions[:level]
         terms.push({term: { parent_code: conditions[:parent_code] }}) if conditions[:parent_code]
-        if conditions[:functional_code]
+        if conditions.has_key?(:functional_code)
           if conditions[:area_name] == FunctionalArea.area_name
             conditions[:area_name] = EconomicArea.area_name
-            terms.push({term: { functional_code: conditions[:functional_code] }})
+            if conditions[:functional_code].present?
+              terms.push(term: { functional_code: conditions[:functional_code] })
+            else
+              terms.push(exists: { field: "functional_code" })
+            end
           else
             conditions[:area_name] = FunctionalArea.area_name
-            return functional_codes_for_economic_budget_line(conditions)
+            return functional_codes_for_economic_budget_line(where: conditions)
           end
-        elsif conditions[:custom_code]
+        elsif conditions.has_key?(:custom_code)
           if conditions[:area_name] == CustomArea.area_name
             conditions[:area_name] = EconomicArea.area_name
-            terms.push({term: { custom_code: conditions[:custom_code] }})
+            if conditions[:custom_code].present?
+              terms.push(term: { custom_code: conditions[:custom_code] })
+            else
+              terms.push(exists: { field: "custom_code" })
+            end
           # else
           #   conditions[:area_name] = CustomArea.area_name
           #   return functional_codes_for_economic_budget_line(conditions)

--- a/app/presenters/gobierto_budgets/budget_line_export_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_export_presenter.rb
@@ -13,20 +13,7 @@ module GobiertoBudgets
     end
 
     def self.csv_columns
-      ['ID',
-       'code',
-       'year',
-       'area',
-       'income/expense',
-       'name',
-       'description',
-       'value_budget_initial',
-       'value_budget_modified',
-       'value_execution',
-       'level',
-       'parent_code',
-       'updated_at',
-       'organization_id']
+      %w(year code area kind name description initial_value modified_value executed_value organization_id functional_code custom_code ID parent_code level updated_atorganization_id)
     end
 
     def index_values
@@ -61,9 +48,11 @@ module GobiertoBudgets
         code: code,
         year: year,
         area: area_name,
-        income_expense: kind,
+        kind: kind,
         name: name,
         description: description,
+        functional_code: functional_code,
+        custom_code: custom_code,
         level: level,
         parent_code: parent_code,
         updated_at: updated_at,
@@ -71,9 +60,8 @@ module GobiertoBudgets
     end
 
     def as_csv
-      [id,
+      [year,
        code,
-       year,
        area_name,
        kind,
        name,
@@ -81,10 +69,13 @@ module GobiertoBudgets
        index_values[:value_budget_initial],
        index_values[:value_budget_modified],
        index_values[:value_budget_execution],
-       level,
+       organization_id,
+       functional_code,
+       custom_code,
+       id,
        parent_code,
-       updated_at,
-       organization_id]
+       level,
+       updated_at]
     end
   end
 end

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -9,10 +9,10 @@ module GobiertoBudgets
 
       case decomposition_bit
       when "c"
-        organization_id, year, custom_code, code, decomposition_bit, kind, area_name = id_split
+        organization_id, year, custom_code, code, _decomposition_bit, kind, area_name = id_split
         decomposition_attrs = { custom_code: custom_code }
       when "f"
-        organization_id, year, functional_code, code, decomposition_bit, kind, area_name = id_split
+        organization_id, year, functional_code, code, _decomposition_bit, kind, area_name = id_split
         decomposition_attrs = { functional_code: functional_code }
       else
         organization_id, year, code, kind, area_name = id_split
@@ -26,11 +26,15 @@ module GobiertoBudgets
              when CustomArea.area_name
                CustomArea
              end
-      self.new({ organization_id: organization_id, year: year, code: code, kind: kind, area: area, site: site }.merge(decomposition_attrs))
+      new({ organization_id: organization_id, year: year, code: code, kind: kind, area: area, site: site }.merge(decomposition_attrs))
     end
 
     def initialize(attributes)
       @attributes = attributes.symbolize_keys
+    end
+
+    def loadable_id
+      [id, area_name].join("/")
     end
 
     def id

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -20,7 +20,22 @@ module GobiertoBudgets
     end
 
     def id
-      (@attributes.values_at(:organization_id, :year, :code, :kind) + [@attributes[:area].area_name]).join("/")
+      [
+        @attributes[:organization_id],
+        @attributes[:year],
+        area_code,
+        @attributes[:kind]
+      ].join("/")
+    end
+
+    def area_code
+      if @attributes[:custom_code].present?
+        [@attributes[:custom_code], @attributes[:code], "c"].join("/")
+      elsif @attributes[:functional_code].present?
+        [@attributes[:functional_code], @attributes[:code], "f"].join("/")
+      else
+        code
+      end
     end
 
     def category

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -94,6 +94,14 @@ module GobiertoBudgets
       @attributes[:code]
     end
 
+    def custom_code
+      @attributes[:custom_code]
+    end
+
+    def functional_code
+      @attributes[:functional_code]
+    end
+
     def level
       @attributes[:level]
     end

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -107,7 +107,13 @@ module GobiertoBudgets
     end
 
     def area_name
-      area.area_name
+      if @attributes[:custom_code].present?
+        "economic-custom"
+      elsif @attributes[:functional_code].present?
+        "economic-functional"
+      else
+        area.area_name
+      end
     end
 
     def year

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -155,7 +155,7 @@
         <% if budget_lines_feedback_active? %>
           <div class="pure-u-1-2 pure-u-md-1-5 metric_box cta open_budget_line_feedback tipsit" title="<%= t('.give_your_opinion_cta') %>" data-box="feedback">
             <div class="inner">
-              <%= link_to gobierto_budgets_feedback_step1_path(year: @year, id: @budget_line.id), remote: true do %>
+              <%= link_to gobierto_budgets_feedback_step1_path(year: @year, id: @budget_line.loadable_id), remote: true do %>
                 <div class="main"><%= t('.raise_hand') %> <i class="fas fa-hand-paper-o"></i></div>
                 <div class="lite"><%= t('.give_your_opinion') %></div>
               <% end %>

--- a/app/views/gobierto_budgets/shared/_enough_information.html.erb
+++ b/app/views/gobierto_budgets/shared/_enough_information.html.erb
@@ -4,7 +4,7 @@
 
     <p><%= t('.enough_information_desc') %></p>
 
-    <%= link_to t('.enough_information_cta', to_your_organization_name: @site.determined_organization_name(:to_your)), gobierto_budgets_feedback_load_ask_more_information_path(id: @budget_line.try(:id)), remote: true, class: 'button' %>
+    <%= link_to t('.enough_information_cta', to_your_organization_name: @site.determined_organization_name(:to_your)), gobierto_budgets_feedback_load_ask_more_information_path(id: @budget_line.try(:loadable_id)), remote: true, class: 'button' %>
 
     <div id="load_ask_more_information"></div>
   </div>


### PR DESCRIPTION
Closes PopulateTools/issues#1347


## :v: What does this PR do?

* Adapts a method to send queries to elasticsearch allowing to get data of lines with existing custom_code and functional_code
* Uses the previous method to include these missing lines in the export files
* Changes the format of CSV and JSON export file:
  * Renames the income/expense to kind column/field
  * Changes the generation of id and area to include details of lines with custom_code and functional_code
  * Includes a custom_code and functional_code columns/attributes

## :mag: How should this be manually tested?

call the `rails gobierto_budgets:data:sites_annual` task and review the files available in /descarga-datos path

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No