### PR TITLE
Gobierto Visualizations / Costs: selects the last year

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/costs/Home.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/costs/Home.vue
@@ -75,7 +75,7 @@ export default {
       labelDescription2: I18n.t("gobierto_visualizations.visualizations.costs.description_2") || "",
       labelDescription3: I18n.t("gobierto_visualizations.visualizations.costs.description_3") || "",
       labelDescriptionCovid: I18n.t("gobierto_visualizations.visualizations.costs.description_covid") || "",
-      yearFiltered: this.$root.$data.yearsCosts[0],
+      yearFiltered: this.$root.$data.yearsCosts[this.$root.$data.yearsCosts.length - 1],
       years: this.$root.$data.yearsCosts,
       costDataFilter: [],
       groupDataFilter: []


### PR DESCRIPTION
## :v: What does this PR do?

Selects the last year available in the data.

## :mag: How should this be manually tested?

[Staging](https://mataro.gobify.net/visualizaciones/costes/)

## :eyes: Screenshots

### After this PR
![Screenshot 2021-09-30 at 10 03 42](https://user-images.githubusercontent.com/2649175/135412716-6e7efaf5-1eb6-4aa9-8e49-fac7f55a7662.png)

