### PR TITLE
1352 rename gobierto budgets data gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,8 @@ gem "savon", "~> 2.12.0"
 # Image management
 gem "cloudinary"
 
-# Gobierto data
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+# Gobierto budgets data
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 
 # API
 gem "rubyXL"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 7db1fa4d63f08ca30d334255469144bdbc246673
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 17761ea394fdb07418ee89a751482da4c6ebdaaf
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack
       activesupport
       aws-sdk-s3
@@ -561,7 +561,7 @@ DEPENDENCIES
   font-awesome-sass (~> 5.6)
   foreman
   geocoder
-  gobierto_data!
+  gobierto_budgets_data!
   google-api-client
   hashie
   i18n-js (>= 3.0.0.rc11)

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,5 @@ require File.expand_path("../config/application", __FILE__)
 Rails.application.load_tasks
 
 # Load tasks from gobierto_data
-spec = Gem::Specification.find_by_name "gobierto_data"
+spec = Gem::Specification.find_by_name "gobierto_budgets_data"
 load "#{spec.gem_dir}/lib/tasks/data.rake"

--- a/app/models/gobierto_budgets/search_engine_configuration/budget_line.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/budget_line.rb
@@ -9,19 +9,19 @@ module GobiertoBudgets
       end
 
       def self.index_forecast
-        GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
       end
 
       def self.index_executed
-        GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED
       end
 
       def self.index_executed_series
-        GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED_SERIES
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED_SERIES
       end
 
       def self.index_forecast_updated
-        GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
       end
     end
   end

--- a/app/models/gobierto_budgets/search_engine_configuration/invoice.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/invoice.rb
@@ -8,11 +8,11 @@ module GobiertoBudgets
       end
 
       def self.index
-        GobiertoData::GobiertoBudgets::ES_INDEX_INVOICES
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_INVOICES
       end
 
       def self.type
-        GobiertoData::GobiertoBudgets::INVOICE_TYPE
+        GobiertoBudgetsData::GobiertoBudgets::INVOICE_TYPE
       end
     end
   end

--- a/lib/budgets_seeder.rb
+++ b/lib/budgets_seeder.rb
@@ -12,7 +12,7 @@ class BudgetsSeeder
         default_args = {
           area: area_name,
           year: year,
-          kind: GobiertoData::GobiertoBudgets::EXPENSE
+          kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE
         }
 
         %w(1 2 3).each do |code|

--- a/lib/tasks/gobierto_budgets/custom_categories.rake
+++ b/lib/tasks/gobierto_budgets/custom_categories.rake
@@ -19,7 +19,7 @@ namespace :gobierto_budgets do
         exit(-1)
       end
 
-      importer = GobiertoData::GobiertoBudgets::CustomCategoriesCsvImporter.new(CSV.read(csv_path, headers: true), site: site)
+      importer = GobiertoBudgetsData::GobiertoBudgets::CustomCategoriesCsvImporter.new(CSV.read(csv_path, headers: true), site: site)
 
       nitems = importer.import!
       puts "[SUCCESS] Imported #{nitems}"

--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -12,7 +12,7 @@ namespace :gobierto_budgets do
         exit(-1)
       end
 
-      importer = GobiertoData::GobiertoBudgets::BudgetLinesCsvImporter.new(CSV.read(csv_path, headers: true))
+      importer = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesCsvImporter.new(CSV.read(csv_path, headers: true))
 
       organization_ids = importer.csv.map { |row| row.field("organization_id") }.uniq
       sites = Site.where(organization_id: organization_ids)
@@ -22,9 +22,9 @@ namespace :gobierto_budgets do
 
       # Calculate total amounts
       TOTAL_BUDGET_INDEXES = [
-        GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST,
-        GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED,
-        GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST,
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED,
+        GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
       ].freeze
 
       if organization_ids.any?
@@ -33,7 +33,7 @@ namespace :gobierto_budgets do
             TOTAL_BUDGET_INDEXES.each do |index|
               puts " - Calculating totals for #{organization_id} in year #{year} for index #{index}"
 
-              total_budget_calculator = GobiertoData::GobiertoBudgets::TotalBudgetCalculator.new(
+              total_budget_calculator = GobiertoBudgetsData::GobiertoBudgets::TotalBudgetCalculator.new(
                 organization_id: organization_id,
                 year: year,
                 index: index
@@ -58,7 +58,7 @@ namespace :gobierto_budgets do
       # Recalculate bubbles
       if organization_ids.any?
         organization_ids.each do |organization_id|
-          GobiertoData::GobiertoBudgets::Bubbles.dump(organization_id)
+          GobiertoBudgetsData::GobiertoBudgets::Bubbles.dump(organization_id)
           puts "[SUCCESS] Calculated bubbles for organization #{organization_id}"
         end
       end

--- a/lib/tasks/gobierto_budgets/data/extra_data.rake
+++ b/lib/tasks/gobierto_budgets/data/extra_data.rake
@@ -39,15 +39,15 @@ namespace :gobierto_budgets do
         debt_data = [
           {
             index: {
-              _index: GobiertoData::GobiertoBudgets::ES_INDEX_DATA,
-              _type: GobiertoData::GobiertoBudgets::DEBT_TYPE,
+              _index: GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_DATA,
+              _type: GobiertoBudgetsData::GobiertoBudgets::DEBT_TYPE,
               _id: id,
               data: item
             }
           }
         ]
 
-        GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: debt_data)
+        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: debt_data)
         puts "[SUCCESS] Debt #{debt} for #{year}"
 
         item = {
@@ -62,14 +62,14 @@ namespace :gobierto_budgets do
         population_data = [
           {
             index: {
-              _index: GobiertoData::GobiertoBudgets::ES_INDEX_DATA,
-              _type: GobiertoData::GobiertoBudgets::POPULATION_TYPE,
+              _index: GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_DATA,
+              _type: GobiertoBudgetsData::GobiertoBudgets::POPULATION_TYPE,
               _id: id,
               data: item
             }
           }
         ]
-        GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: population_data)
+        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: population_data)
 
         puts "[SUCCESS] Population #{population} for #{year}"
       end

--- a/test/factories/budgets_factory.rb
+++ b/test/factories/budgets_factory.rb
@@ -32,11 +32,11 @@ module BudgetsFactory
     end
 
     def default_kind
-      GobiertoData::GobiertoBudgets::EXPENSE
+      GobiertoBudgetsData::GobiertoBudgets::EXPENSE
     end
 
     def default_area
-      GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME
+      GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
     end
 
     def default_year

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -40,7 +40,7 @@ class GobiertoBudgets::ExecutionPageTest < ActionDispatch::IntegrationTest
 
   def test_execution_summary_boxes
     f1 = TotalBudgetFactory.new(year: last_year)
-    f2 = TotalBudgetFactory.new(year: last_year, kind: GobiertoData::GobiertoBudgets::INCOME)
+    f2 = TotalBudgetFactory.new(year: last_year, kind: GobiertoBudgetsData::GobiertoBudgets::INCOME)
 
     with(factories: [f1, f2], js: true) do
       with_current_site(placed_site) do
@@ -60,8 +60,8 @@ class GobiertoBudgets::ExecutionPageTest < ActionDispatch::IntegrationTest
   end
 
   def test_execution_graphs
-    f1 = BudgetLineFactory.new(year: last_year, area: GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME)
-    f2 = BudgetLineFactory.new(year: last_year, area: GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME, kind: GobiertoData::GobiertoBudgets::INCOME)
+    f1 = BudgetLineFactory.new(year: last_year, area: GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME)
+    f2 = BudgetLineFactory.new(year: last_year, area: GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME, kind: GobiertoBudgetsData::GobiertoBudgets::INCOME)
 
     with(site: placed_site, js: true, factories: [f1, f2]) do
       visit @path

--- a/test/models/gobierto_budgets/site_stats_test.rb
+++ b/test/models/gobierto_budgets/site_stats_test.rb
@@ -39,7 +39,7 @@ module GobiertoBudgets
 
     def total_income(params = {})
       TotalBudgetFactory.new(
-        factory_params(params).merge(kind: GobiertoData::GobiertoBudgets::INCOME)
+        factory_params(params).merge(kind: GobiertoBudgetsData::GobiertoBudgets::INCOME)
       )
     end
 

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/integration/budgets_plugin_test.rb
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/test/integration/budgets_plugin_test.rb
@@ -33,11 +33,11 @@ class BudgetsPluginTest < ActionDispatch::IntegrationTest
 
   def seed_budget_lines
     common_args = {
-      kind: GobiertoData::GobiertoBudgets::EXPENSE,
+      kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE,
       indexes: [:forecast]
     }
 
-    BudgetLineFactory.new(common_args.merge(code: "1", year: 2014, area: GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME))
+    BudgetLineFactory.new(common_args.merge(code: "1", year: 2014, area: GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME))
   end
 
   def test_show


### PR DESCRIPTION
Related to PopulateTools/issues#1352


## :v: What does this PR do?

Replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`

## :mag: How should this be manually tested?

Budgets module should work as usual

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
