### PR TITLE
1358 prefix default vocabularies

### DIFF
--- a/app/models/concerns/gobierto_common/module_name_prefixable.rb
+++ b/app/models/concerns/gobierto_common/module_name_prefixable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module ModuleNamePrefixable
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def module_key
+        @module_key ||= name.underscore.split("/")[-2].gsub("gobierto_", "")
+      end
+
+      def module_name_translations
+        @module_name_translations ||= I18n.available_locales.map do |locale|
+          [locale, I18n.with_locale(locale) { I18n.t("gobierto_admin.layouts.application.modules.#{module_key}") }]
+        end.to_h.symbolize_keys
+      end
+
+      def prefix_translations(translations)
+        translations.each_with_object({}) do |(locale, translation), prefixed_translations|
+          prefixed_translations[locale] = "#{module_name_translations[locale.to_sym]} - #{translation}"
+        end
+      end
+    end
+  end
+end

--- a/db/seeds/gobierto_seeds/gobierto_data/recipe.rb
+++ b/db/seeds/gobierto_seeds/gobierto_data/recipe.rb
@@ -3,6 +3,8 @@
 module GobiertoSeeds
   module GobiertoData
     class Recipe
+      include GobiertoCommon::ModuleNamePrefixable
+
       DEFAULT_CATEGORY_NAMES = [
         "Ciencia y tecnología",
         "Comercio",
@@ -44,7 +46,7 @@ module GobiertoSeeds
         if frequency.new_record?
           vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-frequency")
           if vocabulary.new_record?
-            vocabulary.name_translations = { ca: "Freqüència de conjunt de dades", en: "Dataset frequency", es: "Frecuencia de conjunto de datos" }
+            vocabulary.name_translations = prefix_translations({ ca: "Freqüència", en: "Frequency", es: "Frecuencia" })
             vocabulary.save
             vocabulary.terms.create(name_translations: { ca: "Anual", en: "Annual", es: "Anual" }, position: 1)
             vocabulary.terms.create(name_translations: { ca: "Trimestral", en: "Quarterly", es: "Trimestral" }, position: 2)
@@ -64,7 +66,7 @@ module GobiertoSeeds
         if category.new_record?
           vocabulary = site.vocabularies.find_or_initialize_by(slug: "datasets-category")
           if vocabulary.new_record?
-            vocabulary.name_translations = { ca: "Categoria de conjunt de dades", en: "Dataset Category", es: "Categoría de conjunto de datos" }
+            vocabulary.name_translations = prefix_translations({ ca: "Categoria", en: "Category", es: "Categoría" })
             vocabulary.save
             DEFAULT_CATEGORY_NAMES.each_with_index do |category_name, index|
               vocabulary.terms.create(
@@ -102,7 +104,7 @@ module GobiertoSeeds
         if license.new_record?
           vocabulary = site.vocabularies.find_or_initialize_by(slug: "dataset-license")
           if vocabulary.new_record?
-            vocabulary.name_translations = { ca: "Llicència", en: "License", es: "Licencia" }
+            vocabulary.name_translations = prefix_translations({ ca: "Llicència", en: "License", es: "Licencia" })
             vocabulary.save
             vocabulary.terms.create(
               name_translations: {

--- a/db/seeds/gobierto_seeds/gobierto_plans/recipe.rb
+++ b/db/seeds/gobierto_seeds/gobierto_plans/recipe.rb
@@ -3,12 +3,13 @@
 module GobiertoSeeds
   module GobiertoPlans
     class Recipe
+      include GobiertoCommon::ModuleNamePrefixable
 
       def self.run(site)
         # Create vocabulary
         vocabulary = site.vocabularies.find_or_initialize_by(slug: "sdgs-vocabulary")
         if vocabulary.new_record?
-          vocabulary.name_translations = { ca: "Vocabulari d'ODSs", en: "SDGs vocabulary", es: "Vocabulario de ODSs" }
+          vocabulary.name_translations = prefix_translations({ ca: "Vocabulari d'ODSs", en: "SDGs vocabulary", es: "Vocabulario de ODSs" })
           vocabulary.save
         end
 


### PR DESCRIPTION
Closes PopulateTools/issues#1358


## :v: What does this PR do?

* Adds a concern to prefix translations with module name translations (taken from admin layouts translations)
* Uses the concern to prefix default vocabularies used in Data and Plans modules

## :mag: How should this be manually tested?

Visit https://cortegada.gobify.net/admin/vocabularies

## :eyes: Screenshots

### Before this PR

### After this PR

![Screenshot from 2021-10-01 20-03-37](https://user-images.githubusercontent.com/446459/135666727-12540f32-532a-4225-b5f9-2aaf16da7ac4.png)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No