### PR TITLE
Add task to import invoices from CSV using gobierto budgets data gem

### DIFF
--- a/lib/tasks/gobierto_budgets/data/invoices.rake
+++ b/lib/tasks/gobierto_budgets/data/invoices.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :gobierto_budgets do
+  namespace :data do
+    desc "Import invoices from CSV with gobierto_budgets_data format"
+    task :import_gobierto_invoices_data, [:csv_path, :organization_id] => :environment do |_t, args|
+
+      # Import invoices
+      csv_path = args[:csv_path]
+      unless File.file?(csv_path)
+        puts "[ERROR] No CSV file found: #{csv_path}"
+        exit(-1)
+      end
+
+      organization_id = args[:organization_id]
+      opts = organization_id.present? ? { organization_id: organization_id } : {}
+
+      importer = GobiertoBudgetsData::GobiertoBudgets::InvoicesCsvImporter.new(CSV.read(csv_path, headers: true), **opts)
+
+      organization_ids = importer.rows.map(&:organization_id).uniq.compact
+      sites = Site.where(organization_id: organization_ids)
+
+      nitems = importer.import!
+      puts "[SUCCESS] Imported #{nitems}"
+
+      # Publish updated activity
+      action = "providers_updated"
+      sites.each do |site|
+        Publishers::GobiertoBudgetsActivity.broadcast_event(action, {
+          action: action,
+          site_id: site.id
+        })
+      end
+      puts "[SUCCESS] Published activity providers_updated"
+
+      # Expire Rails cache
+      Rails.cache.clear
+      puts "[SUCCESS] Expired Rails cache"
+    end
+  end
+end


### PR DESCRIPTION
Closes  PopulateTools/issues#1360
Related to  PopulateTools/issues#1363


## :v: What does this PR do?

Adds a task to import invoices from a CSV with the format described in documentation. To do this run:

```
rails gobierto_budgets:data:import_gobierto_invoices_data[csv_path,organization_id]
```

The task has 2 arguments:
* `csv_path` - Mandatory. Path of the CSV file with data to import
* `organization_id` - Optional. Although this argument is optional it must be provided in some way, if not provided as task argument there should be an `organization_id` column in the CSV to generate the data without errors 

## :mag: How should this be manually tested?

Go to staging console and call the task

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Pending