### PR TITLE
Disable accessibility testing in production

### DIFF
--- a/app/javascript/gobierto_budgets/index.js
+++ b/app/javascript/gobierto_budgets/index.js
@@ -10,6 +10,8 @@ import { checkAndReportAccessibility } from 'lib/shared'
 
 document.addEventListener('DOMContentLoaded', () => {
 
-  checkAndReportAccessibility()
+  if (process.env.NODE_ENV === 'development') {
+    checkAndReportAccessibility()
+  }
 
 });

--- a/app/javascript/gobierto_plans/modules/plan_types_controller.js
+++ b/app/javascript/gobierto_plans/modules/plan_types_controller.js
@@ -1,5 +1,10 @@
 import Vue from "vue";
 import { createRouter } from "../webapp/lib/router";
+import { checkAndReportAccessibility } from "lib/vue/accesibility";
+
+if (Vue.config.devtools) {
+  Vue.use(checkAndReportAccessibility)
+}
 
 Vue.config.productionTip = false;
 Vue.config.devtools = true;


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1350

## :v: What does this PR do?

Disable accessibility testing for budgets, and add testing to plans_types.

## :mag: How should this be manually tested?

[Staging budgets](https://getafe.gobify.net/presupuestos/resumen/2020) open devTools

## :eyes: Screenshots

### Before this PR

![Screenshot 2021-10-07 at 15 46 19](https://user-images.githubusercontent.com/2649175/136397846-56fac20c-8749-416a-851f-0a22854f2c83.png)
### After this PR


![Screenshot 2021-10-07 at 15 53 03](https://user-images.githubusercontent.com/2649175/136398326-b54238a1-4ba9-49a2-b047-3e68ebce3ae4.png)

