### PR TITLE
1277 breakdown functional economic

### DIFF
--- a/app/assets/stylesheets/comp-budget_el.scss
+++ b/app/assets/stylesheets/comp-budget_el.scss
@@ -184,7 +184,6 @@
   background: rgba(var(--color-base-string), 0.06);
   .table-breakdown-element {
     color: var(--color-base);
-    margin-left: .5rem;
     cursor: pointer;
   }
   tr.show-sublevel {
@@ -200,6 +199,7 @@
   }
   i {
     color: var(--color-base);
+    margin-right: .5rem;
   }
 
 }

--- a/app/assets/stylesheets/comp-budget_el.scss
+++ b/app/assets/stylesheets/comp-budget_el.scss
@@ -179,3 +179,48 @@
   height: 1px;
   color: #999;
 }
+
+.table-breakdown {
+  background: rgba(var(--color-base-string), 0.06);
+  .table-breakdown-element {
+    color: var(--color-base);
+    margin-left: .5rem;
+    cursor: pointer;
+  }
+  tr.show-sublevel {
+    .table-breakdown-element {
+      font-weight: bold;
+    }
+    + .container-breakdown-sublevel {
+      display: table-row;
+    }
+    i {
+      transform: rotate(90deg);
+    }
+  }
+  i {
+    color: var(--color-base);
+  }
+
+}
+
+.container-breakdown-sublevel {
+  display: none;
+  table {
+    width: 91%;
+    margin-left: 9%;
+  }
+  .container-breakdown-sublevel-td-element {
+    .table-breakdown-element {
+      margin-left: 0;
+    }
+    &.align-right {
+      text-align: right;
+    }
+  }
+}
+
+.container-breakdown-sublevel-td {
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -71,9 +71,9 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
   def budget_line_composition
     case @area_name
     when GobiertoBudgets::FunctionalArea.area_name
-      updated_forecast(functional_code: @code)
+      updated_forecast(functional_code: @code).group_by(&:first_level_parent_code)
     when GobiertoBudgets::CustomArea.area_name
-      updated_forecast(custom_code: @code)
+      updated_forecast(custom_code: @code).group_by(&:first_level_parent_code)
     else
       []
     end

--- a/app/javascript/gobierto_budgets/modules/application.js
+++ b/app/javascript/gobierto_budgets/modules/application.js
@@ -208,4 +208,10 @@ $(document).on("turbolinks:load", function() {
     trigger: "hover",
     html: true
   });
+
+  $(".table-breakdown-element").click(function() {
+    $('.table-breakdown-element').not(this).closest('tr').removeClass('show-sublevel')
+    $(this).closest('tr').toggleClass('show-sublevel')
+  });
+
 });

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -160,6 +160,13 @@ module GobiertoBudgets
       @attributes[:parent_code].to_s
     end
 
+    def first_level_parent_code
+      return unless decomposition_type.present?
+      return :root if level.blank? || level == 1
+
+      code[0]
+    end
+
     def to_param
       {
         id: code,

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -221,7 +221,7 @@
                   <td><span class="table-breakdown-element"><i class="fas fa-angle-right"></i><%= root_budget_line.name %></span>
                   </td>
                   <td class="qty"><%= percentage_fraction_format(root_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
-                  <td class="amount"><%= format_currency(root_budget_line.amount) %></td>
+                  <td class="amount right"><%= format_currency(root_budget_line.amount) %></td>
                 </tr>
                 <tr class="container-breakdown-sublevel">
                   <td class="container-breakdown-sublevel-td" colspan="3">
@@ -232,7 +232,7 @@
                             <tr>
                               <td class="container-breakdown-sublevel-td-element"><span class="table-breakdown-element"><%= descendant_budget_line.name %></span></td>
                               <td class="container-breakdown-sublevel-td-element align-right" class="qty"><%= percentage_fraction_format(descendant_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
-                              <td class="container-breakdown-sublevel-td-element" class="amount"><%= format_currency(descendant_budget_line.amount) %></td>
+                              <td class="container-breakdown-sublevel-td-element" class="amount right"><%= format_currency(descendant_budget_line.amount) %></td>
                             </tr>
                           <% end %>
                         <% end %>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -217,17 +217,24 @@
           <% if @budget_line_composition.any? && @budget_line_composition[:root].present? %>
             <table class="table-breakdown">
               <% @budget_line_composition[:root].each do |root_budget_line| %>
+                <% has_subitems = @budget_line_composition[root_budget_line.code].present? %>
                 <tr>
-                  <td><span class="table-breakdown-element"><i class="fas fa-angle-right"></i><%= root_budget_line.name %></span>
+                  <td>
+                    <span class="<%= "table-breakdown-element" if has_subitems %>">
+                      <% if has_subitems %>
+                        <i class="fas fa-angle-right"></i>
+                      <% end %>
+                      <%= root_budget_line.name %>
+                    </span>
                   </td>
                   <td class="qty"><%= percentage_fraction_format(root_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                   <td class="amount"><%= format_currency(root_budget_line.amount) %></td>
                 </tr>
-                <tr class="container-breakdown-sublevel">
-                  <td class="container-breakdown-sublevel-td" colspan="3">
-                    <div>
-                      <table>
-                        <% if @budget_line_composition[root_budget_line.code].present? %>
+                <% if has_subitems %>
+                  <tr class="container-breakdown-sublevel">
+                    <td class="container-breakdown-sublevel-td" colspan="3">
+                      <div>
+                        <table>
                           <% @budget_line_composition[root_budget_line.code].each do |descendant_budget_line| %>
                             <tr>
                               <td class="container-breakdown-sublevel-td-element"><span class="table-breakdown-element"><%= descendant_budget_line.name %></span></td>
@@ -235,11 +242,11 @@
                               <td class="container-breakdown-sublevel-td-element" class="amount"><%= format_currency(descendant_budget_line.amount) %></td>
                             </tr>
                           <% end %>
-                        <% end %>
-                      </table>
-                    </div>
-                  </td>
-                </tr>
+                        </table>
+                      </div>
+                    </td>
+                  </tr>
+                <% end %>
               <% end %>
             </table>
           <% else %>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -218,7 +218,7 @@
             <table class="table-breakdown">
               <% @budget_line_composition[:root].each do |root_budget_line| %>
                 <tr>
-                  <td><i class="fas fa-angle-right"></i><span class="table-breakdown-element"><%= root_budget_line.name %></span>
+                  <td><span class="table-breakdown-element"><i class="fas fa-angle-right"></i><%= root_budget_line.name %></span>
                   </td>
                   <td class="qty"><%= percentage_fraction_format(root_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                   <td class="amount"><%= format_currency(root_budget_line.amount) %></td>
@@ -230,7 +230,7 @@
                         <% if @budget_line_composition[root_budget_line.code].present? %>
                           <% @budget_line_composition[root_budget_line.code].each do |descendant_budget_line| %>
                             <tr>
-                              <td class="container-breakdown-sublevel-td-element"></i><span class="table-breakdown-element"><%= descendant_budget_line.name %></span></td>
+                              <td class="container-breakdown-sublevel-td-element"><span class="table-breakdown-element"><%= descendant_budget_line.name %></span></td>
                               <td class="container-breakdown-sublevel-td-element align-right" class="qty"><%= percentage_fraction_format(descendant_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                               <td class="container-breakdown-sublevel-td-element" class="amount"><%= format_currency(descendant_budget_line.amount) %></td>
                             </tr>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -215,12 +215,28 @@
 
           <h2><%= t('.budget_lines_distribution') %></h2>
           <% if @budget_line_composition.any? %>
-            <table>
+            <table class="table-breakdown">
               <% @budget_line_composition.each do |budget_line| %>
                 <tr>
-                  <td><%= link_to truncate(budget_line.name, length: 75), gobierto_budgets_budget_line_path(budget_line.to_param), title: budget_line.name %></td>
+                  <td><i class="fas fa-angle-right"></i><span class="table-breakdown-element"><%= budget_line.name %></span>
+                  </td>
                   <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                   <td class="amount"><%= format_currency(budget_line.amount) %></td>
+                </tr>
+                <tr class="container-breakdown-sublevel">
+                  <td class="container-breakdown-sublevel-td" colspan="3">
+                    <div>
+                      <table>
+                        <% @budget_line_composition.each do |budget_line| %>
+                          <tr>
+                            <td class="container-breakdown-sublevel-td-element"></i><span class="table-breakdown-element"><%= budget_line.name %></span></td>
+                            <td class="container-breakdown-sublevel-td-element align-right" class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
+                            <td class="container-breakdown-sublevel-td-element" class="amount"><%= format_currency(budget_line.amount) %></td>
+                          </tr>
+                        <% end %>
+                      </table>
+                    </div>
+                  </td>
                 </tr>
               <% end %>
             </table>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -214,25 +214,27 @@
           <% end %>
 
           <h2><%= t('.budget_lines_distribution') %></h2>
-          <% if @budget_line_composition.any? %>
+          <% if @budget_line_composition.any? && @budget_line_composition[:root].present? %>
             <table class="table-breakdown">
-              <% @budget_line_composition.each do |budget_line| %>
+              <% @budget_line_composition[:root].each do |root_budget_line| %>
                 <tr>
-                  <td><i class="fas fa-angle-right"></i><span class="table-breakdown-element"><%= budget_line.name %></span>
+                  <td><i class="fas fa-angle-right"></i><span class="table-breakdown-element"><%= root_budget_line.name %></span>
                   </td>
-                  <td class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
-                  <td class="amount"><%= format_currency(budget_line.amount) %></td>
+                  <td class="qty"><%= percentage_fraction_format(root_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
+                  <td class="amount"><%= format_currency(root_budget_line.amount) %></td>
                 </tr>
                 <tr class="container-breakdown-sublevel">
                   <td class="container-breakdown-sublevel-td" colspan="3">
                     <div>
                       <table>
-                        <% @budget_line_composition.each do |budget_line| %>
-                          <tr>
-                            <td class="container-breakdown-sublevel-td-element"></i><span class="table-breakdown-element"><%= budget_line.name %></span></td>
-                            <td class="container-breakdown-sublevel-td-element align-right" class="qty"><%= percentage_fraction_format(budget_line.percentage_compared_with(@budget_line.amount)) %></td>
-                            <td class="container-breakdown-sublevel-td-element" class="amount"><%= format_currency(budget_line.amount) %></td>
-                          </tr>
+                        <% if @budget_line_composition[root_budget_line.code].present? %>
+                          <% @budget_line_composition[root_budget_line.code].each do |descendant_budget_line| %>
+                            <tr>
+                              <td class="container-breakdown-sublevel-td-element"></i><span class="table-breakdown-element"><%= descendant_budget_line.name %></span></td>
+                              <td class="container-breakdown-sublevel-td-element align-right" class="qty"><%= percentage_fraction_format(descendant_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
+                              <td class="container-breakdown-sublevel-td-element" class="amount"><%= format_currency(descendant_budget_line.amount) %></td>
+                            </tr>
+                          <% end %>
                         <% end %>
                       </table>
                     </div>


### PR DESCRIPTION
Closes PopulateTools/issues#1277
Related to PopulateTools/gobierto_budgets_data#117

## :v: What does this PR do?

Displays the breakdown of functional-economic and custom-economic, showing the values at the first economic level and the values at the last level

## :mag: How should this be manually tested?

Visit some examples

https://cortegada.gobify.net/presupuestos/partidas/13/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/15/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/22/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/2/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/1/2010/functional/G

## :eyes: Screenshots

### Before this PR

![Screenshot from 2021-10-14 18-49-51](https://user-images.githubusercontent.com/446459/137361893-f2612b40-d126-4f54-a8a8-bae6d0a7945a.png)



### After this PR

![Screenshot from 2021-10-14 18-43-35](https://user-images.githubusercontent.com/446459/137361927-8aeda5cd-3f99-4833-8694-eac71538e2b3.png)




## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
