### PR TITLE
CMS doesn't load frontend resources

### DIFF
--- a/app/views/gobierto_cms/pages/meta_welcome.html.erb
+++ b/app/views/gobierto_cms/pages/meta_welcome.html.erb
@@ -2,5 +2,13 @@
   <% title(@page.title) %>
   <% description(truncate(strip_tags(@page.body), length: 100)) %>
 
+  <% content_for :javascript_module_link do %>
+    <%= javascript_packs_with_chunks_tag 'cms', 'data-turbolinks-track': true %>
+  <% end %>
+
+  <% content_for :stylesheet_module_link do %>
+    <%= stylesheet_packs_with_chunks_tag 'cms' %>
+  <% end %>
+
   <%= render @page.template %>
 <% end %>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1374

## :v: What does this PR do?
Gobierto CMS doesn't load the usual `layouts/application.html.erb`. Instead, it renders `pages/meta_controller.html.erb` due to https://github.com/PopulateTools/gobierto/blob/master/app/controllers/meta_welcome_controller.rb#L33. As a consequence the frontend resources (js & css) were ignored in the DOM loading workflow.

This PR adds the resources in the `meta_controller.html.erb`

Test url: https://getafe.gobify.net/
