### PR TITLE
Gobierto Data / Add a new type for date

### DIFF
--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -38,12 +38,6 @@ module GobiertoData
           sql: "select (to_date(nullif(trim($1), '#null_value'), '#date_format'));",
           optional_params: { date_format: "YYY-MM-DD", null_value: "" }
         },
-        datetime: {
-          input_type: "text",
-          output_type: "timestamp",
-          sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format'));",
-          optional_params: { date_format: "YYY-MM-DD HH24:MI:SS", null_value: "" }
-        },
         time: {
           input_type: "text",
           output_type: "time",
@@ -54,13 +48,13 @@ module GobiertoData
           input_type: "text",
           output_type: "timestamp",
           sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format')::timestamp without time zone);",
-          optional_params: { date_format: "YYY-MM-DD", null_value: "" }
+          optional_params: { date_format: "YYY-MM-DD HH24:MI:SS", null_value: "" }
         },
         timestamptz: {
           input_type: "text",
           output_type: "timestamptz",
           sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format'));",
-          optional_params: { date_format: "YYY-MM-DD", null_value: "" }
+          optional_params: { date_format: "YYY-MM-DD HH24:MI:SS", null_value: "" }
         },
         boolean: {
           input_type: "text",

--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -38,6 +38,12 @@ module GobiertoData
           sql: "select (to_date(nullif(trim($1), '#null_value'), '#date_format'));",
           optional_params: { date_format: "YYY-MM-DD", null_value: "" }
         },
+        datetime: {
+          input_type: "text",
+          output_type: "timestamp",
+          sql: "select (to_timestamp(nullif(trim($1), '#null_value'), '#date_format'));",
+          optional_params: { date_format: "YYY-MM-DD HH24:MI:SS", null_value: "" }
+        },
         time: {
           input_type: "text",
           output_type: "time",


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1375


## :v: What does this PR do?

Create a new type called datetime for dates containing HH:MM:SS.

Caveats: Perspective transforms the hours incorrectly, depending on the month add one or two more hours.

related https://github.com/finos/perspective/issues/1252


## :mag: How should this be manually tested?



## :eyes: Screenshots

**Dataset loaded with `type: timestamp`**

![type_timestamp](https://user-images.githubusercontent.com/2649175/137938037-52dfbf0d-4dfc-46fc-8f4f-fd89c7081e3c.png)

**Dataset loaded with `type: string`**

![type_string](https://user-images.githubusercontent.com/2649175/137938049-9aa080ff-bfff-4d77-9e27-1f50f9f2ae88.png)

**Dataset loaded with the new `type: datetime`**

![type_datetime](https://user-images.githubusercontent.com/2649175/137938051-8744bed7-7949-4d92-9401-971e27569a66.png)



## :book: Does this PR require updating the documentation?

Yes, changes submitted. [datasets csv schema](https://gobierto.readme.io/docs/datasets-csv-schema)
