### PR TITLE
Include plan preview_token in API requests

### DIFF
--- a/app/javascript/gobierto_plans/webapp/Main.vue
+++ b/app/javascript/gobierto_plans/webapp/Main.vue
@@ -71,6 +71,9 @@ export default {
           name: routes.DASHBOARDS
         }
       ].filter(Boolean);
+    },
+    previewToken() {
+      return this.$root?.$data?.previewToken;
     }
   },
   async created() {
@@ -79,9 +82,9 @@ export default {
       { data: { data: projects } = {} } = {},
       { data: { data: meta } = {} } = {}
     ] = await Promise.all([
-      this.getPlan(this.planId),
-      this.getProjects(this.planId),
-      this.getMeta(this.planId)
+      this.getPlan(this.planId, { preview_token: this.previewToken }),
+      this.getProjects(this.planId, { preview_token: this.previewToken }),
+      this.getMeta(this.planId, { preview_token: this.previewToken })
     ]);
 
     const {

--- a/app/views/gobierto_plans/plan_types/show.html.erb
+++ b/app/views/gobierto_plans/plan_types/show.html.erb
@@ -39,7 +39,8 @@
       data-plan-id="<%= @plan.id %>"
       data-context="<%= @plan.context %>"
       data-pipe="<%= @plan.data_pipe %>"
-      data-dashboards="<%= dashboards_enabled? %>">
+      data-dashboards="<%= dashboards_enabled? %>"
+      data-preview-token="<%= params[:preview_token] %>">
     </div>
   <% end %>
 

--- a/test/integration/gobierto_plans/plans/plan_show_test.rb
+++ b/test/integration/gobierto_plans/plans/plan_show_test.rb
@@ -11,6 +11,14 @@ module GobiertoPlans
       plan.touch
     end
 
+    def admin
+      @admin ||= gobierto_admin_admins(:tony)
+    end
+
+    def admin_token
+      @admin_token ||= admin.preview_token
+    end
+
     def site
       @site ||= sites(:madrid)
     end
@@ -67,6 +75,34 @@ module GobiertoPlans
 
     def test_plan
       with(site: site, js: true) do
+        visit @path
+
+        assert has_content? "Strategic Plan introduction"
+
+        within "div.header-detail" do
+          assert has_content? "#{axes.count} axes"
+          assert has_content? "1 line of action"
+          assert has_content? "#{actions.count} actions"
+          assert has_content? "#{projects.published.count} project"
+        end
+
+        within "section.level_0" do
+          assert has_selector?("div.node-root", count: axes.count)
+
+          axes.each_with_index do |axe, index|
+            assert has_content?(axe.name.to_s)
+          end
+        end
+
+        assert has_content? "Strategic Plan footer"
+      end
+    end
+
+    def test_preview_draft_plan
+      with(site: site, js: true, admin: admin) do
+        plan.draft!
+        @path = gobierto_plans_plan_path(slug: plan_type.slug, year: plan.year, preview_token: admin_token)
+
         visit @path
 
         assert has_content? "Strategic Plan introduction"


### PR DESCRIPTION
Closes #3962


## :v: What does this PR do?

* Adds the preview token to the requests sent to the API previewing a plan
* Adds an integration test

## :mag: How should this be manually tested?

From admin edit a plan and set draft visibility level. Use the link from the table of plans to preview the plan in front. The plan should appear

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No