### PR TITLE
Load resources outside the cache

### DIFF
--- a/app/views/gobierto_cms/pages/meta_welcome.html.erb
+++ b/app/views/gobierto_cms/pages/meta_welcome.html.erb
@@ -1,14 +1,14 @@
+<% content_for :javascript_module_link do %>
+  <%= javascript_packs_with_chunks_tag 'cms', 'data-turbolinks-track': true %>
+<% end %>
+
+<% content_for :stylesheet_module_link do %>
+  <%= stylesheet_packs_with_chunks_tag 'cms' %>
+<% end %>
+
 <% cache(["gobierto_cms/pages/meta_welcome", current_site, I18n.locale]) do %>
   <% title(@page.title) %>
   <% description(truncate(strip_tags(@page.body), length: 100)) %>
-
-  <% content_for :javascript_module_link do %>
-    <%= javascript_packs_with_chunks_tag 'cms', 'data-turbolinks-track': true %>
-  <% end %>
-
-  <% content_for :stylesheet_module_link do %>
-    <%= stylesheet_packs_with_chunks_tag 'cms' %>
-  <% end %>
 
   <%= render @page.template %>
 <% end %>


### PR DESCRIPTION
Fixes https://github.com/PopulateTools/gobierto/pull/3966

## :v: What does this PR do?

Resources should be loaded outside the cache block, otherwise they were only loaded when the cache wasn't set.