### PR TITLE
Restore budgets activities

### DIFF
--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -3,6 +3,7 @@
 Rails.application.config.to_prepare do
   Subscribers::AdminActivity.attach_to("activities/admins")
   Subscribers::AdminGroupActivity.attach_to("activities/admins")
+  Subscribers::GobiertoBudgetsActivity.attach_to("activities/gobierto_budgets")
   Subscribers::CensusActivity.attach_to("activities/census")
   Subscribers::GobiertoPeopleActivity.attach_to("trackable")
   Subscribers::GobiertoCalendarsActivity.attach_to("trackable")


### PR DESCRIPTION
Fixes a bug after #3912


## :v: What does this PR do?

Restores the subscriber of budgets activity, it was removed in the budgets consultation removal and it wasn't updated the  budgets updated date:

![Screenshot 2021-10-21 at 05 29 43](https://user-images.githubusercontent.com/17616/138206666-ae8486cb-ce8a-48fc-9dc8-89d9508e4026.png)

## :mag: How should this be manually tested?

Activity is now updated

