### PR TITLE
Fix year in elaboration

### DIFF
--- a/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/_data_block.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="highlight-proposal">
-    <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
+    <p><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data) %></p>
   </div>
 
   <div class="pure-g metric_boxes">
@@ -120,7 +120,7 @@
           <th><span style="display:none" aria-hidden="true">WCAG 2.0 AA</span></th>
           <th><span style="display:none" aria-hidden="true">WCAG 2.0 AA</span></th>
           <th class="highlight-proposal" colspan="4">
-            <p class="left"><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: Date.current.year) %></p>
+            <p class="left"><span>&#9632;</span><%= t('gobierto_budgets.budgets_elaboration.index.next_year_proposal', year: GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data) %></p>
           </th>
         </tr>
         <tr>


### PR DESCRIPTION
## :v: What does this PR do?

Don't know why but we were not using the correct method to display the year in the elaboration page.

## :mag: How should this be manually tested?

In a site with elaboration enabled, check:

![Screenshot 2021-10-21 at 06 02 56](https://user-images.githubusercontent.com/17616/138209488-d573a1ad-406b-4aa2-9a42-236ca8e782a8.png)

