### PR TITLE
Return false on separator_check when CSV can't detect more than one column

### DIFF
--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -83,7 +83,8 @@ namespace :gobierto_budgets do
     end
 
     def separator_check(filename, separator)
-      CSV.read(filename, col_sep: separator).map(&:size).uniq.size == 1
+      columns_counts = CSV.read(filename, col_sep: separator).map(&:size).uniq
+      columns_counts.size == 1 && columns_counts.first > 1
     end
 
   end


### PR DESCRIPTION
Related to PopulateTools/issues#1379

## :v: What does this PR do?

Avoids to set as valid separator a character when the result of parsing the file with it returns only a column in the task to import budget lines from a CSV

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No