### PR TITLE
Add dependency to access GobiertoBudgets::Category from task

### DIFF
--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+
 namespace :gobierto_budgets do
   namespace :data do
     desc "Import budgets from CSV with gobierto_budgets_data format"
     task :import_gobierto_budgets_data, [:csv_path] => :environment do |_t, args|
+      require "gobierto_budgets/category"
 
       # Import budgets
       csv_path = args[:csv_path]


### PR DESCRIPTION
## :v: What does this PR do?

Adds a dependency to have `GobiertoBudgets::Category` model available

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No