### PR TITLE
Extract csv separator detector to lib and use it for categories and invoices

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,6 @@ require "googleauth"
 require "google/api_client/client_secrets"
 require "googleauth/stores/file_token_store"
 require_relative "../lib/middlewares/override_welcome_action"
-require_relative "../lib/utils/csv_utils"
 
 Bundler.require(*Rails.groups)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ require "googleauth"
 require "google/api_client/client_secrets"
 require "googleauth/stores/file_token_store"
 require_relative "../lib/middlewares/override_welcome_action"
+require_relative "../lib/utils/csv_utils"
 
 Bundler.require(*Rails.groups)
 

--- a/lib/tasks/gobierto_budgets/custom_categories.rake
+++ b/lib/tasks/gobierto_budgets/custom_categories.rake
@@ -19,7 +19,8 @@ namespace :gobierto_budgets do
         exit(-1)
       end
 
-      importer = GobiertoBudgetsData::GobiertoBudgets::CustomCategoriesCsvImporter.new(CSV.read(csv_path, headers: true), site: site)
+      csv_data = CSV.read(csv_path, col_sep: Utils::CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
+      importer = GobiertoBudgetsData::GobiertoBudgets::CustomCategoriesCsvImporter.new(csv_data, site: site)
 
       nitems = importer.import!
       puts "[SUCCESS] Imported #{nitems}"

--- a/lib/tasks/gobierto_budgets/custom_categories.rake
+++ b/lib/tasks/gobierto_budgets/custom_categories.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "#{Rails.root}/lib/utils/csv_utils"
+
 namespace :gobierto_budgets do
   namespace :custom_categories do
     desc "Import custom categories from CSV with gobierto_budgets_data format. Site domain is required"
@@ -19,7 +21,7 @@ namespace :gobierto_budgets do
         exit(-1)
       end
 
-      csv_data = CSV.read(csv_path, col_sep: Utils::CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
+      csv_data = CSV.read(csv_path, col_sep: CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
       importer = GobiertoBudgetsData::GobiertoBudgets::CustomCategoriesCsvImporter.new(csv_data, site: site)
 
       nitems = importer.import!

--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 namespace :gobierto_budgets do
   namespace :data do
     desc "Import budgets from CSV with gobierto_budgets_data format"
@@ -14,7 +13,7 @@ namespace :gobierto_budgets do
         exit(-1)
       end
 
-      csv_data = CSV.read(csv_path, col_sep: detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
+      csv_data = CSV.read(csv_path, col_sep: Utils::CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
       importer = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesCsvImporter.new(csv_data)
 
       organization_ids = importer.csv.map { |row| row.field("organization_id") }.uniq
@@ -74,19 +73,6 @@ namespace :gobierto_budgets do
       # Expire Rails cache
       Rails.cache.clear
       puts "[SUCCESS] Expired Rails cache"
-    end
-
-    def detect_separator(filename)
-      %w( , ; ).each do |separator|
-        return separator if separator_check(filename, separator)
-      end
-
-      raise "No separator found for #{filename}"
-    end
-
-    def separator_check(filename, separator)
-      columns_counts = CSV.read(filename, col_sep: separator).map(&:size).uniq
-      columns_counts.size == 1 && columns_counts.first > 1
     end
 
   end

--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "#{Rails.root}/lib/utils/csv_utils"
+
 namespace :gobierto_budgets do
   namespace :data do
     desc "Import budgets from CSV with gobierto_budgets_data format"
@@ -13,7 +15,7 @@ namespace :gobierto_budgets do
         exit(-1)
       end
 
-      csv_data = CSV.read(csv_path, col_sep: Utils::CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
+      csv_data = CSV.read(csv_path, col_sep: CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
       importer = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesCsvImporter.new(csv_data)
 
       organization_ids = importer.csv.map { |row| row.field("organization_id") }.uniq

--- a/lib/tasks/gobierto_budgets/data/invoices.rake
+++ b/lib/tasks/gobierto_budgets/data/invoices.rake
@@ -4,7 +4,6 @@ namespace :gobierto_budgets do
   namespace :data do
     desc "Import invoices from CSV with gobierto_budgets_data format"
     task :import_gobierto_invoices_data, [:csv_path, :organization_id] => :environment do |_t, args|
-
       # Import invoices
       csv_path = args[:csv_path]
       unless File.file?(csv_path)
@@ -15,7 +14,8 @@ namespace :gobierto_budgets do
       organization_id = args[:organization_id]
       opts = organization_id.present? ? { organization_id: organization_id } : {}
 
-      importer = GobiertoBudgetsData::GobiertoBudgets::InvoicesCsvImporter.new(CSV.read(csv_path, headers: true), **opts)
+      csv_data = CSV.read(csv_path, col_sep: Utils::CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
+      importer = GobiertoBudgetsData::GobiertoBudgets::InvoicesCsvImporter.new(csv_data, **opts)
 
       organization_ids = importer.rows.map(&:organization_id).uniq.compact
       sites = Site.where(organization_id: organization_ids)

--- a/lib/tasks/gobierto_budgets/data/invoices.rake
+++ b/lib/tasks/gobierto_budgets/data/invoices.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "#{Rails.root}/lib/utils/csv_utils"
+
 namespace :gobierto_budgets do
   namespace :data do
     desc "Import invoices from CSV with gobierto_budgets_data format"
@@ -14,7 +16,7 @@ namespace :gobierto_budgets do
       organization_id = args[:organization_id]
       opts = organization_id.present? ? { organization_id: organization_id } : {}
 
-      csv_data = CSV.read(csv_path, col_sep: Utils::CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
+      csv_data = CSV.read(csv_path, col_sep: CsvUtils.detect_separator(csv_path), headers: true, header_converters: [lambda { |header| header.downcase }])
       importer = GobiertoBudgetsData::GobiertoBudgets::InvoicesCsvImporter.new(csv_data, **opts)
 
       organization_ids = importer.rows.map(&:organization_id).uniq.compact

--- a/lib/utils/csv_utils.rb
+++ b/lib/utils/csv_utils.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
-module Utils
-  class CsvUtils
-    def self.detect_separator(filename)
-      %w( , ; ).each do |separator|
-        return separator if separator_check(filename, separator)
-      end
-
-      raise "No separator found for #{filename}"
+class CsvUtils
+  def self.detect_separator(filename)
+    %w( , ; ).each do |separator|
+      return separator if separator_check(filename, separator)
     end
 
-    def self.separator_check(filename, separator)
-      columns_counts = CSV.read(filename, col_sep: separator).map(&:size).uniq
-      columns_counts.size == 1 && columns_counts.first > 1
-    end
+    raise "No separator found for #{filename}"
+  end
+
+  def self.separator_check(filename, separator)
+    columns_counts = CSV.read(filename, col_sep: separator).map(&:size).uniq
+    columns_counts.size == 1 && columns_counts.first > 1
   end
 end

--- a/lib/utils/csv_utils.rb
+++ b/lib/utils/csv_utils.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Utils
+  class CsvUtils
+    def self.detect_separator(filename)
+      %w( , ; ).each do |separator|
+        return separator if separator_check(filename, separator)
+      end
+
+      raise "No separator found for #{filename}"
+    end
+
+    def self.separator_check(filename, separator)
+      columns_counts = CSV.read(filename, col_sep: separator).map(&:size).uniq
+      columns_counts.size == 1 && columns_counts.first > 1
+    end
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

This PR make categories and invoices import resilient to other separators than comma (i.e ;) by automatically detecting it.

## :mag: How should this be manually tested?

Import in staging a CSV of categories that uses ; to separate cells.
