### PR TITLE
Hide counters

### DIFF
--- a/app/assets/stylesheets/module-plans.scss
+++ b/app/assets/stylesheets/module-plans.scss
@@ -298,11 +298,13 @@ $nodeLevel1HeightMobile: 20vh;
           font-size: $f3;
         }
 
-        h3.counter {
-          &::before {
-            counter-increment: section;
-            content: counter(section) ". ";
-          }
+        .counter::before {
+          counter-increment: section;
+          content: counter(section) ". ";
+        }
+
+        .counter.hide-counter::before {
+          display: none;
         }
 
         span {

--- a/app/javascript/gobierto_plans/webapp/components/NodeRoot.vue
+++ b/app/javascript/gobierto_plans/webapp/components/NodeRoot.vue
@@ -16,7 +16,10 @@
           :style="{ width: progressWidth }"
         />
         <div class="info-content">
-          <h3 class="counter">
+          <h3
+            class="counter"
+            :class="{ 'hide-counter': hideCounter }"
+          >
             {{ title }}
           </h3>
           <span>{{ progress | percent }}</span>
@@ -63,11 +66,12 @@ export default {
   },
   created() {
     const { attributes: { name } = {}, progress } = this.model
-    const { logo } = this.options
+    const { logo, hideCounter } = this.options
 
     this.image = logo
     this.progress = progress
     this.title = name
+    this.hideCounter = hideCounter
   },
   methods: {
     open() {

--- a/app/javascript/gobierto_plans/webapp/components/SectionZero.vue
+++ b/app/javascript/gobierto_plans/webapp/components/SectionZero.vue
@@ -11,7 +11,7 @@
           { 'is-root-open': rootid === index }
         ]"
         :model="model"
-        :options="rootOptions[index] || {}"
+        :options="{ ...rootOptions[index] || {}, hideCounter }"
         :style="`--category: var(--category-${(index % json.length) + 1})`"
         @open-menu-mobile="openMenu = !openMenu"
       />
@@ -45,12 +45,14 @@ export default {
   data() {
     return {
       openMenu: false,
+      hideCounter: false,
       rootOptions: {}
     };
   },
   created() {
     const { options } = PlansStore.state
     this.rootOptions = options["level0_options"] || {};
+    this.hideCounter = options["hide_level0_counters"]
   }
 };
 </script>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1398

## :v: What does this PR do?
Hide the counters if the backoffice option is enabled

Test: https://badia.gobify.net/planes/pam-2023/2020

## Screenshots

Before
![imagen](https://user-images.githubusercontent.com/817526/139462163-e86e7ee2-b768-4115-ae9b-ec8237b49d0e.png)

After
![imagen](https://user-images.githubusercontent.com/817526/139462209-ab1e79e5-bcee-4517-955f-ee3337ffefb3.png)
