### PR TITLE
Recover documents section on CMS pages

### DIFF
--- a/app/views/gobierto_cms/pages/templates/_page.html.erb
+++ b/app/views/gobierto_cms/pages/templates/_page.html.erb
@@ -27,6 +27,22 @@
 
             <%== render_liquid(@page.body) %>
 
+            <% if @page.attachments.any? %>
+              <div class="page_attachments">
+                <h3><%= t(".documents") %></h3>
+                <% @page.attachments.each do |attachment| %>
+                  <div class="file">
+                    <%= link_to attachment.human_readable_path do %>
+                      <div class="icon"><%= filetype_icon(attachment) %></div>
+                      <h4><%= attachment.name %></h4>
+                      <div class="meta">
+                        <%= attachment.extension.upcase %> · <%= number_to_human_size(attachment.file_size, precision: 2, separator: ",") %> · <%= attachment.file_name %>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           </article>
 
         </div>

--- a/config/locales/gobierto_cms/views/ca.yml
+++ b/config/locales/gobierto_cms/views/ca.yml
@@ -9,3 +9,7 @@ ca:
       gobierto_cms_section_item_created: Pàgina afegida a una secció
       gobierto_cms_section_item_deleted: Pàgina esborrada de secció
       gobierto_cms_section_updated: Secció actualitzada
+    pages:
+      templates:
+        page:
+          documents: Documents

--- a/config/locales/gobierto_cms/views/en.yml
+++ b/config/locales/gobierto_cms/views/en.yml
@@ -9,3 +9,7 @@ en:
       gobierto_cms_section_item_created: Page added to section
       gobierto_cms_section_item_deleted: Page deleted from section
       gobierto_cms_section_updated: Section updated
+    pages:
+      templates:
+        page:
+          documents: Documents

--- a/config/locales/gobierto_cms/views/es.yml
+++ b/config/locales/gobierto_cms/views/es.yml
@@ -9,3 +9,7 @@ es:
       gobierto_cms_section_item_created: Página añadida a sección
       gobierto_cms_section_item_deleted: Página borrada de sección
       gobierto_cms_section_updated: Sección actualizada
+    pages:
+      templates:
+        page:
+          documents: Documentos


### PR DESCRIPTION
Closes PopulateTools/issues#1385


## :v: What does this PR do?

Recovers an attachments sections removed in a recent PR

## :mag: How should this be manually tested?

Visit a CMS page with attachments, a section of documents should appear


## :eyes: Screenshots

### Before this PR

![Screenshot from 2021-11-02 18-17-21](https://user-images.githubusercontent.com/446459/139913854-c1292df1-8f3f-42de-90d3-29c203169d5a.png)


### After this PR

![Screenshot from 2021-11-02 17-42-01](https://user-images.githubusercontent.com/446459/139913678-62fbb6fd-52d2-48bc-ac9a-21df3b88f12a.png)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
