### PR TITLE
Gobierto Data / Fix the permalink of the visualizations

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
+++ b/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
@@ -3,7 +3,7 @@
     v-if="publicVisualizations && publicVisualizations.length"
     class="gobierto-data-visualization--grid"
   >
-    <template v-for="{ items, config, name, id, slug, datasetName } in publicVisualizations">
+    <template v-for="{ items, config, columns, name, id, slug, datasetName } in publicVisualizations">
       <router-link
         :key="id"
         :to="`/datos/${slug}/v/${id}`"
@@ -16,7 +16,7 @@
           <Visualizations
             v-if="items"
             :items="items"
-            :object-columns="config.columns"
+            :object-columns="columns"
             :config="config"
           />
           <router-link

--- a/app/javascript/gobierto_data/webapp/pages/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Visualizations.vue
@@ -45,10 +45,14 @@ export default {
     return {
       publicVisualizations: [],
       isLoading: true,
-      labelVisualizations: I18n.t("gobierto_data.projects.visualizations") || ""
+      labelVisualizations: I18n.t("gobierto_data.projects.visualizations") || "",
+      listDatasets: []
     };
   },
-  created() {
+  async created() {
+    //Get all the datasets to extract the slug of those that have visualizations.
+    const { data: { data } } = await this.getDatasets();
+    this.listDatasets = data
     this.getDataVizs();
   },
   methods: {
@@ -69,6 +73,7 @@ export default {
         const {
           attributes: {
             query_id,
+            dataset_id,
             user_id,
             sql = "",
             spec = {},
@@ -86,8 +91,14 @@ export default {
           );
         }
 
+        //Filter by id to get the slug and the columns.
+        const [{ attributes: { columns, slug: slugDataset } }] = this.listDatasets.filter(({ id }) => id == dataset_id)
+
         return {
           config: spec,
+          dataset_id,
+          columns,
+          slug: slugDataset,
           name,
           privacy_status,
           query_id,


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1411


## :v: What does this PR do?

Fix the permalink of the vizualizations. For the permalink we need to get the slug of the datasets that have visualizations in the page.

## :mag: How should this be manually tested?

[Staging](https://getafe.gobify.net/datos/v/visualizaciones)

## :eyes: Screenshots

### After this PR

![after-vizzs](https://user-images.githubusercontent.com/2649175/141483162-6b4a3f74-28b1-44c4-adae-c9301495b6e2.gif)
