### PR TITLE
Reload site datasets relation before calculating cache key

### DIFF
--- a/test/models/gobierto_data/cache_test.rb
+++ b/test/models/gobierto_data/cache_test.rb
@@ -27,5 +27,13 @@ module GobiertoData
       last_modified_new = GobiertoData::Cache.last_modified(site)
       refute_equal last_modified_old, last_modified_new
     end
+
+    def test_current_site_datasets_cache_key_updated_when_dataset_updated
+      old_key = GobiertoData::Cache.current_site_datasets_cache_key(site)
+      dataset.touch
+      new_key = GobiertoData::Cache.current_site_datasets_cache_key(site)
+
+      refute_equal old_key, new_key
+    end
   end
 end


### PR DESCRIPTION
Closes #3999 

## :v: What does this PR do?

This PR ensures the relation `site.datasets` is fresh when the cache key is calculated. In consequence, when a dataset is updated, the API calls return fresh results instead of cached results.

## :mag: How should this be manually tested?

You need to create a dataset reading other dataset data (i.e our workflow to load contracts from a customer). Steps:

- load the contracts using an api call and check the cache has been generated in disk
- run the ETL to load the dataset (this ETL should use the previous query)
- verify the loaded ETL doesn't have the result of the old cached query but a new one