### PR TITLE
Add bigint type to GobiertoData datasets

### DIFF
--- a/app/queries/gobierto_data/sql_function/transformation.rb
+++ b/app/queries/gobierto_data/sql_function/transformation.rb
@@ -14,6 +14,12 @@ module GobiertoData
           sql: "select (nullif(trim($1), '#null_value')::integer);",
           optional_params: { null_value: "" }
         },
+        bigint: {
+          input_type: "text",
+          output_type: "bigint",
+          sql: "select (nullif(trim($1), '#null_value')::bigint);",
+          optional_params: { null_value: "" }
+        },
         numeric: {
           input_type: "text",
           output_type: "numeric",

--- a/test/fixtures/files/gobierto_data/dataset1.csv
+++ b/test/fixtures/files/gobierto_data/dataset1.csv
@@ -1,5 +1,5 @@
-integer_column,decimal_column,text_column,date_column
-1,3.1416,Dog,2020-01-01
-2,2.7183,Cat,2019-01-01
-3,1.4142,Horse,2019-12-31
-4,10,Some words,2000-01-01
+integer_column,decimal_column,text_column,date_column,bigint_column
+1,3.1416,Dog,2020-01-01,9359742486783681
+2,2.7183,Cat,2019-01-01,9359742486783682
+3,1.4142,Horse,2019-12-31,9359742486783683
+4,10,Some words,2000-01-01,9359742486783684

--- a/test/fixtures/files/gobierto_data/invalid_type_schema.json
+++ b/test/fixtures/files/gobierto_data/invalid_type_schema.json
@@ -2,5 +2,6 @@
   "integer_column":{"type":"invent"},
   "decimal_column":{"type":"numeric"},
   "text_column":{"type":"text"},
-  "date_column":{"type":"date"}
+  "date_column":{"type":"date"},
+  "bigint_column":{"type":"bigint"}
 }

--- a/test/fixtures/files/gobierto_data/malformed_schema.json
+++ b/test/fixtures/files/gobierto_data/malformed_schema.json
@@ -2,5 +2,6 @@
   "integer_column":{"type":"integer"}
   "decimal_column":{"type":"numeric"},
   "text_column":{"type":"text"},
-  "date_column":{"type":"date"}
+  "date_column":{"type":"date"},
+  "bigint_column":{"type":"bigint"}
 ccº}

--- a/test/fixtures/files/gobierto_data/schema.json
+++ b/test/fixtures/files/gobierto_data/schema.json
@@ -2,5 +2,6 @@
   "integer_column":{"type":"integer"},
   "decimal_column":{"type":"numeric"},
   "text_column":{"type":"text"},
-  "date_column":{"type":"date"}
+  "date_column":{"type":"date"},
+  "bigint_column":{"type":"bigint"}
 }

--- a/test/fixtures/files/gobierto_data/schema_rename_columns.json
+++ b/test/fixtures/files/gobierto_data/schema_rename_columns.json
@@ -2,5 +2,6 @@
   "integer_column_changed":{"original_name":"integer_column", "type":"integer"},
   "decimal_column_changed":{"original_name":"decimal_column", "type":"numeric"},
   "text_column_changed":{"original_name":"text_column", "type":"text"},
-  "date_column_changed":{"original_name":"date_column", "type":"date"}
+  "date_column_changed":{"original_name":"date_column", "type":"date"},
+  "bigint_column_changed":{"original_name":"bigint_column", "type":"bigint"}
 }


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1418

## :v: What does this PR do?

- Adds the type bigint 

## :mag: How should this be manually tested?

Load a dataset with bigint numbers, it shouldn't fail with:

```
PG::NumericValueOutOfRange (ERROR:  value "xxxxxxxxx" is out of range for type integer)
```

## :book: Does this PR require updating the documentation?

Yes: https://gobierto.readme.io/docs/datasets-csv-schema
