### PR TITLE
1277 breakdown functional economic

### DIFF
--- a/app/javascript/gobierto_budgets/modules/application.js
+++ b/app/javascript/gobierto_budgets/modules/application.js
@@ -209,7 +209,7 @@ $(document).on("turbolinks:load", function() {
     html: true
   });
 
-  $(".table-breakdown-element").click(function() {
+  $(".table-breakdown-element-caret").click(function() {
     $('.table-breakdown-element').not(this).closest('tr').removeClass('show-sublevel')
     $(this).closest('tr').toggleClass('show-sublevel')
   });

--- a/app/presenters/gobierto_budgets/budget_line_presenter.rb
+++ b/app/presenters/gobierto_budgets/budget_line_presenter.rb
@@ -172,7 +172,7 @@ module GobiertoBudgets
         id: code,
         year: year,
         kind: kind,
-        area_name: area_name
+        area_name: area.area_name
       }
     end
 

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -222,7 +222,7 @@
                   <td>
                     <span class="<%= "table-breakdown-element" if has_subitems %>">
                       <% if has_subitems %>
-                        <i class="fas fa-angle-right"></i>
+                        <i class="fas fa-angle-right table-breakdown-element-caret"></i>
                       <% end %>
                       <%= link_to truncate(root_budget_line.name, length: 75), gobierto_budgets_budget_line_path(root_budget_line.to_param), title: root_budget_line.name %>
                     </span>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -224,7 +224,7 @@
                       <% if has_subitems %>
                         <i class="fas fa-angle-right"></i>
                       <% end %>
-                      <%= root_budget_line.name %>
+                      <%= link_to truncate(root_budget_line.name, length: 75), gobierto_budgets_budget_line_path(root_budget_line.to_param), title: root_budget_line.name %>
                     </span>
                   </td>
                   <td class="qty"><%= percentage_fraction_format(root_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
@@ -237,7 +237,11 @@
                         <table>
                           <% @budget_line_composition[root_budget_line.code].each do |descendant_budget_line| %>
                             <tr>
-                              <td class="container-breakdown-sublevel-td-element"><span class="table-breakdown-element"><%= descendant_budget_line.name %></span></td>
+                              <td class="container-breakdown-sublevel-td-element">
+                                <span class="table-breakdown-element">
+                                  <%= link_to truncate(descendant_budget_line.name, length: 75), gobierto_budgets_budget_line_path(descendant_budget_line.to_param), title: descendant_budget_line.name %>
+                                </span>
+                              </td>
                               <td class="container-breakdown-sublevel-td-element align-right" class="qty"><%= percentage_fraction_format(descendant_budget_line.percentage_compared_with(@budget_line.amount)) %></td>
                               <td class="container-breakdown-sublevel-td-element" class="amount right"><%= format_currency(descendant_budget_line.amount) %></td>
                             </tr>


### PR DESCRIPTION
Related to #3963


## :v: What does this PR do?

* Fixes the generation of links of budget lines in the economic-functional and economic-custom areas
* Adds a link to the lines in the distribution

## :mag: How should this be manually tested?
Visit https://getafe.gobify.net/presupuestos/partidas/320/2020/functional/G. The lines of the distribution should be linked

## :eyes: Screenshots

### Before this PR

![Screenshot from 2021-11-15 12-52-48](https://user-images.githubusercontent.com/446459/141778232-a58fa2b0-da1f-4e54-8774-bcc660d60b3b.png)

### After this PR

![Screenshot from 2021-11-15 12-57-22](https://user-images.githubusercontent.com/446459/141778257-796f3c58-c03a-4e40-91aa-3e7309723146.png)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No