### PR TITLE
Remove the loose option for babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -41,12 +41,7 @@ module.exports = function(api) {
       '@babel/plugin-syntax-dynamic-import',
       isTestEnv && 'babel-plugin-dynamic-import-node',
       '@babel/plugin-transform-destructuring',
-      [
-        '@babel/plugin-proposal-class-properties',
-        {
-          loose: true
-        }
-      ],
+      '@babel/plugin-proposal-class-properties'
       [
         '@babel/plugin-proposal-object-rest-spread',
         {
@@ -66,7 +61,7 @@ module.exports = function(api) {
         {
           async: false
         }
-      ]
+      ],
     ].filter(Boolean)
   }
 }


### PR DESCRIPTION
Closes #4002

## :v: What does this PR do?
Some babel/plugins must have the same configuration options each other. Restore the original behaviour instead omitting the warnings