### PR TITLE
Gobierto Data / Transform visualizations into images

### DIFF
--- a/app/javascript/gobierto_data/lib/commons.js
+++ b/app/javascript/gobierto_data/lib/commons.js
@@ -1,3 +1,5 @@
+import * as htmlToImage from 'html-to-image';
+
 export const baseUrl = `${location.origin}/api/v1/data`
 
 //TODO: extract handleOutsideClick outside directive
@@ -168,3 +170,45 @@ export const sqlKeywords = [
   }
 ]
 
+export const convertVizToImgMixin = {
+  methods: {
+    data() {
+      return {
+        labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
+        labelDashboard: I18n.t('gobierto_data.projects.dashboards') || "",
+        labelSavedVisualization: I18n.t("gobierto_data.projects.savedVisualization") || "",
+        labelModifiedVizualition: I18n.t("gobierto_data.projects.modifiedVisualization") || "",
+        labelQuery: I18n.t("gobierto_data.projects.query") || "",
+        items: null,
+        config: {},
+        vizSaveID: null,
+        queryID: '',
+        queryName: '',
+        user: null,
+        queryViz: '',
+        isVizElementSavingVisible: false,
+        name: '',
+        isQuerySavingPromptVisible: false,
+        saveLoader: false,
+        configMapZoom: { ...this.configMap, zoom: true },
+        imageApi: null
+      }
+    },
+    convertVizToImg(opts) {
+      let node = document.querySelector('.gobierto-data-visualization--aspect-ratio-16-9');
+      const perspectiveChart = document.querySelector("perspective-viewer").shadowRoot
+      const perspectiveSidePanel = perspectiveChart.getElementById("side_panel")
+      const perspectiveTopPanel = perspectiveChart.getElementById("top_panel")
+      perspectiveSidePanel.style.display = "none"
+      perspectiveTopPanel.style.display = "none"
+      htmlToImage.toPng(node)
+        .then(function (dataUrl) {
+          this.imageApi = dataUrl
+          this.onSaveEventHandler(opts)
+        }.bind(this))
+        .catch(function (error) {
+          console.error('oops, something went wrong!', error);
+        });
+    }
+  }
+}

--- a/app/javascript/gobierto_data/lib/commons.js
+++ b/app/javascript/gobierto_data/lib/commons.js
@@ -174,23 +174,6 @@ export const convertVizToImgMixin = {
   methods: {
     data() {
       return {
-        labelVisualize: I18n.t('gobierto_data.projects.visualize') || "",
-        labelDashboard: I18n.t('gobierto_data.projects.dashboards') || "",
-        labelSavedVisualization: I18n.t("gobierto_data.projects.savedVisualization") || "",
-        labelModifiedVizualition: I18n.t("gobierto_data.projects.modifiedVisualization") || "",
-        labelQuery: I18n.t("gobierto_data.projects.query") || "",
-        items: null,
-        config: {},
-        vizSaveID: null,
-        queryID: '',
-        queryName: '',
-        user: null,
-        queryViz: '',
-        isVizElementSavingVisible: false,
-        name: '',
-        isQuerySavingPromptVisible: false,
-        saveLoader: false,
-        configMapZoom: { ...this.configMap, zoom: true },
         imageApi: null
       }
     },
@@ -203,6 +186,7 @@ export const convertVizToImgMixin = {
       perspectiveTopPanel.style.display = "none"
       htmlToImage.toPng(node)
         .then(function (dataUrl) {
+          this.saveLoader = true
           this.imageApi = dataUrl
           this.onSaveEventHandler(opts)
         }.bind(this))

--- a/app/javascript/gobierto_data/lib/commons.js
+++ b/app/javascript/gobierto_data/lib/commons.js
@@ -174,25 +174,20 @@ export const convertVizToImgMixin = {
   methods: {
     data() {
       return {
-        imageApi: null
+        imageApi: null,
+        saveLoader: false
       }
     },
-    convertVizToImg(opts) {
-      let node = document.querySelector('.gobierto-data-visualization--aspect-ratio-16-9');
-      const perspectiveChart = document.querySelector("perspective-viewer").shadowRoot
-      const perspectiveSidePanel = perspectiveChart.getElementById("side_panel")
-      const perspectiveTopPanel = perspectiveChart.getElementById("top_panel")
-      perspectiveSidePanel.style.display = "none"
-      perspectiveTopPanel.style.display = "none"
+    convertVizToImg(node, cb) {
       htmlToImage.toPng(node)
         .then(function (dataUrl) {
           this.saveLoader = true
           this.imageApi = dataUrl
-          this.onSaveEventHandler(opts)
+          cb()
         }.bind(this))
         .catch(function (error) {
           console.error('oops, something went wrong!', error);
         });
-    }
+    },
   }
 }

--- a/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
+++ b/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
@@ -3,7 +3,7 @@
     v-if="publicVisualizations && publicVisualizations.length"
     class="gobierto-data-visualization--grid"
   >
-    <template v-for="{ items, config, columns, name, id, slug, datasetName } in publicVisualizations">
+    <template v-for="{ config, name, id, slug, nameDataset } in publicVisualizations">
       <router-link
         :key="id"
         :to="`/datos/${slug}/v/${id}`"
@@ -22,7 +22,7 @@
             class="gobierto-data-visualizations-name"
           >
             <h4 class="gobierto-data-visualization--dataset">
-              {{ datasetName }}
+              {{ nameDataset }}
             </h4>
           </router-link>
         </CardVisualization>

--- a/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
+++ b/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
@@ -13,12 +13,7 @@
           <template v-slot:title>
             {{ name }}
           </template>
-          <Visualizations
-            v-if="items"
-            :items="items"
-            :object-columns="columns"
-            :config="config"
-          />
+          <img :src="config.base64">
           <router-link
             :to="`/datos/${slug}/`"
             class="gobierto-data-visualizations-name"
@@ -33,12 +28,10 @@
   </div>
 </template>
 <script>
-import Visualizations from "./../commons/Visualizations.vue";
 import CardVisualization from "./../../layouts/CardVisualization.vue";
 export default {
   name: "VisualizationsGrid",
   components: {
-    Visualizations,
     CardVisualization
   },
   props: {

--- a/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
+++ b/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
@@ -3,7 +3,7 @@
     v-if="publicVisualizations && publicVisualizations.length"
     class="gobierto-data-visualization--grid"
   >
-    <template v-for="{ config, name, id, slug, nameDataset } in publicVisualizations">
+    <template v-for="{ config, name, id, slug, datasetName, items, columns } in publicVisualizations">
       <router-link
         :key="id"
         :to="`/datos/${slug}/v/${id}`"
@@ -13,16 +13,26 @@
           <template v-slot:title>
             {{ name }}
           </template>
-          <img
-            class="gobierto-data-visualization--image"
-            :src="config.base64"
-          >
+          <template v-if="config.base64">
+            <img
+              class="gobierto-data-visualization--image"
+              :src="config.base64"
+            >
+          </template>
+          <template v-else>
+            <Visualizations
+              v-if="items"
+              :items="items"
+              :object-columns="columns"
+              :config="config"
+            />
+          </template>
           <router-link
             :to="`/datos/${slug}/`"
             class="gobierto-data-visualizations-name"
           >
             <h4 class="gobierto-data-visualization--dataset">
-              {{ nameDataset }}
+              {{ datasetName }}
             </h4>
           </router-link>
         </CardVisualization>
@@ -31,11 +41,13 @@
   </div>
 </template>
 <script>
+import Visualizations from "./../commons/Visualizations.vue";
 import CardVisualization from "./../../layouts/CardVisualization.vue";
 export default {
   name: "VisualizationsGrid",
   components: {
-    CardVisualization
+    CardVisualization,
+    Visualizations
   },
   props: {
     publicVisualizations: {

--- a/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
+++ b/app/javascript/gobierto_data/webapp/components/landingviz/VisualizationsGrid.vue
@@ -13,7 +13,10 @@
           <template v-slot:title>
             {{ name }}
           </template>
-          <img :src="config.base64">
+          <img
+            class="gobierto-data-visualization--image"
+            :src="config.base64"
+          >
           <router-link
             :to="`/datos/${slug}/`"
             class="gobierto-data-visualizations-name"

--- a/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
@@ -62,13 +62,8 @@
         </h2>
       </template>
       <div class="gobierto-data-visualization--aspect-ratio-16-9">
-        <Visualizations
-          v-if="showMap"
-          :items="items"
-          :config="config"
-          :object-columns="objectColumns"
-          :config-map="configMap"
-        />
+        <!-- Add styles to fit image -->
+        <img :src="config.base64">
       </div>
     </Dropdown>
 
@@ -142,7 +137,6 @@
 
 <script>
 import VisualizationsTab from "./VisualizationsTab.vue";
-import Visualizations from "./../commons/Visualizations.vue";
 import Resources from "./../commons/Resources.vue";
 import Info from "./../commons/Info.vue";
 import Queries from "./../commons/Queries.vue";
@@ -168,7 +162,6 @@ export default {
     Description,
     VisualizationsTab,
     SkeletonSpinner,
-    Visualizations,
     DownloadLink
   },
   filters: {

--- a/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
@@ -62,10 +62,13 @@
         </h2>
       </template>
       <div class="gobierto-data-visualization--aspect-ratio-16-9">
-        <img
-          class="gobierto-data-visualization--image"
-          :src="config.base64"
-        >
+        <Visualizations
+          v-if="showMap"
+          :items="items"
+          :config="config"
+          :object-columns="objectColumns"
+          :config-map="configMap"
+        />
       </div>
     </Dropdown>
 
@@ -139,6 +142,7 @@
 
 <script>
 import VisualizationsTab from "./VisualizationsTab.vue";
+import Visualizations from "./../commons/Visualizations.vue";
 import Resources from "./../commons/Resources.vue";
 import Info from "./../commons/Info.vue";
 import Queries from "./../commons/Queries.vue";
@@ -164,6 +168,7 @@ export default {
     Description,
     VisualizationsTab,
     SkeletonSpinner,
+    Visualizations,
     DownloadLink
   },
   filters: {

--- a/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
@@ -62,8 +62,10 @@
         </h2>
       </template>
       <div class="gobierto-data-visualization--aspect-ratio-16-9">
-        <!-- Add styles to fit image -->
-        <img :src="config.base64">
+        <img
+          class="gobierto-data-visualization--image"
+          :src="config.base64"
+        >
       </div>
     </Dropdown>
 

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
@@ -248,7 +248,6 @@ export default {
   },
   methods: {
     onSaveEventHandler(opts) {
-      this.saveLoader = true
       //Add visualization ID to opts object, we need it to update a viz saved
       opts.vizID = Number(this.vizSaveID)
       opts.user = Number(this.user)

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
@@ -23,7 +23,7 @@
           :show-private-viz="showPrivateViz"
           :show-label-edit="showLabelEdit"
           :reset-private="resetPrivate"
-          @save="convertVizToImg"
+          @save="convertVizHandler"
           @keyDownInput="updateVizName"
           @handlerFork="handlerForkViz"
           @isPrivateChecked="isPrivateChecked"
@@ -44,7 +44,10 @@
         </router-link>
       </div>
     </div>
-    <div class="gobierto-data-visualization--aspect-ratio-16-9">
+    <div
+      ref="visualization-container"
+      class="gobierto-data-visualization--aspect-ratio-16-9"
+    >
       <template v-if="saveLoader">
         <Loading />
       </template>
@@ -193,8 +196,7 @@ export default {
       name: '',
       isQuerySavingPromptVisible: false,
       saveLoader: false,
-      configMapZoom: { ...this.configMap, zoom: true },
-      imageApi: null
+      configMapZoom: { ...this.configMap, zoom: true }
     }
   },
   computed: {
@@ -247,6 +249,13 @@ export default {
     this.$root.$emit('showSavingDialogEventViz', false)
   },
   methods: {
+    convertVizHandler(opts) {
+      const perspectiveSidePanel = this.$refs.viewer.$el.shadowRoot.getElementById("side_panel")
+      const perspectiveTopPanel = this.$refs.viewer.$el.shadowRoot.getElementById("top_panel")
+      perspectiveSidePanel.style.display = "none"
+      perspectiveTopPanel.style.display = "none"
+      this.convertVizToImg(this.$refs["visualization-container"], () => this.onSaveEventHandler(opts))
+    },
     onSaveEventHandler(opts) {
       //Add visualization ID to opts object, we need it to update a viz saved
       opts.vizID = Number(this.vizSaveID)

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsItem.vue
@@ -70,7 +70,7 @@ import { Loading } from "lib/vue/components";
 import Visualizations from "./../commons/Visualizations.vue";
 import SavingDialog from "./../commons/SavingDialog.vue";
 import { getUserId } from "./../../../lib/helpers";
-import * as htmlToImage from 'html-to-image';
+import { convertVizToImgMixin } from "./../../../lib/commons.js";
 
 export default {
   name: "VisualizationsItem",
@@ -79,6 +79,7 @@ export default {
     SavingDialog,
     Loading
   },
+  mixins: [convertVizToImgMixin],
   props: {
     datasetId: {
       type: Number,
@@ -270,22 +271,7 @@ export default {
       }
     },
     //TODO: Extract to common.js
-    convertVizToImg(opts) {
-      let node = document.querySelector('.gobierto-data-visualization--aspect-ratio-16-9');
-      const perspectiveChart = document.querySelector("perspective-viewer").shadowRoot
-      const perspectiveSidePanel = perspectiveChart.getElementById("side_panel")
-      const perspectiveTopPanel = perspectiveChart.getElementById("top_panel")
-      perspectiveSidePanel.style.display = "none"
-      perspectiveTopPanel.style.display = "none"
-      htmlToImage.toPng(node)
-        .then(function (dataUrl) {
-          this.imageApi = dataUrl
-          this.onSaveEventHandler(opts)
-        }.bind(this))
-        .catch(function (error) {
-          console.error('oops, something went wrong!', error);
-        });
-    },
+
     updateVizName(value) {
       const {
         name: vizName

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
@@ -16,7 +16,7 @@
           </template>
           <template v-else>
             <template v-if="privateVisualizations.length">
-              <template v-for="{ items, config, name, privacy_status, id, user_id } in privateVisualizations">
+              <template v-for="{ config: { base64 }, name, privacy_status, id, user_id } in privateVisualizations">
                 <div
                   :key="id"
                   class="gobierto-data-visualization--container"
@@ -32,7 +32,7 @@
                       </template>
                       <img
                         class="gobierto-data-visualization--image"
-                        :src="config.base64"
+                        :src="base64"
                       >
                     </CardVisualization>
                   </router-link>
@@ -71,7 +71,7 @@
 
       <div class="gobierto-data-visualization--grid">
         <template v-if="publicVisualizations.length">
-          <template v-for="{ items, config, name, id, user_id } in publicVisualizations">
+          <template v-for="{ config: { base64 }, name, id, user_id } in publicVisualizations">
             <div :key="id">
               <router-link
                 :to="`/datos/${$route.params.id}/v/${id}`"
@@ -84,7 +84,7 @@
                   </template>
                   <img
                     class="gobierto-data-visualization--image"
-                    :src="config.base64"
+                    :src="base64"
                   >
                 </CardVisualization>
               </router-link>
@@ -164,21 +164,14 @@ export default {
   watch: {
     isPrivateVizLoading(newValue) {
       if (!newValue) {
-        this.removeAllIcons()
         this.deleteAndReload = false
       }
-    },
-    isPublicVizLoading(newValue) {
-      if (!newValue) this.removeAllIcons()
     },
     privateVisualizations(newValue, oldValue) {
       if (newValue !== oldValue) {
         this.deleteAndReload = false
       }
     }
-  },
-  mounted() {
-    this.removeAllIcons()
   },
   methods: {
     loadViz(vizName, user) {
@@ -195,17 +188,6 @@ export default {
       const answerDelete = confirm(this.labelDeleteViz);
       if (answerDelete) {
         this.$emit('emitDelete', id)
-      }
-    },
-    removeAllIcons() {
-      /*Method to remove the config icon for all visualizations, we need to wait to load both lists when they are loaded, we select alls visualizations, and iterate over them with a loop to remove every icon.*/
-      if (!this.isPrivateVizLoading && !this.isPublicVizLoading) {
-        this.$nextTick(() => {
-          let vizList = document.querySelectorAll("perspective-viewer");
-          for (let index = 0; index < vizList.length; index++) {
-            vizList[index].shadowRoot.querySelector("div#config_button").style.display = "none";
-          }
-        })
       }
     }
   }

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
@@ -16,7 +16,7 @@
           </template>
           <template v-else>
             <template v-if="privateVisualizations.length">
-              <template v-for="{ config: { base64 }, name, privacy_status, id, user_id } in privateVisualizations">
+              <template v-for="{ config, items, name, privacy_status, id, user_id } in privateVisualizations">
                 <div
                   :key="id"
                   class="gobierto-data-visualization--container"
@@ -30,10 +30,20 @@
                       <template v-slot:title>
                         {{ name }}
                       </template>
-                      <img
-                        class="gobierto-data-visualization--image"
-                        :src="base64"
-                      >
+                      <template v-if="config.base64">
+                        <img
+                          class="gobierto-data-visualization--image"
+                          :src="config.base64"
+                        >
+                      </template>
+                      <template v-else>
+                        <Visualizations
+                          :items="items"
+                          :config="config"
+                          :object-columns="objectColumns"
+                          :config-map="configMap"
+                        />
+                      </template>
                     </CardVisualization>
                   </router-link>
                   <div class="gobierto-data-visualization--icons">
@@ -68,10 +78,9 @@
           </template>
         </h3>
       </template>
-
       <div class="gobierto-data-visualization--grid">
         <template v-if="publicVisualizations.length">
-          <template v-for="{ config: { base64 }, name, id, user_id } in publicVisualizations">
+          <template v-for="{ config, items, name, id, user_id } in publicVisualizations">
             <div :key="id">
               <router-link
                 :to="`/datos/${$route.params.id}/v/${id}`"
@@ -82,10 +91,20 @@
                   <template v-slot:title>
                     {{ name }}
                   </template>
-                  <img
-                    class="gobierto-data-visualization--image"
-                    :src="base64"
-                  >
+                  <template v-if="config.base64">
+                    <img
+                      class="gobierto-data-visualization--image"
+                      :src="config.base64"
+                    >
+                  </template>
+                  <template v-else>
+                    <Visualizations
+                      :items="items"
+                      :config="config"
+                      :object-columns="objectColumns"
+                      :config-map="configMap"
+                    />
+                  </template>
                 </CardVisualization>
               </router-link>
             </div>
@@ -102,6 +121,7 @@
 <script>
 import { Loading, Dropdown } from "lib/vue/components";
 import Caret from "./../commons/Caret.vue";
+import Visualizations from "./../commons/Visualizations.vue";
 import PrivateIcon from './../commons/PrivateIcon.vue';
 import { getUserId } from "./../../../lib/helpers";
 import CardVisualization from "./../../layouts/CardVisualization.vue";
@@ -110,6 +130,7 @@ import CardVisualization from "./../../layouts/CardVisualization.vue";
 export default {
   name: "VisualizationsList",
   components: {
+    Visualizations,
     PrivateIcon,
     Dropdown,
     Caret,

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
@@ -30,12 +30,8 @@
                       <template v-slot:title>
                         {{ name }}
                       </template>
-                      <Visualizations
-                        :items="items"
-                        :config="config"
-                        :object-columns="objectColumns"
-                        :config-map="configMap"
-                      />
+                      <!-- Add styles to fit image -->
+                      <img :src="config.base64">
                     </CardVisualization>
                   </router-link>
                   <div class="gobierto-data-visualization--icons">
@@ -84,12 +80,8 @@
                   <template v-slot:title>
                     {{ name }}
                   </template>
-                  <Visualizations
-                    :items="items"
-                    :config="config"
-                    :object-columns="objectColumns"
-                    :config-map="configMap"
-                  />
+                  <!-- Add styles to fit image -->
+                  <img :src="config.base64">
                 </CardVisualization>
               </router-link>
             </div>
@@ -106,15 +98,14 @@
 <script>
 import { Loading, Dropdown } from "lib/vue/components";
 import Caret from "./../commons/Caret.vue";
-import Visualizations from "./../commons/Visualizations.vue";
 import PrivateIcon from './../commons/PrivateIcon.vue';
 import { getUserId } from "./../../../lib/helpers";
 import CardVisualization from "./../../layouts/CardVisualization.vue";
 
+
 export default {
   name: "VisualizationsList",
   components: {
-    Visualizations,
     PrivateIcon,
     Dropdown,
     Caret,

--- a/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/VisualizationsList.vue
@@ -30,8 +30,10 @@
                       <template v-slot:title>
                         {{ name }}
                       </template>
-                      <!-- Add styles to fit image -->
-                      <img :src="config.base64">
+                      <img
+                        class="gobierto-data-visualization--image"
+                        :src="config.base64"
+                      >
                     </CardVisualization>
                   </router-link>
                   <div class="gobierto-data-visualization--icons">
@@ -80,8 +82,10 @@
                   <template v-slot:title>
                     {{ name }}
                   </template>
-                  <!-- Add styles to fit image -->
-                  <img :src="config.base64">
+                  <img
+                    class="gobierto-data-visualization--image"
+                    :src="config.base64"
+                  >
                 </CardVisualization>
               </router-link>
             </div>

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -95,7 +95,7 @@ import DownloadButton from "./../../commons/DownloadButton.vue";
 import DownloadLink from "./../../commons/DownloadLink.vue";
 import SavingDialog from "./../../commons/SavingDialog.vue";
 import Visualizations from "./../../commons/Visualizations.vue";
-import * as htmlToImage from 'html-to-image';
+import { convertVizToImgMixin } from "./../../../../lib/commons.js";
 
 export default {
   name: "SQLEditorResults",
@@ -106,6 +106,7 @@ export default {
     SavingDialog,
     DownloadLink
   },
+  mixins: [convertVizToImgMixin],
   props: {
     arrayFormats: {
       type: Object,
@@ -182,8 +183,7 @@ export default {
       removeLabelBtn: false,
       perspectiveChanged: false,
       config: null,
-      configMapZoom: { ...this.configMap, zoom: true },
-      imageApi: null
+      configMapZoom: { ...this.configMap, zoom: true }
     };
   },
   computed: {
@@ -216,26 +216,6 @@ export default {
       const config = this.$refs.viewer.getConfig()
       config.base64 = this.imageApi
       this.$root.$emit("storeCurrentVisualization", config, opts);
-    },
-    //TODO: Extract to common.js
-    convertVizToImg(opts) {
-      let node = document.querySelector('.gobierto-data-visualization--aspect-ratio-16-9');
-      const perspectiveChart = document.querySelector("perspective-viewer").shadowRoot
-      //Hide the top filters and the left sidebar
-      const perspectiveSidePanel = perspectiveChart.getElementById("side_panel")
-      const perspectiveTopPanel = perspectiveChart.getElementById("top_panel")
-      perspectiveSidePanel.style.display = "none"
-      perspectiveTopPanel.style.display = "none"
-      htmlToImage.toPng(node)
-        .then(function (dataUrl) {
-          this.imageApi = dataUrl
-          this.onSaveEventHandler(opts)
-          perspectiveSidePanel.style.display = "flex"
-          perspectiveTopPanel.style.display = "flex"
-        }.bind(this))
-        .catch(function (error) {
-          console.error('oops, something went wrong!', error);
-        });
     },
     updateVizNameHandler(value) {
       const {

--- a/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/data/SQLEditorResults.vue
@@ -34,7 +34,7 @@
           :enabled-viz-saved-button="enabledVizSavedButton"
           :show-private-public-icon-viz="showPrivatePublicIconViz"
           :registration-disabled="registrationDisabled"
-          @save="convertVizToImg"
+          @save="convertVizHandler"
           @keyDownInput="updateVizNameHandler"
           @isPrivateChecked="isPrivateChecked"
         />
@@ -74,7 +74,10 @@
       </transition>
     </div>
 
-    <div class="gobierto-data-visualization--aspect-ratio-16-9">
+    <div
+      ref="visualization-container"
+      class="gobierto-data-visualization--aspect-ratio-16-9"
+    >
       <Visualizations
         v-if="items"
         ref="viewer"
@@ -183,6 +186,7 @@ export default {
       removeLabelBtn: false,
       perspectiveChanged: false,
       config: null,
+      saveLoader: false,
       configMapZoom: { ...this.configMap, zoom: true }
     };
   },
@@ -211,6 +215,13 @@ export default {
     }
   },
   methods: {
+    convertVizHandler(opts) {
+      const perspectiveSidePanel = this.$refs.viewer.$el.shadowRoot.getElementById("side_panel")
+      const perspectiveTopPanel = this.$refs.viewer.$el.shadowRoot.getElementById("top_panel")
+      perspectiveSidePanel.style.display = "none"
+      perspectiveTopPanel.style.display = "none"
+      this.convertVizToImg(this.$refs["visualization-container"], () => this.onSaveEventHandler(opts))
+    },
     onSaveEventHandler(opts) {
       // get children configuration
       const config = this.$refs.viewer.getConfig()

--- a/app/javascript/gobierto_data/webapp/pages/Visualizations.vue
+++ b/app/javascript/gobierto_data/webapp/pages/Visualizations.vue
@@ -77,13 +77,14 @@ export default {
         } = x;
 
         //Filter by id to get the slug and the columns.
-        const [{ attributes: { slug: slugDataset } }] = this.listDatasets.filter(({ id }) => id == dataset_id)
+        const [{ attributes: { slug: slugDataset, name: nameDataset } }] = this.listDatasets.filter(({ id }) => id == dataset_id)
 
         return {
           config: spec,
           dataset_id,
           slug: slugDataset,
           name,
+          nameDataset,
           id
         };
       });

--- a/app/javascript/stylesheets/gobierto-data.scss
+++ b/app/javascript/stylesheets/gobierto-data.scss
@@ -24,6 +24,7 @@
   --transition: .1s ease-in;
   --shadow: 0 2px 20px rgba(0, 0, 0, .3);
   --grey-dataset: rgba(51, 51, 51, .5);
+  --grey-text: #666;
 }
 
 .gobierto-data {
@@ -94,7 +95,7 @@
   &-tab-sidebar--tab {
     font-style: normal;
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
     cursor: pointer;
     width: 100%;
     display: inline-block;
@@ -131,7 +132,6 @@
     letter-spacing: 0;
 
     &-big {
-      font-size: 24px;
       margin-bottom: 0;
     }
   }
@@ -210,10 +210,19 @@
     box-sizing: border-box;
   }
 
+  &-summary-body {
+    background: #f5f5f5;
+  }
+
   &-summary-header-description {
     margin-top: 0;
+    padding-right: 2rem;
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
+    line-height: 1.45;
+    p {
+      margin: .25rem 0;
+    }
   }
 
   &-summary-header-description-link {
@@ -221,15 +230,10 @@
     cursor: pointer;
   }
 
-  &-summary-header-container {
-    margin: .5rem 0;
-  }
-
   &-summary-header-container-text,
   &-summary-header-container-label,
   &-summary-header-container-text-link {
-    font-size: 1rem;
-    color: #666;
+    color: var(--grey-text);
     display: inline-block;
   }
 
@@ -238,8 +242,9 @@
   }
 
   &-summary-header-container-label {
-    width: 110px;
+    width: 100px;
     color: rgba(102, 102, 102, .5);
+    font-weight: 600;
   }
 
   &-summary-btn-download-data {
@@ -247,6 +252,8 @@
     color: var(--color-base);
     border-radius: 3px;
     padding: 1.5rem;
+    margin: 0;
+    margin-top: .5rem;
     border: 1px solid rgba(1, 120, 168, .2);
   }
 
@@ -274,15 +281,72 @@
     margin-bottom: 1rem;
   }
 
-  &-info-list-element {
-    width: 100%;
-    border: 1px solid rgba(var(--color-base-string), 0.3);
-    border-radius: 3px;
-    padding: 1em 1.25em;
+  &-info-list-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+  }
 
-    &:not(:last-child) {
-      margin-bottom: 2rem;
+  &-info-list-top {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &-info-list-title {
+    min-height: 50px;
+    transition: color .3s ease-in;
+  }
+
+  &-info-list-element {
+    text-decoration: none;
+    background: #fff;
+    border: 1px solid #F5F5F5;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, .1);
+    border-radius: 4px;
+    &:hover {
+      text-decoration: none;
+      .gobierto-data-info-list-title {
+        color: #fff;
+      }
+      .gobierto-data-summary-header {
+        background: var(--color-base);
+      }
+      .gobierto-data-summary-body {
+        background: #fff;
+      }
+      .gobierto-data-summary-header-container-text {
+        color: #fff;
+      }
     }
+    .gobierto-data-summary-header {
+      padding: 1rem 1rem .5rem 1rem;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
+      transition: background .3s ease-in;
+      max-height: 140px;
+      min-height: 140px;
+    }
+
+    .gobierto-data-summary-header-description {
+      padding-right: 0;
+    }
+
+    .gobierto-data-summary-body {
+      padding: .5rem 1rem 1rem 1rem;
+      min-height: 115px;
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      transition: background .3s ease-in;
+      position: relative;
+
+      i {
+        position: absolute;
+        top: 80%;
+        left: 90%;
+        color: var(--color-base);
+      }
+    }
+
   }
 
   &-resources-list-element-name {
@@ -359,26 +423,36 @@
     margin-top: 0;
     font-family: monospace;
     font-size: 12px;
-    color: #666;
+    color: var(--grey-text);
     position: sticky;
     top: 0;
   }
 
   &-btn-download-data {
     border: 1px solid rgba(var(--color-base-string), .2);
-    padding: 1rem;
+    padding: .5rem;
     font-size: 1rem;
     font-family: $font_text;
     font-weight: 600;
     min-width: 250px;
-    margin: 1rem 1rem .5rem .25rem;
+    margin: 0 0 .5rem 0;
     position: relative;
     text-transform: unset;
     vertical-align: top;
   }
 
+  &-summary-header-btns {
+    margin-bottom: 1rem;
+    width: 100%;
+
+    a.gobierto-data-btn-download-data {
+      width: 100%;
+    }
+  }
+
   a.gobierto-data-btn-download-data {
     display: inline-block;
+    box-sizing: border-box;
     background: #fff;
     text-align: center;
     text-decoration: none;
@@ -391,7 +465,7 @@
 
   &-container-btn-download-data {
     position: relative;
-    width: max-content;
+    width: 100%;
     display: inline-flex;
 
     &.arrow-top {
@@ -569,7 +643,7 @@
     background-color: transparent;
     transition: background-color var(--transition);
     padding: .5rem 1rem;
-    color: #000;
+    color: var(--grey-text);
     display: block;
     width: 100%;
     text-decoration: none;
@@ -599,7 +673,7 @@
 
   .CodeMirror-code {
     font-size: 12px;
-    color: #666;
+    color: var(--grey-text);
     font-family: monospace;
   }
 
@@ -725,7 +799,7 @@
 
   &-sql-editor-container-save-label {
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
     padding-right: .5em;
     cursor: pointer;
   }
@@ -743,7 +817,7 @@
   &-sql-editor-modified-label,
   &-sql-editor-modified-event {
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
     opacity: .5;
   }
 
@@ -759,7 +833,7 @@
   &-sql-editor-footer-guide {
     display: inline-block;
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
     opacity: .6;
   }
 
@@ -779,6 +853,10 @@
 
   &-sql-editor-tabs {
     margin-top: 2rem;
+
+    .gobierto-data-container-btn-download-data {
+      width: max-content;
+    }
 
     .gobierto-data-btn-download-data-modal {
       margin-top: 1rem;
@@ -805,7 +883,7 @@
       border: 1px solid rgba(#666, .1);
       border-top: 0;
       font-size: $f7;
-      color: #666;
+      color: var(--grey-text);
 
       thead,
       tr,
@@ -856,7 +934,7 @@
     text-transform: none !important;
     box-sizing: border-box;
     position: relative;
-    color: #666;
+    color: var(--grey-text);
     font-family: monospace;
 
     &:hover,
@@ -948,7 +1026,7 @@
 
   &-summary-queries-container-name {
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
     display: inline-block;
     vertical-align: middle;
     width: 78%;
@@ -962,7 +1040,7 @@
 
   &-visualizations-name {
     font-size: $f7;
-    color: #666;
+    color: var(--grey-text);
     display: inline-block;
     vertical-align: middle;
     width: 100%;
@@ -1054,7 +1132,7 @@
   &-sidebar-datasets-name {
     font-size: $f7;
     cursor: pointer;
-    color: #000;
+    color: var(--grey-text);
     text-decoration: none;
   }
 
@@ -1171,7 +1249,7 @@
     border-radius: 3px;
     min-height: 350px;
     .gobierto-data-visualization--image {
-      height: 90%;
+      height: 80%;
     }
   }
 
@@ -1203,7 +1281,7 @@
   }
 
   &-visualization--image {
-    height: 80%;
+    height: 90%;
     width: 100%;
     object-fit: contain;
   }
@@ -1215,7 +1293,12 @@
   }
 
   &-btn-preview {
-    margin-left: 1.25rem;
+    width: 100%;
+    display: inline-block;
+
+    .gobierto-data-btn-download-data {
+      width: 100%;
+    }
 
     &:hover {
       color: var(--color-base);
@@ -1225,10 +1308,6 @@
   &-columns-icon {
     font-size: 11px;
     opacity: .5;
-  }
-
-  &-summary-header-btns {
-    margin-top: 1.5rem;
   }
 
   &-columns-icon-boolean::before,
@@ -1323,5 +1402,43 @@
   &-summary-visualizations {
     padding: 0 1rem 1rem 1rem;
   }
+
+  &-description-details {
+    margin: .5rem 0;
+  }
+
+  &-description-details-orders:first-of-type,
+  &-description-details-columns {
+    margin-top: 2rem;
+  }
+
+  &-description-summary-title {
+    cursor: pointer;
+    &::marker {
+      color: var(--color-base);
+    }
+  }
+  &-description-summary-grid,
+  &-description-summary-grid-two-columns {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    padding: 0 .25rem;
+  }
+  &-description-summary-grid-two-columns {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  &-description-summary-grid-element {
+    display: grid;
+    grid-template-columns: 75% 1fr;
+    margin-bottom: .125rem;
+  }
+  &-description-summary-grid-element-link {
+    color: var(--color-base);
+  }
+  &-description-summary-grid-element-size {
+    /* TO_DO: Create a var/custom-property */
+    color: #9B9B9B;
+  }
+
 
 }

--- a/app/javascript/stylesheets/gobierto-data.scss
+++ b/app/javascript/stylesheets/gobierto-data.scss
@@ -1199,6 +1199,12 @@
     margin: 0 0 1rem;
   }
 
+  &-visualization--image {
+    height: 90%;
+    width: 100%;
+    object-fit: contain;
+  }
+
   &-description {
     height: auto;
     columns: 3;

--- a/app/javascript/stylesheets/gobierto-data.scss
+++ b/app/javascript/stylesheets/gobierto-data.scss
@@ -24,7 +24,6 @@
   --transition: .1s ease-in;
   --shadow: 0 2px 20px rgba(0, 0, 0, .3);
   --grey-dataset: rgba(51, 51, 51, .5);
-  --grey-text: #666;
 }
 
 .gobierto-data {
@@ -95,7 +94,7 @@
   &-tab-sidebar--tab {
     font-style: normal;
     font-size: $f7;
-    color: var(--grey-text);
+    color: #666;
     cursor: pointer;
     width: 100%;
     display: inline-block;
@@ -132,6 +131,7 @@
     letter-spacing: 0;
 
     &-big {
+      font-size: 24px;
       margin-bottom: 0;
     }
   }
@@ -210,19 +210,10 @@
     box-sizing: border-box;
   }
 
-  &-summary-body {
-    background: #f5f5f5;
-  }
-
   &-summary-header-description {
     margin-top: 0;
-    padding-right: 2rem;
     font-size: $f7;
-    color: var(--grey-text);
-    line-height: 1.45;
-    p {
-      margin: .25rem 0;
-    }
+    color: #666;
   }
 
   &-summary-header-description-link {
@@ -230,10 +221,15 @@
     cursor: pointer;
   }
 
+  &-summary-header-container {
+    margin: .5rem 0;
+  }
+
   &-summary-header-container-text,
   &-summary-header-container-label,
   &-summary-header-container-text-link {
-    color: var(--grey-text);
+    font-size: 1rem;
+    color: #666;
     display: inline-block;
   }
 
@@ -242,9 +238,8 @@
   }
 
   &-summary-header-container-label {
-    width: 100px;
+    width: 110px;
     color: rgba(102, 102, 102, .5);
-    font-weight: 600;
   }
 
   &-summary-btn-download-data {
@@ -252,8 +247,6 @@
     color: var(--color-base);
     border-radius: 3px;
     padding: 1.5rem;
-    margin: 0;
-    margin-top: .5rem;
     border: 1px solid rgba(1, 120, 168, .2);
   }
 
@@ -281,72 +274,15 @@
     margin-bottom: 1rem;
   }
 
-  &-info-list-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 2rem;
-  }
-
-  &-info-list-top {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  &-info-list-title {
-    min-height: 50px;
-    transition: color .3s ease-in;
-  }
-
   &-info-list-element {
-    text-decoration: none;
-    background: #fff;
-    border: 1px solid #F5F5F5;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, .1);
-    border-radius: 4px;
-    &:hover {
-      text-decoration: none;
-      .gobierto-data-info-list-title {
-        color: #fff;
-      }
-      .gobierto-data-summary-header {
-        background: var(--color-base);
-      }
-      .gobierto-data-summary-body {
-        background: #fff;
-      }
-      .gobierto-data-summary-header-container-text {
-        color: #fff;
-      }
-    }
-    .gobierto-data-summary-header {
-      padding: 1rem 1rem .5rem 1rem;
-      border-top-left-radius: 4px;
-      border-top-right-radius: 4px;
-      transition: background .3s ease-in;
-      max-height: 140px;
-      min-height: 140px;
-    }
+    width: 100%;
+    border: 1px solid rgba(var(--color-base-string), 0.3);
+    border-radius: 3px;
+    padding: 1em 1.25em;
 
-    .gobierto-data-summary-header-description {
-      padding-right: 0;
+    &:not(:last-child) {
+      margin-bottom: 2rem;
     }
-
-    .gobierto-data-summary-body {
-      padding: .5rem 1rem 1rem 1rem;
-      min-height: 115px;
-      border-bottom-left-radius: 4px;
-      border-bottom-right-radius: 4px;
-      transition: background .3s ease-in;
-      position: relative;
-
-      i {
-        position: absolute;
-        top: 80%;
-        left: 90%;
-        color: var(--color-base);
-      }
-    }
-
   }
 
   &-resources-list-element-name {
@@ -423,36 +359,26 @@
     margin-top: 0;
     font-family: monospace;
     font-size: 12px;
-    color: var(--grey-text);
+    color: #666;
     position: sticky;
     top: 0;
   }
 
   &-btn-download-data {
     border: 1px solid rgba(var(--color-base-string), .2);
-    padding: .5rem;
+    padding: 1rem;
     font-size: 1rem;
     font-family: $font_text;
     font-weight: 600;
     min-width: 250px;
-    margin: 0 0 .5rem 0;
+    margin: 1rem 1rem .5rem .25rem;
     position: relative;
     text-transform: unset;
     vertical-align: top;
   }
 
-  &-summary-header-btns {
-    margin-bottom: 1rem;
-    width: 100%;
-
-    a.gobierto-data-btn-download-data {
-      width: 100%;
-    }
-  }
-
   a.gobierto-data-btn-download-data {
     display: inline-block;
-    box-sizing: border-box;
     background: #fff;
     text-align: center;
     text-decoration: none;
@@ -465,7 +391,7 @@
 
   &-container-btn-download-data {
     position: relative;
-    width: 100%;
+    width: max-content;
     display: inline-flex;
 
     &.arrow-top {
@@ -643,7 +569,7 @@
     background-color: transparent;
     transition: background-color var(--transition);
     padding: .5rem 1rem;
-    color: var(--grey-text);
+    color: #000;
     display: block;
     width: 100%;
     text-decoration: none;
@@ -673,7 +599,7 @@
 
   .CodeMirror-code {
     font-size: 12px;
-    color: var(--grey-text);
+    color: #666;
     font-family: monospace;
   }
 
@@ -799,7 +725,7 @@
 
   &-sql-editor-container-save-label {
     font-size: $f7;
-    color: var(--grey-text);
+    color: #666;
     padding-right: .5em;
     cursor: pointer;
   }
@@ -817,7 +743,7 @@
   &-sql-editor-modified-label,
   &-sql-editor-modified-event {
     font-size: $f7;
-    color: var(--grey-text);
+    color: #666;
     opacity: .5;
   }
 
@@ -833,7 +759,7 @@
   &-sql-editor-footer-guide {
     display: inline-block;
     font-size: $f7;
-    color: var(--grey-text);
+    color: #666;
     opacity: .6;
   }
 
@@ -853,10 +779,6 @@
 
   &-sql-editor-tabs {
     margin-top: 2rem;
-
-    .gobierto-data-container-btn-download-data {
-      width: max-content;
-    }
 
     .gobierto-data-btn-download-data-modal {
       margin-top: 1rem;
@@ -883,7 +805,7 @@
       border: 1px solid rgba(#666, .1);
       border-top: 0;
       font-size: $f7;
-      color: var(--grey-text);
+      color: #666;
 
       thead,
       tr,
@@ -934,7 +856,7 @@
     text-transform: none !important;
     box-sizing: border-box;
     position: relative;
-    color: var(--grey-text);
+    color: #666;
     font-family: monospace;
 
     &:hover,
@@ -1026,7 +948,7 @@
 
   &-summary-queries-container-name {
     font-size: $f7;
-    color: var(--grey-text);
+    color: #666;
     display: inline-block;
     vertical-align: middle;
     width: 78%;
@@ -1040,7 +962,7 @@
 
   &-visualizations-name {
     font-size: $f7;
-    color: var(--grey-text);
+    color: #666;
     display: inline-block;
     vertical-align: middle;
     width: 100%;
@@ -1132,7 +1054,7 @@
   &-sidebar-datasets-name {
     font-size: $f7;
     cursor: pointer;
-    color: var(--grey-text);
+    color: #000;
     text-decoration: none;
   }
 
@@ -1293,12 +1215,7 @@
   }
 
   &-btn-preview {
-    width: 100%;
-    display: inline-block;
-
-    .gobierto-data-btn-download-data {
-      width: 100%;
-    }
+    margin-left: 1.25rem;
 
     &:hover {
       color: var(--color-base);
@@ -1308,6 +1225,10 @@
   &-columns-icon {
     font-size: 11px;
     opacity: .5;
+  }
+
+  &-summary-header-btns {
+    margin-top: 1.5rem;
   }
 
   &-columns-icon-boolean::before,
@@ -1402,43 +1323,5 @@
   &-summary-visualizations {
     padding: 0 1rem 1rem 1rem;
   }
-
-  &-description-details {
-    margin: .5rem 0;
-  }
-
-  &-description-details-orders:first-of-type,
-  &-description-details-columns {
-    margin-top: 2rem;
-  }
-
-  &-description-summary-title {
-    cursor: pointer;
-    &::marker {
-      color: var(--color-base);
-    }
-  }
-  &-description-summary-grid,
-  &-description-summary-grid-two-columns {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    padding: 0 .25rem;
-  }
-  &-description-summary-grid-two-columns {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  &-description-summary-grid-element {
-    display: grid;
-    grid-template-columns: 75% 1fr;
-    margin-bottom: .125rem;
-  }
-  &-description-summary-grid-element-link {
-    color: var(--color-base);
-  }
-  &-description-summary-grid-element-size {
-    /* TO_DO: Create a var/custom-property */
-    color: #9B9B9B;
-  }
-
 
 }

--- a/app/javascript/stylesheets/gobierto-data.scss
+++ b/app/javascript/stylesheets/gobierto-data.scss
@@ -1170,6 +1170,9 @@
     padding: 16px;
     border-radius: 3px;
     min-height: 350px;
+    .gobierto-data-visualization--image {
+      height: 90%;
+    }
   }
 
   &-visualization--content {
@@ -1200,7 +1203,7 @@
   }
 
   &-visualization--image {
-    height: 90%;
+    height: 80%;
     width: 100%;
     object-fit: contain;
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "fullcalendar": "^3.9.0",
     "geocomplete": "^1.7.0",
     "gobierto-vizzs": "^0.0.5",
+    "html-to-image": "^1.9.0",
     "i18n-js": "^3.0.3",
     "jest": "^27.0.3",
     "jqtree": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6793,6 +6793,11 @@ html-tags@^3.1.0:
   resolved "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
+html-to-image@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.9.0.tgz#cb49bf9f4b37376771c85cfdd65863ae9420b268"
+  integrity sha512-9gaDCIYg62Ek07F2pBk76AHgYZ2gxq2YALU7rK3gNCqXuhu6cWzsOQqM7qGbjZiOzxGzrU1deDqZpAod2NEwbA==
+
 htmlparser2@^3.10.0:
   version "3.10.1"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz"


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1421


## :v: What does this PR do?

- Transform the vizzs into an image only when saved them.
- Store it the image into the API.
- Use the image to show a preview of the vizzs in the listings.
- Remove and reduce code 


## :mag: How should this be manually tested?

- Select a viz from [here](https://getafe.gobify.net/datos/licitaciones/visualizaciones) or another dataset.
- Edit and Save the vizz
- Then go to the [Visualizations Pages](https://getafe.gobify.net/datos/v/visualizaciones), [summary tab](https://getafe.gobify.net/datos/licitaciones/resumen), and [visualizations tab](https://getafe.gobify.net/datos/licitaciones/visualizaciones) to check if the image is shown.

You can also create a viz from the editor and check that the viz image is generated

## :eyes: Screenshots

### After this PR

https://user-images.githubusercontent.com/2649175/144232817-ac4d67e1-fb1e-4d7a-a326-b614e139d6ff.mov