### PR TITLE
Enable custom field records module to CMS pages

### DIFF
--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -17,6 +17,7 @@ module GobiertoCms
     include GobiertoCommon::Sluggable
     include GobiertoCommon::Collectionable
     include GobiertoCommon::Sectionable
+    include GobiertoCommon::HasCustomFieldRecords
 
     multisearchable(
       against: [:title_en, :title_es, :title_ca, :searchable_body],


### PR DESCRIPTION
## :v: What does this PR do?

This PR enables the module `HasCustomFieldRecors` to `GobiertoCms::Page` class. This module should be enabled IMHO because the class is defined to have custom fields.

## :mag: How should this be manually tested?

From now on, an instance of a page should respond to `custom_field_records` relation.
