### PR TITLE
Fix homepage layout when is configured to be a CMS page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ app/javascript/custom_fields_progress_plugin
 app/javascript/packs/custom_fields_progress_plugin.js
 app/javascript/custom_fields_table_plugin
 app/javascript/packs/custom_fields_table_plugin.js
+app/javascript/glovo
+app/javascript/packs/glovo.js
+
 
 # Custom fields plugins
 !vendor/gobierto_engines/custom-fields-*-plugin

--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -30,7 +30,7 @@ class MetaWelcomeController < ApplicationController
 
       @page = GobiertoCms::PageDecorator.new(page)
 
-      render "gobierto_cms/pages/meta_welcome"
+      render "gobierto_cms/pages/meta_welcome", layout: "gobierto_cms/layouts/application"
     end
   end
 end

--- a/app/views/gobierto_data/welcome/index.html.erb
+++ b/app/views/gobierto_data/welcome/index.html.erb
@@ -1,16 +1,14 @@
 <% title t('gobierto_data.layouts.application.gobierto_data') %>
 
 <div class="column">
-    <div class="m_b_2">
+  <div class="m_b_2">
     <div class="container sandbox">
         <div id="gobierto-datos-app"
              data-site-name="<%= @site.name %>"
              data-logo-url="<%= @site.configuration.logo_with_fallback %>"
              data-registration-disabled="<%= @site.configuration.registration_disabled? %>"
              data-home-url="<%= root_url %>">
-
         </div>
     </div>
-    </div>
-
+  </div>
 </div>


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes the layout used by a site configured to use a CMS Page as homepage to be explicitly the layout of the CMS module.

## :mag: How should this be manually tested?

- In a site configured like this, check the picked layout is the one from the cms module
- Check you can redefine the layout of the cms in an engine and it works

