### PR TITLE
Render collection items in collection index

### DIFF
--- a/app/controllers/gobierto_cms/pages_controller.rb
+++ b/app/controllers/gobierto_cms/pages_controller.rb
@@ -8,20 +8,23 @@ module GobiertoCms
     def index
       @collection = find_collection
 
-      check_collection_type
+      @collection_items = current_site.
+        pages.
+        where(id: @collection.pages_in_collection).
+        page(params[:page]).
+        active.
+        order(published_on: :desc)
     end
 
     def show
       @page = find_page
       @section_item = find_section_item if @section
-
-      check_collection_type
     end
 
     protected
 
     def find_collection
-      current_site.collections.find_by!(slug: params[:id])
+      current_site.collections.find_by!(slug: params[:id], item_type: "GobiertoCms::Page")
     end
 
     def load_section
@@ -51,10 +54,6 @@ module GobiertoCms
       if @collection
         @pages = current_site.pages.where(id: @collection.pages_in_collection).active
       end
-    end
-
-    def check_collection_type
-      render_404 and return false if @collection.item_type != "GobiertoCms::Page"
     end
 
     def processes_scope

--- a/app/helpers/gobierto_cms/page_helper.rb
+++ b/app/helpers/gobierto_cms/page_helper.rb
@@ -3,6 +3,29 @@
 module GobiertoCms
   module PageHelper
 
+    def last_collection_items(collection_slug, limit = 3)
+      @last_collection_items ||= begin
+                                   collection = current_site.collections.find_by!(slug: collection_slug, item_type: "GobiertoCms::Page")
+
+                                   current_site.
+                                     pages.
+                                     where(id: collection.pages_in_collection).
+                                     limit(limit).
+                                     active.
+                                     order(published_on: :desc)
+                                 end
+    end
+
+    def collection_item_custom_field_value(collection_item, custom_field_uid)
+      if custom_field = current_site.custom_fields.find_by(uid: custom_field_uid)
+
+       collection_item.
+         custom_field_records.
+         find_by(custom_field: custom_field).
+         value_string
+      end
+    end
+
     # TODO - Refactor
     def section_tree(nodes, viewables)
       html = ["<ul>"]

--- a/test/integration/gobierto_cms/visit_news_collection_test.rb
+++ b/test/integration/gobierto_cms/visit_news_collection_test.rb
@@ -9,7 +9,7 @@ module GobiertoCms
     end
 
     def site_collection
-      @site_collection ||= gobierto_common_collections(:site_news)
+      @site_collection ||= gobierto_common_collections(:site_pages)
     end
 
     def site_collection_pages
@@ -22,7 +22,7 @@ module GobiertoCms
 
     def test_visit_site_collection
       with_current_site(site) do
-        visit gobierto_cms_news_index_path(site_collection.slug)
+        visit gobierto_cms_pages_path(site_collection.slug)
 
         assert has_content?(site_collection.title)
 


### PR DESCRIPTION
## :v: What does this PR do?

This PR improves the Gobierto CMS module in different ways:

- creates a instance variable with the last paginated items of a collection
- refactors a bit the controller to remove a method not very clear to read
- introduces a couple of generic helpers to be able to reuse views in engines

## :mag: How should this be manually tested?

- You should be able to use this instance variable in an engine over a re-defined view
- You should be able to use the new helpers in the engine
