### PR TITLE
Refactor legacy js-dropdown

### DIFF
--- a/app/javascript/gobierto_budgets/index.js
+++ b/app/javascript/gobierto_budgets/index.js
@@ -6,6 +6,7 @@ import "./modules/execution.js";
 import "./modules/indicators_controller.js";
 import "./modules/invoices_controller.js";
 import "./modules/receipt_controller.js";
+import setDropdowns from "./modules/dropdown.js";
 import { checkAndReportAccessibility } from 'lib/shared'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -15,3 +16,5 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
 });
+
+document.addEventListener("turbolinks:load", () => setDropdowns())

--- a/app/javascript/gobierto_budgets/modules/dropdown.js
+++ b/app/javascript/gobierto_budgets/modules/dropdown.js
@@ -1,4 +1,4 @@
-function dropdown({ target }) {
+function dropdown({ currentTarget }) {
   /*
     HOW TO USE JS-DROPDOWN
 
@@ -11,7 +11,7 @@ function dropdown({ target }) {
     - Add 'js-dropdown' class to the trigger (button tag or whatever) and 'hidden' to the contents
   */
 
-  const { dropdown } = target.dataset;
+  const { dropdown } = currentTarget.dataset;
   const content = document.querySelector(`[data-dropdown="${dropdown}"]:not(.js-dropdown)`)
 
   content.classList.toggle("hidden");

--- a/app/javascript/gobierto_budgets/modules/dropdown.js
+++ b/app/javascript/gobierto_budgets/modules/dropdown.js
@@ -1,0 +1,23 @@
+function dropdown({ target }) {
+  /*
+    HOW TO USE JS-DROPDOWN
+
+    <div>
+      <button class="js-dropdown" data-dropdown="NAME"></button>
+      <div class="hidden" data-dropdown="NAME"></div>
+    </div>
+
+    - Notice that NAME property must be equal both trigger and contents
+    - Add 'js-dropdown' class to the trigger (button tag or whatever) and 'hidden' to the contents
+  */
+
+  const { dropdown } = target.dataset;
+  const content = document.querySelector(`[data-dropdown="${dropdown}"]:not(.js-dropdown)`)
+
+  content.classList.toggle("hidden");
+  content.parentElement.style.position = "relative";
+}
+
+export default function () {
+  document.querySelectorAll(".js-dropdown").forEach(element => element.addEventListener("click", dropdown))
+}

--- a/app/javascript/lib/commons/index.js
+++ b/app/javascript/lib/commons/index.js
@@ -22,6 +22,7 @@ import "./modules/module-search";
 import "./modules/module-sessions";
 import "./modules/module-site_header";
 import "./modules/magnific-popup";
+import "./modules/globals.js";
 import "./modules/tabs";
 import "./modules/velocity_settings";
 import "./modules/shareContent";

--- a/app/javascript/lib/commons/modules/globals.js
+++ b/app/javascript/lib/commons/modules/globals.js
@@ -48,30 +48,4 @@ $(document).on("turbolinks:load", function() {
   $("[data-toggle]").click(function() {
     toggleTarget($(this));
   });
-
-  // js-disabled elements
-  $(".js-disabled").click(function(e) {
-    e.preventDefault();
-  });
-
-  // js-dropdown
-  $(".js-dropdown").on("click", function() {
-    /*
-      HOW TO USE JS-DROPDOWN
-
-      <div>
-        <button class="js-dropdown" data-dropdown="NAME"></button>
-        <div class="hidden" data-dropdown="NAME"></div>
-      </div>
-
-      - Notice that NAME property must be equal both trigger and contents
-      - Add 'js-dropdown' class to the trigger (button tag or whatever) and 'hidden' to the contents
-    */
-
-    const dropdownname = $(this).data("dropdown");
-    const $content = $('[data-dropdown="' + dropdownname + '"]:not(.js-dropdown)');
-
-    $content.toggleClass("hidden");
-    $content.parent().css("position", "relative");
-  });
 });

--- a/app/javascript/stylesheets/gobierto-budgets.scss
+++ b/app/javascript/stylesheets/gobierto-budgets.scss
@@ -44,3 +44,4 @@
 @import "comp-tabs";
 @import "comp-timeline";
 @import "comp-content";
+@import "comp-dropdown";


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1461

## :v: What does this PR do?
Fixes a bug where the budget dropdown functionality was missing. Besides:

- remove jquery
- extract it from globals.js
- move to budgets (only used there)
- remove some unused feature

Test url: https://mataro.gobify.net/presupuestos/proveedores-facturas

