### PR TITLE
Take only the first line of CSV to inspect automatic schema loading datasets

### DIFF
--- a/app/queries/gobierto_data/datasets/creation_statements.rb
+++ b/app/queries/gobierto_data/datasets/creation_statements.rb
@@ -115,7 +115,7 @@ module GobiertoData
       end
 
       def inspect_csv_schema(source_file, csv_separator:)
-        data = CSV.parse(File.open(source_file, "r").first(2).join, headers: true, col_sep: csv_separator)
+        data = CSV.parse(File.open(source_file, "r").first, headers: true, col_sep: csv_separator)
         blank_cols = 0
         data.headers.inject({}) do |cols, col|
           col_name = if col.blank?
@@ -123,7 +123,6 @@ module GobiertoData
                        "column_#{blank_cols}"
                      else
                        col.parameterize.underscore.to_sym
-
                      end
           cols.update(
             col_name => { original_name: col, type: "text" }

--- a/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_creation_test.rb
@@ -98,7 +98,7 @@ module GobiertoData
 
               assert_response :unprocessable_entity
               response_data = response.parsed_body
-              assert_match(/CSV file malformed or with wrong encoding/, response_data.to_s)
+              assert_match(/Database error loading CSV/, response_data.to_s)
               refute site.activities.where(subject_type: "GobiertoData::Dataset").exists?
             end
           end


### PR DESCRIPTION

Closes PopulateTools/issues#1460

## :v: What does this PR do?

Avoids errors generating default schema from a CSV by parsing only the first 2 lines of file. This may fail if the first row of the csv contains linebreaks because the 2nd line doesn't contain all the data required to parsing successfully the broken file.

The solution is to inspect only the first line of the file to get the colmn names. If the CSV is malformed an error message in the API will be generated the same, but will occur trying to load the CSV instead of inspecting the headers, and the error text will be different.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No