### PR TITLE
Gobierto Visualizations / Add a new barChart to show the amount grouped by process type

### DIFF
--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -422,19 +422,6 @@ export class ContractsController {
   }
 
   _renderProcessTypePerAmountChart() {
-    /*const _contractsData = this._currentDataSource().contractsData;
-    var result = [];
-    _contractsData.reduce(function(res, value) {
-      if (!res[value.process_type]) {
-        res[value.process_type] = { process_type: value.process_type, final_amount_no_taxes: 0 };
-        result.push(res[value.process_type])
-      }
-      res[value.process_type].final_amount_no_taxes += value.final_amount_no_taxes;
-      return res;
-    }, {});
-
-    this.ndx_process_per_amount = crossfilter(result);
-    const dimension = this.ndx_process_per_amount.dimension(contract => contract.process_type);*/
     const dimension = this.ndx.dimension(contract => contract.process_type);
 
     const renderOptions = {

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -255,6 +255,7 @@ export class ContractsController {
     this._renderDateChart();
     this._renderCategoriesChart();
     this._renderEntitiesChart();
+    this._renderProcessTypePerAmountChart();
   }
 
   _refreshData(reducedContractsData, filters, tendersAttribute) {
@@ -418,6 +419,42 @@ export class ContractsController {
     };
 
     this.charts["process_types"] = new GroupPctDistributionBars(renderOptions);
+  }
+
+  _renderProcessTypePerAmountChart() {
+    /*const _contractsData = this._currentDataSource().contractsData;
+    var result = [];
+    _contractsData.reduce(function(res, value) {
+      if (!res[value.process_type]) {
+        res[value.process_type] = { process_type: value.process_type, final_amount_no_taxes: 0 };
+        result.push(res[value.process_type])
+      }
+      res[value.process_type].final_amount_no_taxes += value.final_amount_no_taxes;
+      return res;
+    }, {});
+
+    this.ndx_process_per_amount = crossfilter(result);
+    const dimension = this.ndx_process_per_amount.dimension(contract => contract.process_type);*/
+    const dimension = this.ndx.dimension(contract => contract.process_type);
+
+    const renderOptions = {
+      containerSelector: "#process-type-per-amount-bars",
+      dimension: dimension,
+      groupValue: 'final_amount_no_taxes',
+      onFilteredFunction: (chart, filter) => {
+        this._refreshData(
+          dimension.top(Infinity),
+          chart.filters(),
+          "final_amount_no_taxes"
+        );
+        EventBus.$emit("dc-filter-selected", {
+          title: filter,
+          id: "process_types_per_amount"
+        });
+      }
+    };
+
+    this.charts["process_types_per_amount"] = new GroupPctDistributionBars(renderOptions);
   }
 
   _renderDateChart() {

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -436,7 +436,7 @@ export class ContractsController {
         );
         EventBus.$emit("dc-filter-selected", {
           title: filter,
-          id: "process_types_per_amount"
+          id: "process_types"
         });
       }
     };

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Aside.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Aside.vue
@@ -17,7 +17,7 @@
               :title="filter.title"
               class="visualizations-home-aside--block-header"
               see-link
-              :rotate="filter.isToggle"
+              :rotate="!filter.isToggle"
               :label-alt="filter.isEverythingChecked"
               @select-all="e => handleIsEverythingChecked({ ...e, filter })"
               @toggle="toggle(filter)"

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -61,7 +61,7 @@
       </div>
 
       <div class="pure-u-1 pure-u-lg-1-2 header_block_inline">
-        <div>
+        <div class="m_b_3">
           <h3 class="mt1 graph-title">
             {{ labelAmountDistribution }}
           </h3>

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -44,35 +44,30 @@
 
     <Tips :labels="tips" />
 
-    <div class="pure-g block">
-      <div class="pure-u-1 pure-u-lg-1-2 p_h_r_3">
-        <div class="m_b_3">
-          <h3 class="mt1 graph-title">
-            {{ labelContractType }}
-          </h3>
-          <div id="contract-type-bars" />
-        </div>
-        <div>
-          <h3 class="mt1 graph-title">
-            {{ labelAmountProcessType }}
-          </h3>
-          <div id="process-type-per-amount-bars" />
-        </div>
+    <div class="gobierto-visualizations-grid-dc-charts">
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelContractType }}
+        </h3>
+        <div id="contract-type-bars" />
       </div>
-
-      <div class="pure-u-1 pure-u-lg-1-2 header_block_inline">
-        <div class="m_b_3">
-          <h3 class="mt1 graph-title">
-            {{ labelAmountDistribution }}
-          </h3>
-          <div id="amount-distribution-bars" />
-        </div>
-        <div>
-          <h3 class="mt1 graph-title">
-            {{ labelProcessType }}
-          </h3>
-          <div id="process-type-bars" />
-        </div>
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelAmountDistribution }}
+        </h3>
+        <div id="amount-distribution-bars" />
+      </div>
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelAmountProcessType }}
+        </h3>
+        <div id="process-type-per-amount-bars" />
+      </div>
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelProcessType }}
+        </h3>
+        <div id="process-type-bars" />
       </div>
     </div>
 

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -44,30 +44,30 @@
 
     <Tips :labels="tips" />
 
-    <div class="gobierto-visualizations-grid-dc-charts">
-      <div>
-        <h3 class="mt1 graph-title">
-          {{ labelContractType }}
-        </h3>
-        <div id="contract-type-bars" />
+    <div class="pure-g block">
+      <div class="pure-u-1 pure-u-lg-1-2 p_h_r_3">
+        <div class="m_b_3">
+          <h3 class="mt1 graph-title">
+            {{ labelContractType }}
+          </h3>
+          <div id="contract-type-bars" />
+        </div>
+
+        <div>
+          <h3 class="mt1 graph-title">
+            {{ labelProcessType }}
+          </h3>
+          <div id="process-type-bars" />
+        </div>
       </div>
-      <div>
-        <h3 class="mt1 graph-title">
-          {{ labelAmountDistribution }}
-        </h3>
-        <div id="amount-distribution-bars" />
-      </div>
-      <div>
-        <h3 class="mt1 graph-title">
-          {{ labelAmountProcessType }}
-        </h3>
-        <div id="process-type-per-amount-bars" />
-      </div>
-      <div>
-        <h3 class="mt1 graph-title">
-          {{ labelProcessType }}
-        </h3>
-        <div id="process-type-bars" />
+
+      <div class="pure-u-1 pure-u-lg-1-2 header_block_inline">
+        <div>
+          <h3 class="mt1 graph-title">
+            {{ labelAmountDistribution }}
+          </h3>
+          <div id="amount-distribution-bars" />
+        </div>
       </div>
     </div>
 
@@ -135,7 +135,6 @@ export default {
       labelContractType: I18n.t("gobierto_visualizations.visualizations.contracts.contract_type") || "",
       labelProcessType: I18n.t("gobierto_visualizations.visualizations.contracts.process_type") || "",
       labelAmountDistribution: I18n.t("gobierto_visualizations.visualizations.contracts.amount_distribution") || "",
-      labelAmountProcessType: I18n.t("gobierto_visualizations.visualizations.contracts.amount_by_type_of_process") || "",
       treemapButtons: [
         ["final_amount_no_taxes", I18n.t("gobierto_visualizations.visualizations.contracts.contract_amount")],
         ["total", I18n.t('gobierto_visualizations.visualizations.visualizations.tooltip_treemap') || ""],

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -52,12 +52,11 @@
           </h3>
           <div id="contract-type-bars" />
         </div>
-
         <div>
           <h3 class="mt1 graph-title">
-            {{ labelProcessType }}
+            {{ labelAmountProcessType }}
           </h3>
-          <div id="process-type-bars" />
+          <div id="process-type-per-amount-bars" />
         </div>
       </div>
 
@@ -70,9 +69,9 @@
         </div>
         <div>
           <h3 class="mt1 graph-title">
-            {{ labelAmountDistribution }}
+            {{ labelProcessType }}
           </h3>
-          <div id="process-type-per-amount-bars" />
+          <div id="process-type-bars" />
         </div>
       </div>
     </div>
@@ -141,6 +140,7 @@ export default {
       labelContractType: I18n.t("gobierto_visualizations.visualizations.contracts.contract_type") || "",
       labelProcessType: I18n.t("gobierto_visualizations.visualizations.contracts.process_type") || "",
       labelAmountDistribution: I18n.t("gobierto_visualizations.visualizations.contracts.amount_distribution") || "",
+      labelAmountProcessType: I18n.t("gobierto_visualizations.visualizations.contracts.amount_by_type_of_process") || "",
       treemapButtons: [
         ["final_amount_no_taxes", I18n.t("gobierto_visualizations.visualizations.contracts.contract_amount")],
         ["total", I18n.t('gobierto_visualizations.visualizations.visualizations.tooltip_treemap') || ""],

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -68,6 +68,12 @@
           </h3>
           <div id="amount-distribution-bars" />
         </div>
+        <div>
+          <h3 class="mt1 graph-title">
+            {{ labelAmountDistribution }}
+          </h3>
+          <div id="process-type-per-amount-bars" />
+        </div>
       </div>
     </div>
 

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -44,30 +44,30 @@
 
     <Tips :labels="tips" />
 
-    <div class="pure-g block">
-      <div class="pure-u-1 pure-u-lg-1-2 p_h_r_3">
-        <div class="m_b_3">
-          <h3 class="mt1 graph-title">
-            {{ labelContractType }}
-          </h3>
-          <div id="contract-type-bars" />
-        </div>
-
-        <div>
-          <h3 class="mt1 graph-title">
-            {{ labelProcessType }}
-          </h3>
-          <div id="process-type-bars" />
-        </div>
+    <div class="gobierto-visualizations-grid-dc-charts">
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelContractType }}
+        </h3>
+        <div id="contract-type-bars" />
       </div>
-
-      <div class="pure-u-1 pure-u-lg-1-2 header_block_inline">
-        <div>
-          <h3 class="mt1 graph-title">
-            {{ labelAmountDistribution }}
-          </h3>
-          <div id="amount-distribution-bars" />
-        </div>
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelAmountDistribution }}
+        </h3>
+        <div id="amount-distribution-bars" />
+      </div>
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelAmountProcessType }}
+        </h3>
+        <div id="process-type-per-amount-bars" />
+      </div>
+      <div>
+        <h3 class="mt1 graph-title">
+          {{ labelProcessType }}
+        </h3>
+        <div id="process-type-bars" />
       </div>
     </div>
 
@@ -135,6 +135,7 @@ export default {
       labelContractType: I18n.t("gobierto_visualizations.visualizations.contracts.contract_type") || "",
       labelProcessType: I18n.t("gobierto_visualizations.visualizations.contracts.process_type") || "",
       labelAmountDistribution: I18n.t("gobierto_visualizations.visualizations.contracts.amount_distribution") || "",
+      labelAmountProcessType: I18n.t("gobierto_visualizations.visualizations.contracts.amount_by_type_of_process") || "",
       treemapButtons: [
         ["final_amount_no_taxes", I18n.t("gobierto_visualizations.visualizations.contracts.contract_amount")],
         ["total", I18n.t('gobierto_visualizations.visualizations.visualizations.tooltip_treemap') || ""],

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -72,8 +72,7 @@ export class GroupPctDistributionBars {
             });
           } else {
             //Convert negative zero to positive zero
-            labelValue = labelValue < 0 ? 0 : labelValue
-            labelValue = labelValue.toLocaleString(I18n.locale, {
+            labelValue = Math.max(0, labelValue).toLocaleString(I18n.locale, {
               style: "currency",
               currency: "EUR",
               maximumFractionDigits: 0

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -71,6 +71,8 @@ export class GroupPctDistributionBars {
               minimumFractionDigits: 1
             });
           } else {
+            // https://eslint.org/docs/rules/no-compare-neg-zero
+            labelValue = labelValue === -9.786162991076708e-10 ? 0 : labelValue
             labelValue = labelValue.toLocaleString(I18n.locale, {
               style: "currency",
               currency: "EUR",
@@ -78,8 +80,6 @@ export class GroupPctDistributionBars {
             });
           }
 
-          // https://eslint.org/docs/rules/no-compare-neg-zero
-          labelValue = Object.is(labelValue, -0) ? 0 : labelValue
           return [label, labelValue];
         })
         .enter()

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -55,30 +55,30 @@ export class GroupPctDistributionBars {
         .selectAll("tspan")
         .data(d => {
           let label = truncate(d.key, { length: 25 });
-          let pct;
+          let labelValue;
 
           if (this.hasFilter() && !this.hasFilter(d.key)) {
-            pct = 0.0;
+            labelValue = 0.0;
           } else if (this.hasFilter() && this.hasFilter(d.key)) {
-            pct = !groupValue ? parseFloat(d.value / dimension.top(Infinity).length) : d.value;
+            labelValue = !groupValue ? parseFloat(d.value / dimension.top(Infinity).length) : d.value;
           } else {
-            pct = !groupValue ? parseFloat(d.value / all.value()) : d.value;
+            labelValue = !groupValue ? parseFloat(d.value / all.value()) : d.value;
           }
 
           if (!groupValue) {
-            pct = pct.toLocaleString(I18n.locale, {
+            labelValue = labelValue.toLocaleString(I18n.locale, {
               style: "percent",
               minimumFractionDigits: 1
             });
           } else {
-            pct = pct.toLocaleString(I18n.locale, {
+            labelValue = labelValue.toLocaleString(I18n.locale, {
               style: "currency",
               currency: "EUR",
               maximumFractionDigits: 0
             });
           }
 
-          return [label, pct];
+          return [label, labelValue];
         })
         .enter()
         .append("tspan")

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -10,11 +10,11 @@ const dc = { rowChart };
 export class GroupPctDistributionBars {
   constructor(options) {
     // Declaration
-    const { containerSelector, dimension, onFilteredFunction } = options;
+    const { containerSelector, dimension, onFilteredFunction, groupValue } = options;
     this.container = dc.rowChart(containerSelector, "group");
 
     // Dimensions
-    const groupedDimension = dimension.group().reduceCount(),
+    const groupedDimension = !groupValue ? dimension.group().reduceCount() : dimension.group().reduceSum(d => d[groupValue]),
       all = dimension.groupAll();
 
     // Styling
@@ -22,8 +22,8 @@ export class GroupPctDistributionBars {
     this._gap = 10;
     this._barHeight = 18;
 
-    const _initialLabelOffset = 250,
-      _pctLabelOffset = 50;
+    const _initialLabelOffset = 250
+    const _pctLabelOffset = !groupValue ? 50 : 80;
 
     this.node = this.container.root().node() || document.createElement("div");
 
@@ -60,15 +60,23 @@ export class GroupPctDistributionBars {
           if (this.hasFilter() && !this.hasFilter(d.key)) {
             pct = 0.0;
           } else if (this.hasFilter() && this.hasFilter(d.key)) {
-            pct = parseFloat(d.value / dimension.top(Infinity).length);
+            pct = !groupValue ? parseFloat(d.value / dimension.top(Infinity).length) : d.value;
           } else {
-            pct = parseFloat(d.value / all.value());
+            pct = !groupValue ? parseFloat(d.value / all.value()) : d.value;
           }
 
-          pct = pct.toLocaleString(I18n.locale, {
-            style: "percent",
-            minimumFractionDigits: 1
-          });
+          if (!groupValue) {
+            pct = pct.toLocaleString(I18n.locale, {
+              style: "percent",
+              minimumFractionDigits: 1
+            });
+          } else {
+            pct = pct.toLocaleString(I18n.locale, {
+              style: "currency",
+              currency: "EUR",
+              maximumFractionDigits: 0
+            });
+          }
 
           return [label, pct];
         })

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -71,8 +71,8 @@ export class GroupPctDistributionBars {
               minimumFractionDigits: 1
             });
           } else {
-            // https://eslint.org/docs/rules/no-compare-neg-zero
-            labelValue = labelValue === -9.786162991076708e-10 ? 0 : labelValue
+            //Convert negative zero to positive zero
+            labelValue = labelValue < 0 ? 0 : labelValue
             labelValue = labelValue.toLocaleString(I18n.locale, {
               style: "currency",
               currency: "EUR",

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -78,6 +78,8 @@ export class GroupPctDistributionBars {
             });
           }
 
+          // https://eslint.org/docs/rules/no-compare-neg-zero
+          labelValue = Object.is(labelValue, -0) ? 0 : labelValue
           return [label, labelValue];
         })
         .enter()

--- a/app/javascript/stylesheets/gobierto-visualizations.scss
+++ b/app/javascript/stylesheets/gobierto-visualizations.scss
@@ -567,6 +567,12 @@
     }
   }
 
+  &-grid-dc-charts {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 3rem;
+  }
+
   &-table {
     td {
       display: block;

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -58,6 +58,7 @@ en:
         special_administrative: Special administrative
         supplies: Supplies
       contracts:
+        amount_by_type_of_process: Amount by type of process
         amount_distribution: Amount distribution
         assignee: Assignee
         categories: Categories

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -58,6 +58,7 @@ es:
         special_administrative: Administrativo especial
         supplies: Suministros
       contracts:
+        amount_by_type_of_process: Importe por tipo de procedimiento
         amount_distribution: Distribución por importes
         assignee: Adjudicatario
         categories: Categorías


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1471


## :v: What does this PR do?
- Add a new chart to show the total `final_amount_no_taxes` grouped by `contract_type`
- Add a new parameter in the options to group by value using `.group()` of dc.js. This reuses the code that was already there and does not create a new type of chart.
- Reorder charts and replace purecss by pure-grid-css

## :mag: How should this be manually tested?
[Staging Castellon](https://dip-castellon.gobify.net/visualizaciones/contratos/)

## :eyes: Screenshots

### After this PR

https://user-images.githubusercontent.com/2649175/149985260-cdee4ed0-68a8-4aff-a1a5-37ab91f867a7.mov