### PR TITLE
Gobierto Data / Latest marked update causes a bug

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/commons/Info.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Info.vue
@@ -36,7 +36,7 @@
 import { date, truncate } from "lib/vue/filters"
 import InfoBlockText from "./../commons/InfoBlockText.vue";
 //Parse markdown to HTML
-const marked = require('marked');
+import { marked } from 'marked';
 
 export default {
   name: "Info",
@@ -105,7 +105,7 @@ export default {
     compiledHTMLMarkdown() {
       /*This method is to remove only the <p>| |</p> and |<br> elements that CodeMirror adds when exporting from the editor. We need to remove them to convert the Markdown tables to HTML correctly.*/
       const descriptionHTML = this.descriptionDataset.replace(/\|<br>|<p>\||\|<\/p>/g, '|');
-      const mdText = marked(descriptionHTML, {
+      const mdText = marked.parse(descriptionHTML, {
         sanitize: false,
         tables: true
       })

--- a/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
@@ -85,7 +85,7 @@ import DownloadLink from "./../commons/DownloadLink.vue";
 import Button from "./../commons/Button.vue";
 import { tabs } from "../../../lib/router";
 //Parse markdown to HTML
-const marked = require('marked');
+import { marked } from 'marked';
 
 export default {
   name: "InfoTab",
@@ -157,7 +157,7 @@ export default {
     compiledHTMLMarkdown() {
       /*This method is to remove only the <p>| |</p> and |<br> elements that CodeMirror adds when exporting from the editor. We need to remove them to convert the Markdown tables to HTML correctly.*/
       const descriptionHTML = this.descriptionDataset.replace(/\|<br>|<p>\||\|<\/p>/g, '|');
-      const mdText = marked(descriptionHTML, {
+      const mdText = marked.parse(descriptionHTML, {
         sanitize: false,
         tables: true
       })


### PR DESCRIPTION
## :v: What does this PR do?

Related https://github.com/PopulateTools/gobierto/pull/4030

Dependatbot Bump marked from 2.1.3 to 4.0.10. In the last version, converting the markdown into HTML is necessary to use the `marked.parse()` method.


## :mag: How should this be manually tested?

[Staging Getafe](https://getafe.gobify.net/datos/)