### PR TITLE
Downgrade marked from 4.0.10 to 3.0.8

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/commons/Info.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/Info.vue
@@ -35,8 +35,8 @@
 <script>
 import { date, truncate } from "lib/vue/filters"
 import InfoBlockText from "./../commons/InfoBlockText.vue";
-//Parse markdown to HTML
-import { marked } from 'marked';
+//Parse markdown to HTML. Related: https://github.com/PopulateTools/issues/issues/1428#issuecomment-1026617835
+const marked = require('marked');
 
 export default {
   name: "Info",
@@ -105,14 +105,14 @@ export default {
     compiledHTMLMarkdown() {
       /*This method is to remove only the <p>| |</p> and |<br> elements that CodeMirror adds when exporting from the editor. We need to remove them to convert the Markdown tables to HTML correctly.*/
       const descriptionHTML = this.descriptionDataset.replace(/\|<br>|<p>\||\|<\/p>/g, '|');
-      const mdText = marked.parse(descriptionHTML, {
+      const markdownText = marked(descriptionHTML, {
         sanitize: false,
         tables: true
       })
       if (this.truncateIsActive) {
-        return truncate(mdText, { length: 150 })
+        return truncate(markdownText, { length: 150 })
       } else {
-        return mdText
+        return markdownText
       }
     },
     hasDatasetSource() {

--- a/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
@@ -84,8 +84,8 @@ import DownloadButton from "./../commons/DownloadButton.vue";
 import DownloadLink from "./../commons/DownloadLink.vue";
 import Button from "./../commons/Button.vue";
 import { tabs } from "../../../lib/router";
-//Parse markdown to HTML
-import { marked } from 'marked';
+//Parse markdown to HTML. Related: https://github.com/PopulateTools/issues/issues/1428#issuecomment-1026617835
+const marked = require('marked');
 
 export default {
   name: "InfoTab",
@@ -157,11 +157,11 @@ export default {
     compiledHTMLMarkdown() {
       /*This method is to remove only the <p>| |</p> and |<br> elements that CodeMirror adds when exporting from the editor. We need to remove them to convert the Markdown tables to HTML correctly.*/
       const descriptionHTML = this.descriptionDataset.replace(/\|<br>|<p>\||\|<\/p>/g, '|');
-      const mdText = marked.parse(descriptionHTML, {
+      const markdownText = marked(descriptionHTML, {
         sanitize: false,
         tables: true
       })
-      return mdText
+      return markdownText
     },
     hasDatasetSource() {
       return this.sourceDataset && this.sourceDataset?.text !== undefined && this.sourceDataset?.text !== ""

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "magnific-popup": "^1.1.0",
     "mailcheck": "^1.1.1",
     "mapbox-gl": "^1.4.1",
-    "marked": "^4.0.10",
     "moment": "^2.21.0",
     "moment-locales-webpack-plugin": "^1.0.7",
     "mustache": "^2.3.0",
@@ -122,6 +121,7 @@
   },
   "resolutions": {
     "perspective-viewer-d3fc/**/d3-selection": "1.4.2",
-    "perspective-viewer-d3fc/**/d3-transition": "1.3.2"
+    "perspective-viewer-d3fc/**/d3-transition": "1.3.2",
+    "marked": "3.0.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8515,10 +8515,10 @@ mapbox-gl@^1.4.1:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
 
-marked@*, "marked@>= 0.2.7", marked@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.10.tgz#423e295385cc0c3a70fa495e0df68b007b879423"
-  integrity sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==
+marked@*, marked@3.0.8, "marked@>= 0.2.7":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
+  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Related https://github.com/PopulateTools/issues/issues/1428#issuecomment-1026617835


## :v: What does this PR do?

- Downgrade Marked from 4.0.10 to 3.0.8
## :mag: How should this be manually tested?
- Staging, creating a new page from CMS, or updating a page.

## :eyes: Screenshots

### Before this PR
![before](https://user-images.githubusercontent.com/2649175/151955671-cf2d05fc-9271-4224-a54e-770ba0754fc3.png)

### After this PR
![after](https://user-images.githubusercontent.com/2649175/151955688-8753970c-1c3d-4c55-99f5-cb5c3138953e.png)