### PR TITLE
Update only plans with progress plugin 

### DIFF
--- a/vendor/gobierto_engines/custom-fields-progress-plugin/lib/tasks/custom_field_plugins/progress/calculate_progress.rake
+++ b/vendor/gobierto_engines/custom-fields-progress-plugin/lib/tasks/custom_field_plugins/progress/calculate_progress.rake
@@ -6,8 +6,12 @@ namespace :custom_field_plugins do
     task calculate_progress: :environment do
 
       sites_list = []
+      progress_custom_fields_with_plan = GobiertoCommon::CustomField.with_plugin_type("progress").where(instance_type: "GobiertoPlans::Plan")
+      plans_with_progress = GobiertoPlans::Plan.where(id: progress_custom_fields_with_plan.select(:instance_id))
 
-      GobiertoCommon::CustomField.with_plugin_type("progress").where.not(instance: nil).each do |custom_field|
+      progress_custom_fields_with_plan.each do |custom_field|
+        next if custom_field.instance.blank?
+
         sites_list << custom_field.site unless sites_list.include?(custom_field.site) || custom_field.instance.nodes.empty?
 
         custom_field.instance.nodes.each do |node|
@@ -15,18 +19,18 @@ namespace :custom_field_plugins do
         end
       end
 
-      GobiertoPlans::Plan.where.not(id: GobiertoCommon::CustomField.with_plugin_type("progress").where.not(instance: nil)).each do |plan|
-        custom_fields = plan.site.custom_fields.with_plugin_type("progress").where(instance: nil)
-        sites_list << plan.site unless sites_list.include?(plan.site) || custom_fields.empty?
+      GobiertoPlans::Plan.where.not(id: plans_with_progress).each do |plan|
+        free_progress_custom_fields = plan.site.custom_fields.with_plugin_type("progress").where(instance: nil)
+        sites_list << plan.site unless sites_list.include?(plan.site) || free_progress_custom_fields.empty?
 
-        custom_fields.each do |custom_field|
+        free_progress_custom_fields.each do |custom_field|
           plan.nodes.each do |node|
             custom_field.records.find_or_initialize_by(item: node).functions.update_progress!
           end
         end
       end
 
-      GobiertoPlans::Plan.all.each(&:touch)
+      plans_with_progress.each(&:touch)
 
       sites_list.each do |site|
         Publishers::GobiertoPlansProjectActivity.broadcast_event("progresses_updated", ip: "127.0.0.1", subject: site, site_id: site.id)


### PR DESCRIPTION
…lugin

Closes PopulateTools/issues#1058

## :v: What does this PR do?

Refactors queries in the calculate_progress task to find plans with associated progress custom field plugins and updates only that plans after running

## :mag: How should this be manually tested?

Run the task. Only plans with progress plugins should change its "latest update" attribute displayed in its main page

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No