### PR TITLE
Gobierto Visualizations / gobierto vizzs doesn't load

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -123,6 +123,7 @@ export default {
       columns: [],
       showColumns: [],
       value: "",
+      isGobiertoVizzsLoaded: false,
       labelMainAssignees: I18n.t("gobierto_visualizations.visualizations.contracts.main_assignees") || "",
       labelBeesWarm: I18n.t("gobierto_visualizations.visualizations.visualizations.title_beeswarm") || "",
       labelTooltipBeesWarm: I18n.t("gobierto_visualizations.visualizations.visualizations.tooltip_beeswarm") || "",
@@ -184,6 +185,11 @@ export default {
     },
     visualizationsDataExcludeMinorContract(n) {
       this.beeswarm?.setData(n)
+    },
+    $route(to, from) {
+      if (to.path !== from.path && !this.isGobiertoVizzsLoaded) {
+        this.initGobiertoVizzs()
+      }
     }
   },
   created() {
@@ -192,54 +198,59 @@ export default {
     this.tableItems = this.items.map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
   },
   mounted() {
-    const treemapCategory = this.$refs["treemap-category"]
-    const treemapEntity = this.$refs["treemap-entity"]
-    const beeswarm = this.$refs.beeswarm
-
-    // Check if element is visible in DOM - https://stackoverflow.com/a/21696585/5020256
-    if (treemapCategory && treemapCategory.offsetParent !== null) {
-      this.treemapCategory = new TreeMap(treemapCategory, this.visualizationsDataExcludeNoCategory, {
-        rootTitle: this.labelCategories,
-        id: "title",
-        group: ["category_title", "assignee"],
-        value: "final_amount_no_taxes",
-        itemTemplate: this.treemapItemTemplate,
-        tooltip: this.tooltipTreeMap,
-        onLeafClick: this.handleTreeMapLeafClick,
-      })
-    }
-
-    if (treemapEntity && treemapEntity.offsetParent !== null) {
-      this.treemapEntity = new TreeMap(treemapEntity, this.visualizationsDataEntity, {
-        rootTitle: this.labelEntities,
-        id: "title",
-        group: ["contractor", "contract_type", "assignee"],
-        value: "final_amount_no_taxes",
-        itemTemplate: this.treemapItemTemplate,
-        tooltip: this.tooltipTreeMap,
-        onLeafClick: this.handleTreeMapLeafClick,
-      })
-    }
-
-    if (beeswarm && beeswarm.offsetParent !== null) {
-      this.beeswarm = new BeeSwarm(beeswarm, this.visualizationsDataExcludeMinorContract, {
-        x: "gobierto_start_date",
-        y: "contract_type",
-        value: "final_amount_no_taxes",
-        relation: "assignee_routing_id",
-        circleSize: [3, 28],
-        tooltip: this.tooltipBeeSwarm,
-        onClick: this.handleBeeSwarmClick,
-        margin: {
-          left: 120,
-          right: 30,
-          top: 70,
-          bottom: 30
-        }
-      })
-    }
+    this.initGobiertoVizzs()
   },
   methods: {
+    initGobiertoVizzs() {
+      const treemapCategory = this.$refs["treemap-category"]
+      const treemapEntity = this.$refs["treemap-entity"]
+      const beeswarm = this.$refs.beeswarm
+
+      // Check if element is visible in DOM - https://stackoverflow.com/a/21696585/5020256
+      if (treemapCategory && treemapCategory.offsetParent !== null) {
+        this.treemapCategory = new TreeMap(treemapCategory, this.visualizationsDataExcludeNoCategory, {
+          rootTitle: this.labelCategories,
+          id: "title",
+          group: ["category_title", "assignee"],
+          value: "final_amount_no_taxes",
+          itemTemplate: this.treemapItemTemplate,
+          tooltip: this.tooltipTreeMap,
+          onLeafClick: this.handleTreeMapLeafClick,
+        })
+      }
+
+      if (treemapEntity && treemapEntity.offsetParent !== null) {
+        this.treemapEntity = new TreeMap(treemapEntity, this.visualizationsDataEntity, {
+          rootTitle: this.labelEntities,
+          id: "title",
+          group: ["contractor", "contract_type", "assignee"],
+          value: "final_amount_no_taxes",
+          itemTemplate: this.treemapItemTemplate,
+          tooltip: this.tooltipTreeMap,
+          onLeafClick: this.handleTreeMapLeafClick,
+        })
+      }
+
+      if (beeswarm && beeswarm.offsetParent !== null) {
+        this.beeswarm = new BeeSwarm(beeswarm, this.visualizationsDataExcludeMinorContract, {
+          x: "gobierto_start_date",
+          y: "contract_type",
+          value: "final_amount_no_taxes",
+          relation: "assignee_routing_id",
+          circleSize: [3, 28],
+          tooltip: this.tooltipBeeSwarm,
+          onClick: this.handleBeeSwarmClick,
+          margin: {
+            left: 120,
+            right: 30,
+            top: 70,
+            bottom: 30
+          }
+        })
+
+        this.isGobiertoVizzsLoaded = true
+      }
+    },
     tooltipBeeSwarm(d) {
       return `
         <span class="beeswarm-tooltip-header">

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
@@ -104,6 +104,7 @@ export default {
       grantedColumns: grantedColumns,
       showColumns: [],
       value: "",
+      isGobiertoVizzsLoaded: false,
       labelSubsidies: I18n.t("gobierto_visualizations.visualizations.subsidies.subsidies") || "",
       labelCategory: I18n.t("gobierto_visualizations.visualizations.subsidies.category") || "",
       labelAmountDistribution: I18n.t("gobierto_visualizations.visualizations.subsidies.amount_distribution") || "",
@@ -150,28 +151,38 @@ export default {
     visualizationsData(n) {
       this.treemap?.setData(n)
     },
+    $route(to, from) {
+      if (to.path !== from.path && !this.isGobiertoVizzsLoaded) {
+        this.initGobiertoVizzs()
+      }
+    }
   },
   created() {
     this.columns = grantedColumns;
     this.showColumns = ['name', 'count', 'sum']
   },
   mounted() {
-    const treemap = this.$refs.treemap
-
-    // Check if element is visible in DOM - https://stackoverflow.com/a/21696585/5020256
-    if (treemap && treemap.offsetParent !== null) {
-      this.treemap = new TreeMap(treemap, this.visualizationsData, {
-        rootTitle: this.labelSubsidies,
-        id: "categories",
-        group: ["beneficiary_type"],
-        value: "amount",
-        itemTemplate: this.treemapItemTemplate,
-        tooltip: this.tooltipTreeMap,
-        onLeafClick: this.handleTreeMapLeafClick,
-      })
-    }
+    this.initGobiertoVizzs()
   },
   methods: {
+    initGobiertoVizzs() {
+      const treemap = this.$refs.treemap
+
+      // Check if element is visible in DOM - https://stackoverflow.com/a/21696585/5020256
+      if (treemap && treemap.offsetParent !== null) {
+        this.treemap = new TreeMap(treemap, this.visualizationsData, {
+          rootTitle: this.labelSubsidies,
+          id: "categories",
+          group: ["beneficiary_type"],
+          value: "amount",
+          itemTemplate: this.treemapItemTemplate,
+          tooltip: this.tooltipTreeMap,
+          onLeafClick: this.handleTreeMapLeafClick,
+        })
+        this.isGobiertoVizzsLoaded = true
+      }
+
+    },
     handleActiveButton(value) {
       this.activeButton = value
       this.treemap.setValue(this.activeButton === "total" ? undefined : value)


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1494


## :v: What does this PR do?
- Add a watcher to routes to check if the vizzs are loaded. If doesn't loaded throw the method to load them.


## :mag: How should this be manually tested?
[Staging](https://alcobendas.gobify.net/visualizaciones/contratos/adjudicaciones)

## :eyes: Screenshots

### Before this PR

![before-gobierto-visualizations](https://user-images.githubusercontent.com/2649175/152568939-97578bf1-f0f6-48a3-a523-9d2a201689e8.gif)

### After this PR
![after-gobierto-visualizations](https://user-images.githubusercontent.com/2649175/152569612-9f9d834c-842f-4356-a39c-aa9360c5656a.gif)

