### PR TITLE
Add extra details after subsidies description

### DIFF
--- a/app/javascript/stylesheets/gobierto-visualizations.scss
+++ b/app/javascript/stylesheets/gobierto-visualizations.scss
@@ -1225,3 +1225,11 @@
   }
 
 }
+
+.gobierto_visualizations {
+
+  .header_block_inline p.visualizations-text-info {
+    font-size: $f7;
+  }
+
+}

--- a/app/views/gobierto_visualizations/visualizations/subsidies.html.erb
+++ b/app/views/gobierto_visualizations/visualizations/subsidies.html.erb
@@ -9,6 +9,9 @@
       <p>
         <%= t(".description", entity_name: current_site.name) %>
       </p>
+      <p>
+        <%= t(".details", entity_name: current_site.name) %>
+      </p>
     </div>
   </div>
 

--- a/app/views/gobierto_visualizations/visualizations/subsidies.html.erb
+++ b/app/views/gobierto_visualizations/visualizations/subsidies.html.erb
@@ -9,7 +9,7 @@
       <p>
         <%= t(".description", entity_name: current_site.name) %>
       </p>
-      <p>
+      <p class="visualizations-text-info">
         <%= t(".details", entity_name: current_site.name) %>
       </p>
     </div>

--- a/config/locales/gobierto_visualizations/views/ca.yml
+++ b/config/locales/gobierto_visualizations/views/ca.yml
@@ -224,6 +224,11 @@ ca:
         date: Data
         dates: Dates
         description: Visualització i anàlisi de les subvencions concedides per %{entity_name}
+        details: D'acord amb el que preveu l'article 7.8 del Reial Decret 130/2019,
+          la informació sobre concessions romandrà publicada durant els quatre anys
+          naturals següents a l'any en què es va concedir la subvenció en el cas de
+          persones jurídiques, i en el cas de persones físiques la publicitat es redueix
+          a l'any de concessió i l'any següent.
         fromto: De a Nº Subv.
         main_beneficiaries: Principals beneficiaris
         more: Més de

--- a/config/locales/gobierto_visualizations/views/en.yml
+++ b/config/locales/gobierto_visualizations/views/en.yml
@@ -225,6 +225,10 @@ en:
         date: Date
         dates: Dates
         description: Visualizations and analisys for the granted subsidies from %{entity_name}
+        details: In agreement with article 7.8 Real Decreto 130/2019, the information
+          on awards to legal persons will remain published during the four calendar
+          years following the year in which the aid was granted, and in the case of
+          natural persons, publicity is limited to the awarding plus one years.
         fromto: From To No Subs.
         main_beneficiaries: Main beneficiaries
         more: More than

--- a/config/locales/gobierto_visualizations/views/es.yml
+++ b/config/locales/gobierto_visualizations/views/es.yml
@@ -228,6 +228,11 @@ es:
         date: Fecha
         dates: Fechas
         description: Visualización y análisis de las subvenciones concedidas por %{entity_name}
+        details: De acuerdo con lo previsto en el artículo 7.8 del Real Decreto 130/2019,
+          la información sobre concesiones permanecerá publicada durante los cuatro
+          años naturales siguientes al año en que se concedió la subvención en el
+          caso de personas jurídicas, y en el caso de personas físicas la publicidad
+          se reduce al año de concesión y al año siguiente.
         fromto: Desde A Nº. Subv.
         main_beneficiaries: Principales beneficiarios
         more: Más de


### PR DESCRIPTION
Closes PopulateTools/issues#1492

## :v: What does this PR do?

Adds a text after the subsidies description taken from https://www.pap.hacienda.gob.es/bdnstrans/GE/en/concesiones



## :mag: How should this be manually tested?

Visit https://esplugues.gobify.net/visualizaciones/subvenciones/subvenciones

## :eyes: Screenshots

### Before this PR

![Screenshot from 2022-02-07 16-38-17](https://user-images.githubusercontent.com/446459/152820373-d472fe69-fcd4-4dd3-8b6e-8bd6badc40d3.png)


### After this PR

![Screenshot from 2022-02-07 16-37-47](https://user-images.githubusercontent.com/446459/152820396-cb97071f-1589-40e6-8f6b-9705b36c39a7.png)


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No