### PR TITLE
Calendars / Start day at 7AM

### DIFF
--- a/app/javascript/gobierto_people/modules/person_events_controller.js
+++ b/app/javascript/gobierto_people/modules/person_events_controller.js
@@ -50,6 +50,7 @@ window.GobiertoPeople.PersonEventsController = (function() {
       height: 600,
       contentHeight: 600,
       firstDay: 1,
+      scrollTime: '7:00:00',
       timeFormat: 'H:mm',
       views: {
         week: { columnFormat: 'ddd D/M' }


### PR DESCRIPTION
Related https://github.com/PopulateTools/gobierto/issues/4041


## :v: What does this PR do?

Add `scrollTime: 7:00:00` to fullCalendar options.


## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR
![before-calendars](https://user-images.githubusercontent.com/2649175/153242825-551c99bd-2a2f-496e-880a-eac5e4dff57e.png)

