### PR TITLE
Calendars / Start day at 7AM #4046

### DIFF
--- a/app/javascript/gobierto_people/modules/person_events_controller.js
+++ b/app/javascript/gobierto_people/modules/person_events_controller.js
@@ -54,6 +54,23 @@ window.GobiertoPeople.PersonEventsController = (function() {
       timeFormat: 'H:mm',
       views: {
         week: { columnFormat: 'ddd D/M' }
+      },
+      eventAfterRender: function() {
+        /* What is this? It is a function created for when the calendar
+        is inside a div with display none. We wait until the calendar
+        is visible to be able to indicate the start time.*/
+        setInterval(timeScrollToTime, 1000);
+        function timeScrollToTime() {
+          if ($('#calendar').is(':visible')) {
+            setTimeout(function() {
+              window.dispatchEvent(new Event('resize'));
+              $(".fc-scroller").animate({
+                  scrollTop: $('[data-time="07:00:00"]').position().top
+              });
+            })
+            clearInterval(timeScrollToTime);
+          }
+        }
       }
     });
     nextStep();

--- a/app/javascript/stylesheets/gobierto-people.scss
+++ b/app/javascript/stylesheets/gobierto-people.scss
@@ -395,7 +395,9 @@ body.gobierto_people.welcome.index {
 
   .today {
     background: var(--color-base);
-    color: #fff;
+    a {
+      color: #fff;
+    }
   }
 
   th {


### PR DESCRIPTION
Related https://github.com/PopulateTools/gobierto/issues/4041


## :v: What does this PR do?

Add a function to set calendar start day at 7am when the fullcalendar is inside a `<div>` with `display: none`