### PR TITLE
Search input doesn't work in the homepage

### DIFF
--- a/app/javascript/lib/commons/modules/module-search.js
+++ b/app/javascript/lib/commons/modules/module-search.js
@@ -1,7 +1,7 @@
 import { AUTOCOMPLETE_DEFAULTS } from 'lib/shared'
 import 'devbridge-autocomplete'
 
-document.addEventListener('DOMContentLoaded', function() {
+$(document).on('turbolinks:load', function() {
   var $input = $('input#gobierto_search:visible');
   var $mobile_input = $('input#gobierto_search_mobile');
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -41,7 +41,7 @@
         <div class="site_header_logo">
 
           <div class="site_header_image">
-              <%= link_to(logo_image_tag(@site.configuration.logo_with_fallback, { alt: @site.name }), root_url, data: { turbolinks: false }) %>
+              <%= link_to(logo_image_tag(@site.configuration.logo_with_fallback, { alt: @site.name }), root_url) %>
           </div>
 
           <div class="mobile_only right">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -41,7 +41,7 @@
         <div class="site_header_logo">
 
           <div class="site_header_image">
-              <%= link_to(logo_image_tag(@site.configuration.logo_with_fallback, { alt: @site.name }), root_url) %>
+              <%= link_to(logo_image_tag(@site.configuration.logo_with_fallback, { alt: @site.name }), root_url, data: { turbolinks: false }) %>
           </div>
 
           <div class="mobile_only right">


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1501


## :v: What does this PR do?

In the module-search replace [`eventListener('domContentLoaded')`](https://github.com/PopulateTools/gobierto/blob/master/app/javascript/lib/commons/modules/module-search.js#L4) for `('turbolinks:load')` to load the search module when the home-logo is clicked.

## :mag: How should this be manually tested?


## :eyes: Screenshots

### After this PR

https://user-images.githubusercontent.com/2649175/154292102-2e6dbe6d-a341-4c53-9552-41cfc9675047.mov