### PR TITLE
Recover google analytics code in _analytics_footer_site partial

### DIFF
--- a/app/views/layouts/_analytics_footer_site.html.erb
+++ b/app/views/layouts/_analytics_footer_site.html.erb
@@ -1,5 +1,25 @@
 <% if Rails.env.production? && current_site && current_site.configuration.google_analytics_id.present? %>
   <script type="text/javascript">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    function gaCall(){
+      var args = arguments;
+      ga(function() {
+        var allTrackers = ga.getAll();
+        for(var i in allTrackers) {
+          new_args = [allTrackers[i].get('name')+'.'+args[0]];
+          for(var n = 1; n < args.length; n++){
+            new_args.push(args[n]);
+          }
+          ga.apply(this, new_args);
+
+        }
+      });
+    }
+
     ga('create', '<%= current_site.configuration.google_analytics_id %>', 'auto');
     gaCall('send', 'pageview');
   </script>


### PR DESCRIPTION
Closes #4057


## :v: What does this PR do?

Fixes js exceptions when Google Analytics code is called from site footer. The code required was removed in [this PR](https://github.com/PopulateTools/gobierto/pull/4044): 7dfb54e

## :mag: How should this be manually tested?

This can only be tested in production environment

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No