### PR TITLE
Remove hiredis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ gem "invisible_captcha"
 
 # Redis
 gem "redis"
-gem "hiredis"
 
 # Translations
 gem "json_translate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,6 @@ GEM
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
-    hiredis (0.6.3)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -575,7 +574,6 @@ DEPENDENCIES
   gobierto_budgets_data!
   google-api-client
   hashie
-  hiredis
   i18n-js (>= 3.0.0.rc11)
   i18n-tasks
   ine-places (= 0.3.0)


### PR DESCRIPTION
## :v: What does this PR do?

Removes hiredis driver gem because it doesn't support SSL: https://github.com/redis/hiredis-rb/issues/58

The performance gain in hiredis is not that important because we don't make an intensive use of Redis.
