### PR TITLE
Provide a cache_service helper method in GobiertoPeople base controller

### DIFF
--- a/app/controllers/gobierto_people/application_controller.rb
+++ b/app/controllers/gobierto_people/application_controller.rb
@@ -6,7 +6,7 @@ module GobiertoPeople
 
     before_action { module_enabled!(current_site, "GobiertoPeople") }
 
-    helper_method :gifts_service_url, :trips_service_url
+    helper_method :gifts_service_url, :trips_service_url, :cache_service
 
     private
 
@@ -24,5 +24,8 @@ module GobiertoPeople
       @current_site_configuration_variables ||= current_site.configuration.configuration_variables
     end
 
+    def cache_service
+      @cache_service ||= GobiertoCommon::CacheService.new(current_site, "GobiertoPeople")
+    end
   end
 end


### PR DESCRIPTION
Related to PopulateTools/issues#1532


## :v: What does this PR do?

Adds a `cache_service` helper method available in GobiertoPeople controllers and views

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No