### PR TITLE
Povide a cache_service from controllers and use it in views

### DIFF
--- a/app/controllers/gobierto_budgets/application_controller.rb
+++ b/app/controllers/gobierto_budgets/application_controller.rb
@@ -1,7 +1,7 @@
 class GobiertoBudgets::ApplicationController < ApplicationController
   include User::SessionHelper
 
-  helper_method :cache_path
+  helper_method :cache_path, :cache_service
 
   rescue_from GobiertoBudgets::BudgetLine::RecordNotFound, with: :render_404
   rescue_from GobiertoBudgets::BudgetLine::InvalidSearchConditions do |exception|
@@ -17,6 +17,10 @@ class GobiertoBudgets::ApplicationController < ApplicationController
   end
 
   private
+
+  def cache_service
+    @cache_service ||= GobiertoCommon::CacheService.new(current_site, "GobiertoBudgets")
+  end
 
   def cache_path
     "#{current_site.cache_key_with_version}/#{current_module}/#{self.controller_name}/#{self.action_name}/#{I18n.locale}"

--- a/app/controllers/gobierto_cms/application_controller.rb
+++ b/app/controllers/gobierto_cms/application_controller.rb
@@ -5,5 +5,12 @@ module GobiertoCms
 
     layout "gobierto_cms/layouts/application"
 
+    helper_method :cache_service
+
+    private
+
+    def cache_service
+      @cache_service ||= GobiertoCommon::CacheService.new(current_site, "GobiertoCms")
+    end
   end
 end

--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -3,6 +3,8 @@
 class MetaWelcomeController < ApplicationController
   include User::SessionHelper
 
+  helper_method :cache_service
+
   def index
     render_404 and return if current_site.nil?
 
@@ -32,5 +34,11 @@ class MetaWelcomeController < ApplicationController
 
       render "gobierto_cms/pages/meta_welcome", layout: "gobierto_cms/layouts/application"
     end
+  end
+
+  private
+
+  def cache_service
+    @cache_service ||= GobiertoCommon::CacheService.new(current_site, "GobiertoCms")
   end
 end

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -1,4 +1,4 @@
-<% cache(["gobierto_budgets/budget_lines/explorer", current_site, I18n.locale, @year]) do %>
+<% cache_service.fetch(["gobierto_budgets/budget_lines/explorer", I18n.locale, @year].join("/")) do %>
   <div class="block explore_detail">
 
     <h2><%= t('.explore_the_detail') %></h2>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -1,4 +1,4 @@
-<% cache([cache_path, "show_partial"]) do %>
+<% cache_service.fetch([cache_path, "show_partial"].join("/")) do %>
 
   <div class="breadcrumb stick_ip" data-budget-line-breadcrumb="<%= budget_line_breadcrumb(@budget_line, @year, @kind) %>"
                                    data-budget-line-area="<%= @area_name %>" data-budget-line-categories="<%= gobierto_budgets_api_categories_path(format: :json) %>">

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <% cache(["gobierto_budgets/metric_boxes", current_site, I18n.locale, @year]) do %>
+    <% cache_service.fetch(["gobierto_budgets/metric_boxes", I18n.locale, @year].join("/")) do %>
       <div class="pure-g metric_boxes">
 
         <% if @site_stats.population_data? %>
@@ -227,7 +227,7 @@
     </div>
   <% end %>
 
-  <% cache(["gobierto_budgets/interesting_budget_lines", current_site, I18n.locale, @year]) do %>
+  <% cache_service.fetch(["gobierto_budgets/interesting_budget_lines", I18n.locale, @year].join("/")) do %>
     <div class="block">
       <h2 class="with_description"><%= t('.most_interesting_budget_lines') %></h2>
       <p class="description"><%= t('.most_interesting_budget_lines_description') %></p>

--- a/app/views/gobierto_cms/pages/meta_welcome.html.erb
+++ b/app/views/gobierto_cms/pages/meta_welcome.html.erb
@@ -6,7 +6,7 @@
   <%= stylesheet_packs_with_chunks_tag 'cms' %>
 <% end %>
 
-<% cache(["gobierto_cms/pages/meta_welcome", current_site, I18n.locale]) do %>
+<% cache_service.fetch(["gobierto_cms/pages/meta_welcome", I18n.locale].join("/")) do %>
   <% title(@page.title) %>
   <% description(truncate(strip_tags(@page.body), length: 100)) %>
 

--- a/test/integration/gobierto_budgets/budget_line_test.rb
+++ b/test/integration/gobierto_budgets/budget_line_test.rb
@@ -6,6 +6,8 @@ require "factories/budget_line_factory"
 class GobiertoBudgets::BudgetLineIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     super
+    ::GobiertoCommon::CacheService.new(placed_site, "GobiertoBudgets").clear
+    ::GobiertoCommon::CacheService.new(organization_site, "GobiertoBudgets").clear
     @path = gobierto_budgets_budget_line_path("1", last_year, GobiertoBudgets::EconomicArea.area_name, GobiertoBudgets::BudgetLine::EXPENSE)
     @budget_line_factory = BudgetLineFactory.new(year: last_year)
   end


### PR DESCRIPTION
Related to PopulateTools/issues#1532


## :v: What does this PR do?

Extends the use of cache services scoped to different Gobierto modules and sites in views for fragments that are already being cached 

## :mag: How should this be manually tested?

Nothing should change

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No