### PR TITLE
4066 cache cms issues

### DIFF
--- a/app/helpers/gobierto_common/cache_service_helper.rb
+++ b/app/helpers/gobierto_common/cache_service_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module CacheServiceHelper
+    def cache_service_fragment(name = {}, options = {}, &block)
+      key = cache_service.prefixed(name.is_a?(Enumerable) ? name.join("/") : name)
+
+      cache(key, options, &block)
+    end
+  end
+end

--- a/app/services/gobierto_common/cache_service.rb
+++ b/app/services/gobierto_common/cache_service.rb
@@ -11,6 +11,7 @@ module GobiertoCommon
 
     def clear
       Rails.cache.delete_matched("#{cache_prefix}/*")
+      Rails.cache.delete_matched("*/#{cache_prefix}/*")
     end
 
     def delete(name, options = nil)

--- a/app/services/gobierto_common/cache_service.rb
+++ b/app/services/gobierto_common/cache_service.rb
@@ -10,8 +10,8 @@ module GobiertoCommon
     end
 
     def clear
-      Rails.cache.delete_matched("#{cache_prefix}/*")
-      Rails.cache.delete_matched("*/#{cache_prefix}/*")
+      Rails.cache.delete_matched(clear_match_prefix)
+      Rails.cache.delete_matched(clear_match_middle)
     end
 
     def delete(name, options = nil)
@@ -32,9 +32,27 @@ module GobiertoCommon
 
     # These methods are very inefficient
     def keys
-      @keys ||= Rails.cache.redis.keys.select do |key|
-        /\A#{cache_prefix}\//.match? key
-      end
+      @keys ||= if redis_cache?
+                  Rails.cache.redis.keys(clear_match_prefix) + Rails.cache.redis.keys(clear_match_middle)
+                else
+                  Rails.cache.instance_variable_get(:@data).keys.select do |key|
+                    [clear_match_prefix, clear_match_middle].any? { |expression| expression.match?(key) }
+                  end
+                end
+    end
+
+    def redis_cache?
+      @redis_cache ||= Rails.cache.is_a? ActiveSupport::Cache::RedisCacheStore
+    end
+
+    private
+
+    def clear_match_prefix
+      redis_cache? ? "#{cache_prefix}/*" : /\A#{cache_prefix}\/.*/
+    end
+
+    def clear_match_middle
+      redis_cache? ? "*/#{cache_prefix}/*" : /.*\/#{cache_prefix}\/.*/
     end
   end
 end

--- a/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_explorer.html.erb
@@ -1,4 +1,4 @@
-<% cache_service.fetch(["gobierto_budgets/budget_lines/explorer", I18n.locale, @year].join("/")) do %>
+<% cache_service_fragment(["gobierto_budgets/budget_lines/explorer", I18n.locale, @year].join("/")) do %>
   <div class="block explore_detail">
 
     <h2><%= t('.explore_the_detail') %></h2>

--- a/app/views/gobierto_budgets/budget_lines/show.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/show.html.erb
@@ -1,4 +1,4 @@
-<% cache_service.fetch([cache_path, "show_partial"].join("/")) do %>
+<% cache_service_fragment([cache_path, "show_partial"].join("/")) do %>
 
   <div class="breadcrumb stick_ip" data-budget-line-breadcrumb="<%= budget_line_breadcrumb(@budget_line, @year, @kind) %>"
                                    data-budget-line-area="<%= @area_name %>" data-budget-line-categories="<%= gobierto_budgets_api_categories_path(format: :json) %>">

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <% cache_service.fetch(["gobierto_budgets/metric_boxes", I18n.locale, @year].join("/")) do %>
+    <% cache_service_fragment(["gobierto_budgets/metric_boxes", I18n.locale, @year].join("/")) do %>
       <div class="pure-g metric_boxes">
 
         <% if @site_stats.population_data? %>
@@ -227,7 +227,7 @@
     </div>
   <% end %>
 
-  <% cache_service.fetch(["gobierto_budgets/interesting_budget_lines", I18n.locale, @year].join("/")) do %>
+  <% cache_service_fragment(["gobierto_budgets/interesting_budget_lines", I18n.locale, @year].join("/")) do %>
     <div class="block">
       <h2 class="with_description"><%= t('.most_interesting_budget_lines') %></h2>
       <p class="description"><%= t('.most_interesting_budget_lines_description') %></p>

--- a/app/views/gobierto_cms/pages/meta_welcome.html.erb
+++ b/app/views/gobierto_cms/pages/meta_welcome.html.erb
@@ -6,7 +6,7 @@
   <%= stylesheet_packs_with_chunks_tag 'cms' %>
 <% end %>
 
-<% cache_service.fetch(["gobierto_cms/pages/meta_welcome", I18n.locale].join("/")) do %>
+<% cache_service_fragment(["gobierto_cms/pages/meta_welcome", I18n.locale]) do %>
   <% title(@page.title) %>
   <% description(truncate(strip_tags(@page.body), length: 100)) %>
 


### PR DESCRIPTION
Closes PopulateTools/gobierto#4066


## :v: What does this PR do?

* Fixes an error in views trying to use cache service to cache html fragments by:
* Adding a helper method which uses ActionView cache helper method including the key associated to the current cache_service
* Changing the clear cache service method to include keys with the service prefix in the middle (ActionView cache prepends additonal prefixes to the keys so the cached data )

## :mag: How should this be manually tested?

Visit a site where the CMS is defined as homepage. After reloading nothing should change


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
