### PR TITLE
Invoices import fixes

### DIFF
--- a/lib/tasks/gobierto_budgets/data/invoices.rake
+++ b/lib/tasks/gobierto_budgets/data/invoices.rake
@@ -49,10 +49,10 @@ namespace :gobierto_budgets do
     end
 
     desc "Clear previous invoices data"
-    task :clear_previous_invoices_data, [:organization_id,:year] => :environment do |_t, args|
+    task :clear_previous_invoices_data, [:organization_id] => :environment do |_t, args|
       index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_INVOICES
       type =  GobiertoBudgetsData::GobiertoBudgets::INVOICE_TYPE
-      organization_id = ARGV[0].to_s
+      organization_id = args[:organization_id]
 
       puts "[START] clear-previous-providers/run.rb organization_id=#{organization_id}"
 

--- a/lib/utils/csv_utils.rb
+++ b/lib/utils/csv_utils.rb
@@ -10,7 +10,9 @@ class CsvUtils
   end
 
   def self.separator_check(filename, separator)
-    columns_counts = CSV.read(filename, col_sep: separator).map(&:size).uniq
+    # Skip the first line just in case it contains a header
+    # Does a compact, to remove empty cells
+    columns_counts = CSV.read(filename, col_sep: separator)[1..-1].map(&:compact).map(&:size).uniq
     columns_counts.size == 1 && columns_counts.first > 1
   end
 end

--- a/lib/utils/csv_utils.rb
+++ b/lib/utils/csv_utils.rb
@@ -14,5 +14,7 @@ class CsvUtils
     # Does a compact, to remove empty cells
     columns_counts = CSV.read(filename, col_sep: separator)[1..-1].map(&:compact).map(&:size).uniq
     columns_counts.size == 1 && columns_counts.first > 1
+  rescue CSV::MalformedCSVError
+    false
   end
 end


### PR DESCRIPTION
Unexpected

This PR fixes a couple of issues with invoices import:

- in the task, the year argument wasn't necessary
- the utility to detect the separator might be confused by blank cells, so a `.compact` is necessary