### PR TITLE
1362 include locale in cache

### DIFF
--- a/app/controllers/gobierto_data/api/v1/datasets_controller.rb
+++ b/app/controllers/gobierto_data/api/v1/datasets_controller.rb
@@ -22,7 +22,7 @@ module GobiertoData
           respond_to do |format|
             format.json do
               json = if base_relation.exists?
-                       cache_service.fetch("#{filtered_relation.cache_key_with_version}/#{valid_preview_token? ? "all" : "active"}/datasets_collection") do
+                       cache_service.fetch("#{filtered_relation.cache_key_with_version}/#{valid_preview_token? ? "all" : "active"}/#{I18n.locale}/datasets_collection") do
                          json_from_relation(relation, :index)
                        end
                      else

--- a/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
+++ b/app/serializers/concerns/gobierto_common/has_custom_fields_attributes.rb
@@ -58,5 +58,11 @@ module GobiertoCommon
     def serialize_for_search_engine?
       @serialize_for_search_engine ||= instance_options[:serialize_for_search_engine]
     end
+
+    def cache_key(arg)
+      super
+
+      @cache_key = [@cache_key, I18n.locale].join("/")
+    end
   end
 end

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -5,8 +5,6 @@ module GobiertoData
     include Rails.application.routes.url_helpers
     include ::GobiertoCommon::HasCustomFieldsAttributes
 
-    cache key: "dataset"
-
     attributes :id, :name, :slug, :table_name, :data_updated_at
 
     attribute :links, unless: :exclude_links? do

--- a/app/services/gobierto_common/custom_fields_service.rb
+++ b/app/services/gobierto_common/custom_fields_service.rb
@@ -12,7 +12,7 @@ module GobiertoCommon
       @cache_service = opts[:cache_service]
       @site = opts[:site] || @cache_service&.site
       @cache_service ||= CacheService.new(site, resource.class.name.deconstantize) if @site.present?
-      @base_cache_key = "#{relation.cache_key_with_version}/custom_fields"
+      @base_cache_key = "#{relation.cache_key_with_version}#{locale_key}/custom_fields"
     end
 
     def transformed_custom_field_record_values(reset_cache: false)
@@ -26,7 +26,7 @@ module GobiertoCommon
 
     def calculate_transformed_custom_field_record_values
         raw_values = custom_field_record_values
-        return raw_values if localized_custom_fields.blank? && md_custom_fields.blank?
+        return raw_values unless include_locale?
 
         localized_uids = localized_custom_fields.pluck(:uid)
         md_uids = md_custom_fields.pluck(:uid)
@@ -108,6 +108,14 @@ module GobiertoCommon
                          else
                            site.custom_fields.for_class(resource.class)
                          end
+    end
+
+    def locale_key
+      include_locale? ? "/#{I18n.locale}" : ""
+    end
+
+    def include_locale?
+      @include_locale ||= localized_custom_fields.present? || md_custom_fields.present?
     end
 
     def localized_custom_fields


### PR DESCRIPTION
Related to PopulateTools/issues#1362


## :v: What does this PR do?

This PR avoids caching the datasets index in only one locale. To do this:

* It adds the locale key from controller
* In custom fields service used by API controllers and decorators it adds the locale if there are localized custom fields involved.
* Disables redundant cache provided by ActiveModel serializers on DatasetSerializer (the serialized result is already being cached)
* Add locale to cache_key provided ActiveModel serializer  

## :mag: How should this be manually tested?

Send a request to the API to the index of datasets using localized custom fields and change locale. The contents of the localized fields should change

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No