### PR TITLE
Remove size for a format caching datasets if the result is an error

### DIFF
--- a/app/models/gobierto_data/cache.rb
+++ b/app/models/gobierto_data/cache.rb
@@ -43,7 +43,15 @@ module GobiertoData
       if !File.file?(filename) || update
         result = yield
         size = File.write(filename, result, mode: "wb+")
-        dataset.update_attribute(:size, (dataset.size || {}).merge(format => size))
+
+        size_attribute = dataset.size || {}
+        if result.is_a?(Hash)
+          size_attribute.delete(format)
+        else
+          size_attribute.merge!(format => size)
+        end
+
+        dataset.update_attribute(:size, size_attribute)
       end
 
       File.open(filename, "rb")


### PR DESCRIPTION
Related to PopulateTools/issues#1362


## :v: What does this PR do?

There are some situations where the operation to catch the dataset content to a file fails due to a timeout or query error. This PR avoids saving the error message size as the dataset size and if there is a default limit for big datasets is applied to these ones also.  

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No