### PR TITLE
Gobierto Costs / Add the 2021 population of Mataró

### DIFF
--- a/app/javascript/gobierto_visualizations/modules/costs_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/costs_controller.js
@@ -156,7 +156,6 @@ export class CostsController {
         );
       }
     })
-    console.log("rawData", rawData);
 
     let groupDataByYears = [];
 

--- a/app/javascript/gobierto_visualizations/modules/costs_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/costs_controller.js
@@ -118,16 +118,10 @@ export class CostsController {
     //Convert strings with some format to Numbers without format
     function convertStringToNumbers(amount) {
       if (amount === "") {
-        return nanToZero(amount);
+        return +amount || 0;
       } else {
         return Number(parseFloat(amount));
       }
-    }
-
-    //Some values are empty, so we need to transform to zero
-    function nanToZero(val) {
-      val = +val || 0;
-      return val;
     }
 
     //Array with all the strings that we've to convert to Number
@@ -150,22 +144,19 @@ export class CostsController {
       "costdirfin"
     ];
 
-    const population = ["128291", "129661"];
+    const population = ["128291", "129661", "129120"];
 
     let yearsCosts = [...new Set(rawData.map(item => item.any_))];
 
-    for (let index = 0; index < rawData.length; index++) {
-      let d = rawData[index];
-
-      const ix = yearsCosts.findIndex(x => x === d["any_"])
-      d.population = population[ix]
-
-      for (let amounts = 0; amounts < amountStrings.length; amounts++) {
-        d[amountStrings[amounts]] = convertStringToNumbers(
-          d[amountStrings[amounts]]
+    rawData.forEach((item, index) => {
+      rawData[index].population = population[yearsCosts.findIndex(year => year === rawData[index]["any_"])]
+      for (let amounts of amountStrings) {
+        rawData[index][amounts] = convertStringToNumbers(
+          rawData[index][amounts]
         );
       }
-    }
+    })
+    console.log("rawData", rawData);
 
     let groupDataByYears = [];
 

--- a/app/javascript/gobierto_visualizations/modules/costs_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/costs_controller.js
@@ -116,14 +116,7 @@ export class CostsController {
 
   setGlobalVariables(rawData) {
     //Convert strings with some format to Numbers without format
-    function convertStringToNumbers(amount) {
-      if (amount === "") {
-        return +amount || 0;
-      } else {
-        return Number(parseFloat(amount));
-      }
-    }
-
+    const toNumber = (value) => value ? +value || 0 : +(parseFloat(value))
     //Array with all the strings that we've to convert to Number
     const amountStrings = [
       "costdirecte",
@@ -147,13 +140,15 @@ export class CostsController {
     const population = ["128291", "129661", "129120"];
 
     let yearsCosts = [...new Set(rawData.map(item => item.any_))];
+    const setPopulation = (value, item) => value[yearsCosts.findIndex(year => year === item["any_"])]
 
-    rawData.forEach((item, index) => {
-      rawData[index].population = population[yearsCosts.findIndex(year => year === rawData[index]["any_"])]
+    const data = rawData.map((item) => {
       for (let amounts of amountStrings) {
-        rawData[index][amounts] = convertStringToNumbers(
-          rawData[index][amounts]
-        );
+        item[amounts] = toNumber(item[amounts]);
+      }
+      return {
+        population: setPopulation(population, item),
+        ...item
       }
     })
 
@@ -214,7 +209,7 @@ export class CostsController {
       .sort(({ costtotal: a }, { costtotal: b }) => (a > b ? -1 : 1));
 
     this.data = {
-      costData: rawData,
+      costData: data,
       groupData: groupDataByYears,
       yearsCosts: yearsCosts
     };


### PR DESCRIPTION
Related [#1563](https://github.com/PopulateTools/issues/issues/1563)

## :v: What does this PR do?
- Add manually the population of the 2021 of [Mataró](https://www.idescat.cat/emex/?id=081213&lang=es).
- Refactor some functions.

## :mag: How should this be manually tested?
[Staging](https://mataro.gobify.net/visualizaciones/costes)

## :eyes: Screenshots

### Before this PR
![before](https://user-images.githubusercontent.com/2649175/165480675-378fa9f4-7558-4fd1-9614-74288fff51e7.png)

### After this PR
![After](https://user-images.githubusercontent.com/2649175/165481855-22520b65-c603-4910-a779-4433ad45d898.png)

