### PR TITLE
1362 cache datasets meta data summary

### DIFF
--- a/app/jobs/gobierto_data/cache_datasets_metadata.rb
+++ b/app/jobs/gobierto_data/cache_datasets_metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  class CacheDatasetsMetadata < ActiveJob::Base
+    queue_as :cached_data
+
+    def perform(dataset)
+      GobiertoData::DatasetMetaSerializer.new(dataset).to_json
+    end
+  end
+end

--- a/app/jobs/gobierto_data/cache_datasets_metadata.rb
+++ b/app/jobs/gobierto_data/cache_datasets_metadata.rb
@@ -5,7 +5,7 @@ module GobiertoData
     queue_as :cached_data
 
     def perform(dataset)
-      GobiertoData::DatasetMetaSerializer.new(dataset).to_json
+      dataset.rows_count
     end
   end
 end

--- a/app/models/gobierto_data/cache.rb
+++ b/app/models/gobierto_data/cache.rb
@@ -51,7 +51,7 @@ module GobiertoData
           size_attribute.merge!(format => size)
         end
 
-        dataset.update_attribute(:size, size_attribute)
+        dataset.update_column(:size, size_attribute)
       end
 
       File.open(filename, "rb")

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -99,10 +99,10 @@ module GobiertoData
       cache_service.fetch("#{cache_key_with_version}/rows_count") do
         count_result = ::GobiertoData::Connection.execute_query(
           site,
-          Arel.sql("SELECT COUNT(1) FROM #{table_name} LIMIT 1"),
+          Arel.sql("SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = 'public.#{table_name}' ::regclass;"),
           include_draft: true
         )
-        count_result.first["count"] if count_result.is_a?(PG::Result)
+        count_result.first["estimate"] if count_result.is_a?(PG::Result)
       end
     end
 

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -95,6 +95,17 @@ module GobiertoData
       end
     end
 
+    def rows_count
+      cache_service.fetch("#{cache_key_with_version}/rows_count") do
+        count_result = ::GobiertoData::Connection.execute_query(
+          site,
+          Arel.sql("SELECT COUNT(1) FROM #{table_name} LIMIT 1"),
+          include_draft: true
+        )
+        count_result.first["count"] if count_result.is_a?(PG::Result)
+      end
+    end
+
     def load_data_from_file(file_path, schema_file: nil, csv_separator: ",", append: false)
       statements = GobiertoData::Datasets::CreationStatements.new(
         self,

--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -109,7 +109,7 @@ module GobiertoData
       set_schema
       unless query_result.blank? || query_result.has_key?(:errors)
         touch(:data_updated_at)
-        refresh_cached_downloads
+        refresh_cached_data
       end
 
       {
@@ -158,8 +158,9 @@ module GobiertoData
       GobiertoData::Connection.execute_query(site, "drop table #{table_name}")
     end
 
-    def refresh_cached_downloads
-      CacheDatasetsDownloads.perform_later self
+    def refresh_cached_data
+      GobiertoData::CacheDatasetsDownloads.perform_later self
+      GobiertoData::CacheDatasetsMetadata.perform_later self
     end
 
     def schema_from_file(schema_file, append)

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -33,16 +33,7 @@ module GobiertoData
     end
 
     attribute :data_summary do
-      object.cache_service.fetch("#{base_cache_key}/data_summary") do
-        count_result = ::GobiertoData::Connection.execute_query(
-          object.site,
-          Arel.sql("SELECT COUNT(1) FROM #{object.table_name} LIMIT 1"),
-          include_draft: true
-        )
-        {
-          number_of_rows: count_result.is_a?(PG::Result) ? count_result.first.dig("count") : nil
-        }
-      end
+      { number_of_rows: object.rows_count }
     end
 
     attribute :formats do

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -33,14 +33,16 @@ module GobiertoData
     end
 
     attribute :data_summary do
-      count_result = ::GobiertoData::Connection.execute_query(
-        object.site,
-        Arel.sql("SELECT COUNT(1) FROM #{object.table_name} LIMIT 1"),
-        include_draft: true
-      )
-      {
-        number_of_rows: count_result.is_a?(PG::Result) ? count_result.first.dig("count") : nil
-      }
+      object.cache_service.fetch("#{base_cache_key}/data_summary") do
+        count_result = ::GobiertoData::Connection.execute_query(
+          object.site,
+          Arel.sql("SELECT COUNT(1) FROM #{object.table_name} LIMIT 1"),
+          include_draft: true
+        )
+        {
+          number_of_rows: count_result.is_a?(PG::Result) ? count_result.first.dig("count") : nil
+        }
+      end
     end
 
     attribute :formats do
@@ -75,5 +77,8 @@ module GobiertoData
       object.rails_model.present? && object.rails_model.table_exists?
     end
 
+    def base_cache_key
+      [object.cache_key_with_version, "dataset_meta"].join("/")
+    end
   end
 end


### PR DESCRIPTION
Related to  PopulateTools/issues#1362


## :v: What does this PR do?

When tables associated to datasets have a big number of rows the meta endpoint of datasets takes too long the first time (the response is cached). This PR:
* Uses data cache service to store the result of the rows count query in a rows_count method defined in the dataset model. This method is called by the dataset metadata endpoint
* Adds a job to cache the method result in the callback after uploading a dataset
* The cache key includes the timestamp of the dataset. To avoid expiring the cache key the PR changes the dataset_cache operation (which saves the csv of dataset into a file) to not change the dataset timestamp 

## :mag: How should this be manually tested?

Run a datasets load ETL with huge tables and visit a dataset for the first time. The page load should take less than 1s

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No