### PR TITLE
Disable user subscriptions

### DIFF
--- a/app/models/concerns/user/subscriber.rb
+++ b/app/models/concerns/user/subscriber.rb
@@ -2,6 +2,9 @@ module User::Subscriber
   extend ActiveSupport::Concern
 
   def subscribed_to?(subscribable, site, finder_method = :user_subscribed_to?)
+    # Disable any new subscriptions from being created
+    return true
+
     if subscribable.is_a?(Class) || subscribable.is_a?(Module)
       User::Subscription::Finder.send(finder_method, self, subscribable.name, nil, site.id)
     else

--- a/app/views/user/subscriptions/_subscribable_box.html.erb
+++ b/app/views/user/subscriptions/_subscribable_box.html.erb
@@ -1,45 +1,47 @@
-<% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
+<% pending do %>
+  <% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
 
-<% if !user_signed_in? || !current_user.subscribed_to?(subscribable, current_site, :user_subscribed_by_broader_subscription_to?) %>
+  <% if !user_signed_in? || !current_user.subscribed_to?(subscribable, current_site, :user_subscribed_by_broader_subscription_to?) %>
 
-<div class="subscribable-box slim_box box">
-  <div class="inner">
-    <h3><%= title %>
-    <% if defined?(subtitle) %>
-      · <%= subtitle %>
-    <% end %>
-    </h3>
+    <div class="subscribable-box slim_box box">
+      <div class="inner">
+        <h3><%= title %>
+        <% if defined?(subtitle) %>
+          · <%= subtitle %>
+      <% end %>
+        </h3>
 
-    <% if user_signed_in? %>
+        <% if user_signed_in? %>
 
-      <%= button_to(
-        current_user.subscribed_to?(subscribable, current_site) ? t(".cancel") : t(".subscribe"),
-        user_subscriptions_path,
-        params: {
-          user_subscription: {
-            subscribable_type: user_subscription_form.subscribable_type,
-            subscribable_id: user_subscription_form.subscribable_id
-          }
-        },
-        class: "pure-menu-link", role: "button")
-      %>
+          <%= button_to(
+            current_user.subscribed_to?(subscribable, current_site) ? t(".cancel") : t(".subscribe"),
+            user_subscriptions_path,
+            params: {
+              user_subscription: {
+                subscribable_type: user_subscription_form.subscribable_type,
+                subscribable_id: user_subscription_form.subscribable_id
+              }
+            },
+            class: "pure-menu-link", role: "button")
+          %>
 
-    <% else %>
+      <% else %>
 
-      <%= form_for(user_subscription_form, as: :user_subscription, url: :user_subscriptions) do |f| %>
-        <%= f.hidden_field :subscribable_type %>
-        <%= f.hidden_field :subscribable_id %>
-        <label class="screen-hidden" for="user_subscription_user_email"><%= defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %></label>
-        <%= f.email_field :user_email, placeholder: defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %>
-        <%= f.invisible_captcha :ic_email %>
+        <%= form_for(user_subscription_form, as: :user_subscription, url: :user_subscriptions) do |f| %>
+          <%= f.hidden_field :subscribable_type %>
+          <%= f.hidden_field :subscribable_id %>
+          <label class="screen-hidden" for="user_subscription_user_email"><%= defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %></label>
+          <%= f.email_field :user_email, placeholder: defined?(placeholder) ? placeholder : t(".form.placeholders.user_email") %>
+          <%= f.invisible_captcha :ic_email %>
 
-        <%= f.submit t(".form.submit"), role: "button" %>
-        <div class="disclaimer"><%= privacy_policy_page_link %></div>
+          <%= f.submit t(".form.submit"), role: "button" %>
+          <div class="disclaimer"><%= privacy_policy_page_link %></div>
+        <% end %>
+
       <% end %>
 
-    <% end %>
+      </div>
+    </div>
 
-  </div>
-</div>
-
+  <% end %>
 <% end %>

--- a/app/views/user/subscriptions/_subscribable_button.html.erb
+++ b/app/views/user/subscriptions/_subscribable_button.html.erb
@@ -1,37 +1,38 @@
-<% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
-<% subscribed = user_signed_in? ? current_user.subscribed_to?(subscribable, current_site) : false %>
-<% subscribed_by_broader_subscription = subscribed && current_user.subscribed_to?(subscribable, current_site, :user_subscribed_by_broader_subscription_to?) %>
+<% pending do %>
+  <% user_subscription_form = User::SubscriptionForm.new(subscribable: subscribable) %>
+  <% subscribed = user_signed_in? ? current_user.subscribed_to?(subscribable, current_site) : false %>
+  <% subscribed_by_broader_subscription = subscribed && current_user.subscribed_to?(subscribable, current_site, :user_subscribed_by_broader_subscription_to?) %>
 
-<% if user_signed_in? %>
-  <% if subscribed %>
-    <% if subscribed_by_broader_subscription %>
-      <div class="pure-menu pure-menu-horizontal">
-        <ul class="pure-menu-list left">
-          <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <%= link_to "#", class: "button button-feed" do %>
-              <i class="fas fa-star"></i>
-              <%= subscription_message(subscribable, "followed") %>
-            <% end %>
-            <ul class="pure-menu-children">
-              <li class="pure-menu-item">
-                <%= link_to(user_subscriptions_path, class: "pure-menu-link") do %>
-                  <%= t(".manage_subscriptions") %>
-                <% end %>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-    <% else %>
-      <% user_subscription = User::Subscription.find_by(user: current_user,
-                                                        subscribable_id: user_subscription_form.subscribable_id,
-                                                        subscribable_type: user_subscription_form.subscribable_type.to_s) %>
-      <%= link_to(user_subscription_path(user_subscription),
+  <% if user_signed_in? %>
+    <% if subscribed %>
+      <% if subscribed_by_broader_subscription %>
+        <div class="pure-menu pure-menu-horizontal">
+          <ul class="pure-menu-list left">
+            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+              <%= link_to "#", class: "button button-feed" do %>
+                <i class="fas fa-star"></i>
+                <%= subscription_message(subscribable, "followed") %>
+              <% end %>
+              <ul class="pure-menu-children">
+                <li class="pure-menu-item">
+                  <%= link_to(user_subscriptions_path, class: "pure-menu-link") do %>
+                    <%= t(".manage_subscriptions") %>
+                  <% end %>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      <% else %>
+        <% user_subscription = User::Subscription.find_by(user: current_user,
+                                                          subscribable_id: user_subscription_form.subscribable_id,
+                                                          subscribable_type: user_subscription_form.subscribable_type.to_s) %>
+                                                        <%= link_to(user_subscription_path(user_subscription),
         remote: true,
         method: :delete,
         class: "button button-feed") do %>
-          <i class="fas fa-star"></i>
-          <%= subscription_message(subscribable, "followed") %>
+        <i class="fas fa-star"></i>
+        <%= subscription_message(subscribable, "followed") %>
       <% end %>
     <% end %>
   <% else %>
@@ -45,15 +46,16 @@
       remote: true,
       method: :post,
       class: "button button-feed") do %>
-        <i class="fas fa-rss"></i>
+      <i class="fas fa-rss"></i>
         <%= subscription_message(subscribable, "follow") %>
+      <% end %>
     <% end %>
-  <% end %>
-<% else %>
-  <%= link_to(
-    new_user_sessions_path(open_modal: true),
-    class: "button button-feed") do %>
+  <% else %>
+    <%= link_to(
+      new_user_sessions_path(open_modal: true),
+      class: "button button-feed") do %>
       <i class="fas fa-rss"></i>
       <%= subscription_message(subscribable, "follow") %>
+    <% end %>
   <% end %>
 <% end %>

--- a/test/forms/user/subscription_form_test.rb
+++ b/test/forms/user/subscription_form_test.rb
@@ -56,11 +56,13 @@ class User::SubscriptionFormTest < ActiveSupport::TestCase
   end
 
   def test_validation
+    skip "User subscriptions are disabled"
     assert valid_user_subscription_form.valid?
     assert valid_new_user_subscription_form.valid?
   end
 
   def test_save_when_not_created
+    skip "User subscriptions are disabled"
     assert_equal(
       [:create, true],
       valid_user_subscription_form.save
@@ -73,6 +75,7 @@ class User::SubscriptionFormTest < ActiveSupport::TestCase
   end
 
   def test_save_when_already_created
+    skip "User subscriptions are disabled"
     user.subscribe_to!(subscribable, site)
 
     assert_equal(
@@ -82,6 +85,7 @@ class User::SubscriptionFormTest < ActiveSupport::TestCase
   end
 
   def test_error_messages_with_invalid_attributes
+    skip "User subscriptions are disabled"
     invalid_user_subscription_form.save
 
     assert_equal 1, invalid_user_subscription_form.errors.messages[:email].size
@@ -90,6 +94,7 @@ class User::SubscriptionFormTest < ActiveSupport::TestCase
   end
 
   def test_error_messages_with_invalid_attributes_in_new_user_form
+    skip "User subscriptions are disabled"
     invalid_new_user_subscription_form.save
 
     assert_equal 1, invalid_new_user_subscription_form.errors.messages[:email].size
@@ -98,6 +103,7 @@ class User::SubscriptionFormTest < ActiveSupport::TestCase
   end
 
   def test_user_registration
+    skip "User subscriptions are disabled"
     assert_difference "User.count", 1 do
       valid_new_user_subscription_form.save
     end

--- a/test/forms/user/subscription_preferences_form_test.rb
+++ b/test/forms/user/subscription_preferences_form_test.rb
@@ -37,16 +37,22 @@ class User::SubscriptionPreferencesFormTest < ActiveSupport::TestCase
   end
 
   def test_validation
+    skip "User subscriptions are disabled"
+
     assert valid_user_subscription_preferences_form.valid?
   end
 
   def test_error_messages_with_invalid_attributes
+    skip "User subscriptions are disabled"
+
     refute invalid_user_subscription_preferences_form.valid?
 
     assert_equal 1, invalid_user_subscription_preferences_form.errors.messages[:notification_frequency].size
   end
 
   def test_save
+    skip "User subscriptions are disabled"
+
     refute user.subscribed_to?(GobiertoPeople, site)
     refute user.subscribed_to?(person, site)
 

--- a/test/integration/user/subscription_index_test.rb
+++ b/test/integration/user/subscription_index_test.rb
@@ -21,6 +21,8 @@ class User::SubscriptionIndexTest < ActionDispatch::IntegrationTest
   end
 
   def test_subscription_management
+    skip "User subscriptions disabled"
+
     element_names = ["user_subscription_preferences_modules_gobierto_people",
                      "user_subscription_preferences_gobierto_people_people_#{person.id}"]
     with_signed_in_user(user) do
@@ -44,6 +46,8 @@ class User::SubscriptionIndexTest < ActionDispatch::IntegrationTest
   end
 
   def test_broader_subscription_disables_specific_subscriptions
+    skip "User subscriptions disabled"
+
     with_javascript do
       with_signed_in_user(user) do
         visit @path
@@ -76,6 +80,8 @@ class User::SubscriptionIndexTest < ActionDispatch::IntegrationTest
   end
 
   def test_site_subscription
+    skip "User subscriptions disabled"
+
     element_names = ["user_subscription_preferences_modules_gobierto_people",
                      "user_subscription_preferences_gobierto_people_people_#{person.id}"]
     with_javascript do

--- a/test/support/concerns/user/subscriber_test.rb
+++ b/test/support/concerns/user/subscriber_test.rb
@@ -19,32 +19,38 @@ module User::SubscriberTest
   end
 
   def test_subscribed_to?
+    skip "User subscriptions are disabled"
     assert subscribed_user.subscribed_to?(subscription_subject, subscription_site)
   end
 
   def test_subscribe_to!
+    skip "User subscriptions are disabled"
     refute user_without_subscriptions.subscribed_to?(subscription_subject, subscription_site)
     assert user_without_subscriptions.subscribe_to!(subscription_subject, subscription_site)
     assert user_without_subscriptions.subscribed_to?(subscription_subject, subscription_site)
   end
 
   def test_subscribe_to_when_already_subscribed
+    skip "User subscriptions are disabled"
     assert subscribed_user.subscribe_to!(subscription_subject, subscription_site)
     assert subscribed_user.subscribed_to?(subscription_subject, subscription_site)
   end
 
   def test_unsubscribe_from!
+    skip "User subscriptions are disabled"
     assert user_other.subscribe_to!(subscription_subject, subscription_site)
     assert user_other.unsubscribe_from!(subscription_subject, subscription_site)
     refute user_other.subscribed_to?(subscription_subject, subscription_site)
   end
 
   def test_unsubscribe_from_when_not_subscribed
+    skip "User subscriptions are disabled"
     user_other.unsubscribe_from!(subscription_subject, subscription_site)
     assert_nil user_other.unsubscribe_from!(subscription_subject, subscription_site)
   end
 
   def test_toggle_subscription_when_already_subscribed
+    skip "User subscriptions are disabled"
     subscribed_user.subscribe_to!(subscription_subject, subscription_site)
     assert_equal(
       [:delete, true],
@@ -53,6 +59,7 @@ module User::SubscriberTest
   end
 
   def test_toggle_subscription_when_not_subscribed
+    skip "User subscriptions are disabled"
     subscribed_user.unsubscribe_from!(subscription_subject, subscription_site)
 
     assert_equal(


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1579


## :v: What does this PR do?

This PR disables the creation of User::Subscription instances to prevent any new notification to be generated. In production any user subscription should be removed after this PR has been deployed.

It also hides the subscribe button and the subscribe box.

## :mag: How should this be manually tested?

- no buttons should appear
- there shouldn't be possible to generate new subscriptions
