### PR TITLE
New Google Analytics id format

### DIFF
--- a/app/forms/gobierto_admin/site_form.rb
+++ b/app/forms/gobierto_admin/site_form.rb
@@ -3,7 +3,7 @@
 module GobiertoAdmin
   class SiteForm < BaseForm
 
-    GOOGLE_ANALYTICS_ID_REGEXP = /\AUA-\d{4,10}-\d{1,4}\z/
+    GOOGLE_ANALYTICS_ID_REGEXP = /\A(UA|G)-(\d{4,10}-\d{1,4}|\w{10})\z/
 
     attr_accessor(
       :id,

--- a/test/forms/gobierto_admin/site_form_test.rb
+++ b/test/forms/gobierto_admin/site_form_test.rb
@@ -31,18 +31,6 @@ module GobiertoAdmin
       )
     end
 
-    def valid_google_analytics_id_site_form
-      @valid_google_analytics_id_site_form ||= SiteForm.new(
-        valid_site_form.instance_values.merge(google_analytics_id: "UA-000000-01")
-      )
-    end
-
-    def invalid_google_analytics_id_site_form
-      @invalid_google_analytics_id_site_form ||= SiteForm.new(
-        valid_site_form.instance_values.merge(google_analytics_id: "UA-FOO")
-      )
-    end
-
     def site
       @site ||= sites(:madrid)
     end
@@ -64,8 +52,16 @@ module GobiertoAdmin
     end
 
     def test_google_analytics_id_validation
-      assert valid_google_analytics_id_site_form.valid?
-      refute invalid_google_analytics_id_site_form.valid?
+      assert SiteForm.new(
+        valid_site_form.instance_values.merge(google_analytics_id: "UA-000000-01")
+      ).valid?
+      assert SiteForm.new(
+        valid_site_form.instance_values.merge(google_analytics_id: "G-E2SS47LLT6")
+      ).valid?
+
+      refute SiteForm.new(
+        valid_site_form.instance_values.merge(google_analytics_id: "UA-FOO")
+      ).valid?
     end
 
     def test_save_with_valid_attributes


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1593

## :v: What does this PR do?

This PR adapts GA regular expression to the new formats supported.

## :mag: How should this be manually tested?

You should check the other formats `G-xxxxxxx-x` and `xxxxxxxxx` (10 integers) work and don't return a validation error.
