### PR TITLE
Avoid liquid exceptions when collection of pages is not available

### DIFF
--- a/lib/liquid/gobierto_cms/tags/list_children_pages.rb
+++ b/lib/liquid/gobierto_cms/tags/list_children_pages.rb
@@ -37,6 +37,8 @@ module Liquid
             if nodes.any?
               html << "<div class='page_children'>"
               nodes.each do |node|
+                next if node.item.collection.blank?
+
                 html << "<div class='page_child'>"
                 html << ::ActionController::Base.helpers.link_to(node.item.title,
                                                                 gobierto_cms_page_or_news_path(node.item))


### PR DESCRIPTION
## :v: What does this PR do?

This PR avoid exceptions when a child page of another doesn't belong to a collection and the `list_children_page` liquid tag is called from the parent page.

## :mag: How should this be manually tested?

From admin interface I've tried to move a page from a collection to a section with pages of other collection and no error is produced. The error appears if the collection is deleted, but there is no way to do it from admin

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
