### PR TITLE
Fix Attachments search via API

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -13,8 +13,8 @@ module GobiertoAdmin
         before_action :load_collection, only: [:create, :update]
 
         def index
-          attachments = if params[:search_string]
-                          ::GobiertoAttachments::Attachment.search(params[:search_string], page: params[:page])
+          attachments = if params[:search_string] && params[:search_string].present?
+                          current_site.multisearch(params[:search_string], searchable_type: "GobiertoAttachments::Attachment", limit: 100, page: params[:page]).map(&:searchable)
                         elsif @attachable
                           @attachable.attachments.page(params[:page])
                         else

--- a/app/javascript/gobierto_admin/modules/gobierto_attachments_controller.js
+++ b/app/javascript/gobierto_admin/modules/gobierto_attachments_controller.js
@@ -60,6 +60,7 @@ window.GobiertoAdmin.GobiertoAttachmentsController = (function() {
             }
           };
           $.magnificPopup.open(config);
+          $('input.slim').focus();
         }
       }
     };


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1627

## :v: What does this PR do?

This PR:

- fixes the search call over attachments model in the API endpoint
- improves the UI keeping the focus on the input, so the live search can be performed without having to focus on each reload

## :mag: How should this be manually tested?

It's in staging:

1. Go to admin
2. Edit a page
3. Click on include attachments
4. Search any attachment
