### PR TITLE
Disable HTTP cache if admins are authorized

### DIFF
--- a/app/controllers/concerns/http_cache.rb
+++ b/app/controllers/concerns/http_cache.rb
@@ -2,7 +2,7 @@ module HttpCache
   extend ActiveSupport::Concern
 
   def set_cache_headers
-    if user_signed_in?
+    if user_signed_in? || admin_authorized?
       response.headers["Cache-Control"] = "private"
     else
       response.headers["Cache-Control"] = "public,#{60*60*24}" # 1 day

--- a/app/controllers/concerns/user/api_authentication_helper.rb
+++ b/app/controllers/concerns/user/api_authentication_helper.rb
@@ -50,7 +50,12 @@ module User::ApiAuthenticationHelper
   end
 
   def find_current_admin
-    @current_admin ||= ::GobiertoAdmin::Admin.joins(:api_tokens).find_by(admin_api_tokens: { token: token })
+    @current_admin ||= if token.present?
+                         ::GobiertoAdmin::Admin.joins(:api_tokens).find_by(admin_api_tokens: { token: token })
+                       elsif session[:admin_id].present?
+                         # This way of loading the admin works only on API calls called from the Gobierto UI
+                         ::GobiertoAdmin::Admin.find(session[:admin_id])
+                       end
   end
 
   def raise_unauthorized


### PR DESCRIPTION
## :v: What does this PR do?

This PR disables HTTP cache if admins are authorized to see the current resource.

Admins can be authorized in two ways:

- pure API way: using an API token
- (new) via Gobierto session: if the API is being used by Gobierto itself via the UI, this way detects the admin is logged in

## :mag: How should this be manually tested?

- Log in as Admin
- Visit a resource with cache (GobiertoData, GobiertoDocs, GobiertoPlans) and check the cache is not stored when there's an admin session
- You can also check the Response Headers of the API call, it should include "Cache: private" if there's a session from an user or an admin
