### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
       - run: cp config/database.yml.example config/database.yml
 
       # Setup the database
-      - run: bin/rails db:create db:migrate db:test:prepare
+      - run: bin/rails db:create db:migrate
 
       # Install custom engines
       - run: script/custom_engines_ci_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,10 @@ defaults: &defaults
         # Up to circle-ci plan max. RAM
         NODE_OPTIONS: --max-old-space-size=6144
         RAILS_ENV: test
+        NODE_ENV: test
         PGHOST: localhost
         PGUSER: gobierto
+        PSQL_PAGER: ''
         # Disable spring so bin/rails works. See: https://github.com/rails/spring/pull/546
         DISABLE_SPRING: true
     - image: postgres:12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ defaults: &defaults
     - image: elasticsearch:2.4.1
     - image: redis:6.2.5
 
-orbs:
-  browser-tools: circleci/browser-tools@1.3.0
-
 commands:
   restore_bundler_cache:
     steps:
@@ -90,6 +87,9 @@ commands:
             bin/rails gobierto_budgets:fixtures:load
             echo '::BudgetsSeeder.seed!' | bin/rails c
 
+orbs:
+  browser-tools: circleci/browser-tools@1.3.0
+
 jobs:
   bundle_dependencies:
     <<: *defaults
@@ -126,6 +126,9 @@ jobs:
 
       # Compile I18n JS file
       - run: bin/rails i18n:js:export
+
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
 
       # Compile assets
       - restore_assets_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
 defaults: &defaults
   working_directory: *working_directory
   docker:
-    - image: circleci/ruby:2.7.4-node-browsers
+    - image: cimg/ruby:2.7.4-browsers
       environment:
         # Up to circle-ci plan max. RAM
         NODE_OPTIONS: --max-old-space-size=6144
@@ -26,6 +26,9 @@ defaults: &defaults
         POSTGRES_PASSWORD: gobierto
     - image: elasticsearch:2.4.1
     - image: redis:6.2.5
+
+orbs:
+  browser-tools: circleci/browser-tools@1.3.0
 
 commands:
   restore_bundler_cache:
@@ -52,6 +55,8 @@ commands:
       - checkout
       - attach_workspace:
           at: *working_directory
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - restore_bundler_cache
       - restore_yarn_cache
       - restore_assets_cache
@@ -72,7 +77,7 @@ commands:
       - run: cp config/database.yml.example config/database.yml
 
       # Setup the database
-      - run: bin/rails db:create db:migrate
+      - run: bin/rails db:create db:migrate db:test:prepare
 
       # Install custom engines
       - run: script/custom_engines_ci_setup


### PR DESCRIPTION
## :v: What does this PR do?

CircleCI has deprecated [the base images](https://github.com/PopulateTools/gobierto-contratos/blob/master/.circleci/config.yml#L10) we use with Ruby and Node.

See the following link to address the change:

https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

This PR addresses these changes

## :mag: How should this be manually tested?

Tests should pass
