### PR TITLE
Add comp-tables.scss to gobierto-cms

### DIFF
--- a/app/javascript/stylesheets/_comp-tables.scss
+++ b/app/javascript/stylesheets/_comp-tables.scss
@@ -237,7 +237,8 @@ th.icon_col {
   width: 15px;
 }
 
-table.block_content {
+table.block_content,
+.gobierto_cms {
   th {
     background: rgba(var(--color-base-string), 0.15);
     text-align: left;
@@ -299,7 +300,8 @@ table.block_content {
   cursor: pointer;
 }
 
-.gobierto_admin {
+.gobierto_admin,
+.gobierto_cms {
   table.results_report {
     th,
     td {

--- a/app/javascript/stylesheets/gobierto-cms.scss
+++ b/app/javascript/stylesheets/gobierto-cms.scss
@@ -13,6 +13,7 @@
 @import "comp-layout";
 @import "comp-site_header";
 @import "comp-social_buttons";
+@import "comp-tables";
 @import "defaults";
 
 @import "comp-text_content";


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1640


## :v: What does this PR do?

- Add the `comp-tables.scss` to gobierto-cms, to style the tables generated from admin.


## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR
![177309073-3f491831-35b2-4084-8ee3-f7a2810daa06](https://user-images.githubusercontent.com/2649175/177350156-4c72bf56-c757-4c8b-92c9-524a1ffee504.png)

### After this PR
![after-table-cms](https://user-images.githubusercontent.com/2649175/177350015-cb14818c-0a77-425e-be32-82d51cdd4d68.png)

