### PR TITLE
Increase attachments search results

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
 
         def index
           attachments = if params[:search_string]
-                          current_site.multisearch(params[:search_string]).where(searchable_type: ["GobiertoAttachments::Attachment"])..map(&:searchable)
+                          current_site.multisearch(params[:search_string]).where(searchable_type: ["GobiertoAttachments::Attachment"]).page(params[:page]).map(&:searchable)
                         elsif @attachable
                           @attachable.attachments.page(params[:page])
                         else

--- a/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_attachments/api/attachments_controller.rb
@@ -14,7 +14,7 @@ module GobiertoAdmin
 
         def index
           attachments = if params[:search_string]
-                          current_site.multisearch(params[:search_string]).where(searchable_type: ["GobiertoAttachments::Attachment"]).page(params[:page]).map(&:searchable)
+                          current_site.multisearch(params[:search_string]).where(searchable_type: ["GobiertoAttachments::Attachment"])..map(&:searchable)
                         elsif @attachable
                           @attachable.attachments.page(params[:page])
                         else

--- a/app/javascript/stylesheets/_comp-modals.scss
+++ b/app/javascript/stylesheets/_comp-modals.scss
@@ -100,6 +100,11 @@
     color: #946b04;
   }
 
+  .filelist-wrapper {
+    height: 80vh;
+    overflow: auto;
+  }
+
   table {
     tbody {
       overflow-y: scroll;

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -4,7 +4,7 @@ module GobiertoAttachments
   class Attachment < ApplicationRecord
     acts_as_paranoid column: :archived_at
 
-    paginates_per 8
+    paginates_per 20
 
     attr_accessor :admin_id
 

--- a/app/models/gobierto_attachments/attachment.rb
+++ b/app/models/gobierto_attachments/attachment.rb
@@ -4,7 +4,7 @@ module GobiertoAttachments
   class Attachment < ApplicationRecord
     acts_as_paranoid column: :archived_at
 
-    paginates_per 20
+    paginates_per 30
 
     attr_accessor :admin_id
 

--- a/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_attachment.html.erb
@@ -44,19 +44,21 @@
 
           <input type="text" placeholder="<%= t('.search') %>..." v-model="q" @keyup="search" class="slim"/>
 
-          <table class="m_v_1" v-if="attachments.length">
-            <tbody>
-              <tr v-for="attachment in attachments" @click="associateAttachment(attachment)">
-                <td>
-                  <a href="#" @click.prevent target="_blank">{{attachment.name || attachment.file_name}} <span class="soft" v-if="attachment.name !== ''">({{(attachment.file_name)}})</span></a>
-                </td>
-                <td class="right">{{fileExtension(attachment.file_name)}}</td>
-                <td class="right">{{bytesToSize(attachment.file_size)}}</td>
-                <td class="right">{{formatDate(attachment.created_at)}}</td>
-              </tr>
-            </tbody>
-          </table>
-          <p v-else><%= t('.no_docs') %></p>
+          <div class="filelist-wrapper">
+            <table class="m_v_1" v-if="attachments.length">
+              <tbody>
+                <tr v-for="attachment in attachments" @click="associateAttachment(attachment)">
+                  <td>
+                    <a href="#" @click.prevent target="_blank">{{attachment.name || attachment.file_name}} <span class="soft" v-if="attachment.name !== ''">({{(attachment.file_name)}})</span></a>
+                  </td>
+                  <td class="right">{{fileExtension(attachment.file_name)}}</td>
+                  <td class="right">{{bytesToSize(attachment.file_size)}}</td>
+                  <td class="right">{{formatDate(attachment.created_at)}}</td>
+                </tr>
+              </tbody>
+            </table>
+            <p v-else><%= t('.no_docs') %></p>
+          </div>
         </div>
       </div>
       <div class="file-sidebar pure-u-1-3" :class="{dragged: fileDragged}">


### PR DESCRIPTION
## :v: What does this PR do?

Related with #4097, this PR increases the number of elements returned by the API to 30, and adds an internal scroll to the table.

## :mag: How should this be manually tested?

1. Go to staging
2. Login as admin, and go to CMS and edit a page
3. click on Attach file
4. You should see at most 30 elements with an internal scroll in the table

## :eyes: Screenshots

### After this PR

![Screenshot 2022-07-06 at 04 16 20](https://user-images.githubusercontent.com/17616/177453431-f1080a59-f023-4ca7-8bdd-bc14d9ecc96d.png)
