### PR TITLE
Gobierto Visualizations / If there is only one entity show the second level of treemap

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -220,8 +220,9 @@ export default {
       }
 
       if (treemapEntity && treemapEntity.offsetParent !== null) {
+        let getContractors = [...new Set(this.visualizationsDataEntity.map(item => item.contractor))]
         this.treemapEntity = new TreeMap(treemapEntity, this.visualizationsDataEntity, {
-          rootTitle: this.labelEntities,
+          rootTitle: getContractors.length > 1 ? this.labelEntities : '',
           id: "title",
           group: ["contractor", "contract_type", "assignee"],
           value: "final_amount_no_taxes",

--- a/app/javascript/stylesheets/gobierto-visualizations.scss
+++ b/app/javascript/stylesheets/gobierto-visualizations.scss
@@ -399,6 +399,7 @@
 
   .treemap-breadcrumb {
     color: rgba(var(--color-base-string), .8);
+    fill: rgba(var(--color-base-string), .8);
     width: max-content;
     cursor: pointer;
     font-size: $f6;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "flightjs": "^1.5.2",
     "fullcalendar": "^3.9.0",
     "geocomplete": "^1.7.0",
-    "gobierto-vizzs": "^1.2.3",
+    "gobierto-vizzs": "^1.2.4",
     "html-to-image": "^1.9.0",
     "i18n-js": "^3.0.3",
     "jest": "^27.0.3",


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1158


## :v: What does this PR do?

- Upgrade gobierto-vizzs. If the data only contains a one entity show directly the second level.


## :mag: How should this be manually tested?

[Ribaroja](https://ribaroja.gobify.net/visualizaciones/contratos/)
[Esplugues](https://esplugues.gobify.net/visualizaciones/contratos)


## :eyes: Screenshots

### After this PR

https://user-images.githubusercontent.com/2649175/191555067-c832eca3-6869-4869-977b-e92eff6382ed.mov

