### PR TITLE
Visualizations beeswarm / filter dates that comes as null

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -173,8 +173,8 @@ export default {
     },
     visualizationsDataExcludeMinorContract() {
       return this.visualizationsDataEntity
-        .filter(({ minor_contract: minor }) => minor === "f")
-    },
+        .filter(({ minor_contract: minor, gobierto_start_date }) => minor === "f" && new Date(gobierto_start_date).toString() !== 'Invalid Date')
+    }
   },
   watch: {
     visualizationsDataExcludeNoCategory(n) {


### PR DESCRIPTION
## :v: What does this PR do?

- Sometimes `gobierto_start_date` comes as `null`, and `d3` thrown an error in the console. Add a` filter()` to to exclude the `nulls`.

## :mag: How should this be manually tested?

[Staging](https://esplugues.gobify.net/visualizaciones/contratos/)
[PRO](https://portalobert.esplugues.cat/visualizaciones/contratos)


## :eyes: Screenshots

### Before this PR

![before](https://user-images.githubusercontent.com/2649175/193051289-2235512c-e45b-4dbb-ac7a-94bf58ec55c8.png)


### After this PR

![after](https://user-images.githubusercontent.com/2649175/193051306-380a7cc0-85e2-4c67-a947-0c7fb26f3819.png)
