### PR TITLE
Budgets / Responsive review

### DIFF
--- a/app/javascript/gobierto_budgets/modules/application.js
+++ b/app/javascript/gobierto_budgets/modules/application.js
@@ -131,22 +131,33 @@ $(document).on("turbolinks:load", function() {
       $(".bread_links").html(arr.join(sep) + sep);
     });
 
-  $(".bread_hover").hover(
-    function() {
+
+  //Show the selector of budgets with hover in desktop and with click in mobile/table
+  if ($(window).width() > 768) {
+    $(".bread_hover").hover(
+      function() {
+        $(".bread_links a").attr("aria-expanded", true);
+        $(".line_browser").velocity("fadeIn", { duration: 50 });
+      },
+      function() {
+        $(".bread_links a").attr("aria-expanded", false);
+        $(".line_browser").velocity("fadeOut", { duration: 50 });
+      }
+    );
+    $(".bread_links a").focus(function() {
+      $(this).attr("aria-expanded", true);
+      $(".bread_links").addClass("hasFocus");
+      $(".line_browser").velocity("fadeIn", { duration: 50 });
+    });
+  } else {
+    $(".bread_hover").click(function (event) {
+      if (event.target.classList.contains("selected-year")){
+        event.preventDefault();
+      }
       $(".bread_links a").attr("aria-expanded", true);
       $(".line_browser").velocity("fadeIn", { duration: 50 });
-    },
-    function() {
-      $(".bread_links a").attr("aria-expanded", false);
-      $(".line_browser").velocity("fadeOut", { duration: 50 });
-    }
-  );
-
-  $(".bread_links a").focus(function() {
-    $(this).attr("aria-expanded", true);
-    $(".bread_links").addClass("hasFocus");
-    $(".line_browser").velocity("fadeIn", { duration: 50 });
-  });
+    });
+  }
 
   // Function to make the menu accessible with the keyboard
   $("#popup-year table tr a").blur(function() {
@@ -188,8 +199,11 @@ $(document).on("turbolinks:load", function() {
     $(".line_browser").velocity("fadeOut", { duration: 150 });
   });
 
-  $(window).click(function() {
-    $(".line_browser").velocity("fadeOut", { duration: 150 });
+  $(window).click(function(e) {
+    //Close the selector of budgets when the user clickOutSide or select a year
+    if (!$(".bread_hover").has(e.target).length > 0 || e.target.nodeName === 'A' && !e.target.classList.contains("selected-year")){
+      $(".line_browser").velocity("fadeOut", { duration: 150 });
+    }
   });
 
   $(".tooltiped-budget-lines").tipsy({

--- a/app/views/gobierto_admin/users/index.html.erb
+++ b/app/views/gobierto_admin/users/index.html.erb
@@ -70,7 +70,7 @@
         <% if user.census_verified? %>
           <i class="fas fa-check"></i>
         <% else %>
-          <i class="fas fa-close"></i>
+          <i class="fas fa-times"></i>
         <% end %>
       </td>
       <td>

--- a/app/views/gobierto_budgets/shared/_year_breadcrumb.html.erb
+++ b/app/views/gobierto_budgets/shared/_year_breadcrumb.html.erb
@@ -3,7 +3,7 @@
     <div class="bread_hover">
 
       <div class="bread_links">
-        <%= link_to selected_year, selected_year_path, id: selected_year, 'aria-haspopup' => 'true', 'aria-label' => 'Escoge el año de los datos', 'aria-owns' => 'popup-year', 'aria-controls' => 'popup-year', 'aria-expanded' => 'false' %>
+        <%= link_to selected_year, selected_year_path, id: selected_year, class: 'selected-year', 'aria-haspopup' => 'true', 'aria-label' => 'Escoge el año de los datos', 'aria-owns' => 'popup-year', 'aria-controls' => 'popup-year', 'aria-expanded' => 'false' %>
         <i class="fas fa-sort-down"></i>
       </div>
 

--- a/app/views/layouts/_navigation_mobile.html.erb
+++ b/app/views/layouts/_navigation_mobile.html.erb
@@ -32,7 +32,7 @@
           <div class="column dropdown-items">
             <%= render_if_exists "#{current_module}/layouts/navigation.sub" %>
             <div class="dropdown-button js-submenu-toggle">
-              <i class="fas fa-close"></i>
+              <i class="fas fa-times"></i>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1731


## :v: What does this PR do?

- Use the click event to show the budgets selector in responsive, close it when you click out-side or select a year.
- Replace the old icon fa-close by fa-times to can close the menu.


## :mag: How should this be manually tested?

[Staging](https://leliana.gobify.net/)

## :eyes: Screenshots

### Before this PR

https://user-images.githubusercontent.com/2649175/198018693-137ff103-92ae-488f-bc70-b1934eb59e9b.MP4

### After this PR


https://user-images.githubusercontent.com/2649175/198025682-83d9e38a-f7c5-454c-bf02-58575afe58fb.MP4

