### PR TITLE
1715 refresh welcome cms cache

### DIFF
--- a/app/controllers/meta_welcome_controller.rb
+++ b/app/controllers/meta_welcome_controller.rb
@@ -8,32 +8,20 @@ class MetaWelcomeController < ApplicationController
   def index
     render_404 and return if current_site.nil?
 
-    if current_site.configuration.home_page != "GobiertoCms"
-      render_404 and return
+    # This code allows the homepage to render a page without redirecting to the page url
+    page = current_site.configuration.welcome_page
+    render_404 and return if page.nil?
+
+    if @section ||= page.section
+      @section_item = ::GobiertoCms::SectionItem.find_by!(item: page, section: @section)
     else
-      # This code allows the homepage to render a page without redirecting to the page url
-      item = GlobalID::Locator.locate(current_site.configuration.home_page_item_id)
-      render_404 and return if item.nil?
-
-      if item.is_a?(GobiertoCms::Section)
-        @section = item
-        page = @section.first_item(only_public: true)
-      else
-        page = item
-      end
-      render_404 and return if page.nil?
-
-      if @section ||= page.section
-        @section_item = ::GobiertoCms::SectionItem.find_by!(item: page, section: @section)
-      else
-        @collection = page.collection
-        @pages = current_site.pages.where(id: @collection.pages_in_collection).active.includes(:collection, :sections)
-      end
-
-      @page = GobiertoCms::PageDecorator.new(page)
-
-      render "gobierto_cms/pages/meta_welcome", layout: "gobierto_cms/layouts/application"
+      @collection = page.collection
+      @pages = current_site.pages.where(id: @collection.pages_in_collection).active.includes(:collection, :sections)
     end
+
+    @page = GobiertoCms::PageDecorator.new(page)
+
+    render "gobierto_cms/pages/meta_welcome", layout: "gobierto_cms/layouts/application"
   end
 
   private

--- a/app/forms/gobierto_admin/gobierto_cms/page_form.rb
+++ b/app/forms/gobierto_admin/gobierto_cms/page_form.rb
@@ -24,7 +24,7 @@ module GobiertoAdmin
         :published_on
       )
 
-      delegate :persisted?, to: :page
+      delegate :persisted?, :cache_service, to: :page
 
       validates :site, :visibility_level, :collection_id, presence: true
       validate :confirm_presence_of_homepage
@@ -122,6 +122,7 @@ module GobiertoAdmin
           @page.save
 
           save_section_item(@page.id, section, parent)
+          cache_service.delete_including("gobierto_cms/pages/meta_welcome") if page == site.configuration.welcome_page
 
           @page
         else

--- a/app/helpers/gobierto_common/cache_service_helper.rb
+++ b/app/helpers/gobierto_common/cache_service_helper.rb
@@ -3,7 +3,7 @@
 module GobiertoCommon
   module CacheServiceHelper
     def cache_service_fragment(name = {}, options = {}, &block)
-      key = cache_service.prefixed(name.is_a?(Enumerable) ? name.join("/") : name)
+      key = cache_service.prefixed(name)
 
       cache(key, options, &block)
     end

--- a/app/models/gobierto_cms/page.rb
+++ b/app/models/gobierto_cms/page.rb
@@ -18,6 +18,7 @@ module GobiertoCms
     include GobiertoCommon::Collectionable
     include GobiertoCommon::Sectionable
     include GobiertoCommon::HasCustomFieldRecords
+    include GobiertoCommon::HasCacheService
 
     multisearchable(
       against: [:title_en, :title_es, :title_ca, :searchable_body],

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -101,6 +101,16 @@ class SiteConfiguration
     privacy_page.present?
   end
 
+  def welcome_page
+    return if home_page != "GobiertoCms"
+
+    home_page_item = GlobalID::Locator.locate(home_page_item_id)
+    return if home_page_item.blank?
+    return home_page_item.first_item(only_public: true) if home_page_item.is_a?(GobiertoCms::Section)
+
+    home_page_item
+  end
+
   def modules_with_notifications
     modules_with_frontend_enabled & MODULES_WITH_NOTIFICATONS
   end

--- a/app/services/gobierto_common/cache_service.rb
+++ b/app/services/gobierto_common/cache_service.rb
@@ -27,7 +27,7 @@ module GobiertoCommon
     end
 
     def prefixed(name)
-      "#{cache_prefix}/#{name}"
+      "#{cache_prefix}/#{name.is_a?(Enumerable) ? name.join("/") : name}"
     end
 
     # These methods are very inefficient

--- a/app/services/gobierto_common/cache_service.rb
+++ b/app/services/gobierto_common/cache_service.rb
@@ -18,6 +18,10 @@ module GobiertoCommon
       Rails.cache.delete(prefixed(name), options)
     end
 
+    def delete_including(name)
+      Rails.cache.delete_matched(clear_match_middle(prefixed(name)))
+    end
+
     def cache_prefix
       @cache_prefix ||= "#{gobierto_module.cache_base_key}#{site.id}"
     end
@@ -47,12 +51,12 @@ module GobiertoCommon
 
     private
 
-    def clear_match_prefix
-      redis_cache? ? "#{cache_prefix}/*" : /\A#{cache_prefix}\/.*/
+    def clear_match_prefix(name = cache_prefix)
+      redis_cache? ? "#{name}/*" : /\A#{name}\/.*/
     end
 
-    def clear_match_middle
-      redis_cache? ? "*/#{cache_prefix}/*" : /.*\/#{cache_prefix}\/.*/
+    def clear_match_middle(name = cache_prefix)
+      redis_cache? ? "*/#{name}/*" : /.*\/#{name}\/.*/
     end
   end
 end


### PR DESCRIPTION
Closes PopulateTools/issues#1715

## :v: What does this PR do?

This PR:
* Adds a callback on pages form when pages are saved which detects if the page saved is used as welcome page and deletes its associated cache entries.
* Adds a callback on sites form when saved and the home_page_item_id is changed to remove associated cache

## :mag: How should this be manually tested?

Edit in admin the page configured as welcome page in the homepage and visit the root path of the site. The html should reflect the changes
Change home page from site configuration in admin and save. The home page in front should change also 

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No