### PR TITLE
Consider elaboration year when calculating totals

### DIFF
--- a/app/models/gobierto_budgets/search_engine_configuration/year.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration/year.rb
@@ -26,6 +26,10 @@ module GobiertoBudgets
         cached(:all) { last.downto(first).to_a }
       end
 
+      def self.all_with_data
+        cached(:all_with_data) { last_year_with_data.downto(first).to_a }
+      end
+
       def self.with_data(params={})
         cached :with_data, params do
           all.select do |year|

--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -16,7 +16,7 @@ namespace :gobierto_budgets do
 
       if organization_ids.any?
         organization_ids.each do |organization_id|
-          GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
+          GobiertoBudgets::SearchEngineConfiguration::Year.all_with_data.each do |year|
             TOTAL_BUDGET_INDEXES.each do |index|
               puts " - Calculating totals for #{organization_id} in year #{year} for index #{index}"
 


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR fixes the calculation of total years data when using the Sicalwin importer for elaboration data.

Instead of calculating from current year, now the importer calculates the totals from all years with any data.
