### PR TITLE
Remove column when no population data is available

### DIFF
--- a/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_budget_line_row.html.erb
@@ -9,7 +9,9 @@
     <%= link_to budget_line.name, gobierto_budgets_budget_line_path(budget_line.to_param) %>
   </td>
   <td class="qty big_qty"><%= number_to_currency budget_line.amount, precision: 2 %></td>
-  <%= content_tag :td, number_to_currency(budget_line.amount_per_inhabitant, precision: 2), class: "qty" if budget_line.amount_per_inhabitant %>
+  <% if @site_stats&.population_data? %>
+    <%= content_tag :td, number_to_currency(budget_line.amount_per_inhabitant, precision: 2), class: "qty" if budget_line.amount_per_inhabitant %>
+  <% end %>
   <td class="qty"><%= number_with_precision(budget_line.percentage_of_total, precision: 2) + ' %' %></td>
   <td class="bar"><div class="bar" style="width:<%= budget_line.percentage_of_total %>%"></div></td>
 </tr>

--- a/app/views/gobierto_budgets/budget_lines/_index.html.erb
+++ b/app/views/gobierto_budgets/budget_lines/_index.html.erb
@@ -72,7 +72,7 @@
       <tr>
         <th class="budget_line"><span><%= t('.budget_line') %></span></th>
         <th class="qty big_qty"><%= t('.amount') %></th>
-        <%= content_tag :th, t('.per_inhabitant'), class: "qty" if @site_stats.population_data? %>
+        <%= content_tag :th, t('.per_inhabitant'), class: "qty" if @site_stats&.population_data? %>
         <th class="qty">%</th>
         <th class="qty bar"><span style="display:none" aria-hidden="true">WCAG 2.0 AA</span></th>
       </tr>


### PR DESCRIPTION
Unexpected

## :v: What does this PR do?

This PR fixes elaboration section details table when the population has not been set (hello Diputaciones). Before, the `<td>` with the amount per inhabitant was displayed, but not the header, so the whole table was wrong.

## :eyes: Screenshots

### After this PR

![Screenshot 2022-11-14 at 12 00 38](https://user-images.githubusercontent.com/17616/201643763-beafb66f-c36b-42d4-bd3a-0cff16fde809.png)
