### PR TITLE
Gobierto Data / Summary data

### DIFF
--- a/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
@@ -12,7 +12,7 @@
         icon="database"
         :icon-color="'#666'"
         :label="labelNumberOfRows"
-        :text="numberOfRows"
+        :text="formatNumberOfRows"
       />
       <InfoBlockText
         v-if="dateUpdated"
@@ -86,7 +86,8 @@
   </div>
 </template>
 <script>
-import { date } from "lib/vue/filters"
+import { date } from "lib/vue/filters";
+import { formatNumbers } from "lib/shared";
 import InfoBlockText from "./../commons/InfoBlockText.vue";
 import DownloadButton from "./../commons/DownloadButton.vue";
 import DownloadLink from "./../commons/DownloadLink.vue";
@@ -184,6 +185,9 @@ export default {
     },
     moreThanOneFormat() {
       return Object.keys(this.arrayFormats).length > 1
+    },
+    formatNumberOfRows() {
+      return formatNumbers(this.numberOfRows)
     }
   },
   created(){

--- a/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
@@ -4,53 +4,55 @@
       <div
         v-if="compiledHTMLMarkdown"
         id="gobierto-data-summary-header"
-        class="gobierto-data-summary-header-description"
+        class="gobierto-data-summary-header-description gobierto-data-summary-separator"
         v-html="compiledHTMLMarkdown"
       />
-      <InfoBlockText
-        v-if="numberOfRows"
-        icon="database"
-        :icon-color="'#666'"
-        :label="labelNumberOfRows"
-        :text="formatNumberOfRows"
-      />
-      <InfoBlockText
-        v-if="dateUpdated"
-        icon="clock"
-        :icon-color="'#666'"
-        :label="labelUpdated"
-        :text="dateUpdated | convertDate"
-      />
-      <InfoBlockText
-        v-if="frequencyDataset"
-        icon="calendar"
-        :icon-color="'#666'"
-        :label="labelFrequency"
-        :text="frequencyDataset"
-      />
-      <InfoBlockText
-        v-if="categoryDataset"
-        icon="tag"
-        :icon-color="'#666'"
-        :label="labelSubject"
-        :text="categoryDataset"
-      />
-      <InfoBlockText
-        v-if="hasDatasetSource"
-        icon="building"
-        :icon-color="'#666'"
-        :label="labelSource"
-        :text="sourceDatasetText"
-        :url="sourceDatasetUrl"
-      />
-      <InfoBlockText
-        v-if="hasDatasetLicense"
-        icon="certificate"
-        :icon-color="'#666'"
-        :label="labelLicense"
-        :text="licenseDatasetText"
-        :url="licenseDatasetUrl"
-      />
+      <div class="gobierto-data-summary-separator">
+        <InfoBlockText
+          v-if="numberOfRows"
+          icon="database"
+          :icon-color="'#666'"
+          :label="labelNumberOfRows"
+          :text="formatNumberOfRows"
+        />
+        <InfoBlockText
+          v-if="dateUpdated"
+          icon="clock"
+          :icon-color="'#666'"
+          :label="labelUpdated"
+          :text="dateUpdated | convertDate"
+        />
+        <InfoBlockText
+          v-if="frequencyDataset"
+          icon="calendar"
+          :icon-color="'#666'"
+          :label="labelFrequency"
+          :text="frequencyDataset"
+        />
+        <InfoBlockText
+          v-if="categoryDataset"
+          icon="tag"
+          :icon-color="'#666'"
+          :label="labelSubject"
+          :text="categoryDataset"
+        />
+        <InfoBlockText
+          v-if="hasDatasetSource"
+          icon="building"
+          :icon-color="'#666'"
+          :label="labelSource"
+          :text="sourceDatasetText"
+          :url="sourceDatasetUrl"
+        />
+        <InfoBlockText
+          v-if="hasDatasetLicense"
+          icon="certificate"
+          :icon-color="'#666'"
+          :label="labelLicense"
+          :text="licenseDatasetText"
+          :url="licenseDatasetUrl"
+        />
+      </div>
     </div>
     <div class="pure-u-7-24 gobierto-data-summary-info-tab">
       <div

--- a/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
@@ -2,41 +2,18 @@
   <div class="pure-g">
     <div class="pure-u-17-24 gobierto-data-summary-header">
       <div
+        v-if="compiledHTMLMarkdown"
         id="gobierto-data-summary-header"
         class="gobierto-data-summary-header-description"
         v-html="compiledHTMLMarkdown"
       />
-    </div>
-    <div class="pure-u-7-24 gobierto-data-summary-info-tab">
-      <div
-        class="gobierto-data-summary-header-btns"
-      >
-        <template v-if="moreThanOneFormat">
-          <DownloadButton
-            :array-formats="arrayFormats"
-            class="arrow-top modal-left"
-          />
-        </template>
-        <template v-else>
-          <DownloadLink
-            :editor="false"
-            :array-formats="arrayFormats"
-          />
-        </template>
-        <router-link
-          :to="`/datos/${$route.params.id}/${tabs[1]}`"
-          class="gobierto-data-btn-preview"
-        >
-          <Button
-            :text="labelPreview"
-            icon="table"
-            color="rgba(var(--color-base)"
-            icon-color="rgba(var(--color-base-string), .5)"
-            class="gobierto-data-btn-download-data "
-            background="#fff"
-          />
-        </router-link>
-      </div>
+      <InfoBlockText
+        v-if="numberOfRows"
+        icon="database"
+        :icon-color="'#666'"
+        :label="labelNumberOfRows"
+        :text="numberOfRows"
+      />
       <InfoBlockText
         v-if="dateUpdated"
         icon="clock"
@@ -74,6 +51,37 @@
         :text="licenseDatasetText"
         :url="licenseDatasetUrl"
       />
+    </div>
+    <div class="pure-u-7-24 gobierto-data-summary-info-tab">
+      <div
+        class="gobierto-data-summary-header-btns"
+      >
+        <template v-if="moreThanOneFormat">
+          <DownloadButton
+            :array-formats="arrayFormats"
+            class="arrow-top modal-left"
+          />
+        </template>
+        <template v-else>
+          <DownloadLink
+            :editor="false"
+            :array-formats="arrayFormats"
+          />
+        </template>
+        <router-link
+          :to="`/datos/${$route.params.id}/${tabs[1]}`"
+          class="gobierto-data-btn-preview"
+        >
+          <Button
+            :text="labelPreview"
+            icon="table"
+            color="rgba(var(--color-base)"
+            icon-color="rgba(var(--color-base-string), .5)"
+            class="gobierto-data-btn-download-data "
+            background="#fff"
+          />
+        </router-link>
+      </div>
     </div>
   </div>
 </template>
@@ -133,10 +141,15 @@ export default {
       type: Object,
       default: () => {}
     },
+    numberOfRows: {
+      type: Number,
+      default: 0
+    },
   },
   data() {
     return {
       labelUpdated: I18n.t("gobierto_data.projects.updated") || '',
+      labelNumberOfRows: I18n.t("gobierto_data.projects.numberOfRows") || '',
       labelFrequency: I18n.t("gobierto_data.projects.frequency") || '',
       labelSubject: I18n.t("gobierto_data.projects.subject") || '',
       labelDownloadData: I18n.t("gobierto_data.projects.downloadData") || '',

--- a/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/InfoTab.vue
@@ -77,7 +77,6 @@
           <Button
             :text="labelPreview"
             icon="table"
-            color="rgba(var(--color-base)"
             icon-color="rgba(var(--color-base-string), .5)"
             class="gobierto-data-btn-download-data "
             background="#fff"

--- a/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
+++ b/app/javascript/gobierto_data/webapp/components/sets/SummaryTab.vue
@@ -8,6 +8,7 @@
       :source-dataset="datasetSourceObject"
       :date-updated="dateUpdated"
       :array-formats="arrayFormats"
+      :number-of-rows="datasetNumberOfRows"
     />
 
     <Resources
@@ -255,6 +256,7 @@ export default {
       frequency: {},
       dateUpdated: null,
       datasetLicense: null,
+      datasetNumberOfRows: null,
       datasetLicenseUrl: null,
       datasetSource: null,
       datasetSourceUrl: null,
@@ -294,6 +296,7 @@ export default {
   },
   created() {
     ({
+      data_summary: { number_of_rows: this.datasetNumberOfRows },
       data_updated_at: this.dateUpdated,
       category: [{ name_translations: this.category } = {}] = [],
       frequency: [{ name_translations: this.frequency } = {}] = [],

--- a/app/javascript/lib/shared/index.js
+++ b/app/javascript/lib/shared/index.js
@@ -17,6 +17,7 @@ import { RangeSlider } from "./modules/range-slider.js";
 import { Middleware } from "./modules/middleware.js";
 import { debounce } from "./modules/debounce.js";
 import { checkAndReportAccessibility } from "./modules/accessibility.js";
+import { formatNumbers } from "./modules/d3-format-numbers.js";
 
 export {
   AUTOCOMPLETE_DEFAULTS,
@@ -32,5 +33,6 @@ export {
   Middleware,
   slugString,
   debounce,
-  checkAndReportAccessibility
+  checkAndReportAccessibility,
+  formatNumbers
 };

--- a/app/javascript/lib/shared/modules/d3-format-numbers.js
+++ b/app/javascript/lib/shared/modules/d3-format-numbers.js
@@ -1,0 +1,8 @@
+import { d3locale } from "lib/shared";
+import { format, formatDefaultLocale } from 'd3-format';
+const d3 = { format, formatDefaultLocale };
+
+export const formatNumbers = (value) => {
+  const lang = I18n.locale || "es";
+  return value.length >= 7 ? d3.format(".2s")(value) : d3.formatDefaultLocale(d3locale[lang]).format(',.0f')(value)
+};

--- a/app/javascript/lib/shared/modules/d3-format-numbers.js
+++ b/app/javascript/lib/shared/modules/d3-format-numbers.js
@@ -4,5 +4,5 @@ const d3 = { format, formatDefaultLocale };
 
 export const formatNumbers = (value) => {
   const lang = I18n.locale || "es";
-  return value.length >= 7 ? d3.format(".2s")(value) : d3.formatDefaultLocale(d3locale[lang]).format(',.0f')(value)
+  return value.toString().length >= 7 ? d3.format(".2s")(value) : d3.formatDefaultLocale(d3locale[lang]).format(',.0f')(value)
 };

--- a/app/javascript/stylesheets/gobierto-data-summary.scss
+++ b/app/javascript/stylesheets/gobierto-data-summary.scss
@@ -15,6 +15,7 @@
 
   &-summary-header-description {
     margin-top: 0;
+    margin-bottom: 1rem;
     padding-right: 2rem;
     font-size: $f7;
     color: var(--grey-text);
@@ -48,7 +49,7 @@
   }
 
   &-summary-header-container-label {
-    width: 100px;
+    width: 140px;
     color: rgba(102, 102, 102, .5);
     font-weight: 600;
     font-size: 14px;

--- a/app/javascript/stylesheets/gobierto-data-summary.scss
+++ b/app/javascript/stylesheets/gobierto-data-summary.scss
@@ -5,17 +5,13 @@
     display: list-item;
   }
 
-  &-summary-header {
-    box-sizing: border-box;
-  }
-
   &-summary-body {
     background: #f5f5f5;
   }
 
   &-summary-header-description {
     margin-top: 0;
-    margin-bottom: 1rem;
+    margin-bottom: $f6;
     padding-right: 2rem;
     font-size: $f7;
     color: var(--grey-text);
@@ -187,7 +183,10 @@
     padding-left: 20px;
   }
 
-  &-summary-info-tab {
+  &-summary-header {
+    box-sizing: border-box;
+    padding-right: $f3;
+
     .gobierto-data-summary-header-container-label {
       font-size: 14px;
     }

--- a/config/locales/gobierto_data/views/ca.yml
+++ b/config/locales/gobierto_data/views/ca.yml
@@ -52,6 +52,7 @@ ca:
       map: Mapa
       modifiedQuery: Consulta modificada
       modifiedVisualization: Visualització modificada
+      numberOfRows: Nombre de registres
       preview: Previsualitzeu
       private: Privat
       queries: Consultes

--- a/config/locales/gobierto_data/views/en.yml
+++ b/config/locales/gobierto_data/views/en.yml
@@ -52,6 +52,7 @@ en:
       map: Map
       modifiedQuery: Modified Query
       modifiedVisualization: Modified visualization
+      numberOfRows: Number of rows
       preview: Preview
       private: Private
       queries: Queries

--- a/config/locales/gobierto_data/views/es.yml
+++ b/config/locales/gobierto_data/views/es.yml
@@ -52,6 +52,7 @@ es:
       map: Mapa
       modifiedQuery: Consulta modificada
       modifiedVisualization: Visualización modificada
+      numberOfRows: Número de registros
       preview: Previsualizar
       private: Privada
       queries: Consultas


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1758

## :v: What does this PR do?

- Add the number of rows in a dataset to the metadata block.
- Place the metadata block in the main column, below the description.

## :mag: How should this be manually tested?

[Staging](https://esplugues.gobify.net/datos/poblacion-edad-sexo?sql=SELECT%2520%2a%2520FROM%2520poblacion_edad_sexo)

## :eyes: Screenshots

### Before this PR
![before-rows](https://user-images.githubusercontent.com/2649175/205122155-811a9c7f-f162-499b-af5c-c490d6b5d4d0.png)

### After this PR
<img width="1032" alt="after-rows" src="https://user-images.githubusercontent.com/2649175/205122173-14a85588-50a9-44d0-80e6-7c98742edfd9.png">
