### PR TITLE
Map custom PG types to GobiertoData API schema types

### DIFF
--- a/app/serializers/concerns/gobierto_data/has_custom_types.rb
+++ b/app/serializers/concerns/gobierto_data/has_custom_types.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GobiertoData
+  module HasCustomTypes
+    extend ActiveSupport::Concern
+
+    CUSTOM_TYPES = {
+      decimal: :numeric,
+      int: :integer,
+      char: :text
+    }.freeze
+
+    def map_type(type)
+      CUSTOM_TYPES.has_key?(type) ? CUSTOM_TYPES[type] : type
+    end
+  end
+end

--- a/app/serializers/gobierto_data/dataset_meta_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_meta_serializer.rb
@@ -4,6 +4,7 @@ module GobiertoData
   class DatasetMetaSerializer < ActiveModel::Serializer
     include Rails.application.routes.url_helpers
     include ::GobiertoCommon::HasCustomFieldsAttributes
+    include ::GobiertoData::HasCustomTypes
 
     cache key: "dataset_meta"
 
@@ -27,7 +28,7 @@ module GobiertoData
         object.rails_model.columns.inject({}) do |columns, column|
           columns.update(
             column.name => {
-              type: column.type
+              type: map_type(column.type)
             }
           )
         end

--- a/app/serializers/gobierto_data/dataset_serializer.rb
+++ b/app/serializers/gobierto_data/dataset_serializer.rb
@@ -4,6 +4,7 @@ module GobiertoData
   class DatasetSerializer < ActiveModel::Serializer
     include Rails.application.routes.url_helpers
     include ::GobiertoCommon::HasCustomFieldsAttributes
+    include ::GobiertoData::HasCustomTypes
 
     attributes :id, :name, :slug, :table_name, :data_updated_at
 
@@ -21,7 +22,7 @@ module GobiertoData
         object.rails_model.columns.inject({}) do |columns, column|
           columns.update(
             column.name => {
-              type: column.type
+              type: map_type(column.type)
             }
           )
         end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1761

## :v: What does this PR do?

This PR unifies the types returned by the metadata endpoint with the schema types. This is necessary for the automatic ETLs we are building