### PR TITLE
Fix detect separator method

### DIFF
--- a/lib/utils/csv_utils.rb
+++ b/lib/utils/csv_utils.rb
@@ -12,8 +12,9 @@ class CsvUtils
   def self.separator_check(filename, separator)
     # Skip the first line just in case it contains a header
     # Does a compact, to remove empty cells
-    columns_counts = CSV.read(filename, col_sep: separator)[1..-1].map(&:compact).map(&:size).uniq
-    columns_counts.first > 1
+    data = columns_counts = CSV.read(filename, col_sep: separator)[1..-1].map(&:compact)
+    first_row_size = data.first.size
+    data.all? { |row| row.size == first_row_size }
   rescue CSV::MalformedCSVError
     false
   end


### PR DESCRIPTION
Unexpected

This PR improves the separator detection in CSV files imported for budgets.

The error happened when the separator is a ; and some cells included a , in their value.