### PR TITLE
No caching dataset on wrong result

### DIFF
--- a/app/models/gobierto_data/cache.rb
+++ b/app/models/gobierto_data/cache.rb
@@ -40,8 +40,13 @@ module GobiertoData
       dirname = Rails.root.join("#{BASE_PATH}/datasets")
       FileUtils.mkdir_p(dirname)
       filename = "#{dirname}/#{dataset.id}.#{format}"
+
       if !File.file?(filename) || update
         result = yield
+        if result.is_a?(Hash) && result.has_key?(:errors)
+          return result
+        end
+
         size = File.write(filename, result, mode: "wb+")
 
         size_attribute = dataset.size || {}
@@ -52,6 +57,8 @@ module GobiertoData
         end
 
         dataset.update_column(:size, size_attribute)
+
+        return result
       end
 
       File.open(filename, "rb")


### PR DESCRIPTION
## :v: What does this PR do?

This PR handles the situation where the content of a dataset returns an error (for example, when the table doesn't exist) and the download action is requested. In those cases, instead of caching the result (which is an error message) it just bypasses it to the client.

## :mag: How should this be manually tested?

You should be able to test it by removing a table and clicking on download. No CSV should be downloaded. Once the dataset has been restored the CSV works as usual.