### PR TITLE
Gobierto Data / Add missing marker's to perspective-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "moment-locales-webpack-plugin": "^1.0.7",
     "mustache": "^2.3.0",
     "normalize.css": "^8.0.1",
-    "perspective-map": "^1.0.4",
+    "perspective-map": "^1.1.0",
     "purecss": "^2.0.6",
     "regenerator-runtime": "^0.13.9",
     "resolve-url-loader": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "moment-locales-webpack-plugin": "^1.0.7",
     "mustache": "^2.3.0",
     "normalize.css": "^8.0.1",
-    "perspective-map": "^1.1.0",
+    "perspective-map": "^1.2.0",
     "purecss": "^2.0.6",
     "regenerator-runtime": "^0.13.9",
     "resolve-url-loader": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9611,10 +9611,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-perspective-map@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/perspective-map/-/perspective-map-1.0.4.tgz"
-  integrity sha512-U4cTxhbtCd1Lz9rAQs0Due6g7uNfTCkzIeNQeBrL+Ae32xS9+LodBohWRiwhWvjVvZf0gpVtp/urXN2DUjO+/w==
+perspective-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/perspective-map/-/perspective-map-1.1.0.tgz#b5a871fa82986244f56ed149f0785627294d1fe8"
+  integrity sha512-FFiKXB/yTxxnWXLP21GHABgWiqGZn2d1R5+vsaZdFU5YLnQZaZbuLq0vdQ1zUMH5CwfIc25XB3z42sWUBdQp2Q==
   dependencies:
     "@finos/perspective-viewer" "0.6.2"
     leaflet "^1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9611,12 +9611,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-perspective-map@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/perspective-map/-/perspective-map-1.1.0.tgz#b5a871fa82986244f56ed149f0785627294d1fe8"
-  integrity sha512-FFiKXB/yTxxnWXLP21GHABgWiqGZn2d1R5+vsaZdFU5YLnQZaZbuLq0vdQ1zUMH5CwfIc25XB3z42sWUBdQp2Q==
+"perspective-map@file:.yalc/perspective-map":
+  version "1.0.4"
   dependencies:
     "@finos/perspective-viewer" "0.6.2"
+    file-loader "^6.2.0"
     leaflet "^1.5.1"
     topojson-client "^3.1.0"
 


### PR DESCRIPTION
Closes #https://github.com/PopulateTools/issues/issues/1785


## :v: What does this PR do?

- Bump Perspective-map to 1.2.0. New versión contains a fixes a Webpack bug when compiling Leaflet images, [similar to this one.](https://github.com/PopulateTools/gobierto/blob/master/app/javascript/gobierto_investments/webapp/components/Map.vue#L44-L51). Also, it doesn't create the legend if the geometry type is a Point.


## :mag: How should this be manually tested?

[Staging](https://esplugues.gobify.net/datos/geo-equipamientos?sql=SELECT%2520%2a%2520FROM%2520geo_equipamientos) but we should update the geometry column as this format is not supported by the plugin.


## :eyes: Screenshots


![perspective-map-marker](https://user-images.githubusercontent.com/2649175/217280814-712be9d1-8626-4261-ad6d-ec6a4a95f706.png)

