### PR TITLE
Fix translations

### DIFF
--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -391,7 +391,7 @@ ca:
           el pressupost inicial actualitzat. Hi poden haver canvis, perquè és impossible
           preveure totes les despeses amb precisió absoluta
         economic: Econòmica
-        economic_button: Per a què es gasta
+        economic_button: En què es gasta
         euros: En euros
         execution_disclaimer: Es normal que hi haja desviacions ja que és impossible
           preveure totes les despeses amb precisió absoluta.
@@ -400,7 +400,7 @@ ca:
         expenses_executed: Despeses executades
         expenses_planned: Despeses pressupostades
         functional: Funcional
-        functional_button: En què es gasta
+        functional_button: Per a què es gasta
         higher_execution: Més execució
         income_executed: Ingressos executats
         income_planned: Ingressos pressupostats

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -372,7 +372,7 @@ en:
           It's normal to find deviations from the budget, as its impossible to predict
           the expenses with a great precision
         economic: economic
-        economic_button: For what is spent
+        economic_button: In what is spent
         euros: In euros
         execution_disclaimer: It's very common to have deviatiatons, due to the difficulty
           of foreseeing the expenses.
@@ -380,7 +380,7 @@ en:
         expenses_executed: Executed expenses
         expenses_planned: Planned expenses
         functional: functional
-        functional_button: In what is spent
+        functional_button: For what is spent
         higher_execution: Higher execution
         income_executed: Executed income
         income_planned: Planned income

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -384,7 +384,7 @@ es:
           el presupuesto inicial modificado. Es normal que haya desviaciones ya que
           es imposible preveer todos los gastos con precisión absoluta
         economic: Económica
-        economic_button: Para qué se gasta
+        economic_button: En qué se gasta
         euros: En euros
         execution_disclaimer: Es normal que haya desviaciones ya que es imposible
           preveer todos los gastos con precisión absoluta.
@@ -393,7 +393,7 @@ es:
         expenses_executed: Gastos ejecutados
         expenses_planned: Gastos presupuestados
         functional: Functional
-        functional_button: En qué se gasta
+        functional_button: Para qué se gasta
         higher_execution: Mayor ejecución
         income_executed: Ingresos ejecutados
         income_planned: Ingresos presupuestados


### PR DESCRIPTION
## :v: What does this PR do?

This PR swaps the translation of economic/functional labels in the execution page, because a client reported they are switched.


## :mag: How should this be manually tested?

https://mataro.gobify.net/presupuestos/ejecucion/2022#economic,economic
