### PR TITLE
Query security check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,9 @@ gem 'rack-rewrite'
 # Log
 gem "lograge"
 
+# Gobierto Data query analyzer
+gem "pg_query"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ GEM
       google-apis-core (~> 0.1)
       google-apis-discovery_v1 (~> 0.0)
       thor (>= 0.20, < 2.a)
+    google-protobuf (3.23.2)
     googleauth (0.14.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
@@ -368,6 +369,8 @@ GEM
     parser (3.0.1.1)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pg_query (4.2.1)
+      google-protobuf (>= 3.22.3)
     pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
@@ -600,6 +603,7 @@ DEPENDENCIES
   paper_trail
   paranoia
   pg (~> 1.1)
+  pg_query
   pg_search (= 2.3.5)
   puma
   rack-cors

--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -16,7 +16,7 @@ module GobiertoData
     class << self
 
       def execute_query(site, query, include_stats: false, write: false, include_draft: false)
-        unless secure_query?(query)
+        if !secure_query?(query) && !write
           raise ActiveRecord::StatementInvalid.new("Query not allowed")
         end
 
@@ -96,10 +96,6 @@ module GobiertoData
 
       def execute_write_query_from_file_using_stdin(site, query, file_path: nil, include_draft: false)
         return unless file_path.present?
-
-        unless secure_query?(query)
-          raise ActiveRecord::StatementInvalid.new("Query not allowed")
-        end
 
         with_connection(db_config(site), fallback: configuration_missing_error, connection_key: :write_db_config) do
           connection_pool.connection.execute("CREATE SCHEMA IF NOT EXISTS draft") if include_draft

--- a/test/controllers/gobierto_data/api/v1/datasets_deletion_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_deletion_test.rb
@@ -31,7 +31,7 @@ module GobiertoData
         end
 
         def exists_table_for_dataset?
-          dataset.table_name == ::GobiertoData::Connection.execute_query(site, "SELECT to_regclass('#{dataset.table_name}')" ).first["to_regclass"]
+          dataset.table_name == ::GobiertoData::Connection.execute_query(site, "SELECT to_regclass('#{dataset.table_name}')", write: true ).first["to_regclass"]
         end
 
         # DELETE /api/v1/data/datasets/:dataset-slug


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1829

## :v: What does this PR do?

This PR adds some basic checks on Gobierto Data queries:

- prevents queries without table
- prevents queries to `pg_` tables
- prevents queries to schemas
- prevents queries to pg_stats