### PR TITLE
Calendars / Introduce param to isolate calendar view

### DIFF
--- a/app/controllers/gobierto_people/application_controller.rb
+++ b/app/controllers/gobierto_people/application_controller.rb
@@ -6,7 +6,7 @@ module GobiertoPeople
 
     before_action { module_enabled!(current_site, "GobiertoPeople") }
 
-    helper_method :gifts_service_url, :trips_service_url, :cache_service
+    helper_method :gifts_service_url, :trips_service_url, :cache_service, :show_only_calendar?
 
     private
 
@@ -27,5 +27,10 @@ module GobiertoPeople
     def cache_service
       @cache_service ||= GobiertoCommon::CacheService.new(current_site, "GobiertoPeople")
     end
+
+    def show_only_calendar?
+      params[:only_calendar].present?
+    end
+
   end
 end

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -6,8 +6,6 @@ module GobiertoPeople
 
     before_action :check_active_submodules
 
-    helper_method :show_only_calendar?
-
     def index
       set_events
       render_404 and return if params[:page].present? && @events.empty?
@@ -88,10 +86,5 @@ module GobiertoPeople
         (Time.zone.now.at_beginning_of_month.at_beginning_of_week)..(Time.zone.now.at_end_of_month.at_end_of_week)
       end
     end
-
-    def show_only_calendar?
-      params[:only_calendar].present?
-    end
-
   end
 end

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -6,6 +6,8 @@ module GobiertoPeople
 
     before_action :check_active_submodules
 
+    helper_method :show_only_calendar?
+
     def index
       set_events
       render_404 and return if params[:page].present? && @events.empty?
@@ -85,6 +87,10 @@ module GobiertoPeople
       else
         (Time.zone.now.at_beginning_of_month.at_beginning_of_week)..(Time.zone.now.at_end_of_month.at_end_of_week)
       end
+    end
+
+    def show_only_calendar?
+      params[:only_calendar].present?
     end
 
   end

--- a/app/views/gobierto_people/layouts/people.html.erb
+++ b/app/views/gobierto_people/layouts/people.html.erb
@@ -4,6 +4,7 @@
 
     <div class="pure-g">
 
+      <% unless show_only_calendar? %>
       <div class="pure-u-1 pure-u-md-7-24">
 
         <div class="person_header_small clearfix">
@@ -16,6 +17,7 @@
         <%= render "gobierto_people/people/navigation" %>
 
       </div>
+      <% end %>
 
       <div class="pure-u-1 pure-u-md-17-24 main_people_content">
 

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -69,3 +69,9 @@
 <% content_for :javascript_hook do %>
   window.GobiertoPeople.person_events_controller.index();
 <% end %>
+
+<% if show_only_calendar? %>
+<style>
+header, footer { display: none; }
+</style>
+<% end %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -1,47 +1,51 @@
 <div class="column">
 
-  <div class="block">
-    <h2 data-share-text><%= title t(".title", site_name: whom(current_site.name)) %></h2>
-  </div>
+  <% unless show_only_calendar? %>
+    <div class="block">
+      <h2 data-share-text><%= title t(".title", site_name: whom(current_site.name)) %></h2>
+    </div>
 
-  <%= render "gobierto_people/person_events/person_events_filter" %>
+    <%= render "gobierto_people/person_events/person_events_filter" %>
+  <% end %>
 
   <div class="pure-g">
 
-    <div class="pure-u-1 pure-u-md-7-24">
+    <% unless show_only_calendar? %>
+      <div class="pure-u-1 pure-u-md-7-24">
 
-      <div class="agenda-switcher m_v_2">
+        <div class="agenda-switcher m_v_2">
 
-        <div><strong><%= t(".agenda_switcher.title") %></strong></div>
-        <p><small><%= t(".agenda_switcher.subtitle") %></small></p>
+          <div><strong><%= t(".agenda_switcher.title") %></strong></div>
+          <p><small><%= t(".agenda_switcher.subtitle") %></small></p>
 
-        <div class="hidden_options">
-          <ul>
-            <% @people.each do |person| %>
-              <li><%= link_to person.name, gobierto_people_person_events_path(person.slug) %></li>
-            <% end %>
-          </ul>
+          <div class="hidden_options">
+            <ul>
+              <% @people.each do |person| %>
+                <li><%= link_to person.name, gobierto_people_person_events_path(person.slug) %></li>
+              <% end %>
+            </ul>
+          </div>
+
         </div>
 
-      </div>
+        <div class="calendar-component m_v_2">
+          <%= month_calendar(
+            partial: "gobierto_people/person_events/calendar_template",
+            events: @calendar_events,
+            attribute: :starts_at,
+            start_date: params[:start_date] || Date.current
+          ) do |date, events| %>
+            <%= link_to_if events.any?, date.day, date: date, start_date: params[:start_date] %>
+          <% end %>
+        </div>
 
-      <div class="calendar-component m_v_2">
-        <%= month_calendar(
-          partial: "gobierto_people/person_events/calendar_template",
-          events: @calendar_events,
-          attribute: :starts_at,
-          start_date: params[:start_date] || Date.current
-        ) do |date, events| %>
-          <%= link_to_if events.any?, date.day, date: date, start_date: params[:start_date] %>
+        <% disabled do %>
+          <%= render("user/subscriptions/subscribable_box",
+                    subscribable: GobiertoCalendars::Event,
+                    title: t(".subscribable_box.title")) %>
         <% end %>
       </div>
-
-      <% disabled do %>
-        <%= render("user/subscriptions/subscribable_box",
-                   subscribable: GobiertoCalendars::Event,
-                   title: t(".subscribable_box.title")) %>
-      <% end %>
-    </div>
+    <% end %>
 
     <div id="person-agenda" class="pure-u-1 pure-u-md-17-24 main_people_content">
 
@@ -108,3 +112,9 @@
 </div>
 
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>
+
+<% if show_only_calendar? %>
+<style>
+header, footer { display: none; }
+</style>
+<% end %>

--- a/app/views/gobierto_people/person_events/index.html.erb
+++ b/app/views/gobierto_people/person_events/index.html.erb
@@ -1,51 +1,47 @@
 <div class="column">
 
-  <% unless show_only_calendar? %>
-    <div class="block">
-      <h2 data-share-text><%= title t(".title", site_name: whom(current_site.name)) %></h2>
-    </div>
+  <div class="block">
+    <h2 data-share-text><%= title t(".title", site_name: whom(current_site.name)) %></h2>
+  </div>
 
-    <%= render "gobierto_people/person_events/person_events_filter" %>
-  <% end %>
+  <%= render "gobierto_people/person_events/person_events_filter" %>
 
   <div class="pure-g">
 
-    <% unless show_only_calendar? %>
-      <div class="pure-u-1 pure-u-md-7-24">
+    <div class="pure-u-1 pure-u-md-7-24">
 
-        <div class="agenda-switcher m_v_2">
+      <div class="agenda-switcher m_v_2">
 
-          <div><strong><%= t(".agenda_switcher.title") %></strong></div>
-          <p><small><%= t(".agenda_switcher.subtitle") %></small></p>
+        <div><strong><%= t(".agenda_switcher.title") %></strong></div>
+        <p><small><%= t(".agenda_switcher.subtitle") %></small></p>
 
-          <div class="hidden_options">
-            <ul>
-              <% @people.each do |person| %>
-                <li><%= link_to person.name, gobierto_people_person_events_path(person.slug) %></li>
-              <% end %>
-            </ul>
-          </div>
-
+        <div class="hidden_options">
+          <ul>
+            <% @people.each do |person| %>
+              <li><%= link_to person.name, gobierto_people_person_events_path(person.slug) %></li>
+            <% end %>
+          </ul>
         </div>
 
-        <div class="calendar-component m_v_2">
-          <%= month_calendar(
-            partial: "gobierto_people/person_events/calendar_template",
-            events: @calendar_events,
-            attribute: :starts_at,
-            start_date: params[:start_date] || Date.current
-          ) do |date, events| %>
-            <%= link_to_if events.any?, date.day, date: date, start_date: params[:start_date] %>
-          <% end %>
-        </div>
+      </div>
 
-        <% disabled do %>
-          <%= render("user/subscriptions/subscribable_box",
-                    subscribable: GobiertoCalendars::Event,
-                    title: t(".subscribable_box.title")) %>
+      <div class="calendar-component m_v_2">
+        <%= month_calendar(
+          partial: "gobierto_people/person_events/calendar_template",
+          events: @calendar_events,
+          attribute: :starts_at,
+          start_date: params[:start_date] || Date.current
+        ) do |date, events| %>
+          <%= link_to_if events.any?, date.day, date: date, start_date: params[:start_date] %>
         <% end %>
       </div>
-    <% end %>
+
+      <% disabled do %>
+        <%= render("user/subscriptions/subscribable_box",
+                  subscribable: GobiertoCalendars::Event,
+                  title: t(".subscribable_box.title")) %>
+      <% end %>
+    </div>
 
     <div id="person-agenda" class="pure-u-1 pure-u-md-17-24 main_people_content">
 
@@ -112,9 +108,3 @@
 </div>
 
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>
-
-<% if show_only_calendar? %>
-<style>
-header, footer { display: none; }
-</style>
-<% end %>


### PR DESCRIPTION
This PR introduces a parameter in a person calendar view called `only_calendar=true` which allows to have a view of the events calendar without any header, footer or sidebar.

Screenshot:

![Screenshot 2023-06-11 at 06 17 51](https://github.com/PopulateTools/gobierto/assets/17616/87c5bcc1-035d-42fd-b871-1e814b2a140b)
