### PR TITLE
Move site head configuration into head tag

### DIFF
--- a/app/views/layouts/_gobierto_head.html.erb
+++ b/app/views/layouts/_gobierto_head.html.erb
@@ -34,3 +34,7 @@
 <% else %>
   <%= render 'layouts/favicon' %>
 <% end %>
+
+<% if @site.configuration.head_markup.present? %>
+  <%= render_liquid @site.configuration.head_markup %>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,10 +30,6 @@
       </div>
     </div>
 
-    <% if @site.configuration.head_markup.present? %>
-      <%= render_liquid @site.configuration.head_markup %>
-    <% end %>
-
     <div class="site_header">
 
       <div class="column site_header_block">


### PR DESCRIPTION
## :v: What does this PR do?

This PR moves the site head custom configuration inside the `<head>` tag

## :mag: How should this be manually tested?

In https://mataro.gobify.net/ you should be able to see inside the `<head>` the content: `<meta name="robots" content="noindex">`

