### PR TITLE
Gobierto Costs / Add fallback to calculate taxes

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/costs/table/TableItem.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/costs/table/TableItem.vue
@@ -232,7 +232,7 @@
                   {{ labelPublicTax }}
                 </span>
                 <span class="gobierto-visualizations-table-item-right-table-amount">
-                  {{ taxs | money }}
+                  {{ calculateTax | money }}
                 </span>
               </div>
               <i
@@ -265,7 +265,7 @@
                   {{ labelTotalIncome }}
                 </span>
                 <span class="gobierto-visualizations-table-item-right-table-amount">
-                  {{ totalIncomes | money }}
+                  {{ income | money }}
                 </span>
               </div>
               <i
@@ -413,9 +413,8 @@ export default {
     }
   },
   computed: {
-    //Get the total of all values in the incomes table
-    totalIncomes() {
-      return this.taxs + this.subsidies
+    calculateTax() {
+      return this.taxs === 0 ? this.income - this.subsidies : this.taxs
     }
   },
   created() {

--- a/app/javascript/gobierto_visualizations/webapp/containers/costs/table/TableItem.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/costs/table/TableItem.vue
@@ -413,8 +413,15 @@ export default {
     }
   },
   computed: {
+    /*
+    Calculate the taxapreub because the 2022 data doesn't contain the taxapreub,
+    so we need to calculate it with (this.income - this.subsidies).
+    What is this this.codiAct !== "44111001"??? is an exception
+    la actividad 44111001 dónde este año hemos incorporado los ingresos
+    de la concesionaria y no corresponden a ninguna de las dos columnas(ingressos or subsidies).
+    */
     calculateTax() {
-      return this.taxs === 0 ? this.income - this.subsidies : this.taxs
+      return this.taxs === 0 && this.codiAct !== "44111001" ? this.income - this.subsidies : this.taxs
     }
   },
   created() {
@@ -447,7 +454,8 @@ export default {
         ingressos_cost: incomeCost,
         ingressos: income,
         agrupacio: agrupacio,
-        costtotal: costTotal
+        costtotal: costTotal,
+        codiact: codiAct
       }] = this.dataGroup
 
       this.description = description
@@ -467,6 +475,7 @@ export default {
       this.agrupacioID = agrupacio
       this.costTotal = costTotal
       this.coverage = (income * 100) / costTotal
+      this.codiAct = codiAct
     },
     loadTable(value) {
       this.$emit('changeTableHandler', value)

--- a/app/javascript/stylesheets/gobierto-visualizations.scss
+++ b/app/javascript/stylesheets/gobierto-visualizations.scss
@@ -1165,7 +1165,7 @@
   }
 
   .range-slider-costs {
-    width: 150px;
+    width: max-content;
     margin: 1rem auto;
   }
 
@@ -1175,7 +1175,17 @@
 
     &:last-child {
       .range-slider-costs--values-circle {
-        left: calc(100% - 24px);
+        left: calc(100% - 22px);
+      }
+
+      .range-slider-costs--values-text {
+        left: calc(100% - 32px);
+      }
+    }
+
+    &:not(:first-child):not(:last-child) {
+      .range-slider-costs--values-circle {
+        left: calc(100% - 32px);
       }
     }
 
@@ -1195,11 +1205,12 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
 
     &::after {
       content: '';
       height: 10px;
-      width: 98%;
+      width: 100%;
       background-color: #ddd;
       margin: auto;
       position: absolute;
@@ -1223,6 +1234,7 @@
   .range-slider-costs--values-text {
     font-size: 1.25rem;
     font-weight: 300;
+    position: relative;
   }
 
   .header_block_inline p.visualizations-text-info {


### PR DESCRIPTION
Closes (https://github.com/PopulateTools/issues/issues/1846)


## :v: What does this PR do?

- Add a fallback to calculate taxapreub(income - subsidies).
- Add space between the slider years.

## :mag: How should this be manually tested?

[Staging](https://mataro.gobify.net/visualizaciones/costes/2022/6/33331004)

## :eyes: Screenshots

### Before this PR
Slider
![Captura de pantalla 2023-08-23 a las 10 03 06](https://github.com/PopulateTools/gobierto/assets/2649175/2fa631ec-cc89-4ca6-a743-5326bd6f8729)

### After this PR
Slider
![Captura de pantalla 2023-08-23 a las 10 09 25](https://github.com/PopulateTools/gobierto/assets/2649175/bebf303f-5a51-49ae-8069-47f8ea4ca447)

Taxapreub
![Captura de pantalla 2023-08-23 a las 10 08 53](https://github.com/PopulateTools/gobierto/assets/2649175/d03959d7-ac6e-44af-9d3a-4615cf20e4a5)

