### PR TITLE
Ignore jobs namespaces in staging and production

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -28,8 +28,18 @@ test:
 
 staging:
   <<: *defaults
+  revision: "<%= `[ -f REVISION ] && cat REVISION`.strip %>"
   active: true
+  ignore_namespaces:
+    - background_job
+    - background
+    - ignore_on_appsignal
 
 production:
   <<: *defaults
   active: true
+  revision: "<%= `[ -f REVISION ] && cat REVISION`.strip %>"
+  ignore_namespaces:
+    - background_job
+    - background
+    - ignore_on_appsignal


### PR DESCRIPTION
## :v: What does this PR do?

This PR ignores background jobs in staging and pro environments. It's specially noisy the job that tracks ahoy visits.
