### PR TITLE
Vocabularies api

### DIFF
--- a/app/controllers/gobierto_common/api/v1/terms_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/terms_controller.rb
@@ -93,7 +93,7 @@ module GobiertoCommon
         end
 
         def vocabulary
-          @vocabulary ||= current_site.vocabularies.find_by(id: params[:vocabulary_id])
+          @vocabulary ||= current_site.vocabularies.find_by(id: params[:vocabulary_id]) || current_site.vocabularies.find_by(slug: params[:vocabulary_id])
         end
 
         def find_item

--- a/app/controllers/gobierto_common/api/v1/terms_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/terms_controller.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module Api
+    module V1
+      class TermsController < ApiBaseController
+        include ::GobiertoCommon::SecuredWithAdminToken
+
+        # GET /api/v1/vocabularies/1/terms
+        # GET /api/v1/vocabularies/1/terms.json
+        def index
+          render(json: base_relation, each_serializer: ::GobiertoCommon::ApiTermSerializer, adapter: :json_api)
+        end
+
+        # GET /api/v1/vocabularies/1/terms/1
+        # GET /api/v1/vocabularies/1/terms/1.json
+        def show
+          find_item
+
+          render(json: @item, serializer: ::GobiertoCommon::ApiTermSerializer, adapter: :json_api)
+        end
+
+        # GET /api/v1/vocabularies/1/terms/new
+        # GET /api/v1/vocabularies/1/terms/new.json
+        def new
+          render(
+            json: base_relation.new(name_translations: available_locales_hash, description_translations: available_locales_hash),
+            serializer: ::GobiertoCommon::ApiTermSerializer,
+            adapter: :json_api
+          )
+        end
+
+        # POST /api/v1/vocabularies/1/terms
+        # POST /api/v1/vocabularies/1/terms.json
+        def create
+          @form = GobiertoAdmin::GobiertoCommon::TermForm.new(term_form_params)
+
+          if @form.save
+            term = @form.term
+
+            render(
+              json: term,
+              serializer: ::GobiertoCommon::ApiTermSerializer,
+              status: :created,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        # PUT /api/v1/vocabularies/1/terms/1
+        # PUT /api/v1/vocabularies/1/terms/1.json
+        def update
+          find_item
+          @form = GobiertoAdmin::GobiertoCommon::TermForm.new(term_form_params.merge(id: @item.id))
+
+          if @form.save
+            term = @form.term
+
+            render(
+              json: term,
+              serializer: ::GobiertoCommon::ApiTermSerializer,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        # DELETE /api/v1/vocabularies/1/terms/1
+        # DELETE /api/v1/vocabularies/1/terms/1.json
+        def destroy
+          find_item
+
+          @item.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def term_id
+          return term_params[:term_id] if term_params[:term_id].present?
+          return base_relation.find_by(external_id: term_params[:parent_external_id])&.id if term_params[:parent_external_id].present?
+        end
+
+        def base_relation
+          return GobiertoCommon::Term.none if vocabulary.blank?
+
+          vocabulary.terms
+        end
+
+        def vocabulary
+          @vocabulary ||= current_site.vocabularies.find_by(id: params[:vocabulary_id])
+        end
+
+        def find_item
+          @item = base_relation.find(params[:id])
+        end
+
+        def term_form_params
+          term_params.except(:parent_external_id).merge(site_id: current_site.id, vocabulary_id: vocabulary.id, term_id:)
+        end
+
+        def term_params
+          @term_params ||= ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: writable_attributes)
+        end
+
+        def writable_attributes
+          [:name_translations, :description_translations, :slug, :position, :term_id, :external_id, :parent_external_id]
+        end
+
+        def available_locales_hash
+          @available_locales_hash ||= available_locales.each_with_object({}) { |key, locales| locales[key] = nil }
+        end
+
+        def available_locales
+          @available_locales ||= current_site.configuration.available_locales
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_common/api/v1/terms_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/terms_controller.rb
@@ -33,7 +33,7 @@ module GobiertoCommon
         # POST /api/v1/vocabularies/1/terms
         # POST /api/v1/vocabularies/1/terms.json
         def create
-          @form = GobiertoAdmin::GobiertoCommon::TermForm.new(term_form_params)
+          @form = ::GobiertoAdmin::GobiertoCommon::TermForm.new(term_form_params)
 
           if @form.save
             term = @form.term
@@ -53,7 +53,7 @@ module GobiertoCommon
         # PUT /api/v1/vocabularies/1/terms/1.json
         def update
           find_item
-          @form = GobiertoAdmin::GobiertoCommon::TermForm.new(term_form_params.merge(id: @item.id))
+          @form = ::GobiertoAdmin::GobiertoCommon::TermForm.new(term_form_params.merge(id: @item.id))
 
           if @form.save
             term = @form.term

--- a/app/controllers/gobierto_common/api/v1/terms_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/terms_controller.rb
@@ -83,6 +83,7 @@ module GobiertoCommon
         def term_id
           return term_params[:term_id] if term_params[:term_id].present?
           return base_relation.find_by(external_id: term_params[:parent_external_id])&.id if term_params[:parent_external_id].present?
+          return (base_relation.find_by(id: term_params[:parent_id])&.id || base_relation.find_by(external_id: term_params[:parent_id])&.id) if term_params[:parent_id].present?
         end
 
         def base_relation
@@ -100,7 +101,7 @@ module GobiertoCommon
         end
 
         def term_form_params
-          term_params.except(:parent_external_id).merge(site_id: current_site.id, vocabulary_id: vocabulary.id, term_id:)
+          term_params.except(:parent_external_id, :parent_id).merge(site_id: current_site.id, vocabulary_id: vocabulary.id, term_id:)
         end
 
         def term_params
@@ -108,7 +109,7 @@ module GobiertoCommon
         end
 
         def writable_attributes
-          [:name_translations, :description_translations, :slug, :position, :term_id, :external_id, :parent_external_id]
+          [:name_translations, :description_translations, :slug, :position, :term_id, :external_id, :parent_external_id, :parent_id]
         end
 
         def available_locales_hash

--- a/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
@@ -33,7 +33,7 @@ module GobiertoCommon
         # POST /api/v1/vocabularies
         # POST /api/v1/vocabularies.json
         def create
-          @form = GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id))
+          @form = ::GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id))
 
           if @form.save
             vocabulary = @form.vocabulary
@@ -55,7 +55,7 @@ module GobiertoCommon
         # PUT /api/v1/vocabularies/1.json
         def update
           find_item
-          @form = GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id, id: @item.id))
+          @form = ::GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id, id: @item.id))
 
           if @form.save
             vocabulary = @form.vocabulary
@@ -88,7 +88,7 @@ module GobiertoCommon
           if terms_data.blank?
             yield(vocabulary)
           else
-            @terms_form = GobiertoAdmin::GobiertoCommon::TermsForm.new(terms: terms_data, site_id: current_site.id, vocabulary_id: vocabulary.id)
+            @terms_form = ::GobiertoAdmin::GobiertoCommon::TermsForm.new(terms: terms_data, site_id: current_site.id, vocabulary_id: vocabulary.id)
             if @terms_form.save
               yield(vocabulary)
             else

--- a/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
@@ -87,26 +87,6 @@ module GobiertoCommon
           end
         end
 
-        def create_or_update
-          find_item
-          @form = GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id, id: @item.id))
-
-          if @form.save
-            vocabulary = @form.vocabulary
-            if (terms_data = vocabulary_params[:terms]).present?
-              @terms_form = GobiertoAdmin::GobiertoCommon::TermsForm.new(terms: terms_data, site_id: current_site.id, vocabulary_id: vocabulary.id)
-            end
-
-            if terms_data.blank? || @terms_form.save
-              yield(vocabulary)
-            else
-              api_errors_render(@terms_form, adapter: :json_api)
-            end
-          else
-            api_errors_render(@form, adapter: :json_api)
-          end
-        end
-
         def base_relation
           current_site.vocabularies
         end

--- a/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  module Api
+    module V1
+      class VocabulariesController < ApiBaseController
+        include ::GobiertoCommon::SecuredWithAdminToken
+
+        # GET /api/v1/vocabularies
+        # GET /api/v1/vocabularies.json
+        def index
+          render(json: base_relation, each_serializer: ::GobiertoCommon::VocabularySerializer, adapter: :json_api)
+        end
+
+        # GET /api/v1/vocabularies/1
+        # GET /api/v1/vocabularies/1.json
+        def show
+          find_item
+
+          render(json: @item, adapter: :json_api)
+        end
+
+        # GET /api/v1/vocabularies/new
+        # GET /api/v1/vocabularies/new.json
+        def new
+          render(
+            json: base_relation.new(name_translations: available_locales_hash),
+            serializer: ::GobiertoCommon::VocabularySerializer,
+            adapter: :json_api
+          )
+        end
+
+        # POST /api/v1/vocabularies
+        # POST /api/v1/vocabularies.json
+        def create
+          @form = GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id))
+
+          if @form.save
+            vocabulary = @form.vocabulary
+
+            create_or_update_terms(vocabulary, terms_params) do
+              render(
+                json: vocabulary,
+                serializer: ::GobiertoCommon::VocabularySerializer,
+                status: :created,
+                adapter: :json_api
+              )
+            end
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        # PUT /api/v1/vocabularies/1
+        # PUT /api/v1/vocabularies/1.json
+        def update
+          find_item
+          @form = GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id, id: @item.id))
+
+          if @form.save
+            vocabulary = @form.vocabulary
+
+            create_or_update_terms(vocabulary, terms_params) do
+              render(
+                json: vocabulary,
+                serializer: ::GobiertoCommon::VocabularySerializer,
+                adapter: :json_api
+              )
+            end
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        private
+
+        def create_or_update_terms(vocabulary, terms_data)
+          if terms_data.blank?
+            yield(vocabulary)
+          else
+            @terms_form = GobiertoAdmin::GobiertoCommon::TermsForm.new(terms: terms_data, site_id: current_site.id, vocabulary_id: vocabulary.id)
+            if @terms_form.save
+              yield(vocabulary)
+            else
+              api_errors_render(@terms_form, adapter: :json_api)
+            end
+          end
+        end
+
+        def create_or_update
+          find_item
+          @form = GobiertoAdmin::GobiertoCommon::VocabularyForm.new(vocabulary_params.merge(site_id: current_site.id, id: @item.id))
+
+          if @form.save
+            vocabulary = @form.vocabulary
+            if (terms_data = vocabulary_params[:terms]).present?
+              @terms_form = GobiertoAdmin::GobiertoCommon::TermsForm.new(terms: terms_data, site_id: current_site.id, vocabulary_id: vocabulary.id)
+            end
+
+            if terms_data.blank? || @terms_form.save
+              yield(vocabulary)
+            else
+              api_errors_render(@terms_form, adapter: :json_api)
+            end
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        def base_relation
+          current_site.vocabularies
+        end
+
+        def find_item
+          @item = base_relation.find(params[:id])
+        end
+
+        def vocabulary_params
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: writable_attributes)
+        end
+
+        def terms_params
+          ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:terms])[:terms]
+        end
+
+        def writable_attributes
+          [:name_translations, :slug]
+        end
+
+        def available_locales_hash
+          @available_locales_hash ||= available_locales.each_with_object({}) { |key, locales| locales[key] = nil }
+        end
+
+        def available_locales
+          @available_locales ||= current_site.configuration.available_locales
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
@@ -72,6 +72,16 @@ module GobiertoCommon
           end
         end
 
+        # DELETE /api/v1/vocabularies/1
+        # DELETE /api/v1/vocabularies/1.json
+        def destroy
+          find_item
+
+          @item.destroy
+
+          head :no_content
+        end
+
         private
 
         def create_or_update_terms(vocabulary, terms_data)

--- a/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
+++ b/app/controllers/gobierto_common/api/v1/vocabularies_controller.rb
@@ -102,7 +102,7 @@ module GobiertoCommon
         end
 
         def find_item
-          @item = base_relation.find(params[:id])
+          @item = base_relation.find_by(id: params[:id]) || base_relation.find_by!(slug: params[:id])
         end
 
         def vocabulary_params

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -8,12 +8,15 @@ module GobiertoAdmin
         :id,
         :site_id,
         :vocabulary_id,
-        :name_translations,
         :description_translations,
         :position,
         :slug,
         :term_id,
         :external_id
+      )
+
+      attr_writer(
+        :name_translations
       )
 
       delegate :persisted?, to: :term
@@ -27,6 +30,10 @@ module GobiertoAdmin
 
       def build_term
         vocabulary.terms.new(position: next_position)
+      end
+
+      def name_translations
+        @name_translations ||= term.name_translations
       end
 
       def save
@@ -55,8 +62,8 @@ module GobiertoAdmin
         @term = term.tap do |attributes|
           attributes.vocabulary_id = vocabulary.id
           attributes.name_translations = name_translations
-          attributes.description_translations = description_translations
-          attributes.slug = slug
+          attributes.description_translations = description_translations if description_translations.present?
+          attributes.slug = slug if slug.present?
           attributes.term_id = term_id
           attributes.position = position if position.present?
           attributes.external_id = external_id if external_id.present?

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -36,11 +36,13 @@ module GobiertoAdmin
       end
 
       def build_term
+        return if vocabulary.blank?
+
         vocabulary.terms.new(position: next_position)
       end
 
       def name_translations
-        @name_translations ||= term.name_translations
+        @name_translations ||= term&.name_translations
       end
 
       def save

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -26,7 +26,7 @@ module GobiertoAdmin
       validate :external_id_uniqueness_by_vocabulary
 
       def initialize(attributes = {})
-        @reset_term_id = attributes.has_key?("term_id")
+        @reset_term_id = attributes.with_indifferent_access.has_key?(:term_id)
 
         super
       end

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -10,6 +10,7 @@ module GobiertoAdmin
         :vocabulary_id,
         :name_translations,
         :description_translations,
+        :position,
         :slug,
         :term_id,
         :external_id
@@ -57,6 +58,7 @@ module GobiertoAdmin
           attributes.description_translations = description_translations
           attributes.slug = slug
           attributes.term_id = term_id
+          attributes.position = position if position.present?
           attributes.external_id = external_id if external_id.present?
         end
 

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -26,7 +26,7 @@ module GobiertoAdmin
       validate :external_id_uniqueness_by_vocabulary
 
       def initialize(attributes = {})
-        @reset_term_id = attributes.with_indifferent_access.has_key?(:term_id)
+        @reset_term_id = attributes.to_h.with_indifferent_access.has_key?(:term_id)
 
         super
       end

--- a/app/forms/gobierto_admin/gobierto_common/term_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/term_form.rb
@@ -12,6 +12,7 @@ module GobiertoAdmin
         :position,
         :slug,
         :term_id,
+        :reset_term_id,
         :external_id
       )
 
@@ -23,6 +24,12 @@ module GobiertoAdmin
 
       validates :name_translations, :site, :vocabulary, presence: true
       validate :external_id_uniqueness_by_vocabulary
+
+      def initialize(attributes = {})
+        @reset_term_id = attributes.has_key?("term_id")
+
+        super
+      end
 
       def term
         @term ||= term_relation.find_by(id: id) || build_term
@@ -64,7 +71,7 @@ module GobiertoAdmin
           attributes.name_translations = name_translations
           attributes.description_translations = description_translations if description_translations.present?
           attributes.slug = slug if slug.present?
-          attributes.term_id = term_id
+          attributes.term_id = term_id if reset_term_id
           attributes.position = position if position.present?
           attributes.external_id = external_id if external_id.present?
         end

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -32,19 +32,19 @@ module GobiertoAdmin
       private
 
       def save_terms
-        existing_terms_data = terms.select do |attrs|
-          find_existing_term(attrs).present?
-        end
-
-        existing_terms_data.each do |attrs|
-          return false unless create_or_update_term(attrs, terms)
-        end
-
         new_terms_data = terms.select do |attrs|
           find_existing_term(attrs).blank?
         end
 
         top_level_items(new_terms_data).each do |attrs|
+          return false unless create_or_update_term(attrs, terms)
+        end
+
+        existing_terms_data = terms.select do |attrs|
+          find_existing_term(attrs).present?
+        end - new_terms_data
+
+        existing_terms_data.each do |attrs|
           return false unless create_or_update_term(attrs, terms)
         end
       end

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -67,6 +67,9 @@ module GobiertoAdmin
 
         if (term = find_existing_term(attributes)).present?
           term_form_attributes["id"] = term.id
+          %w(name_translations description_translations).each do |attr|
+            term_form_attributes[attr] = term.name_translations.merge(term_form_attributes[attr]) if term_form_attributes[attr].present?
+          end
         end
 
         if attributes.has_key?("parent_id")

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -51,8 +51,8 @@ module GobiertoAdmin
 
       def top_level_items(data)
         data.select do |attributes|
-          parent_external_id = attributes["parent_external_id"]
-          parent_external_id.blank? || data.none? { |attrs| attrs["external_id"] == parent_external_id }
+          parent_id = attributes["parent_id"]
+          parent_id.blank? || data.none? { |attrs| attrs["external_id"] == parent_id }
         end
       end
 
@@ -69,8 +69,8 @@ module GobiertoAdmin
           term_form_attributes["id"] = term.id
         end
 
-        if (parent_id = get_parent_id(attributes["parent_external_id"])).present?
-          term_form_attributes["term_id"] = parent_id
+        if attributes.has_key?("parent_id")
+          term_form_attributes["term_id"] = get_parent_id(attributes["parent_id"])
         end
 
         term_form = TermForm.new(term_form_attributes)
@@ -81,7 +81,7 @@ module GobiertoAdmin
         end
 
         if (external_id = attributes["external_id"]).present?
-          data.select { |attrs| attrs["parent_external_id"] == external_id }.each do |attrs|
+          data.select { |attrs| attrs["parent_id"] == external_id }.each do |attrs|
             next if attrs["id"].blank? && vocabulary.terms.where(attrs.slice(*TERM_FORM_EXTERNAL_ATTRIBUTES)).exists?
 
             return false unless create_or_update_term(attrs, data)

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -80,13 +80,14 @@ module GobiertoAdmin
           return false
         end
 
-        external_id = attributes["external_id"]
         if (external_id = attributes["external_id"]).present?
           data.select { |attrs| attrs["parent_external_id"] == external_id }.each do |attrs|
             next if attrs["id"].blank? && vocabulary.terms.where(attrs.slice(*TERM_FORM_EXTERNAL_ATTRIBUTES)).exists?
 
             return false unless create_or_update_term(attrs, data)
           end
+        else
+          term_form.term
         end
       end
 

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoCommon
+    class TermsForm < BaseForm
+
+      TERM_FORM_EXTERNAL_ATTRIBUTES = %w(
+      id
+      name_translations
+      description_translations
+      slug
+      position
+      external_id
+      )
+
+      attr_accessor(
+        :terms,
+        :site_id,
+        :vocabulary_id
+      )
+
+      validates :vocabulary, :site, presence: true
+
+      def save
+        return unless valid?
+
+        ActiveRecord::Base.transaction do
+          save_terms
+        end
+      end
+
+      private
+
+      def save_terms
+        existing_terms_data = terms.select do |attrs|
+          find_existing_term(attrs).present?
+        end
+
+        existing_terms_data.each do |attrs|
+          return false unless create_or_update_term(attrs, terms)
+        end
+
+        new_terms_data = terms.select do |attrs|
+          find_existing_term(attrs).blank?
+        end
+
+        top_level_items(new_terms_data).each do |attrs|
+          return false unless create_or_update_term(attrs, terms)
+        end
+      end
+
+      def top_level_items(data)
+        data.select do |attributes|
+          parent_external_id = attributes["parent_external_id"]
+          parent_external_id.blank? || data.none? { |attrs| attrs["external_id"] == parent_external_id }
+        end
+      end
+
+      def vocabulary
+        return unless site
+
+        @vocabulary ||= site.vocabularies.find_by_id(vocabulary_id)
+      end
+
+      def create_or_update_term(attributes, data)
+        term_form_attributes = attributes.slice(*TERM_FORM_EXTERNAL_ATTRIBUTES).merge(site_id:, vocabulary_id:)
+
+        if (term = find_existing_term(attributes)).present?
+          term_form_attributes["id"] = term.id
+        end
+
+        if (parent_id = get_parent_id(attributes["parent_external_id"])).present?
+          term_form_attributes["term_id"] = parent_id
+        end
+
+        term_form = TermForm.new(term_form_attributes)
+
+        unless term_form.save
+          promote_errors(term_form.errors)
+          return false
+        end
+
+        external_id = attributes["external_id"]
+        if (external_id = attributes["external_id"]).present?
+          data.select { |attrs| attrs["parent_external_id"] == external_id }.each do |attrs|
+            next if attrs["id"].blank? && vocabulary.terms.where(attrs.slice(*TERM_FORM_EXTERNAL_ATTRIBUTES)).exists?
+
+            return false unless create_or_update_term(attrs, data)
+          end
+        end
+      end
+
+      def find_or_initialize_term(attributes)
+        if (term = find_existing_term(attributes)).present?
+          term.assign_attributes(attributes.slice("name_translations", "description_translations", "slug", "position", "external_id"))
+          return term
+        end
+
+        vocabulary.terms.new(attributes.slice("name_translations", "slug", "position", "external_id"))
+      end
+
+      def find_existing_term(attributes)
+        if attributes["id"].present?
+          vocabulary.terms.find_by(id: attributes["id"])
+        elsif attributes["external_id"].present?
+          vocabulary.terms.find_by(external_id: attributes["external_id"])
+        end
+      end
+
+      def get_parent_id(parent_external_id)
+        return if parent_external_id.blank?
+
+        parent_term = vocabulary.terms.find_by(external_id: parent_external_id)
+        return if parent_term.blank?
+
+        parent_term.id
+      end
+
+      def site
+        @site ||= Site.find_by(id: site_id)
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -91,15 +91,6 @@ module GobiertoAdmin
         end
       end
 
-      def find_or_initialize_term(attributes)
-        if (term = find_existing_term(attributes)).present?
-          term.assign_attributes(attributes.slice("name_translations", "description_translations", "slug", "position", "external_id"))
-          return term
-        end
-
-        vocabulary.terms.new(attributes.slice("name_translations", "slug", "position", "external_id"))
-      end
-
       def find_existing_term(attributes)
         if attributes["id"].present?
           vocabulary.terms.find_by(id: attributes["id"])

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -108,10 +108,10 @@ module GobiertoAdmin
         end
       end
 
-      def get_parent_id(parent_external_id)
-        return if parent_external_id.blank?
+      def get_parent_id(id)
+        return if id.blank?
 
-        parent_term = vocabulary.terms.find_by(external_id: parent_external_id)
+        parent_term = vocabulary.terms.find_by(external_id: id) || vocabulary.terms.find_by(id:)
         return if parent_term.blank?
 
         parent_term.id

--- a/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
@@ -6,7 +6,10 @@ module GobiertoAdmin
 
       attr_accessor(
         :id,
-        :site_id,
+        :site_id
+      )
+
+      attr_writer(
         :name_translations,
         :slug
       )
@@ -22,6 +25,14 @@ module GobiertoAdmin
 
       def build_vocabulary
         vocabulary_relation.new
+      end
+
+      def name_translations
+        @name_translations ||= vocabulary.name_translations
+      end
+
+      def slug
+        @slug ||= vocabulary.slug
       end
 
       def save

--- a/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/vocabulary_form.rb
@@ -44,6 +44,9 @@ module GobiertoAdmin
       def save_vocabulary
         @vocabulary = vocabulary.tap do |attributes|
           attributes.site_id = site_id
+          if vocabulary.name_translations.present? && name_translations.present? && (vocabulary.name_translations.keys - name_translations.keys).present?
+            @name_translations = vocabulary.name_translations.merge(@name_translations)
+          end
           attributes.name_translations = name_translations
           attributes.slug = slug
         end

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -42,6 +42,10 @@ module GobiertoCommon
       vocabulary&.name
     end
 
+    def parent_id
+      parent_external_id.presence || term_id
+    end
+
     def parent_external_id
       parent_term&.external_id
     end

--- a/app/models/gobierto_common/term.rb
+++ b/app/models/gobierto_common/term.rb
@@ -42,6 +42,10 @@ module GobiertoCommon
       vocabulary&.name
     end
 
+    def parent_external_id
+      parent_term&.external_id
+    end
+
     def destroy
       dependent_resources_decorator = TermDependentResourcesDecorator.new(self)
       if dependent_resources_decorator.has_dependent_resources?

--- a/app/serializers/gobierto_common/api_term_serializer.rb
+++ b/app/serializers/gobierto_common/api_term_serializer.rb
@@ -5,6 +5,7 @@ module GobiertoCommon
     attributes(
       :id,
       :name_translations,
+      :description_translations,
       :slug,
       :position,
       :level,

--- a/app/serializers/gobierto_common/api_term_serializer.rb
+++ b/app/serializers/gobierto_common/api_term_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class ApiTermSerializer < ActiveModel::Serializer
+    attributes(
+      :id,
+      :name_translations,
+      :slug,
+      :position,
+      :level,
+      :term_id,
+      :parent_external_id,
+      :external_id
+    )
+  end
+end

--- a/app/serializers/gobierto_common/api_term_serializer.rb
+++ b/app/serializers/gobierto_common/api_term_serializer.rb
@@ -11,6 +11,7 @@ module GobiertoCommon
       :level,
       :term_id,
       :parent_external_id,
+      :parent_id,
       :external_id
     )
   end

--- a/app/serializers/gobierto_common/vocabulary_serializer.rb
+++ b/app/serializers/gobierto_common/vocabulary_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class VocabularySerializer < ActiveModel::Serializer
+    attributes(
+      :id,
+      :name_translations,
+      :slug,
+      :terms
+    )
+
+    def terms
+      return if object.terms.blank?
+
+      serialize_terms(object.terms.sorted)
+    end
+
+    def serialize_terms(terms_relation)
+      ActiveModelSerializers::SerializableResource.new(terms_relation, each_serializer: ::GobiertoCommon::ApiTermSerializer).as_json
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -604,6 +604,10 @@ Rails.application.routes.draw do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1" do
             get ":module_name/configuration" => "configuration#show", as: :configuration
             get "search" => "search#query", as: :search
+
+            resources :vocabularies, except: [:delete, :edit], defaults: { format: "json" } do
+              resources :terms, except: [:show, :edit]
+            end
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -605,7 +605,7 @@ Rails.application.routes.draw do
             get ":module_name/configuration" => "configuration#show", as: :configuration
             get "search" => "search#query", as: :search
 
-            resources :vocabularies, except: [:delete, :edit], defaults: { format: "json" } do
+            resources :vocabularies, except: [:edit], defaults: { format: "json" } do
               resources :terms, except: [:edit]
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -606,7 +606,7 @@ Rails.application.routes.draw do
             get "search" => "search#query", as: :search
 
             resources :vocabularies, except: [:delete, :edit], defaults: { format: "json" } do
-              resources :terms, except: [:show, :edit]
+              resources :terms, except: [:edit]
             end
           end
         end

--- a/test/controllers/gobierto_common/api/v1/terms_controller_test.rb
+++ b/test/controllers/gobierto_common/api/v1/terms_controller_test.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module Api
+    module V1
+      class TermsControllerTest < GobiertoControllerTest
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin_token
+          @admin_token ||= "Bearer #{gobierto_admin_api_tokens(:natasha_primary_api_token).token}"
+        end
+
+        def user_token
+          @user_token ||= "Bearer #{user_api_tokens(:peter_primary_api_token).token}"
+        end
+
+        def vocabulary
+          @vocabulary ||= gobierto_common_vocabularies(:animals)
+        end
+
+        def term
+          @term ||= gobierto_common_terms(:cat)
+        end
+
+        def other_vocabulary_term
+          @other_vocabulary_term ||= gobierto_common_terms(:culture_term)
+        end
+
+        def terms_count
+          @terms_count ||= vocabulary.terms.count
+        end
+
+        def attributes_data(term)
+          {
+            name_translations: term.name_translations.presence || { "en" => nil, "es" => nil },
+            description_translations: term.description_translations.presence || { "en" => nil, "es" => nil },
+            slug: term.slug,
+            position: term.position, # .to_s?
+            level: term.level,
+            term_id: term.term_id,
+            parent_external_id: term.parent_external_id,
+            external_id: term.external_id
+          }.with_indifferent_access
+        end
+
+        def invalid_params
+          {
+            data:
+            {
+              type: "gobierto_common-terms",
+              attributes:
+              {
+                "name_translations": nil,
+                "slug": nil
+              }
+            }
+          }
+        end
+
+        def valid_params
+          {
+            data:
+            {
+              type: "gobierto_common-term",
+              attributes:
+              {
+                "name_translations": {
+                  "en": "Sheep",
+                  "es": "Oveja"
+                },
+                "slug": "sheep",
+                parent_external_id: 1,
+                external_id: "mammal-sheep"
+              }
+            }
+          }
+        end
+
+        def update_valid_params
+          {
+            data:
+            {
+              type: "gobierto_common-term",
+              attributes:
+              {
+                "external_id": 8,
+                "name_translations": {
+                  "en": "Kitty",
+                  "es": "gatito"
+                },
+                "description_translations": {
+                  "en": "A very small cat",
+                  "es": "Un gato muy chiquitico"
+                }
+              }
+            }
+          }
+        end
+
+        def check_unauthorized
+          with(site:) do
+            yield
+
+            assert_response :unauthorized
+          end
+        end
+
+        # GET /api/v1/vocabularies/1/terms.json
+        def test_index_without_token
+          check_unauthorized { get gobierto_common_api_v1_vocabulary_terms_path(vocabulary), as: :json }
+        end
+
+        def test_index_with_user_token
+          check_unauthorized { get gobierto_common_api_v1_vocabulary_terms_path(vocabulary), headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_index_with_admin_token
+          with(site:) do
+            get gobierto_common_api_v1_vocabulary_terms_path(vocabulary), headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal terms_count, response_data["data"].count
+            terms_names = response_data["data"].map { |item| item.dig("attributes", "name_translations", "en") }
+            assert_includes terms_names, term.name
+            refute_includes terms_names, other_vocabulary_term.name
+          end
+        end
+
+        # GET /api/v1/vocabularies/1/terms/1.json
+        def test_show_without_token
+          check_unauthorized { get gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), as: :json }
+        end
+
+        def test_show_with_user_token
+          check_unauthorized { get gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_show_with_admin_token
+          with(site:) do
+            get gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal term.id.to_s, resource_data["id"]
+            assert_equal "gobierto_common-terms", resource_data["type"]
+
+            attributes = attributes_data(term)
+
+            %w(name_translations description_translations slug position level term_id parent_external_id external_id).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal attributes[attribute], resource_data["attributes"][attribute]
+            end
+          end
+        end
+
+        # GET /api/v1/vocabularies/1/terms/new.json
+        def test_new_without_token
+          check_unauthorized { get new_gobierto_common_api_v1_vocabulary_term_path(vocabulary), as: :json }
+        end
+
+        def test_new_with_user_token
+          check_unauthorized { get new_gobierto_common_api_v1_vocabulary_term_path(vocabulary), headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_new_with_admin_token
+          with(site:) do
+            get new_gobierto_common_api_v1_vocabulary_term_path(vocabulary), headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal "gobierto_common-terms", resource_data["type"]
+            refute response_data.has_key? "id"
+
+            attributes = attributes_data(vocabulary.terms.new)
+
+            %w(name_translations description_translations position level term_id parent_external_id external_id).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal attributes[attribute], resource_data["attributes"][attribute]
+            end
+            assert_nil resource_data["attributes"]["slug"]
+          end
+        end
+
+        # POST /api/v1/vocabularies/1/terms.json
+        def test_create_without_token
+          assert_no_difference "GobiertoCommon::Term.count" do
+            check_unauthorized { post gobierto_common_api_v1_vocabulary_terms_path(vocabulary), as: :json, params: valid_params }
+          end
+        end
+
+        def test_create_with_user_token
+          assert_no_difference "GobiertoCommon::Term.count" do
+            check_unauthorized { post gobierto_common_api_v1_vocabulary_terms_path(vocabulary), headers: { Authorization: user_token }, as: :json, params: valid_params }
+          end
+        end
+
+        def test_create_with_admin_token
+          with(site:) do
+            assert_difference "GobiertoCommon::Term.count", 1 do
+              post gobierto_common_api_v1_vocabulary_terms_path(vocabulary), headers: { Authorization: admin_token }, as: :json, params: valid_params
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_term = GobiertoCommon::Term.last
+              assert_equal vocabulary, new_term.vocabulary
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal new_term.id.to_s, resource_data["id"]
+              assert_equal "gobierto_common-terms", resource_data["type"]
+
+              # attributes
+              attributes = attributes_data(new_term)
+              %w(name_translations slug position level term_id parent_external_id external_id).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+              assert_nil resource_data["attributes"]["description_translations"]
+            end
+          end
+        end
+
+        def test_create_with_admin_token_and_invalid_params
+          with(site:) do
+            assert_no_difference "GobiertoCommon::Term.count" do
+              post gobierto_common_api_v1_vocabulary_terms_path(vocabulary), headers: { Authorization: admin_token }, as: :json, params: invalid_params
+
+              assert_response :unprocessable_entity
+
+              response_data = response.parsed_body
+              assert response_data.has_key? "errors"
+            end
+          end
+        end
+
+        # PUT /api/v1/vocabularies/1/terms/1.json
+        def test_update_without_token
+          check_unauthorized { put gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), as: :json, params: update_valid_params }
+        end
+
+        def test_update_with_user_token
+          check_unauthorized { put gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), headers: { Authorization: user_token }, as: :json, params: update_valid_params }
+        end
+
+        def test_update_with_admin_token
+          with(site:) do
+            assert_no_difference "GobiertoCommon::Term.count" do
+              put gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), headers: { Authorization: admin_token }, as: :json, params: update_valid_params
+
+              assert_response :success
+              response_data = response.parsed_body
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              term.reload
+              assert_equal term.id.to_s, resource_data["id"]
+              assert_equal "gobierto_common-terms", resource_data["type"]
+              assert_equal vocabulary, term.vocabulary
+
+              # attributes
+              attributes = attributes_data(term)
+              %w(name_translations description_translations slug position level term_id parent_external_id external_id).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+            end
+          end
+        end
+
+        # DELETE /api/v1/vocabularies/1/terms/1.json
+        def test_delete_without_token
+          assert_no_difference "GobiertoCommon::Term.count" do
+            check_unauthorized { delete gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), as: :json }
+          end
+        end
+
+        def test_delete_with_user_token
+          assert_no_difference "GobiertoCommon::Term.count" do
+            check_unauthorized { delete gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), headers: { Authorization: user_token }, as: :json }
+          end
+        end
+
+        def test_delete_with_admin_token
+          id = term.id
+          assert_difference "GobiertoCommon::Term.count", -1 do
+            with(site:) do
+              delete gobierto_common_api_v1_vocabulary_term_path(vocabulary, term), headers: { Authorization: admin_token }, as: :json
+
+              assert_response :no_content
+
+              assert_nil ::GobiertoCommon::Term.find_by(id: id)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_common/api/v1/vocabularies_controller_test.rb
+++ b/test/controllers/gobierto_common/api/v1/vocabularies_controller_test.rb
@@ -46,15 +46,6 @@ module GobiertoCommon
           }.with_indifferent_access
         end
 
-        def array_data(vocabulary)
-          attributes = attributes_data(vocabulary)
-          [
-            attributes[:name_translations],
-            attributes[:slug],
-            attributes[:terms]
-          ]
-        end
-
         def invalid_params
           {
             data:

--- a/test/controllers/gobierto_common/api/v1/vocabularies_controller_test.rb
+++ b/test/controllers/gobierto_common/api/v1/vocabularies_controller_test.rb
@@ -101,7 +101,7 @@ module GobiertoCommon
                     "slug": "animales-caballo",
                     "position": 1,
                     "level": 2,
-                    "parent_external_id": "TETRAPOD-1",
+                    "parent_id": "TETRAPOD-1",
                     "external_id": "MAMMAL-1"
                   },
                   {
@@ -113,7 +113,7 @@ module GobiertoCommon
                     "slug": "animales-mamifero",
                     "position": 2,
                     "level": 1,
-                    "parent_external_id": "VERTEBRATES",
+                    "parent_id": "VERTEBRATES",
                     "external_id": "TETRAPOD-1"
                   },
                   {
@@ -125,7 +125,7 @@ module GobiertoCommon
                     "slug": "animales-reptil",
                     "position": 3,
                     "level": 1,
-                    "parent_external_id": "VERTEBRATES",
+                    "parent_id": "VERTEBRATES",
                     "external_id": "TETRAPOD-2"
                   },
                   {
@@ -137,7 +137,7 @@ module GobiertoCommon
                     "slug": "animales-tortuga",
                     "position": 4,
                     "level": 2,
-                    "parent_external_id": "TETRAPOD-2",
+                    "parent_id": "TETRAPOD-2",
                     "external_id": "REPTILE-1"
                   },
                   {
@@ -149,7 +149,7 @@ module GobiertoCommon
                     "slug": "animales-gato",
                     "position": 4,
                     "level": 2,
-                    "parent_external_id": "TETRAPOD-1",
+                    "parent_id": "TETRAPOD-1",
                     "external_id": "MAMMAL-2"
                   },
                   {
@@ -161,7 +161,7 @@ module GobiertoCommon
                     "slug": "animales-vertebrado",
                     "position": 5,
                     "level": 0,
-                    "parent_external_id": nil,
+                    "parent_id": nil,
                     "external_id": "VERTEBRATES"
                   }
                 ]
@@ -188,7 +188,7 @@ module GobiertoCommon
                   },
                   {
                     "external_id": 1,
-                    "parent_external_id": "ANIMALS",
+                    "parent_id": "ANIMALS",
                     "name_translations": {
                       "en": "Mammal updated",
                       "es": "Mamífero actualizado"
@@ -197,7 +197,7 @@ module GobiertoCommon
                   },
                   {
                     "external_id": 4,
-                    "parent_external_id": "ANIMALS",
+                    "parent_id": "ANIMALS",
                     "name_translations": {
                       "en": "Bird updated",
                       "es": "Pájaro actualizado"

--- a/test/controllers/gobierto_common/api/v1/vocabularies_controller_test.rb
+++ b/test/controllers/gobierto_common/api/v1/vocabularies_controller_test.rb
@@ -1,0 +1,500 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  module Api
+    module V1
+      class VocabulariesControllerTest < GobiertoControllerTest
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin
+          @admin ||= admins(:natasha)
+        end
+
+        def admin_token
+          @admin_token ||= "Bearer #{gobierto_admin_api_tokens(:natasha_primary_api_token).token}"
+        end
+
+        def user_token
+          @user_token ||= "Bearer #{user_api_tokens(:peter_primary_api_token).token}"
+        end
+
+        def vocabulary
+          @vocabulary ||= gobierto_common_vocabularies(:animals)
+        end
+
+        def other_vocabulary
+          @other_vocabulary ||= gobierto_common_vocabularies(:plan_categories_vocabulary)
+        end
+
+        def other_site_vocabulary
+          @other_site_vocabulary ||= gobierto_common_vocabularies(:santander_vocabulary)
+        end
+
+        def vocabularies_count
+          @vocabularies_count ||= site.vocabularies.count
+        end
+
+        def attributes_data(vocabulary)
+          {
+            name_translations: vocabulary.name_translations.presence || { "en" => nil, "es" => nil },
+            slug: vocabulary.slug,
+            terms: vocabulary.terms.exists? ? ActiveModelSerializers::SerializableResource.new(vocabulary.terms.sorted, each_serializer: ::GobiertoCommon::ApiTermSerializer).as_json : nil
+          }.with_indifferent_access
+        end
+
+        def array_data(vocabulary)
+          attributes = attributes_data(vocabulary)
+          [
+            attributes[:name_translations],
+            attributes[:slug],
+            attributes[:terms]
+          ]
+        end
+
+        def invalid_params
+          {
+            data:
+            {
+              type: "gobierto_common-vocabularies",
+              attributes:
+              {
+                "name_translations": nil,
+                "slug": nil
+              }
+            }
+          }
+        end
+
+        def valid_params_without_terms
+          {
+            data:
+            {
+              type: "gobierto_common-vocabularies",
+              attributes:
+              {
+                "name_translations": {
+                  "ca": "Sense termes",
+                  "en": "Without terms",
+                  "es": "Sin términos"
+                },
+                "slug": "no-terms-0",
+              }
+            }
+          }
+        end
+
+        def valid_params
+          {
+            data:
+            {
+              type: "gobierto_common-vocabularies",
+              attributes:
+              {
+                "name_translations": {
+                  "ca": "El nou vocabulari",
+                  "en": "This is a totally new vocabulary",
+                  "es": "Mi vocabulario nuevo del todo"
+                },
+                "slug": "nuevo-vocabulario-0",
+                "terms": [
+                  {
+                    "name_translations": {
+                      "ca": "",
+                      "en": "",
+                      "es": "Caballo"
+                    },
+                    "slug": "animales-caballo",
+                    "position": 1,
+                    "level": 2,
+                    "parent_external_id": "TETRAPOD-1",
+                    "external_id": "MAMMAL-1"
+                  },
+                  {
+                    "name_translations": {
+                      "ca": "",
+                      "en": "",
+                      "es": "Mamífero"
+                    },
+                    "slug": "animales-mamifero",
+                    "position": 2,
+                    "level": 1,
+                    "parent_external_id": "VERTEBRATES",
+                    "external_id": "TETRAPOD-1"
+                  },
+                  {
+                    "name_translations": {
+                      "ca": "",
+                      "en": "",
+                      "es": "Reptil"
+                    },
+                    "slug": "animales-reptil",
+                    "position": 3,
+                    "level": 1,
+                    "parent_external_id": "VERTEBRATES",
+                    "external_id": "TETRAPOD-2"
+                  },
+                  {
+                    "name_translations": {
+                      "ca": "",
+                      "en": "",
+                      "es": "Tortuga"
+                    },
+                    "slug": "animales-tortuga",
+                    "position": 4,
+                    "level": 2,
+                    "parent_external_id": "TETRAPOD-2",
+                    "external_id": "REPTILE-1"
+                  },
+                  {
+                    "name_translations": {
+                      "ca": "",
+                      "en": "",
+                      "es": "Gato"
+                    },
+                    "slug": "animales-gato",
+                    "position": 4,
+                    "level": 2,
+                    "parent_external_id": "TETRAPOD-1",
+                    "external_id": "MAMMAL-2"
+                  },
+                  {
+                    "name_translations": {
+                      "ca": "",
+                      "en": "",
+                      "es": "Vertebrado"
+                    },
+                    "slug": "animales-vertebrado",
+                    "position": 5,
+                    "level": 0,
+                    "parent_external_id": nil,
+                    "external_id": "VERTEBRATES"
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        def update_valid_params
+          {
+            data:
+            {
+              attributes:
+              {
+                terms: [
+                  {
+                    "external_id": "ANIMALS",
+                    "name_translations": {
+                      "ca": "Animals",
+                      "en": "Animals",
+                      "es": "Animales"
+                    },
+                    "slug": "ANIMALS"
+                  },
+                  {
+                    "external_id": 1,
+                    "parent_external_id": "ANIMALS",
+                    "name_translations": {
+                      "en": "Mammal updated",
+                      "es": "Mamífero actualizado"
+                    },
+                    "slug": "animals-mammal-updated"
+                  },
+                  {
+                    "external_id": 4,
+                    "parent_external_id": "ANIMALS",
+                    "name_translations": {
+                      "en": "Bird updated",
+                      "es": "Pájaro actualizado"
+                    }
+                  },
+                  {
+                    "external_id": 2,
+                    "slug": "animals-dog-updated"
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        def check_unauthorized
+          with(site:) do
+            yield
+
+            assert_response :unauthorized
+          end
+        end
+
+        # GET /api/v1/vocabularies.json
+        def test_index_without_token
+          check_unauthorized { get gobierto_common_api_v1_vocabularies_path, as: :json }
+        end
+
+        def test_index_with_user_token
+          check_unauthorized { get gobierto_common_api_v1_vocabularies_path, headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_index_with_admin_token
+          with(site:) do
+            get gobierto_common_api_v1_vocabularies_path, headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal vocabularies_count, response_data["data"].count
+            vocabularies_names = response_data["data"].map { |item| item.dig("attributes", "name_translations", "en") }
+            assert_includes vocabularies_names, vocabulary.name
+            assert_includes vocabularies_names, other_vocabulary.name
+            refute_includes vocabularies_names, other_site_vocabulary.name
+          end
+        end
+
+        # GET /api/v1/vocabularies/1.json
+        def test_show_without_token
+          check_unauthorized { get gobierto_common_api_v1_vocabulary_path(vocabulary), as: :json }
+        end
+
+        def test_show_with_user_token
+          check_unauthorized { get gobierto_common_api_v1_vocabulary_path(vocabulary), headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_show_with_admin_token
+          with(site:) do
+            get gobierto_common_api_v1_vocabulary_path(vocabulary), headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal vocabulary.id.to_s, resource_data["id"]
+            assert_equal "gobierto_common-vocabularies", resource_data["type"]
+
+            attributes = attributes_data(vocabulary)
+
+            %w(name_translations slug terms).each do |attribute|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal attributes[attribute], resource_data["attributes"][attribute]
+            end
+          end
+        end
+
+        # GET /api/v1/vocabularies/new.json
+        def test_new_without_token
+          check_unauthorized { get new_gobierto_common_api_v1_vocabulary_path, as: :json }
+        end
+
+        def test_new_with_user_token
+          check_unauthorized { get new_gobierto_common_api_v1_vocabulary_path, headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_new_with_admin_token
+          with(site:) do
+            get new_gobierto_common_api_v1_vocabulary_path, headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal "gobierto_common-vocabularies", resource_data["type"]
+            refute response_data.has_key? "id"
+
+            attributes = attributes_data(site.vocabularies.new)
+
+            assert_equal attributes["name_translations"], resource_data["attributes"]["name_translations"]
+            assert_nil resource_data["attributes"]["slug"]
+            assert_nil resource_data["attributes"]["terms"]
+          end
+        end
+
+        # POST /api/v1/vocabularies.json
+        def test_create_without_token
+          assert_no_difference "GobiertoCommon::Vocabulary.count" do
+            check_unauthorized { post gobierto_common_api_v1_vocabularies_path, as: :json, params: valid_params }
+          end
+        end
+
+        def test_create_with_user_token
+          assert_no_difference "GobiertoCommon::Vocabulary.count" do
+            check_unauthorized { post gobierto_common_api_v1_vocabularies_path, headers: { Authorization: user_token }, as: :json, params: valid_params }
+          end
+        end
+
+        def test_create_with_admin_token
+          with(site:) do
+            assert_difference "GobiertoCommon::Vocabulary.count", 1 do
+              post gobierto_common_api_v1_vocabularies_path, headers: { Authorization: admin_token }, as: :json, params: valid_params
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_vocabulary = GobiertoCommon::Vocabulary.last
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal new_vocabulary.id.to_s, resource_data["id"]
+              assert_equal "gobierto_common-vocabularies", resource_data["type"]
+
+              # attributes
+              attributes = attributes_data(new_vocabulary)
+              %w(name_translations slug terms).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              # terms
+              new_terms = new_vocabulary.terms
+
+              assert_equal new_terms.find_by(external_id: "MAMMAL-1").term_id, new_terms.find_by(external_id: "TETRAPOD-1").id
+              assert_equal new_terms.find_by(external_id: "REPTILE-1").term_id, new_terms.find_by(external_id: "TETRAPOD-2").id
+              assert_equal new_terms.find_by(external_id: "TETRAPOD-1").term_id, new_terms.find_by(external_id: "VERTEBRATES").id
+              assert_equal new_terms.find_by(external_id: "TETRAPOD-2").term_id, new_terms.find_by(external_id: "VERTEBRATES").id
+
+              assert_equal 0, new_terms.find_by(external_id: "VERTEBRATES").level
+              assert_equal 1, new_terms.find_by(external_id: "TETRAPOD-1").level
+              assert_equal 2, new_terms.find_by(external_id: "MAMMAL-1").level
+            end
+          end
+        end
+
+        def test_create_with_admin_token_without_terms_param
+          with(site:) do
+            assert_difference "GobiertoCommon::Vocabulary.count", 1 do
+              post gobierto_common_api_v1_vocabularies_path, headers: { Authorization: admin_token }, as: :json, params: valid_params_without_terms
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_vocabulary = GobiertoCommon::Vocabulary.last
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal new_vocabulary.id.to_s, resource_data["id"]
+              assert_equal "gobierto_common-vocabularies", resource_data["type"]
+
+              # attributes
+              attributes = attributes_data(new_vocabulary)
+              %w(name_translations slug).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              assert_nil resource_data["attributes"]["terms"]
+
+              # terms
+              refute new_vocabulary.terms.exists?
+            end
+          end
+        end
+
+
+        def test_create_with_admin_token_and_invalid_params
+          with(site:) do
+            assert_no_difference "GobiertoCommon::Vocabulary.count" do
+              post gobierto_common_api_v1_vocabularies_path, headers: { Authorization: admin_token }, as: :json, params: invalid_params
+
+              assert_response :unprocessable_entity
+
+              response_data = response.parsed_body
+              assert response_data.has_key? "errors"
+            end
+          end
+        end
+
+        # PUT /api/v1/vocabularies/1.json
+        def test_update_without_token
+          check_unauthorized { put gobierto_common_api_v1_vocabulary_path(vocabulary), as: :json, params: update_valid_params }
+        end
+
+        def test_update_with_user_token
+          check_unauthorized { put gobierto_common_api_v1_vocabulary_path(vocabulary), headers: { Authorization: user_token }, as: :json, params: update_valid_params }
+        end
+
+        def test_update_with_admin_token
+          with(site:) do
+            assert_no_difference "GobiertoCommon::Vocabulary.count" do
+              put gobierto_common_api_v1_vocabulary_path(vocabulary), headers: { Authorization: admin_token }, as: :json, params: update_valid_params
+
+              assert_response :success
+              response_data = response.parsed_body
+
+              # data
+              assert response_data.has_key? "data"
+              resource_data = response_data["data"]
+              assert_equal vocabulary.id.to_s, resource_data["id"]
+              assert_equal "gobierto_common-vocabularies", resource_data["type"]
+
+              # attributes
+              attributes = attributes_data(vocabulary)
+              %w(name_translations slug terms).each do |attribute|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal attributes[attribute], resource_data["attributes"][attribute]
+              end
+
+              # terms
+              terms = vocabulary.terms
+              animals = terms.find_by(external_id: "ANIMALS")
+              mammal = terms.find_by(slug: "animals-mammal-updated")
+              bird = terms.find_by(slug: "animals-bird")
+              dog = terms.find_by(slug: "animals-dog-updated")
+
+              assert_equal 7, terms.count
+
+              assert_equal 0, animals.level
+              assert_equal animals.id, mammal.term_id
+              assert_equal 1, mammal.level
+              assert_equal animals.id, bird.term_id
+              assert_equal 1, bird.level
+              assert_equal mammal.id, dog.term_id
+              assert_equal 2, dog.level
+
+              assert_equal "Mammal updated", mammal.name
+              assert_equal "Bird updated", bird.name
+              assert_equal "Dog", dog.name
+            end
+          end
+        end
+
+        # DELETE /api/v1/vocabularies/1.json
+        def test_delete_without_token
+          assert_no_difference "GobiertoCommon::Vocabulary.count" do
+            check_unauthorized { delete gobierto_common_api_v1_vocabulary_path(vocabulary), as: :json }
+          end
+        end
+
+        def test_delete_with_user_token
+          assert_no_difference "GobiertoCommon::Vocabulary.count" do
+            check_unauthorized { delete gobierto_common_api_v1_vocabulary_path(vocabulary), headers: { Authorization: user_token }, as: :json }
+          end
+        end
+
+        def test_delete_with_admin_token
+          id = vocabulary.id
+          assert_difference "GobiertoCommon::Vocabulary.count", -1 do
+            with(site:) do
+              delete gobierto_common_api_v1_vocabulary_path(vocabulary), headers: { Authorization: admin_token }, as: :json
+
+              assert_response :no_content
+
+              assert_nil ::GobiertoCommon::Vocabulary.find_by(id: id)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes PopulateTools/issues#1844

## :v: What does this PR do?

* Implements API to manage vocabularies and terms
* Documentation updated:
  * https://dash.readme.com/project/gobierto/v0.1/docs/gobierto-admin-vocabularies-terms-copy
  * https://dash.readme.com/project/gobierto/v0.1/docs/gobierto-admin-api 

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [x] significant changes in some feature?
- [x] update API documentation? 
