### PR TITLE
Upgrade SSL version when connecting to agendas

### DIFF
--- a/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
+++ b/app/services/gobierto_people/microsoft_exchange/calendar_integration.rb
@@ -22,7 +22,6 @@ module GobiertoPeople
           config.password = ::SecretAttribute.decrypt(configuration.microsoft_exchange_pwd)
           config.debug    = false
           config.insecure_ssl = true
-          config.ssl_version  = :TLSv1
         end
       end
 


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates SSL version to TLSv1.2


## :mag: How should this be manually tested?

Connect to a Exchange server updated with the latests versions, and everything should work as expected.

