### PR TITLE
Plans api

### DIFF
--- a/app/controllers/gobierto_plans/api/v1/plans_controller.rb
+++ b/app/controllers/gobierto_plans/api/v1/plans_controller.rb
@@ -6,6 +6,9 @@ module GobiertoPlans
       class PlansController < BaseController
 
         include ::GobiertoCommon::CustomFieldsApi
+        include ::GobiertoCommon::SecuredWithAdminToken
+
+        skip_before_action :set_admin_with_token, only: [:index, :show, :meta]
 
         def vocabularies_adapter
           :json_api
@@ -35,6 +38,22 @@ module GobiertoPlans
           render(
             json: @resource,
             serializer: GobiertoPlans::PlanSerializer,
+            adapter: :json_api,
+            with_translations: false,
+            exclude_links: false,
+            exclude_relationships: false,
+            vocabularies_adapter: :json_api
+          )
+        end
+
+        # GET /api/v1/plans/1/admin
+        # GET /api/v1/plans/1/admin.json
+        def admin
+          @resource = current_site.plans.find(params[:id])
+
+          render(
+            json: @resource,
+            serializer: GobiertoPlans::ApiPlanSerializer,
             adapter: :json_api,
             with_translations: false,
             exclude_links: false,

--- a/app/controllers/gobierto_plans/api/v1/projects_controller.rb
+++ b/app/controllers/gobierto_plans/api/v1/projects_controller.rb
@@ -5,6 +5,9 @@ module GobiertoPlans
     module V1
       class ProjectsController < BaseController
         include ::GobiertoCommon::CustomFieldsApi
+        include ::GobiertoCommon::SecuredWithAdminToken
+
+        skip_before_action :set_admin_with_token, only: [:index, :show]
 
         # GET /api/v1/plans/1/projects
         # GET /api/v1/plans/1/projects.json
@@ -25,6 +28,88 @@ module GobiertoPlans
           render json: json
         end
 
+        # GET /api/v1/plans/1/projects/1
+        # GET /api/v1/plans/1/projects/1.json
+        def show
+          find_item
+
+          render(
+            json: @item,
+            serializer: ::GobiertoPlans::NodeSerializer,
+            plan: @plan,
+            custom_fields: custom_fields,
+            preloaded_data: transformed_custom_field_record_values(filtered_relation),
+            versions_indexes: filtered_relation.versions_indexes,
+            category_ids: category_ids,
+            adapter: :json_api
+          )
+        end
+
+        # GET /api/v1/plans/1/projects/new
+        # GET /api/v1/plans/1/projects/new.json
+        def new
+          render(
+            json: base_relation.new(name_translations: available_locales_hash),
+            serializer: ::GobiertoPlans::ApiNodeSerializer,
+            plan: @plan,
+            adapter: :json_api
+          )
+        end
+
+        # POST /api/v1/plans/1/projects
+        # POST /api/v1/plans/1/projects.json
+        def create
+          find_plan
+
+          @form = GobiertoAdmin::GobiertoPlans::ProjectsForm.new(plan_id: @plan.id, site_id: current_site.id, admin: current_admin).project_form(project_params)
+
+          if @form.save
+            project = @form.project
+
+            render(
+              json: project,
+              serializer: ::GobiertoPlans::ApiNodeSerializer,
+              plan: @plan,
+              status: :created,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        # PUT /api/v1/plans/1/projects/1
+        # PUT /api/v1/plans/1/projects/1.json
+        def update
+          find_item
+
+          @form = GobiertoAdmin::GobiertoPlans::ProjectsForm.new(plan_id: @plan.id, site_id: current_site.id, admin: current_admin).project_form(project_params.merge(id: @item.id))
+
+          if @form.save
+            project = @form.project
+
+            render(
+              json: project,
+              serializer: ::GobiertoPlans::ApiNodeSerializer,
+              plan: @plan,
+              status: :created,
+              adapter: :json_api
+            )
+          else
+            api_errors_render(@form, adapter: :json_api)
+          end
+        end
+
+        # DELETE /api/v1/plans/1/projects/1
+        # DELETE /api/v1/plans/1/projects/1.json
+        def destroy
+          find_item
+
+          @item.destroy
+
+          head :no_content
+        end
+
         private
 
         def base_relation
@@ -43,6 +128,26 @@ module GobiertoPlans
 
         def find_plan
           @plan = current_site.plans.send(valid_preview_token? ? :itself : :published).find_by(id: params[:plan_id])
+        end
+
+        def find_item
+          @item = base_relation.find(params[:id])
+        end
+
+        def project_params
+          @project_params ||= ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: project_attributes)
+        end
+
+        def project_attributes
+          @project_attributes ||= GobiertoAdmin::GobiertoPlans::ProjectsForm::WRITABLE_ATTRIBUTES + [:category_external_id, :status_external_id]
+        end
+
+        def available_locales_hash
+          @available_locales_hash ||= available_locales.each_with_object({}) { |key, locales| locales[key] = nil }
+        end
+
+        def available_locales
+          @available_locales ||= current_site.configuration.available_locales
         end
 
         def links(self_key = nil)

--- a/app/forms/concerns/gobierto_plans/versions_helpers.rb
+++ b/app/forms/concerns/gobierto_plans/versions_helpers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  module VersionsHelpers
+    extend ActiveSupport::Concern
+
+    def set_publication(node)
+      return unless plan.publish_last_version_automatically?
+
+      node.published_version = node.versions.count
+      node.published!
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_common/terms_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/terms_form.rb
@@ -22,6 +22,7 @@ module GobiertoAdmin
       validates :vocabulary, :site, presence: true
 
       def save
+        return if terms.blank?
         return unless valid?
 
         ActiveRecord::Base.transaction do

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -186,7 +186,11 @@ module GobiertoAdmin
 
         @visibility_level, @version = visibility_level.to_s.split("-")
 
-        @version ||= node.versions.length if node.versions.present? && publish_last_version_automatically
+        @version ||= if node.versions.present? && publish_last_version_automatically
+                       node.versions.length
+                     elsif @visibility_level == "published" && node.new_record?
+                       1
+                     end
 
         @published_version = @visibility_level == "published" ? (@version || node.published_version).to_i : nil
       end

--- a/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_data_form.rb
@@ -4,6 +4,7 @@ module GobiertoAdmin
   module GobiertoPlans
     class PlanDataForm < BaseForm
       include ::GobiertoAdmin::PermissionsGroupHelpers
+      include ::GobiertoPlans::VersionsHelpers
 
       class CSVRowInvalid < ArgumentError; end
       class StatusMissing < ArgumentError; end
@@ -117,13 +118,6 @@ module GobiertoAdmin
           set_publication(node)
           set_permissions_group(node, action_name: :edit)
         end
-      end
-
-      def set_publication(node)
-        return unless @plan.publish_last_version_automatically?
-
-        node.published_version = node.versions.count
-        node.published!
       end
 
       def save_custom_fields(row_decorator)

--- a/app/forms/gobierto_admin/gobierto_plans/plan_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_form.rb
@@ -13,7 +13,9 @@ module GobiertoAdmin
         :introduction_translations,
         :year,
         :plan_type_id,
-        :slug
+        :slug,
+        :categories_vocabulary,
+        :statuses_vocabulary
       )
 
       attr_writer(
@@ -51,7 +53,7 @@ module GobiertoAdmin
       end
 
       def vocabulary_id
-        @vocabulary_id ||= plan.vocabulary_id
+        @vocabulary_id ||= identify_vocabulary(categories_vocabulary) || plan.vocabulary_id
       end
 
       def configuration_data
@@ -59,7 +61,7 @@ module GobiertoAdmin
       end
 
       def statuses_vocabulary_id
-        @statuses_vocabulary_id ||= plan.statuses_vocabulary_id
+        @statuses_vocabulary_id ||= identify_vocabulary(statuses_vocabulary) || plan.statuses_vocabulary_id
       end
 
       def publish_last_version_automatically
@@ -102,6 +104,15 @@ module GobiertoAdmin
 
           false
         end
+      end
+
+      def identify_vocabulary(id_or_slug)
+        return if id_or_slug.blank?
+
+        is_number = id_or_slug.is_a?(Integer) || /\A\d+\z/.match?(id_or_slug.to_s.strip)
+
+        vocabulary = is_number && site.vocabularies.find_by_id(id_or_slug.to_s.strip) || site.vocabularies.find_by_slug(id_or_slug.to_s)
+        vocabulary&.id
       end
 
       def configuration_data_format

--- a/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/plan_table_custom_fields_form.rb
@@ -6,7 +6,7 @@ module GobiertoAdmin
       REQUIRED_COLUMNS = %w(external_id custom_field).freeze
       TRANSFORMATIONS = {
         text: ->(data) { data.to_s },
-        integer: ->(data) { data. to_i },
+        integer: ->(data) { data.to_i },
         float: ->(data) { ::GobiertoCommon::CustomFieldValue::Numeric.parse_float(data) },
         date: ->(data) { Date.parse(data) }
       }.with_indifferent_access.freeze

--- a/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
@@ -19,7 +19,9 @@ module GobiertoAdmin
 
       CUSTOM_FIELD_WRITABLE_TYPES = [
         :vocabulary_options,
-        :string
+        :string,
+        :paragraph,
+        :date
       ].freeze
 
       include ::GobiertoAdmin::PermissionsGroupHelpers

--- a/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
@@ -4,7 +4,6 @@ module GobiertoAdmin
   module GobiertoPlans
     class ProjectsForm < BaseForm
       WRITABLE_ATTRIBUTES = [
-        :id,
         :external_id,
         :visibility_level,
         :moderation_stage,
@@ -44,6 +43,10 @@ module GobiertoAdmin
         save_plan_data if valid?
       end
 
+      def project_form(attributes)
+        NodeForm.new(form_attributes(attributes))
+      end
+
       private
 
       def form_attributes(data)
@@ -70,7 +73,7 @@ module GobiertoAdmin
       end
 
       def writable_attributes(data)
-        data.slice(*WRITABLE_ATTRIBUTES)
+        data.slice(:id, *WRITABLE_ATTRIBUTES)
       end
 
       def detect_term_id(id, terms)
@@ -109,7 +112,7 @@ module GobiertoAdmin
 
       def import_nodes
         projects.map do |attrs|
-          form = NodeForm.new(form_attributes(attrs))
+          form = project_form(attrs)
 
           if form.node.persisted?
             form.status_id = form.node.status_id if form.status_id.blank?

--- a/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module GobiertoAdmin
+  module GobiertoPlans
+    class ProjectsForm < BaseForm
+      WRITABLE_ATTRIBUTES = [
+        :id,
+        :external_id,
+        :visibility_level,
+        :moderation_stage,
+        :name_translations,
+        :minor_change,
+        :category_id,
+        :status_id,
+        :progress,
+        :starts_at,
+        :ends_at,
+        :position
+      ].freeze
+
+      include ::GobiertoAdmin::PermissionsGroupHelpers
+
+      class StatusMissing < ArgumentError; end
+
+      class CategoryMissing < ArgumentError; end
+
+      class FailedImport < ArgumentError; end
+
+      attr_accessor(
+        :plan_id,
+        :site_id,
+        :projects,
+        :admin
+      )
+
+      attr_writer(
+        :plan,
+        :site
+      )
+
+      validates :plan, :projects, presence: true
+
+      def save
+        save_plan_data if valid?
+      end
+
+      private
+
+      def form_attributes(data)
+        writable_attributes(data).tap do |attrs|
+          attrs.merge!(plan_id:, admin:)
+          if (category_id = detect_term_id(data[:category_external_id].presence || attrs[:category_id], plan.categories)).present?
+            attrs[:category_id] = category_id
+          end
+          if (status_id = detect_term_id(data[:status_external_id].presence || attrs[:status_id], plan.statuses_vocabulary.terms)).present?
+            attrs[:status_id] = status_id
+          end
+          attrs[:id] = plan.nodes.find_by(external_id: attrs[:external_id])&.id if attrs[:id].blank? && attrs[:external_id].present?
+          visibility_level_key, version = attrs[:visibility_level].to_s.split("-")
+
+          attrs[:moderation_visibility_level] = visibility_level_key if attrs[:visibility_level].present?
+          if visibility_level_key == "published"
+            if version.blank?
+              attrs[:publish_last_version_automatically] = true
+            else
+              attrs[:disable_attributes_edition] = true
+            end
+          end
+        end
+      end
+
+      def writable_attributes(data)
+        data.slice(*WRITABLE_ATTRIBUTES)
+      end
+
+      def detect_term_id(id, terms)
+        return id if terms.exists?(id:)
+
+        if id.present? && (term = terms.find_by(external_id: id)).present?
+          term.id
+        else
+          id
+        end
+      end
+
+      def site
+        @site ||= Site.find_by(id: site_id)
+      end
+
+      def plan
+        @plan ||= site.plans.find_by(id: plan_id)
+      end
+
+      def save_plan_data
+        ActiveRecord::Base.transaction do
+          import_nodes
+          plan.touch
+        end
+      rescue StatusMissing, CategoryMissing, FailedImport => e
+        errors.add(:base, e.class.name.demodulize.underscore.to_sym, json_data: e.message)
+        false
+      rescue ::GobiertoCommon::PlainCustomFieldValueDecorator::TermNotFound => e
+        errors.add(:base, e.class.name.demodulize.underscore.to_sym, JSON.parse(e.message).symbolize_keys)
+        false
+      rescue ActiveRecord::RecordNotDestroyed
+        errors.add(:base, :used_resource)
+        false
+      end
+
+      def import_nodes
+        projects.map do |attrs|
+          form = NodeForm.new(form_attributes(attrs))
+
+          if form.node.persisted?
+            form.status_id = form.node.status_id if form.status_id.blank?
+            form.name_translations = form.node.name_translations if form.name_translations.blank?
+          else
+            raise StatusMissing, attrs.to_json if form.status_id.blank?
+            raise CategoryMissing, attrs.to_json if form.category_id.blank?
+          end
+
+          unless form.save
+            raise FailedImport, "#{attrs.to_json} (#{form.errors.full_messages.join(" - ")})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
@@ -99,7 +99,7 @@ module GobiertoAdmin
       end
 
       def custom_fields
-        @custom_fields ||= plan.available_custom_fields
+        @custom_fields ||= plan.available_custom_fields.where(instance: plan)
       end
 
       def detect_term_id(id, terms)

--- a/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/projects_form.rb
@@ -17,6 +17,11 @@ module GobiertoAdmin
         :position
       ].freeze
 
+      CUSTOM_FIELD_WRITABLE_TYPES = [
+        :vocabulary_options,
+        :string
+      ].freeze
+
       include ::GobiertoAdmin::PermissionsGroupHelpers
       include ::GobiertoPlans::VersionsHelpers
 
@@ -93,8 +98,12 @@ module GobiertoAdmin
       end
 
       def custom_fields_attributes
-        @custom_fields_attributes ||= custom_fields.vocabulary_options.each_with_object({}) do |field, hsh|
-          hsh["custom_field_vocabulary_options_#{field.uid.underscore}"] = field
+        @custom_fields_attributes ||= {}.tap do |hsh|
+          CUSTOM_FIELD_WRITABLE_TYPES.each do |type|
+            custom_fields.send(type).each do |field|
+              hsh["custom_field_#{type}_#{field.uid.underscore}"] = field
+            end
+          end
         end
       end
 

--- a/app/forms/gobierto_common/custom_field_records_form.rb
+++ b/app/forms/gobierto_common/custom_field_records_form.rb
@@ -35,7 +35,7 @@ module GobiertoCommon
 
     def custom_field_records=(attributes)
       @custom_field_records = attributes.to_h.map do |attribute, value|
-        custom_field = site.custom_fields.find_by(uid: attribute)
+        custom_field = available_custom_fields.find_by(uid: attribute)
 
         next unless custom_field.present?
 

--- a/app/serializers/gobierto_plans/api_node_serializer.rb
+++ b/app/serializers/gobierto_plans/api_node_serializer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  class ApiNodeSerializer < BaseSerializer
+    include ::GobiertoCommon::Versionable
+    # include ::GobiertoCommon::HasCustomFieldsAttributes
+
+    attributes(
+      :id,
+      :external_id,
+      :visibility_level,
+      :moderation_stage,
+      :name_translations,
+      :category_id,
+      :category_external_id,
+      :status_id,
+      :status_external_id,
+      :progress,
+      :starts_at,
+      :ends_at,
+      :position
+    )
+
+    def category
+      @category ||= object.categories.find_by(gplan_categories_nodes: { category_id: instance_options[:plan].categories })
+    end
+
+    def category_id
+      return if category.blank?
+
+      category.id
+    end
+
+    def category_external_id
+      return if category.blank?
+
+      category.external_id
+    end
+
+    def status_external_id
+      object.status&.external_id
+    end
+
+    # def custom_fields
+    #   instance_options[:custom_fields]
+    # end
+  end
+end

--- a/app/serializers/gobierto_plans/api_node_serializer.rb
+++ b/app/serializers/gobierto_plans/api_node_serializer.rb
@@ -3,7 +3,6 @@
 module GobiertoPlans
   class ApiNodeSerializer < BaseSerializer
     include ::GobiertoCommon::Versionable
-    # include ::GobiertoCommon::HasCustomFieldsAttributes
 
     attributes(
       :id,
@@ -40,9 +39,5 @@ module GobiertoPlans
     def status_external_id
       object.status&.external_id
     end
-
-    # def custom_fields
-    #   instance_options[:custom_fields]
-    # end
   end
 end

--- a/app/serializers/gobierto_plans/api_plan_serializer.rb
+++ b/app/serializers/gobierto_plans/api_plan_serializer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module GobiertoPlans
+  class ApiPlanSerializer < BaseSerializer
+    attributes(
+      :id,
+      :slug,
+      :title_translations,
+      :introduction_translations,
+      :configuration_data,
+      :year,
+      :visibility_level,
+      :css,
+      :footer_translations
+    )
+
+    belongs_to :plan_type, unless: :exclude_relationships?
+    attribute :categories_vocabulary_terms, unless: :exclude_relationships? do
+      serialize_terms(object.categories_vocabulary.terms.sorted)
+    end
+    attribute :statuses_vocabulary_terms, unless: :exclude_relationships? do
+      if object.statuses_vocabulary.present?
+        serialize_terms(object.statuses_vocabulary.terms.sorted)
+      end
+    end
+    attribute :projects, unless: :exclude_relationships?
+
+    def projects
+      return if object.nodes.blank?
+
+      serialize_projects(object.nodes)
+    end
+
+    def serialize_projects(nodes_relation)
+      ActiveModelSerializers::SerializableResource.new(
+        nodes_relation,
+        each_serializer: ::GobiertoPlans::ApiNodeSerializer,
+        plan: object,
+        # custom_fields: object.front_available_custom_fields,
+        serialize_for_search_engine: true,
+        include_draft: true
+      ).as_json
+    end
+  end
+end

--- a/app/serializers/gobierto_plans/api_plan_serializer.rb
+++ b/app/serializers/gobierto_plans/api_plan_serializer.rb
@@ -16,7 +16,9 @@ module GobiertoPlans
 
     belongs_to :plan_type, unless: :exclude_relationships?
     attribute :categories_vocabulary_terms, unless: :exclude_relationships? do
-      serialize_terms(object.categories_vocabulary.terms.sorted)
+      if object.categories_vocabulary.present?
+        serialize_terms(object.categories_vocabulary.terms.sorted)
+      end
     end
     attribute :statuses_vocabulary_terms, unless: :exclude_relationships? do
       if object.statuses_vocabulary.present?

--- a/app/serializers/gobierto_plans/node_serializer.rb
+++ b/app/serializers/gobierto_plans/node_serializer.rb
@@ -16,7 +16,7 @@ module GobiertoPlans
 
     def category_id
       instance_options.dig(:category_ids, object.id) ||
-      object.categories.find_by(gplan_categories_nodes: { category_id: instance_options[:plan].categories })&.id
+        object.categories.find_by(gplan_categories_nodes: { category_id: instance_options[:plan].categories })&.id
     end
 
     def custom_fields

--- a/app/serializers/gobierto_plans/node_serializer.rb
+++ b/app/serializers/gobierto_plans/node_serializer.rb
@@ -6,6 +6,7 @@ module GobiertoPlans
     include ::GobiertoCommon::HasCustomFieldsAttributes
 
     attributes :id, :name, :category_id, :progress, :starts_at, :ends_at, :status_id, :position, :external_id
+    attribute :visibility_level, if: :include_draft?
     attribute :searchable_name, if: :serialize_for_search_engine?
     attribute :name_translations, if: :serialize_for_search_engine?
 

--- a/app/services/gobierto_common/custom_fields_service.rb
+++ b/app/services/gobierto_common/custom_fields_service.rb
@@ -49,7 +49,7 @@ module GobiertoCommon
         if versions_indexes.has_key?(item_id)
           versioned_payloads(records, versions_indexes[item_id])
         else
-          records.pluck(:payload)
+          records.pluck(:payload).compact
         end.inject(:merge)
       end.compact
     end
@@ -83,7 +83,7 @@ module GobiertoCommon
     def versioned_payloads(records, version_index)
       records.map do |record|
         version = record.versions[version_index]
-        return {} unless version.present? && version.object?
+        next {} unless version.present? && version.object?
 
         JSON.parse(version.object_deserialized&.dig("payload") || "{}")
       end

--- a/config/locales/gobierto_admin/gobierto_plans/models/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/ca.yml
@@ -51,3 +51,14 @@ ca:
               file_not_found: Fitxer no trobat
               invalid_columns: No estan totes les columnes necessàries
               invalid_format: Format de fitxer invàlid
+        gobierto_admin/gobierto_plans/projects_form:
+          attributes:
+            base:
+              category_missing: 'Categoria no trobada en dades del projecte. Si us
+                plau, proporcioneu un category_id o category_external_id vàlid. Dades
+                del projecte: %{json_data}'
+              failed_import: 'El projecte amb les dades següents no ha pogut ser importat:
+                %{json_data}'
+              status_missing: 'Estat no trobat en dades del projecte. Si us plau,
+                proporciona un status_id o status_external_id vàlid. Dades del projecte:
+                %{json_data}'

--- a/config/locales/gobierto_admin/gobierto_plans/models/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/en.yml
@@ -51,3 +51,12 @@ en:
               file_not_found: File not found
               invalid_columns: Required columns are missing
               invalid_format: Invalid file format
+        gobierto_admin/gobierto_plans/projects_form:
+          attributes:
+            base:
+              category_missing: 'Category not found in project data. Please, provide
+                a valid category_id or category_external_id. Project data: %{json_data}'
+              failed_import: 'The project with the following data could not be imported:
+                %{json_data}'
+              status_missing: 'Status not found in project data. Please, provide a
+                valid status_id or status_external_id. Project data: %{json_data}'

--- a/config/locales/gobierto_admin/gobierto_plans/models/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/models/es.yml
@@ -52,3 +52,14 @@ es:
               file_not_found: Fichero no encontrado
               invalid_columns: No están todas las columnas necesarias
               invalid_format: Formato de fichero inválido
+        gobierto_admin/gobierto_plans/projects_form:
+          attributes:
+            base:
+              category_missing: 'Categoría no encontrada en datos del proyecto. Por
+                favor, proporciona un category_id o category_external_id válido. Datos
+                del proyecto: %{json_data}'
+              failed_import: 'El proyecto con los siguientes datos no ha podido ser
+                importado: %{json_data}'
+              status_missing: 'Estado no encontrado en datos del proyecto. Por favor,
+                proporciona un status_id o status_external_id válido. Datos del proyecto:
+                %{json_data}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -429,7 +429,7 @@ Rails.application.routes.draw do
         # API
         namespace :api, path: "/" do
           namespace :v1, constraints: ::ApiConstraint.new(version: 1, default: true), path: "/api/v1" do
-            resources :plans, only: [:index, :show], defaults: { format: "json" } do
+            resources :plans, only: [:index, :show, :update], defaults: { format: "json" } do
               member do
                 get :meta
                 get :admin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -436,6 +436,9 @@ Rails.application.routes.draw do
               end
               resources :projects
             end
+            resources :plan_types, only: [], defaults: { format: "json" }, path: "/plans", param: :slug do
+              resources :plans, only: [:new, :create], defaults: { format: "json" }, path: "/", controller: "plans"
+            end
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -432,6 +432,7 @@ Rails.application.routes.draw do
             resources :plans, only: [:index, :show], defaults: { format: "json" } do
               member do
                 get :meta
+                get :admin
               end
               resources :projects, only: [:index]
             end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,7 +434,7 @@ Rails.application.routes.draw do
                 get :meta
                 get :admin
               end
-              resources :projects, only: [:index]
+              resources :projects
             end
           end
         end

--- a/test/controllers/gobierto_plans/api/v1/plans_controller_test.rb
+++ b/test/controllers/gobierto_plans/api/v1/plans_controller_test.rb
@@ -38,6 +38,14 @@ module GobiertoPlans
           @draft_plan ||= gobierto_plans_plans(:economic_plan)
         end
 
+        def new_plan_categories_vocabulary
+          @new_plan_categories_vocabulary ||= gobierto_common_vocabularies(:new_plan_categories_vocabulary)
+        end
+
+        def new_plan_statuses_vocabulary
+          @new_plan_statuses_vocabulary ||= gobierto_common_vocabularies(:plan_projects_statuses_vocabulary)
+        end
+
         def other_plan_project
           @other_plan_project ||= gobierto_plans_nodes(:political_agendas)
         end
@@ -71,6 +79,170 @@ module GobiertoPlans
               {
                 "title_translations": nil,
                 "slug": nil
+              }
+            }
+          }
+        end
+
+        def valid_params_with_existing_vocabularies
+          {
+            data: {
+              type: "gobierto_plans-plans",
+              attributes: {
+                "slug": "new-plan-from-api",
+                "title_translations": {
+                  "en": "New plan from API",
+                  "es": "Nuevo plan desde la API"
+                },
+                "introduction_translations": {
+                  "en": "New plan from API (description)",
+                  "es": "Nuevo plan desde la API (descripción)"
+                },
+                "categories_vocabulary": new_plan_categories_vocabulary.slug,
+                "statuses_vocabulary": new_plan_statuses_vocabulary.id,
+                "configuration_data": {
+                  "level0": {
+                    "one": {
+                      "en": "axe",
+                      "es": "eje"
+                    },
+                    "other": {
+                      "en": "axes",
+                      "es": "ejes"
+                    }
+                  },
+                  "level1": {
+                    "one": {
+                      "en": "actuation line",
+                      "es": "línea de actuación"
+                    },
+                    "other": {
+                      "en": "actuation lines",
+                      "es": "líneas de actuación"
+                    }
+                  },
+                  "level0_options": [],
+                  "show_table_header": false,
+                  "open_node": false
+                },
+                "year": 2025,
+                "visibility_level": "published",
+                "css": ".gobierto_planification section.level_0 .cat_1 {
+                          background-color: rgba(0, 191, 255, 0.95);
+                        }",
+                "footer_translations": { "en": "Footer", "es": "Pie" }
+              }
+            }
+          }
+        end
+
+        def valid_params_with_existing_vocabularies_and_new_items
+          {
+            data: {
+              type: "gobierto_plans-plans",
+              attributes: {
+                "slug": "new-plan-from-api",
+                "title_translations": {
+                  "en": "New plan from API",
+                  "es": "Nuevo plan desde la API"
+                },
+                "introduction_translations": {
+                  "en": "New plan from API (description)",
+                  "es": "Nuevo plan desde la API (descripción)"
+                },
+                "categories_vocabulary": new_plan_categories_vocabulary.slug,
+                "statuses_vocabulary": new_plan_statuses_vocabulary.id,
+                "configuration_data": {
+                  "level0": {
+                    "one": {
+                      "en": "axe",
+                      "es": "eje"
+                    },
+                    "other": {
+                      "en": "axes",
+                      "es": "ejes"
+                    }
+                  },
+                  "level1": {
+                    "one": {
+                      "en": "actuation line",
+                      "es": "línea de actuación"
+                    },
+                    "other": {
+                      "en": "actuation lines",
+                      "es": "líneas de actuación"
+                    }
+                  },
+                  "level0_options": [],
+                  "show_table_header": false,
+                  "open_node": false
+                },
+                "year": 2025,
+                "visibility_level": "published",
+                "css": ".gobierto_planification section.level_0 .cat_1 {
+                          background-color: rgba(0, 191, 255, 0.95);
+                        }",
+                "footer_translations": { "en": "Footer", "es": "Pie" },
+                "categories_vocabulary_terms": [
+                  {
+                    "name_translations": {
+                      "en": "New term 1",
+                      "es": "Nuevo termino 1"
+                    },
+                    "description_translations": {
+                      "en": "New term 1 desc",
+                      "es": "Nuevo termino 1 desc"
+                    },
+                    "slug": "term-slug",
+                    "position": 0,
+                    "level": 0,
+                    "parent_id": "3",
+                    "external_id": "EXT"
+                  }
+                ],
+                "statuses_vocabulary_terms": [
+                  {
+                    "name_translations": {
+                      "en": "Status A",
+                      "es": "Status A"
+                    },
+                    "description_translations": {
+                      "en": "This is the A status",
+                      "es": "This is the A status"
+                    },
+                    "slug": "status-a-slug",
+                    "position": 0,
+                    "level": 0,
+                    "parent_id": nil,
+                    "external_id": "ST000A"
+                  },
+                ],
+                "projects": [
+                  {
+                    "external_id": "PRJ-1",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "The very first project",
+                      "es": "El primerísimo proyecto"
+                    },
+                    "category_external_id": "EXT",
+                    "status_external_id": "ST000A",
+                    "progress": 100.0
+                  },
+                  {
+                    "external_id": "PRJ-2",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "Other project with previously existing terms for category and status",
+                      "es": "Otro proyecto con términos existentes previamente para categoría y estado"
+                    },
+                    "category_external_id": "2",
+                    "status_external_id": "3",
+                    "progress": 99.0
+                  }
+                ]
               }
             }
           }
@@ -605,6 +777,96 @@ module GobiertoPlans
             end
           end
         end
+
+        def test_create_with_admin_token_with_existing_vocabularies
+          with(site:) do
+            assert_difference(
+              "GobiertoPlans::Plan.count" => 1,
+              "GobiertoPlans::Node.count" => 0,
+              "GobiertoCommon::Vocabulary.count" => 0,
+              "GobiertoCommon::Term.count" => 0
+            ) do
+              post gobierto_plans_api_v1_plan_type_plans_path(plan_type.slug), headers: { Authorization: admin_token }, as: :json, params: valid_params_with_existing_vocabularies
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_plan = GobiertoPlans::Plan.last
+              categories_vocabulary = new_plan.categories_vocabulary
+              statuses_vocabulary = new_plan.statuses_vocabulary
+
+              attributes = admin_attributes_data(new_plan)
+              resource_data = response_data["data"]
+
+              attributes.each do |attribute, value|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal value, resource_data["attributes"][attribute]
+              end
+
+              # vocabularies
+              assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+              # assert resource_data["attributes"]["categories_vocabulary_terms"].blank?
+
+              assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+              # assert resource_data["attributes"]["statuses_vocabulary_terms"].blank?
+
+              #projects
+              assert resource_data["attributes"].has_key? "projects"
+              assert resource_data["attributes"]["projects"].blank?
+            end
+          end
+        end
+
+        def test_create_with_admin_token_with_existing_vocabularies_and_new_items
+          with(site:) do
+            assert_difference(
+              "GobiertoPlans::Plan.count" => 1,
+              "GobiertoPlans::Node.count" => 2,
+              "GobiertoCommon::Vocabulary.count" => 0,
+              "GobiertoCommon::Term.count" => 2
+            ) do
+              post gobierto_plans_api_v1_plan_type_plans_path(plan_type.slug), headers: { Authorization: admin_token }, as: :json, params: valid_params_with_existing_vocabularies_and_new_items
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_plan = GobiertoPlans::Plan.last
+              categories_vocabulary = new_plan.categories_vocabulary
+              statuses_vocabulary = new_plan.statuses_vocabulary
+
+              attributes = admin_attributes_data(new_plan)
+              resource_data = response_data["data"]
+
+              attributes.each do |attribute, value|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal value, resource_data["attributes"][attribute]
+              end
+
+              # vocabularies
+              assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+              # assert resource_data["attributes"]["categories_vocabulary_terms"].blank?
+
+              assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+              # assert resource_data["attributes"]["statuses_vocabulary_terms"].blank?
+
+              #projects
+              assert resource_data["attributes"].has_key? "projects"
+              assert_equal new_plan.nodes.count, resource_data["attributes"]["projects"].count
+
+              valid_params_with_existing_vocabularies_and_new_items[:data][:attributes][:projects].each do |project_data|
+                project = new_plan.nodes.find_by_external_id(project_data[:external_id])
+
+                assert_equal project_data[:name_translations], project.name_translations.symbolize_keys
+                assert_equal project_data[:category_external_id], project.categories.first.external_id
+                assert_equal project_data[:status_external_id], project.status.external_id
+                assert_equal project_data[:progress], project.progress
+                assert_equal project_data[:moderation_stage], project.moderation_stage
+                assert_equal project_data[:visibility_level], project.visibility_level
+              end
+            end
+          end
+        end
+
 
         # PUT /api/v1/plans/1
         # PUT /api/v1/plans/1.json

--- a/test/controllers/gobierto_plans/api/v1/plans_controller_test.rb
+++ b/test/controllers/gobierto_plans/api/v1/plans_controller_test.rb
@@ -74,7 +74,6 @@ module GobiertoPlans
           {
             data:
             {
-              type: "gobierto_plans-plans",
               attributes:
               {
                 "title_translations": nil,
@@ -87,7 +86,6 @@ module GobiertoPlans
         def valid_params_with_existing_vocabularies
           {
             data: {
-              type: "gobierto_plans-plans",
               attributes: {
                 "slug": "new-plan-from-api",
                 "title_translations": {
@@ -139,7 +137,6 @@ module GobiertoPlans
         def valid_params_with_existing_vocabularies_and_new_items
           {
             data: {
-              type: "gobierto_plans-plans",
               attributes: {
                 "slug": "new-plan-from-api",
                 "title_translations": {
@@ -251,7 +248,6 @@ module GobiertoPlans
         def valid_params_without_vocabularies_and_projects
           {
             data: {
-              type: "gobierto_plans-plans",
               attributes: {
                 "slug": "new-plan-from-api",
                 "title_translations": {
@@ -301,13 +297,12 @@ module GobiertoPlans
         def valid_params
           {
             data: {
-              type: "gobierto_plans-plans",
               attributes: {
                 "slug": "new-plan-from-api",
                 "title_translations": {
                   "en": "New plan from API",
                   "es": "Nuevo plan desde la API"
-                },
+               },
                 "introduction_translations": {
                   "en": "New plan from API (description)",
                   "es": "Nuevo plan desde la API (descripción)"

--- a/test/controllers/gobierto_plans/api/v1/plans_controller_test.rb
+++ b/test/controllers/gobierto_plans/api/v1/plans_controller_test.rb
@@ -1,0 +1,678 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPlans
+  module Api
+    module V1
+      class PlansControllerTest < GobiertoControllerTest
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin
+          @admin ||= admins(:natasha)
+        end
+
+        def admin_token
+          @admin_token ||= "Bearer #{gobierto_admin_api_tokens(:natasha_primary_api_token).token}"
+        end
+
+        def user_token
+          @user_token ||= "Bearer #{user_api_tokens(:peter_primary_api_token).token}"
+        end
+
+        def plan
+          @plan ||= gobierto_plans_plans(:government_plan)
+        end
+
+        def plan_type
+          @plan_type ||= gobierto_plans_plan_types(:pam)
+        end
+
+        def other_plan
+          @other_plan ||= gobierto_plans_plans(:strategic_plan)
+        end
+
+        def draft_plan
+          @draft_plan ||= gobierto_plans_plans(:economic_plan)
+        end
+
+        def other_plan_project
+          @other_plan_project ||= gobierto_plans_nodes(:political_agendas)
+        end
+
+        def other_plan_draft_project
+          @other_plan_draft_project ||= gobierto_plans_nodes(:scholarships_kindergartens)
+        end
+
+        def plans_count
+          @plans_count ||= site.plans.published.count
+        end
+
+        def public_attributes_data(plan)
+          %w(slug title introduction year visibility_level css footer configuration_data).each_with_object({}) do |k, values|
+            values[k] = plan.send(k)
+          end.with_indifferent_access
+        end
+
+        def admin_attributes_data(plan)
+          %w(slug title_translations introduction_translations configuration_data year visibility_level css footer_translations).each_with_object({}) do |k, values|
+            values[k] = plan.send(k)
+          end.with_indifferent_access
+        end
+
+        def invalid_params
+          {
+            data:
+            {
+              type: "gobierto_plans-plans",
+              attributes:
+              {
+                "title_translations": nil,
+                "slug": nil
+              }
+            }
+          }
+        end
+
+        def valid_params_without_vocabularies_and_projects
+          {
+            data: {
+              type: "gobierto_plans-plans",
+              attributes: {
+                "slug": "new-plan-from-api",
+                "title_translations": {
+                  "en": "New plan from API",
+                  "es": "Nuevo plan desde la API"
+                },
+                "introduction_translations": {
+                  "en": "New plan from API (description)",
+                  "es": "Nuevo plan desde la API (descripción)"
+                },
+                "configuration_data": {
+                  "level0": {
+                    "one": {
+                      "en": "axe",
+                      "es": "eje"
+                    },
+                    "other": {
+                      "en": "axes",
+                      "es": "ejes"
+                    }
+                  },
+                  "level1": {
+                    "one": {
+                      "en": "actuation line",
+                      "es": "línea de actuación"
+                    },
+                    "other": {
+                      "en": "actuation lines",
+                      "es": "líneas de actuación"
+                    }
+                  },
+                  "level0_options": [],
+                  "show_table_header": false,
+                  "open_node": false
+                },
+                "year": 2025,
+                "visibility_level": "published",
+                "css": ".gobierto_planification section.level_0 .cat_1 {
+                          background-color: rgba(0, 191, 255, 0.95);
+                        }",
+                "footer_translations": { "en": "Footer", "es": "Pie" }
+              }
+            }
+          }
+        end
+
+        def valid_params
+          {
+            data: {
+              type: "gobierto_plans-plans",
+              attributes: {
+                "slug": "new-plan-from-api",
+                "title_translations": {
+                  "en": "New plan from API",
+                  "es": "Nuevo plan desde la API"
+                },
+                "introduction_translations": {
+                  "en": "New plan from API (description)",
+                  "es": "Nuevo plan desde la API (descripción)"
+                },
+                "configuration_data": {
+                  "level0": {
+                    "one": {
+                      "en": "axe",
+                      "es": "eje"
+                    },
+                    "other": {
+                      "en": "axes",
+                      "es": "ejes"
+                    }
+                  },
+                  "level1": {
+                    "one": {
+                      "en": "actuation line",
+                      "es": "línea de actuación"
+                    },
+                    "other": {
+                      "en": "actuation lines",
+                      "es": "líneas de actuación"
+                    }
+                  },
+                  "level0_options": [],
+                  "show_table_header": false,
+                  "open_node": false
+                },
+                "year": 2025,
+                "visibility_level": "published",
+                "css": ".gobierto_planification section.level_0 .cat_1 {
+                          background-color: rgba(0, 191, 255, 0.95);
+                        }",
+                "footer_translations": { "en": "Footer", "es": "Pie" },
+                "categories_vocabulary_terms": [
+                  {
+                    "name_translations": {
+                      "en": "New term 1",
+                      "es": "Nuevo termino 1"
+                    },
+                    "description_translations": {
+                      "en": "New term 1 desc",
+                      "es": "Nuevo termino 1 desc"
+                    },
+                    "slug": "term-slug",
+                    "position": 0,
+                    "level": 0,
+                    "parent_id": nil,
+                    "external_id": "E0001"
+                  },
+                  {
+                    "name_translations": {
+                      "en": "New term 1.1",
+                      "es": "Nuevo termino 1.1"
+                    },
+                    "description_translations": {
+                      "en": "New term 1.1 desc",
+                      "es": "Nuevo termino 1.1 desc"
+                    },
+                    "slug": "term-slug-11",
+                    "position": 0,
+                    "level": 1,
+                    "parent_id": "E0001",
+                    "external_id": "E0001.1"
+                  },
+                  {
+                    "name_translations": {
+                      "en": "New term 1.2",
+                      "es": "Nuevo termino 1.2"
+                    },
+                    "description_translations": {
+                      "en": "New term 1.2 desc",
+                      "es": "Nuevo termino 1.2 desc"
+                    },
+                    "slug": "term-slug-12",
+                    "position": 0,
+                    "level": 1,
+                    "parent_id": "E0001",
+                    "external_id": "E0001.2"
+                  }
+                ],
+                "statuses_vocabulary_terms": [
+                  {
+                    "name_translations": {
+                      "en": "Status A",
+                      "es": "Status A"
+                    },
+                    "description_translations": {
+                      "en": "This is the A status",
+                      "es": "This is the A status"
+                    },
+                    "slug": "status-a-slug",
+                    "position": 0,
+                    "level": 0,
+                    "parent_id": nil,
+                    "external_id": "ST000A"
+                  },
+                  {
+                    "name_translations": {
+                      "en": "Status B",
+                      "es": "Status B"
+                    },
+                    "description_translations": {
+                      "en": "This is the B status",
+                      "es": "This is the B status"
+                    },
+                    "slug": "status-b-slug",
+                    "position": 0,
+                    "level": 0,
+                    "parent_id": nil,
+                    "external_id": "ST000B"
+                  },
+                  {
+                    "name_translations": {
+                      "en": "Status C",
+                      "es": "Status C"
+                    },
+                    "description_translations": {
+                      "en": "This is the C status",
+                      "es": "This is the C status"
+                    },
+                    "slug": "status-c-slug",
+                    "position": 0,
+                    "level": 0,
+                    "parent_id": nil,
+                    "external_id": "ST000C"
+                  }
+                ],
+                "projects": [
+                  {
+                    "external_id": "PRJ-1",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "The very first project",
+                      "es": "El primerísimo proyecto"
+                    },
+                    "category_external_id": "E0001.1",
+                    "status_external_id": "ST000B",
+                    "progress": 100.0
+                  },
+                  {
+                    "external_id": "PRJ-2",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "Another project",
+                      "es": "Otro proyecto"
+                    },
+                    "category_external_id": "E0001.1",
+                    "status_external_id": "ST000A",
+                    "progress": 80.0
+                  },
+                  {
+                    "external_id": "PRJ-3",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "Unfinished project",
+                      "es": "Poyecto inacabado"
+                    },
+                    "category_external_id": "E0001.2",
+                    "status_external_id": "ST000B",
+                    "progress": 12.0
+                  },
+                  {
+                    "external_id": "PRJ-4",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "Not started project",
+                      "es": "Proyecto sin empezar"
+                    },
+                    "category_external_id": "E0001.2",
+                    "status_external_id": "ST000C",
+                    "progress": 0.0
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        def update_valid_params
+          {
+            data: {
+              attributes: {
+                projects: [
+                  {
+                    "external_id": "1",
+                    "visibility_level": "published",
+                      "moderation_stage": "approved",
+                      "name_translations": {
+                        "en": "Scholarships in kindergartens UPDATED",
+                        "es": "Becas en guarderías ACTUALIZADAS"
+                      },
+                      "category_external_id": "4",
+                      "status_external_id": "2",
+                      "progress": 25.0
+                  },
+                  {
+                    "external_id": "2",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "Publish political agendas UPDATED",
+                      "es": "Publicar agendas políticas ACTUALIZADAS"
+                    },
+                    "category_external_id": "3",
+                    "status_external_id": "1",
+                    "progress": 0.0
+                  },
+                  {
+                    "external_id": "new",
+                    "visibility_level": "published",
+                    "moderation_stage": "approved",
+                    "name_translations": {
+                      "en": "New project",
+                      "es": "Nuevo proyecto"
+                    },
+                    "category_external_id": "4",
+                    "status_external_id": "2",
+                    "progress": 50.0
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        def check_unauthorized
+          with(site:) do
+            yield
+
+            assert_response :unauthorized
+          end
+        end
+
+        # GET /api/v1/plans
+        # GET /api/v1/plans.json
+        def test_index
+          with(site:) do
+            get gobierto_plans_api_v1_plans_path, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal plans_count, response_data["data"].count
+            plans_titles = response_data["data"].map { |item| item.dig("attributes", "title") }
+            assert_includes plans_titles, plan.title
+            assert_includes plans_titles, other_plan.title
+            refute_includes plans_titles, draft_plan.title
+          end
+        end
+
+        # GET /api/v1/plans/1
+        # GET /api/v1/plans/1.json
+        def test_show
+          with(site:) do
+            get gobierto_plans_api_v1_plan_path(plan)
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal plan.id.to_s, resource_data["id"]
+            assert_equal "gobierto_plans-plans", resource_data["type"]
+
+            attributes = public_attributes_data(plan)
+
+            attributes.each do |attribute, value|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal value, resource_data["attributes"][attribute]
+            end
+
+            # vocabularies
+            categories_terms = plan.categories.map(&:name)
+            statuses_terms = plan.statuses_vocabulary.terms.map(&:name)
+
+            assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+            resource_data["attributes"]["categories_vocabulary_terms"].each do |term|
+              assert_includes categories_terms, term["attributes"]["name"]
+            end
+
+            assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+            resource_data["attributes"]["statuses_vocabulary_terms"].each do |term|
+              assert_includes statuses_terms, term["attributes"]["name"]
+            end
+
+            #projects
+            refute resource_data["attributes"].has_key? "projects"
+          end
+        end
+
+        # GET /api/v1/plans/1/admin
+        # GET /api/v1/plans/1/admin.json
+        def test_admin_show_without_token
+          check_unauthorized { get admin_gobierto_plans_api_v1_plan_path(plan), as: :json }
+        end
+
+        # GET /api/v1/plans/1/admin
+        # GET /api/v1/plans/1/admin.json
+        def test_admin_show_with_user_token
+          check_unauthorized { get admin_gobierto_plans_api_v1_plan_path(plan), headers: { Authorization: user_token }, as: :json }
+        end
+
+        # GET /api/v1/plans/1/admin
+        # GET /api/v1/plans/1/admin.json
+        def test_admin_show_with_admin_token
+          with(site:) do
+            get admin_gobierto_plans_api_v1_plan_path(other_plan), headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal other_plan.id.to_s, resource_data["id"]
+            assert_equal "gobierto_plans-plans", resource_data["type"]
+
+            attributes = admin_attributes_data(other_plan)
+
+            attributes.each do |attribute, value|
+              assert resource_data["attributes"].has_key? attribute
+              assert_equal value, resource_data["attributes"][attribute]
+            end
+
+            # vocabularies
+            categories_terms = other_plan.categories.map(&:name)
+            statuses_terms = other_plan.statuses_vocabulary.terms.map(&:name)
+
+            assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+            resource_data["attributes"]["categories_vocabulary_terms"].each do |term|
+              assert_includes categories_terms, term["attributes"]["name"]
+            end
+
+            assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+            resource_data["attributes"]["statuses_vocabulary_terms"].each do |term|
+              assert_includes statuses_terms, term["attributes"]["name"]
+            end
+
+            #projects
+            assert resource_data["attributes"].has_key? "projects"
+            assert_equal other_plan.nodes.count, resource_data["attributes"]["projects"].count
+            [other_plan_project, other_plan_draft_project].each do |p|
+              assert resource_data["attributes"]["projects"].any? { |data| data["id"] == p.id && data["external_id"] == p.external_id }
+            end
+          end
+        end
+
+        # POST /api/v1/plans/plan-type-slug
+        # POST /api/v1/plans/plan-type-slug.json
+        def test_create_without_token
+          check_unauthorized { post gobierto_plans_api_v1_plan_type_plans_path(plan_type), as: :json, params: valid_params }
+        end
+
+        # POST /api/v1/plans/plan-type-slug
+        # POST /api/v1/plans/plan-type-slug.json
+        def test_create_with_user_token
+          check_unauthorized { post gobierto_plans_api_v1_plan_type_plans_path(plan_type), headers: { Authorization: user_token }, as: :json, params: valid_params }
+        end
+
+        # POST /api/v1/plans/plan-type-slug
+        # POST /api/v1/plans/plan-type-slug.json
+        def test_create_with_admin_token
+          with(site:) do
+            assert_difference(
+              "GobiertoPlans::Plan.count" => 1,
+              "GobiertoPlans::Node.count" => 4,
+              "GobiertoCommon::Vocabulary.count" => 2,
+              "GobiertoCommon::Term.count" => 6
+            ) do
+              post gobierto_plans_api_v1_plan_type_plans_path(plan_type.slug), headers: { Authorization: admin_token }, as: :json, params: valid_params
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_plan = GobiertoPlans::Plan.last
+              categories_vocabulary = new_plan.categories_vocabulary
+              statuses_vocabulary = new_plan.statuses_vocabulary
+
+              attributes = admin_attributes_data(new_plan)
+              resource_data = response_data["data"]
+
+              attributes.each do |attribute, value|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal value, resource_data["attributes"][attribute]
+              end
+
+              # vocabularies
+              categories_terms = categories_vocabulary.terms.map(&:name)
+              statuses_terms = statuses_vocabulary.terms.map(&:name)
+
+              assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+              resource_data["attributes"]["categories_vocabulary_terms"].each do |term|
+                assert_includes categories_terms, term["attributes"]["name"]
+              end
+
+              assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+              resource_data["attributes"]["statuses_vocabulary_terms"].each do |term|
+                assert_includes statuses_terms, term["attributes"]["name"]
+              end
+
+              #projects
+              assert resource_data["attributes"].has_key? "projects"
+              assert_equal new_plan.nodes.count, resource_data["attributes"]["projects"].count
+
+              valid_params[:data][:attributes][:projects].each do |project_data|
+                project = new_plan.nodes.find_by_external_id(project_data[:external_id])
+
+                assert_equal project_data[:name_translations], project.name_translations.symbolize_keys
+                assert_equal project_data[:category_external_id], project.categories.first.external_id
+                assert_equal project_data[:status_external_id], project.status.external_id
+                assert_equal project_data[:progress], project.progress
+                assert_equal project_data[:moderation_stage], project.moderation_stage
+                assert_equal project_data[:visibility_level], project.visibility_level
+              end
+            end
+          end
+        end
+
+        # POST /api/v1/plans/plan-type-slug
+        # POST /api/v1/plans/plan-type-slug.json
+        def test_create_with_admin_token_without_vocabularies_and_projects
+          with(site:) do
+            assert_difference(
+              "GobiertoPlans::Plan.count" => 1,
+              "GobiertoPlans::Node.count" => 0,
+              "GobiertoCommon::Vocabulary.count" => 2,
+              "GobiertoCommon::Term.count" => 0
+            ) do
+              post gobierto_plans_api_v1_plan_type_plans_path(plan_type.slug), headers: { Authorization: admin_token }, as: :json, params: valid_params_without_vocabularies_and_projects
+
+              assert_response :created
+              response_data = response.parsed_body
+
+              new_plan = GobiertoPlans::Plan.last
+              categories_vocabulary = new_plan.categories_vocabulary
+              statuses_vocabulary = new_plan.statuses_vocabulary
+
+              attributes = admin_attributes_data(new_plan)
+              resource_data = response_data["data"]
+
+              attributes.each do |attribute, value|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal value, resource_data["attributes"][attribute]
+              end
+
+              # vocabularies
+              assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+              assert resource_data["attributes"]["categories_vocabulary_terms"].blank?
+
+              assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+              assert resource_data["attributes"]["statuses_vocabulary_terms"].blank?
+
+              #projects
+              assert resource_data["attributes"].has_key? "projects"
+              assert resource_data["attributes"]["projects"].blank?
+            end
+          end
+        end
+
+        # PUT /api/v1/plans/1
+        # PUT /api/v1/plans/1.json
+        def test_update_without_token
+          check_unauthorized { put gobierto_plans_api_v1_plan_path(other_plan), as: :json, params: update_valid_params }
+        end
+
+        # PUT /api/v1/plans/1
+        # PUT /api/v1/plans/1.json
+        def test_update_with_user_token
+          check_unauthorized { put gobierto_plans_api_v1_plan_path(other_plan), headers: { Authorization: user_token }, as: :json, params: update_valid_params }
+        end
+
+        # PUT /api/v1/plans/1
+        # PUT /api/v1/plans/1.json
+        def test_update_with_admin_token
+          with(site:) do
+            assert_no_difference(
+              "GobiertoPlans::Plan.count" => 0,
+              "GobiertoPlans::Node.count" => 1,
+              "GobiertoCommon::Vocabulary.count" => 0,
+              "GobiertoCommon::Term.count" => 0
+            ) do
+              put gobierto_plans_api_v1_plan_path(other_plan), headers: { Authorization: admin_token }, as: :json, params: update_valid_params
+
+              assert_response :success
+              response_data = response.parsed_body
+
+              attributes = admin_attributes_data(other_plan.reload)
+              resource_data = response_data["data"]
+
+              attributes.each do |attribute, value|
+                assert resource_data["attributes"].has_key? attribute
+                assert_equal value, resource_data["attributes"][attribute]
+              end
+
+              # vocabularies
+              categories_terms = other_plan.categories.map(&:name)
+              statuses_terms = other_plan.statuses_vocabulary.terms.map(&:name)
+
+              assert resource_data["attributes"].has_key? "categories_vocabulary_terms"
+              resource_data["attributes"]["categories_vocabulary_terms"].each do |term|
+                assert_includes categories_terms, term["attributes"]["name"]
+              end
+
+              assert resource_data["attributes"].has_key? "statuses_vocabulary_terms"
+              resource_data["attributes"]["statuses_vocabulary_terms"].each do |term|
+                assert_includes statuses_terms, term["attributes"]["name"]
+              end
+
+              #projects
+              assert resource_data["attributes"].has_key? "projects"
+              assert_equal 3, resource_data["attributes"]["projects"].count
+
+              update_valid_params[:data][:attributes][:projects].each do |project_data|
+                project = other_plan.nodes.find_by_external_id(project_data[:external_id])
+
+                assert_equal project_data[:name_translations], project.name_translations.symbolize_keys
+                assert_equal project_data[:category_external_id], project.categories.first.external_id
+                assert_equal project_data[:status_external_id], project.status.external_id
+                assert_equal project_data[:progress], project.progress
+                assert_equal project_data[:moderation_stage], project.moderation_stage
+                assert_equal project_data[:visibility_level], project.visibility_level
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/gobierto_plans/api/v1/projects_controller_test.rb
+++ b/test/controllers/gobierto_plans/api/v1/projects_controller_test.rb
@@ -60,7 +60,6 @@ module GobiertoPlans
           {
             data:
             {
-              type: "gobierto_plans-nodes",
               attributes:
               {
                 "name_translations": nil
@@ -73,7 +72,6 @@ module GobiertoPlans
           {
             data:
             {
-              type: "gobierto_plans-nodes",
               attributes:
               {
                 "external_id": "from_api",
@@ -97,7 +95,6 @@ module GobiertoPlans
           {
             data:
             {
-              type: "gobierto_plans-nodes",
               attributes:
               {
                 "visibility_level": "published",

--- a/test/controllers/gobierto_plans/api/v1/projects_controller_test.rb
+++ b/test/controllers/gobierto_plans/api/v1/projects_controller_test.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoPlans
+  module Api
+    module V1
+      class ProjectsControllerTest < GobiertoControllerTest
+        def site
+          @site ||= sites(:madrid)
+        end
+
+        def admin_token
+          @admin_token ||= "Bearer #{gobierto_admin_api_tokens(:natasha_primary_api_token).token}"
+        end
+
+        def user_token
+          @user_token ||= "Bearer #{user_api_tokens(:peter_primary_api_token).token}"
+        end
+
+        def plan
+          @other_plan ||= gobierto_plans_plans(:strategic_plan)
+        end
+
+        def published_project
+          @published_project ||= gobierto_plans_nodes(:political_agendas)
+        end
+
+        def draft_project
+          @draft_project ||= gobierto_plans_nodes(:scholarships_kindergartens)
+        end
+
+        def attributes_data(project)
+          {
+            "category_id": project.categories.first&.id,
+            "progress": project.progress,
+            "starts_at": project.starts_at&.to_s,
+            "ends_at": project.ends_at&.to_s,
+            "status_id": project.status_id,
+            "position": project.position,
+            "external_id": project.external_id
+        }
+        end
+
+        def public_attributes_data(project)
+          { "name": project.name }.merge(attributes_data(project))
+        end
+
+        def admin_attributes_data(project)
+          {
+            "visibility_level": project.visibility_level,
+            "moderation_stage": project.moderation_stage,
+            "name_translations": project.name_translations.presence || { "en" => nil, "es" => nil },
+            "category_external_id": project.categories.first&.external_id,
+            "status_external_id": project.status&.external_id
+          }.merge(attributes_data(project))
+        end
+
+        def invalid_params
+          {
+            data:
+            {
+              type: "gobierto_plans-nodes",
+              attributes:
+              {
+                "name_translations": nil
+              }
+            }
+          }
+        end
+
+        def valid_params
+          {
+            data:
+            {
+              type: "gobierto_plans-nodes",
+              attributes:
+              {
+                "external_id": "from_api",
+                "visibility_level": "published",
+                "moderation_stage": "approved",
+                "name_translations": {
+                  "es": "Proyectaco",
+                  "en": "Big project"
+                },
+                "category_external_id": "4",
+                "status_external_id": "2",
+                "progress": 14.0,
+                "starts_at": "2023-09-26",
+                "ends_at": "2030-01-01"
+              }
+            }
+          }
+        end
+
+        def update_valid_params
+          {
+            data:
+            {
+              type: "gobierto_plans-nodes",
+              attributes:
+              {
+                "visibility_level": "published",
+                "moderation_stage": "approved",
+                "name_translations": {
+                  "en": "Publish political agendas UPDATED",
+                  "es": "Publicar agendas políticas UPDATED"
+                },
+                "category_external_id": "4",
+                "status_external_id": "2",
+                "progress": 100.0,
+                "starts_at": "2023-09-26",
+                "ends_at": "2030-01-01"
+              }
+            }
+          }
+        end
+
+        def check_unauthorized
+          with(site:) do
+            yield
+
+            assert_response :unauthorized
+          end
+        end
+
+        # GET /api/v1/plans/1/project.json
+        def test_index
+          with(site:) do
+            get gobierto_plans_api_v1_plan_projects_path(plan), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+            assert_equal plan.nodes.published.count, response_data["data"].count
+            projects_names = response_data["data"].map { |item| item["attributes"]["name"] }
+            assert_includes projects_names, published_project.name
+            refute_includes projects_names, draft_project.name
+          end
+        end
+
+        # GET /api/v1/plans/1/projects/1.json
+        def test_show
+          with(site:) do
+            get gobierto_plans_api_v1_plan_project_path(plan, published_project), as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal published_project.id.to_s, resource_data["id"]
+            assert_equal "gobierto_plans-nodes", resource_data["type"]
+
+            attributes = public_attributes_data(published_project)
+
+            attributes.each do |attribute, value|
+              assert resource_data["attributes"].has_key? attribute.to_s
+              assert_equal value, resource_data["attributes"][attribute.to_s]
+            end
+          end
+        end
+
+        # GET /api/v1/vocabularies/1/terms/new.json
+        def test_new_without_token
+          check_unauthorized { get new_gobierto_plans_api_v1_plan_project_path(plan), as: :json }
+        end
+
+        def test_new_with_user_token
+          check_unauthorized { get new_gobierto_plans_api_v1_plan_project_path(plan), headers: { Authorization: user_token }, as: :json }
+        end
+
+        def test_new_with_admin_token
+          with(site:) do
+            get new_gobierto_plans_api_v1_plan_project_path(plan), headers: { Authorization: admin_token }, as: :json
+
+            assert_response :success
+
+            response_data = response.parsed_body
+
+            assert response_data.has_key? "data"
+
+            resource_data = response_data["data"]
+            assert_equal "gobierto_plans-nodes", resource_data["type"]
+            refute response_data.has_key? "id"
+
+            attributes = admin_attributes_data(plan.nodes.new(visibility_level: "published"))
+
+            attributes.each do |attribute, value|
+              assert resource_data["attributes"].has_key? attribute.to_s
+              assert_equal value, resource_data["attributes"][attribute.to_s]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/gobierto_common/vocabularies.yml
+++ b/test/fixtures/gobierto_common/vocabularies.yml
@@ -41,7 +41,7 @@ citizens_services_categories:
 new_plan_categories_vocabulary:
   site: madrid
   name_translations: <%= { es: "Nuevo Plan Estratégico", en: "New Strategic Plan" }.to_json %>
-  slug: strategic-plan
+  slug: new-strategic-plan
 
 indicators_vocabulary:
   site: madrid


### PR DESCRIPTION
Closes PopulateTools/issues#1845


## :v: What does this PR do?

* Implements and endpoint to get info as admin of a plan including their projects and use the same structure provided by the API to update the plan
* It also provides some endpoints to create, update and delete projects
* Adds tests both for plans and projects API controllers
* Fixes a bug which happened when there are more than one plan with custom fields with the same uid. In this case only the first custom fields were correctly updated and the others were updated with blank values

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

Documentation updated in readme.com

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [x] significant changes in some feature?
