### PR TITLE
Add support for new optional columns

### DIFF
--- a/app/javascript/gobierto_budgets/modules/invoices_controller.js
+++ b/app/javascript/gobierto_budgets/modules/invoices_controller.js
@@ -230,6 +230,9 @@ window.GobiertoBudgets.InvoicesController = (function() {
         d.paid = d.paid == "true";
         d.value = Number(d.value);
         d.freelance = d.freelance == "true";
+        // optionals
+        d.payment_date = !!d.payment_date && intl.format(new Date(d.payment_date))
+        d.payment_date_limit = !!d.payment_date_limit && intl.format(new Date(d.payment_date_limit))
       }
 
       // See the [crossfilter API](https://github.com/square/crossfilter/wiki/API-Reference) for reference.
@@ -247,7 +250,7 @@ window.GobiertoBudgets.InvoicesController = (function() {
       _renderByAmountsChart();
 
       // TABLE FILTER - FULL PROVIDERS
-      _renderTableFilter();
+      _renderTableFilter(data);
     });
   }
 
@@ -577,8 +580,12 @@ window.GobiertoBudgets.InvoicesController = (function() {
     new AmountDistributionBars(renderOptions);
   }
 
-  function _renderTableFilter() {
+  function _renderTableFilter(data) {
     var resetFilters = false;
+
+    // Optional fields: if any value exist, returns false
+    const payment_date = data.some(x => !!x.payment_date)
+    const payment_date_limit = data.some(x => !!x.payment_date_limit)
 
     $tableHTML.jsGrid({
       width: "100%",
@@ -698,7 +705,32 @@ window.GobiertoBudgets.InvoicesController = (function() {
           title: I18n.t("gobierto_budgets.invoices.show.table.fields.subject"),
           type: "text",
           autosearch: true
-        }
+        },
+        // optional
+        ...[payment_date && {
+          name: "payment_date",
+          title: I18n.t("gobierto_budgets.invoices.show.table.fields.payment_date"),
+          type: "date",
+          autosearch: true,
+          align: "center",
+          width: 30,
+          itemTemplate: function(value) {
+            console.log(value, new Date(value).toLocaleDateString(I18n.locale));
+            return new Date(value).toLocaleDateString(I18n.locale);
+          }
+        }],
+        // optional
+        ...[payment_date_limit && {
+          name: "payment_date_limit",
+          title: I18n.t("gobierto_budgets.invoices.show.table.fields.payment_date_limit"),
+          type: "date",
+          autosearch: true,
+          align: "center",
+          width: 30,
+          itemTemplate: function(value) {
+            return new Date(value).toLocaleDateString(I18n.locale);
+          }
+        }]
       ]
     });
 

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -508,6 +508,8 @@ ca:
           fields:
             date: Data
             paid: Pagat
+            payment_date: Data de pagament
+            payment_date_limit: Data prevista de pagament
             provider_id: NIF
             provider_name: Proveïdor
             subject: Concepte

--- a/config/locales/gobierto_budgets/views/en.yml
+++ b/config/locales/gobierto_budgets/views/en.yml
@@ -486,6 +486,8 @@ en:
           fields:
             date: Date
             paid: Payed
+            payment_date: Payment date
+            payment_date_limit: Payment date limit
             provider_id: NIF (SSN)
             provider_name: Supplier
             subject: Reason

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -502,6 +502,8 @@ es:
           fields:
             date: Fecha
             paid: Pagado
+            payment_date: Fecha de pago
+            payment_date_limit: Fecha prevista de pago
             provider_id: NIF
             provider_name: Proveedor
             subject: Concepto


### PR DESCRIPTION
Related with https://github.com/PopulateTools/issues/issues/1839

## :v: What does this PR do?
Some datasets will include new columns (payment_date and payment_date_limit), add support to add them optionally

## :eyes: Screenshots
![imagen](https://github.com/PopulateTools/gobierto/assets/817526/253afd0d-2372-4ba8-8693-54913f3909a1)
![imagen](https://github.com/PopulateTools/gobierto/assets/817526/c9d2aeac-e167-4e4a-9e82-953bd1c85735)

