### PR TITLE
Geocoder cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "liquid", "~> 4.0"
 gem "liquid-rails", git: "https://github.com/maierru/liquid-rails.git"
 
 # Google API
-gem "geocoder"
+gem "geocoder", ">= 1.8.2"
 gem "google-api-client"
 
 # Microsoft Exchange calendars

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     foreman (0.87.2)
     forwardable (1.3.3)
     gems (1.2.0)
-    geocoder (1.6.7)
+    geocoder (1.8.2)
     globalid (1.0.1)
       activesupport (>= 5.0)
     google-api-client (0.53.0)
@@ -591,7 +591,7 @@ DEPENDENCIES
   elasticsearch-extensions (~> 0.0.27)
   exchanger
   foreman
-  geocoder
+  geocoder (>= 1.8.2)
   gobierto_budgets_data!
   google-api-client
   hashie

--- a/app/models/gobierto_common/location.rb
+++ b/app/models/gobierto_common/location.rb
@@ -74,6 +74,8 @@ module GobiertoCommon
     end
 
     def add_name(name)
+      return if names.is_a?(Array) && names.include?(name)
+
       if names.is_a?(Array)
         names << name
       else

--- a/app/models/gobierto_common/location.rb
+++ b/app/models/gobierto_common/location.rb
@@ -4,7 +4,7 @@ module GobiertoCommon
   class Location < ApplicationRecord
     include GobiertoCommon::Metadatable
 
-    validates :external_id, uniqueness: true
+    validates :external_id, uniqueness: { allow_nil: true }
 
     metadata_attributes(
       :lat,

--- a/app/models/gobierto_common/location.rb
+++ b/app/models/gobierto_common/location.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module GobiertoCommon
+  class Location < ApplicationRecord
+    include GobiertoCommon::Metadatable
+
+    validates :external_id, uniqueness: true
+
+    metadata_attributes(
+      :lat,
+      :lon,
+      :city_name,
+      :country_code,
+      :country_name,
+      :types
+    )
+
+    scope :by_name, ->(*names) { where("names @> ARRAY[?]::varchar[]", names) }
+
+    def self.search(name)
+      name = name.strip.gsub(/\s/, " ").squeeze(" ")
+      cached_location = by_name(name)
+      return cached_location.first if cached_location.exists?
+
+      location = Geocoder.search(name).first
+
+      if location.present?
+        existing_location = find_by(external_id: location.place_id.to_s)
+        if existing_location.present?
+          existing_location.add_name(name)
+
+          existing_location
+        else
+          create(
+            names: [name],
+            meta: {
+              lat: location.latitude,
+              lon: location.longitude,
+              city_name: location.city,
+              country_code: location.country_code.upcase,
+              country_name: location.country,
+              types: (location.try(:types) || [location.try(:type)]).compact
+            },
+            external_id: location.place_id.to_s
+          )
+        end
+      end
+    end
+
+    def add_name(name)
+      names << name
+      save
+    end
+  end
+end

--- a/app/models/gobierto_common/location.rb
+++ b/app/models/gobierto_common/location.rb
@@ -45,6 +45,19 @@ module GobiertoCommon
       end
     end
 
+    def self.create_from_meta(meta)
+      meta = meta.with_indifferent_access
+      locations = where(external_id: nil).where("meta @> ?", meta.slice(:lat, :lon, :city_name).to_json)
+      if locations.exists?
+        locations.first
+      else
+        create(
+          names: [meta[:name]],
+          meta: meta.slice(:lat, :lon, :city_name, :country_code, :country_name, :types)
+        )
+      end
+    end
+
     def self.find_by_meta(location)
       where(external_id: nil).where("meta @> ?", metadata(location).slice(:lat, :lon, :city_name).to_json).first
     end

--- a/app/models/gobierto_common/location.rb
+++ b/app/models/gobierto_common/location.rb
@@ -25,30 +25,47 @@ module GobiertoCommon
       location = Geocoder.search(name).first
 
       if location.present?
-        existing_location = find_by(external_id: location.place_id.to_s)
+        existing_location = find_by(external_id: location.place_id.to_s) || find_by_meta(location)
         if existing_location.present?
+          if existing_location.external_id.blank?
+            existing_location.update_attribute(:external_id, location.place_id.to_s)
+            existing_location.update_attribute(:meta, metadata(location))
+          end
+
           existing_location.add_name(name)
 
           existing_location
         else
           create(
             names: [name],
-            meta: {
-              lat: location.latitude,
-              lon: location.longitude,
-              city_name: location.city,
-              country_code: location.country_code.upcase,
-              country_name: location.country,
-              types: (location.try(:types) || [location.try(:type)]).compact
-            },
+            meta: metadata(location),
             external_id: location.place_id.to_s
           )
         end
       end
     end
 
+    def self.find_by_meta(location)
+      where(external_id: nil).where("meta @> ?", metadata(location).slice(:lat, :lon, :city_name).to_json).first
+    end
+
+    def self.metadata(location)
+      {
+        lat: location.latitude,
+        lon: location.longitude,
+        city_name: location.city,
+        country_code: location.country_code.upcase,
+        country_name: location.country,
+        types: (location.try(:types) || [location.try(:type)]).compact
+      }
+    end
+
     def add_name(name)
-      names << name
+      if names.is_a?(Array)
+        names << name
+      else
+        self.names = [name]
+      end
       save
     end
   end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -4,5 +4,6 @@ Geocoder.configure(
   lookup: :google,
   api_key: Rails.application.secrets.google_maps_geocoding_api_key || "",
   timeout: 5,
-  units: :km
+  units: :km,
+  cache: Geocoder::CacheStore::Generic.new(Rails.cache, {})
 )

--- a/db/migrate/20231102111229_create_gobierto_common_locations.rb
+++ b/db/migrate/20231102111229_create_gobierto_common_locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGobiertoCommonLocations < ActiveRecord::Migration[6.0]
   def change
     create_table :locations do |t|

--- a/db/migrate/20231102111229_create_gobierto_common_locations.rb
+++ b/db/migrate/20231102111229_create_gobierto_common_locations.rb
@@ -1,0 +1,9 @@
+class CreateGobiertoCommonLocations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :locations do |t|
+      t.string :external_id
+      t.jsonb :meta
+      t.string :names, array: true
+    end
+  end
+end

--- a/test/fixtures/gobierto_common/locations.yml
+++ b/test/fixtures/gobierto_common/locations.yml
@@ -1,0 +1,21 @@
+cortegada:
+  external_id: place1
+  meta: <%= {
+    "lat" => 42.2073223,
+    "lon"=> -8.170119999999999,
+    "types" => ["locality", "political"],
+    "city_name" => "Cortegada",
+    "country_code" => "ES",
+    "country_name" => "Spain"
+  }.to_json %>
+  names: ["Cortegada (Spain)", "Cortegada, Ourense"]
+
+ribadavia:
+  meta: <%= {
+      "lat" => 42.288847,
+      "lon"=> -8.1420491,
+      "city_name" => "Ribadavia",
+      "country_code" => "ES",
+      "country_name" => "Spain"
+  }.to_json %>
+  names: ["Ribadavia, Ourense"]

--- a/test/models/gobierto_common/location_test.rb
+++ b/test/models/gobierto_common/location_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoCommon
+  class LocationTest < ActiveSupport::TestCase
+    def geocoder_response
+      @geocoder_response ||= OpenStruct.new(
+        "place_id" => "place1",
+        "latitude" => 42.2073223,
+        "longitude" => -8.170119999999999,
+        "city" => "Cortegada",
+        "country_code" => "ES",
+        "country" => "Spain",
+        "types" => ["locality", "political"]
+      )
+    end
+
+    def geocoder_other_response
+      @geocoder_other_response ||= OpenStruct.new(
+        "place_id" => "place2",
+        "latitude" => 42.288847,
+        "longitude" => -8.1420491,
+        "city" => "Ribadavia",
+        "country_code" => "ES",
+        "country" => "Spain",
+        "types" => ["locality", "political"]
+      )
+    end
+
+    def geocoder_unregistered_response
+      @geocoder_unregistered_response ||= OpenStruct.new(
+        "place_id" => "place3",
+        "latitude" => 36.1900204,
+        "longitude" => -5.9224799,
+        "city" => "Barbate",
+        "country_code" => "ES",
+        "country" => "Spain",
+        "types" => ["locality", "political"]
+      )
+    end
+
+    def location_with_external_id
+      gobierto_common_locations(:cortegada)
+    end
+
+    def location_without_external_id
+      gobierto_common_locations(:ribadavia)
+    end
+
+    def subject
+      ::GobiertoCommon::Location
+    end
+
+    def test_search_already_existing_location_by_name
+      Geocoder.expects(:search).never
+
+      assert_no_difference "::GobiertoCommon::Location.count" do
+        result = subject.search("Cortegada, Ourense")
+
+        assert_equal result, location_with_external_id
+      end
+    end
+
+    def test_search_already_existing_location_by_other_name
+      Geocoder.expects(:search).with("test").returns([geocoder_response]).once
+
+      refute_includes location_with_external_id.names, "test"
+
+      assert_no_difference "::GobiertoCommon::Location.count" do
+        subject.search("test")
+      end
+
+      location_with_external_id.reload
+      assert_includes location_with_external_id.names, "test"
+      assert_equal location_with_external_id.external_id, "place1"
+      assert_equal location_with_external_id.lat, geocoder_response.latitude
+      assert_equal location_with_external_id.lon, geocoder_response.longitude
+      assert_equal location_with_external_id.city_name, geocoder_response.city
+      assert_equal location_with_external_id.types, geocoder_response.types
+    end
+
+    def test_search_already_existing_location_without_external_id_by_other_name
+      Geocoder.expects(:search).with("test").returns([geocoder_other_response]).once
+
+      refute_includes location_without_external_id.names, "test"
+
+      assert_no_difference "::GobiertoCommon::Location.count" do
+        subject.search("test")
+      end
+
+      location_without_external_id.reload
+      assert_includes location_without_external_id.names, "test"
+      assert_equal location_without_external_id.external_id, "place2"
+      assert_equal location_without_external_id.lat, geocoder_other_response.latitude
+      assert_equal location_without_external_id.lon, geocoder_other_response.longitude
+      assert_equal location_without_external_id.city_name, geocoder_other_response.city
+      assert_equal location_without_external_id.types, geocoder_other_response.types
+    end
+
+    def test_search_unregistered_data
+      Geocoder.expects(:search).with("test").returns([geocoder_unregistered_response]).once
+
+      assert_difference "::GobiertoCommon::Location.count", 1 do
+        subject.search("test")
+      end
+
+      location = subject.last
+
+      assert_equal geocoder_unregistered_response.place_id, location.external_id
+      assert_includes location.names, "test"
+    end
+  end
+end


### PR DESCRIPTION
Closes PopulateTools/issues#1867

## :v: What does this PR do?

* Upgrades version of geocoder gem
* Configures cache in the initializer
* Creates a new `GobiertoCommon::Location` model used to cache locations and save requests to geocoding service. The model provides a search method wich looks in the cached locations by already stored search strings, if there is no string stored uses the geocoder service and checks the existence of a cached location first by an external_id and then by coordinates and city name for locations cached without external_id. If an existing location is found the names list is updated and if the external_id is not present it's also updated and the metadata completed with the information provided by the geocoding service. If no cached location is found a new instance is created.
* Adds some tests

With those changes it's expected to reduce the requests to the geocoding service

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No