### PR TITLE
Block other unsecure schemas for gobierto data

### DIFF
--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -165,7 +165,7 @@ module GobiertoData
 
         return false if parsed_query.tables.empty?
         return false if parsed_query.tables.any? { |t| BLACKLISTED_TABLES.include?(t) }
-        return false if parsed_query.tables.any? { |t| t.starts_with?("pg_") }
+        return false if parsed_query.tables.any? { |t| t.starts_with?("pg_") || t.starts_with?("information_schema") || t.starts_with?("scalegrid") }
 
         true
       end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1861

## :v: What does this PR do?

This PR fixes a vulnerability reported in Gobierto Data module, which allowed to execute queries under the `information_schema.` schema, allowing users to list all the tables in the database.

It was not a big issue, because each site has it's own database, and no other tables could be listed, but makes our API more restricted to just the tables users should be querying.

## :mag: How should this be manually tested?

In a gobierto data instance run the query `SELECT table_name FROM information_schema.tables`, the API should return `Error 400 Query blocked`