### PR TITLE
Use always a default limit

### DIFF
--- a/app/models/gobierto_data/dataset.rb
+++ b/app/models/gobierto_data/dataset.rb
@@ -146,9 +146,7 @@ module GobiertoData
     end
 
     def default_limit
-      return DEFAULT_LIMIT unless api_settings.present?
-      return DEFAULT_LIMIT if format_size.nil?
-      return DEFAULT_LIMIT if max_size_without_limit.present? && max_size_without_limit.positive? && max_size_without_limit <= format_size
+      DEFAULT_LIMIT
     end
 
     private

--- a/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
+++ b/test/controllers/gobierto_data/api/v1/datasets_controller_test.rb
@@ -283,7 +283,7 @@ module GobiertoData
 
             assert_equal 50, big_dataset_response_data["data"]["attributes"]["default_limit"]
             assert_equal 50, no_size_dataset_response_data["data"]["attributes"]["default_limit"]
-            assert_nil small_dataset_response_data["data"]["attributes"]["default_limit"]
+            assert_equal 50, small_dataset_response_data["data"]["attributes"]["default_limit"]
 
             assert_equal 15, big_dataset_response_data["data"]["attributes"]["size"]["csv"]
             assert_equal 3, small_dataset_response_data["data"]["attributes"]["size"]["csv"]

--- a/test/models/gobierto_data/dataset_test.rb
+++ b/test/models/gobierto_data/dataset_test.rb
@@ -28,19 +28,5 @@ module GobiertoData
       # api limit is set to 10 and size is 15.0
       assert_equal 50, subject.default_limit
     end
-
-    def test_default_limit_with_limit_zero
-      module_settings.update_attribute(:settings, default_settings.merge("api_settings" => { "max_dataset_size_for_queries" => 0 }))
-
-      # api limit is set to 0 and size is 15.0
-      assert_nil subject.default_limit
-    end
-
-    def test_defaul_limit_with_no_api_configuration
-      module_settings.update_attribute(:settings, default_settings.merge("api_settings" => {}))
-
-      # api limit is not set and size is 15.0 (default is 2)
-      assert_equal 50, subject.default_limit
-    end
   end
 end


### PR DESCRIPTION
## :v: What does this PR do?

This PR changes the default query limit for all datasets, no matter their size the query will have a limit.

This might require removing the cache of queries and rails cache.

## :mag: How should this be manually tested?

Load any dataset, all of them should have a limit added in the query.
