### PR TITLE
Fix method result of query parser

### DIFF
--- a/app/models/gobierto_data/connection.rb
+++ b/app/models/gobierto_data/connection.rb
@@ -172,8 +172,6 @@ module GobiertoData
 
         secure_tables_called?(parsed_query) &&
           secure_functions_called?(parsed_query)
-
-        true
       rescue PgQuery::ParseError
         # Invalid queries are considered insecure
         false

--- a/test/models/gobierto_data/connection_test.rb
+++ b/test/models/gobierto_data/connection_test.rb
@@ -91,11 +91,14 @@ module GobiertoData
         "CREATE TABLE mytable (mycol text)",
         "INSERT INTO mytable(mycol) VALUES (1)",
         "SELECT inet_server_addr();",
-        "SELECT current_setting('data_directory');"
+        "SELECT current_setting('data_directory');",
+        "SELECT country_code FROM delivery  union select null from pg_sleep(10);",
+        "SELECT country_code FROM delivery where country_code='ES' union select  version()"
       ].each do |query|
-        result = Connection.execute_query_output_csv(site, "SELECT not_existing_column FROM users", {col_sep: ','})
+        result = Connection.execute_query_output_csv(site, query, {col_sep: ','})
         hash_result = JSON.parse(result.to_json)
 
+        assert hash_result.is_a?(Hash), query
         assert hash_result.has_key?("errors")
       end
     end


### PR DESCRIPTION
Related with the PR https://github.com/PopulateTools/gobierto/pull/4181

## :v: What does this PR do?

This PR fixes both the test and the method that checks the security of the queries introduced in https://github.com/PopulateTools/gobierto/pull/4181, which was not being used, as the method always returned true 😵‍💫 

## :mag: How should this be manually tested?

This query shouldn't work: https://demo-datos.gobify.net/datos/calidad-del-aire/editor?sql=SELECT%2520country_code%2520FROM%2520delivery%2520%2520union%2520select%2520null%2520from%2520pg_sleep%2810%29

## :eyes: Screenshots

![Screenshot 2023-12-13 at 11 26 51](https://github.com/PopulateTools/gobierto/assets/17616/60aa13b2-2ceb-445f-99c0-db2d7762902e)
