### PR TITLE
Add pending index in collection items

### DIFF
--- a/db/migrate/20231215043312_add_index_on_collection_items.rb
+++ b/db/migrate/20231215043312_add_index_on_collection_items.rb
@@ -1,0 +1,5 @@
+class AddIndexOnCollectionItems < ActiveRecord::Migration[6.0]
+  def change
+    add_index :collection_items, [:container_type, :item_type, :item_id], name: 'index_collection_items_on_container_type_item_type_and_item_id'
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

This PR adds an index on a slow query very frequent.

Yesterday it was executed 11k times and the cost was around 1.5secs.

After this index, query time is < 10ms

## :mag: How should this be manually tested?

```EXPLAIN (ANALYZE, VERBOSE, BUFFERS) SELECT 1 AS one FROM "gc_events" INNER JOIN collection_items ON collection_items.container_type = 'GobiertoPeople::Person' AND collection_items.item_type = 'GobiertoCalendars::Event' AND collection_items.item_id = gc_events.id INNER JOIN gp_people ON collection_items.container_id = gp_people.id AND gp_people.party = 0 WHERE "gc_events"."archived_at" IS NULL AND "gc_events"."state" = 1 AND "gc_events"."site_id" = 24 LIMIT 1;```

```
 Limit  (cost=1.26..106.48 rows=1 width=4) (actual time=3.245..3.247 rows=1 loops=1)
   Output: 1
   Buffers: shared hit=2742
   ->  Nested Loop  (cost=1.26..27463.70 rows=261 width=4) (actual time=3.244..3.245 rows=1 loops=1)
         Output: 1
         Inner Unique: true
         Buffers: shared hit=2742
         ->  Nested Loop  (cost=0.97..27209.45 rows=6090 width=8) (actual time=0.044..3.047 rows=446 loops=1)
               Output: collection_items.container_id
               Buffers: shared hit=2721
               ->  Index Scan using index_gc_events_on_site_id_and_slug on public.gc_events  (cost=0.42..12817.35 rows=5947 width=4) (actual time=0.018..0.595 rows=446 loops=1)
                     Output: gc_events.id, gc_events.starts_at, gc_events.ends_at, gc_events.state, gc_events.created_at, gc_events.updated_at, gc_events.title_translations, gc_events.description_translations, gc_events.external_id, gc_events.site_id, gc_events.slug, gc_events.collection_id, gc_events.archived_at, gc_events.description_source_translations, gc_events.meta, gc_events.department_id, gc_events.interest_group_id
                     Index Cond: (gc_events.site_id = 24)
                     Filter: ((gc_events.archived_at IS NULL) AND (gc_events.state = 1))
                     Rows Removed by Filter: 70
                     Buffers: shared hit=491
               ->  Index Scan using index_collection_items_on_container_type_item_type_and_item_id on public.collection_items  (cost=0.55..2.41 rows=1 width=16) (actual time=0.005..0.005 rows=1 loops=446)
                     Output: collection_items.id, collection_items.item_type, collection_items.item_id, collection_items.container_type, collection_items.container_id, collection_items.created_at, collection_items.updated_at, collection_items.collection_id
                     Index Cond: (((collection_items.container_type)::text = 'GobiertoPeople::Person'::text) AND ((collection_items.item_type)::text = 'GobiertoCalendars::Event'::text) AND (collection_items.item_id = gc_events.id))
                     Buffers: shared hit=2230
         ->  Memoize  (cost=0.29..0.31 rows=1 width=4) (actual time=0.000..0.000 rows=0 loops=446)
               Output: gp_people.id
               Cache Key: collection_items.container_id
               Cache Mode: logical
               Hits: 439  Misses: 7  Evictions: 0  Overflows: 0  Memory Usage: 1kB
               Buffers: shared hit=21
               ->  Index Scan using gp_people_pkey on public.gp_people  (cost=0.28..0.30 rows=1 width=4) (actual time=0.003..0.003 rows=0 loops=7)
                     Output: gp_people.id
                     Index Cond: (gp_people.id = collection_items.container_id)
                     Filter: (gp_people.party = 0)
                     Rows Removed by Filter: 1
                     Buffers: shared hit=21
 Query Identifier: 2524144251821948775
 Planning:
   Buffers: shared hit=18
 Planning Time: 0.576 ms
 Execution Time: 3.286 ms
```
