### PR TITLE
Force explicity setting of term_id when importing vocabulary terms from CSV

### DIFF
--- a/app/forms/gobierto_admin/gobierto_common/vocabulary_terms_import_form.rb
+++ b/app/forms/gobierto_admin/gobierto_common/vocabulary_terms_import_form.rb
@@ -58,7 +58,11 @@ module GobiertoAdmin
             slug: row["term_id"]&.strip,
             external_id: row["term_id"]&.strip
           )
-          term_form.term_id = extract_parent_id(row["parent_id"]&.strip) if term_form.valid?
+
+          if term_form.valid?
+            term_form.reset_term_id = true
+            term_form.term_id = extract_parent_id(row["parent_id"]&.strip)
+          end
 
           unless term_form.save
             promote_errors(term_form.errors)


### PR DESCRIPTION
## :v: What does this PR do?

This PR avoids errors importing terms from a CSV ignoring parent terms hierarchy. The VocabularyTermsImportForm class makes use of a TermForm class which after recent changes has an attribute which has to be set to true to update the term_id relation of a term. This PR ensures the use of this setting to true

## :mag: How should this be manually tested?

Remove the ODS vocabulary of a site and recreate it re enabling the Plans module. This vocabulary is based on a CSV with parent terms relationship. The ODS vocabulary should be created correctly

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No