### PR TITLE
Fix array ids transformation into array of strings

### DIFF
--- a/app/decorators/gobierto_plans/sdg_decorator.rb
+++ b/app/decorators/gobierto_plans/sdg_decorator.rb
@@ -92,7 +92,7 @@ module GobiertoPlans
 
     def sdgs_root_level_distribution
       @sdgs_root_level_distribution ||= begin
-                                          root_level_ids = sdgs_terms.pluck(:id).to_s
+                                          root_level_ids = sdgs_terms.pluck(:id).map(&:to_s)
                                           sdgs_transformed_values.transform_values do |payload|
                                             payload.values.flatten.select { |sdg_id| root_level_ids.include?(sdg_id) }
                                           end


### PR DESCRIPTION
## :v: What does this PR do?

Fixes a bug processing cached data for SDGs where an array of strings is converted to a whole string instead of an array of strings

## :mag: How should this be manually tested?

After importing a plan with SDGs there should not be errors triyng to view plan in front

## :shipit: Does this PR changes any configuration file?

No
(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No