### PR TITLE
Download button/link query updates

### DIFF
--- a/app/javascript/gobierto_data/lib/factories/download.js
+++ b/app/javascript/gobierto_data/lib/factories/download.js
@@ -12,9 +12,9 @@ export const DownloadFilesFactoryMixin = {
 
       //Create an object to parse query, is the same method which use to run a query. If we don't do this we've to use regex and replace to encode URL with too hacks https://stackoverflow.com/a/32882427
       const objectSql = { sql: sql }
-      let queryUrl = new URLSearchParams(objectSql);
+      const queryUrl = new URLSearchParams(objectSql);
 
-      let datetime = new Date();
+      const datetime = new Date();
       const date = `${datetime.getDate()}_${(datetime.getMonth() + 1)}_${datetime.getFullYear()}`;
 
       const {
@@ -25,13 +25,18 @@ export const DownloadFilesFactoryMixin = {
 
       this.titleFile = titleFile
 
+      const formats = {}
       for (let i = 0; i < keyFormats.length; i++) {
-        this.arrayFormatsQuery[i] = {
+        formats[i] = {
           label: keyFormats[i],
           url: `${endPoint}${keyFormats[i]}?${queryUrl.toString()}`,
           name: `${titleFile}_${date}.${keyFormats[i]}`
         };
       }
+
+      // we need to re-assign the object to trigger reactivity
+      // otherwise, object changes won't be reflected
+      this.arrayFormatsQuery = formats
 
     },
     getFiles(url, name) {

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadButton.vue
@@ -18,18 +18,15 @@
             v-show="!isHidden"
             class="gobierto-data-btn-download-data-modal"
           >
-            <template
+            <a
               v-for="(item, key) in arrayFormats"
+              :key="key"
+              :href="item"
+              :download="titleFile"
+              class="gobierto-data-btn-download-data-modal-element"
             >
-              <a
-                :key="key"
-                :href="item"
-                :download="titleFile"
-                class="gobierto-data-btn-download-data-modal-element"
-              >
-                {{ key }}
-              </a>
-            </template>
+              {{ key }}
+            </a>
           </div>
         </template>
         <template v-else>
@@ -37,18 +34,15 @@
             v-show="!isHidden"
             class="gobierto-data-btn-download-data-modal"
           >
-            <template
+            <a
               v-for="({ url, name, label }, key) in arrayFormatsQuery"
+              :key="key"
+              :href="url"
+              class="gobierto-data-btn-download-data-modal-element"
+              @click.prevent="getFiles(url, name)"
             >
-              <a
-                :key="key"
-                :href="url"
-                class="gobierto-data-btn-download-data-modal-element"
-                @click.prevent="getFiles(url, name)"
-              >
-                {{ label }}
-              </a>
-            </template>
+              {{ label }}
+            </a>
           </div>
         </template>
       </transition>

--- a/app/javascript/gobierto_data/webapp/components/commons/DownloadLink.vue
+++ b/app/javascript/gobierto_data/webapp/components/commons/DownloadLink.vue
@@ -8,34 +8,28 @@
       mode="out-in"
     >
       <template v-if="!editor">
-        <template
+        <a
           v-for="(item, key) in arrayFormats"
+          :key="key"
+          :href="item"
+          :download="titleFile"
+          class="gobierto-data-btn-blue gobierto-data-btn-download-data"
         >
-          <a
-            :key="key"
-            :href="item"
-            :download="titleFile"
-            class="gobierto-data-btn-blue gobierto-data-btn-download-data"
-          >
-            <i class="fas fa-download" />
-            {{ labelDownloadData }}
-          </a>
-        </template>
+          <i class="fas fa-download" />
+          {{ labelDownloadData }}
+        </a>
       </template>
       <template v-else>
-        <template
+        <a
           v-for="({ url, name }, key) in arrayFormatsQuery"
+          :key="key"
+          :href="url"
+          class="gobierto-data-btn-blue gobierto-data-btn-download-data align-right"
+          @click.prevent="getFiles(url, name)"
         >
-          <a
-            :key="key"
-            :href="url"
-            class="gobierto-data-btn-blue gobierto-data-btn-download-data align-right"
-            @click.prevent="getFiles(url, name)"
-          >
-            <i class="fas fa-download" />
-            {{ labelDownloadData }}
-          </a>
-        </template>
+          <i class="fas fa-download" />
+          {{ labelDownloadData }}
+        </a>
       </template>
     </transition>
   </div>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1873

## :v: What does this PR do?
The download button didn't update the endpoint once the query in the editor changes