### PR TITLE
Update bubbles chart

### DIFF
--- a/app/javascript/lib/visualizations/modules/bubbles.js
+++ b/app/javascript/lib/visualizations/modules/bubbles.js
@@ -250,7 +250,7 @@ export class VisBubbles {
   }
 
   setLink(d) {
-    var areaName = d.area_name || this.budget_category === "income" ? "economic" : "functional";
+    var areaName = d.area_name || (this.budget_category === "income" ? "economic" : "functional");
     var budgetCategory = this.budget_category === "income" ? "I" : "G";
     return "/presupuestos/partidas/" + d.id + "/" + d.year + "/" + areaName + "/" + budgetCategory;
   }

--- a/app/javascript/lib/visualizations/modules/bubbles.js
+++ b/app/javascript/lib/visualizations/modules/bubbles.js
@@ -178,6 +178,7 @@ export class VisBubbles {
             values: d.values,
             pct_diffs: d.pct_diff,
             id: d.id,
+            area_name: d.area_name,
             values_per_inhabitant: d.values_per_inhabitant,
             radius: d.values[year] ? this.radiusScale(d.values[year]) : 0,
             value: d.values[year],
@@ -261,9 +262,9 @@ export class VisBubbles {
       .attr(
         "xlink:href",
         function(d) {
-          return this.budget_category === "income"
-            ? "/presupuestos/partidas/" + d.id + "/" + d.year + "/economic/I"
-            : "/presupuestos/partidas/" + d.id + "/" + d.year + "/functional/G";
+          var areaName = d.area_name || this.budget_category === "income" ? "economic" : "functional";
+          var budgetCategory = this.budget_category === "income" ? "I" : "G";
+          return "/presupuestos/partidas/" + d.id + "/" + d.year + "/" + areaName + "/" + budgetCategory;
         }.bind(this)
       )
       .append("circle")

--- a/app/javascript/lib/visualizations/modules/bubbles.js
+++ b/app/javascript/lib/visualizations/modules/bubbles.js
@@ -228,6 +228,9 @@ export class VisBubbles {
         }.bind(this)
       );
 
+    d3.selectAll('.bubble-g a')
+      .attr('xlink:href', function(d) { return this.setLink(d); }.bind(this))
+
     d3.selectAll(".bubble-g text")
       .data(this.nodes, d => d.name)
       .transition()
@@ -246,6 +249,12 @@ export class VisBubbles {
     this.simulation.alpha(1).restart();
   }
 
+  setLink(d) {
+    var areaName = d.area_name || this.budget_category === "income" ? "economic" : "functional";
+    var budgetCategory = this.budget_category === "income" ? "I" : "G";
+    return "/presupuestos/partidas/" + d.id + "/" + d.year + "/" + areaName + "/" + budgetCategory;
+  }
+
   updateRender() {
     // var budgetCategory = this.budget_category;
     this.nodes = this.createNodes(this.data, this.currentYear);
@@ -261,11 +270,7 @@ export class VisBubbles {
       .append("a")
       .attr(
         "xlink:href",
-        function(d) {
-          var areaName = d.area_name || this.budget_category === "income" ? "economic" : "functional";
-          var budgetCategory = this.budget_category === "income" ? "I" : "G";
-          return "/presupuestos/partidas/" + d.id + "/" + d.year + "/" + areaName + "/" + budgetCategory;
-        }.bind(this)
+        function(d) { return this.setLink(d); }.bind(this)
       )
       .append("circle")
       .attr("class", d => `${d.year} bubble`)


### PR DESCRIPTION
## :v: What does this PR do?

This PR adds the same updates made in the budgets comparator on bubbles_chart:
* Takes into account the area_name if present in the JSON data file to build the bubbles path
* Updates the year in the bubbles URL when the slider year is changed

There is a change made in the comparator already present in this application:
* The chart inspect all the years of available data of all codes instead of inspecting only the first code

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No