### PR TITLE
Fix liquid exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/PopulateTools/gobierto_budgets_data.git
-  revision: 2472cf1e64d136f74754187563c4e01b31c82dad
+  revision: c7feacf59d348fe5aaff47f7946611ccc1184121
   specs:
     gobierto_budgets_data (0.1.0)
       actionpack
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/maierru/liquid-rails.git
-  revision: 85428a0f713f27281c72f0df60316c62115cf76b
+  revision: f40da9a09f393726181747492f5bc389e456955f
   specs:
     liquid-rails (0.2.1)
       kaminari (~> 1.2.1)
@@ -129,6 +129,7 @@ GEM
     aws_cf_signer (0.1.3)
     bcrypt (3.1.16)
     before_renders (0.2.0)
+    bigdecimal (3.1.6)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -368,7 +369,8 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nori (2.6.0)
-    oj (3.14.3)
+    oj (3.16.3)
+      bigdecimal (>= 3.0)
     open4 (1.3.4)
     os (1.1.1)
     paper_trail (12.0.0)

--- a/app/helpers/gobierto_helper.rb
+++ b/app/helpers/gobierto_helper.rb
@@ -41,9 +41,9 @@ module GobiertoHelper
 
   def logo_image_tag(logo_src, options = {})
     if logo_src == SiteConfiguration::DEFAULT_LOGO_PATH
-      image_pack_tag(logo_src, options)
+      image_pack_tag(logo_src, **options)
     else
-      image_tag(logo_src, options)
+      image_tag(logo_src, **options)
     end
   end
 

--- a/lib/liquid/gobierto_cms/tags/list_items_from.rb
+++ b/lib/liquid/gobierto_cms/tags/list_items_from.rb
@@ -41,7 +41,7 @@ module Liquid
               collection_item_text << %Q{ <img src="#{page.main_image}"> }
             end
             if @options[:date]
-              collection_item_text << %Q{ <span class="date">#{I18n.l(page.published_on, format: "%d %b %y")}</span> }
+              collection_item_text << %Q{ <span class="date">#{::I18n.l(page.published_on, format: "%d %b %y")}</span> }
             end
             collection_item_text << %Q{ <h2>#{page.title}</h2> }
             if @options[:intro_text]


### PR DESCRIPTION
Closes PopulateTools/issues#1901
Closes PopulateTools/issues#1902

## :v: What does this PR do?

Fixes some errors produced in liquid templates:
* Fixes definition of `logo_image_tag` method used in some templates correcting syntax of inner calls to other methods
* Fixes the namespace scope of `I18n` class call from a helper defined for liquid to avoid ambiguities
* Updates the revisions of liquid and gobierto_budgets_data in Gemfile.lock

## :mag: How should this be manually tested?

Visit https://ribaroja.gobify.net/datos. Both header and footer of the page should appear without `Liquid error: internal` message
Visit https://esplugues.gobify.net/planes/pam/2015, the footer of the plan should appear without `Liquid error: internal` message

## :eyes: Screenshots

![Screenshot from 2024-02-06 18-57-53](https://github.com/PopulateTools/gobierto/assets/446459/f894fb9c-0f69-4edd-a91d-2cb9b0cfd98b)

![Screenshot from 2024-02-06 18-57-53](https://github.com/PopulateTools/gobierto/assets/446459/9ff55448-6b99-4efd-9a0d-ecc5e3a96690)

NOTE: The styles of the list in the footer of the plan seem to be broken. The problem is not related with the changes introduced by this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No