### PR TITLE
Avoid errors calling current_user in track_event callbacks

### DIFF
--- a/app/controllers/concerns/application_concern.rb
+++ b/app/controllers/concerns/application_concern.rb
@@ -62,7 +62,9 @@ module ApplicationConcern
   def track_request
     return true if ignore_tracking_request?
 
-    GobiertoCommon::EventCreatorJob.perform_later current_site.id, current_user&.id, current_visit&.id, filtered_params(request.params.merge(method: request.method))
+    user_id = @current_user&.id
+    extra_params = { method: request.method, admin_id: @current_admin&.id }.compact
+    GobiertoCommon::EventCreatorJob.perform_later current_site.id, user_id, current_visit&.id, filtered_params(request.params.merge(extra_params))
   rescue StandardError => e
     Appsignal.send_error(e)
   end

--- a/test/fixtures/gobierto_calendars/events.yml
+++ b/test/fixtures/gobierto_calendars/events.yml
@@ -168,9 +168,9 @@ neil_tourism_department_very_old:
     'en' => 'Very old event of toursim department',
     'es' => 'Evento muy viejo del departamento de turismo',
   }.to_json %>
-  slug: <%= "#{10.years.ago.strftime('%F')}-tourism-department-event" %>
-  starts_at: <%= 10.years.ago %>
-  ends_at: <%= 10.years.ago + 1.hour %>
+  slug: <%= "2014-02-07-tourism-department-event" %>
+  starts_at: "2014-02-07 10:00"
+  ends_at: "2014-02-07 10:00"
   state: <%= GobiertoCalendars::Event.states["published"] %>
 
 neil_immigration_department_recent:

--- a/test/integration/gobierto_people/api/v1/departments_test.rb
+++ b/test/integration/gobierto_people/api/v1/departments_test.rb
@@ -22,10 +22,6 @@ module GobiertoPeople
           @madrid ||= sites(:madrid)
         end
 
-        def justice_department
-          @justice_department ||= gobierto_people_departments(:justice_department)
-        end
-
         def culture_department
           @culture_department ||= gobierto_people_departments(:culture_department)
         end
@@ -63,7 +59,7 @@ module GobiertoPeople
         end
 
         def test_departments_index_test
-          justice_department.update!(name: "Departament de la Presidència")
+          culture_department.update!(name: "Departament de la Presidència")
 
           with_current_site(madrid) do
 

--- a/test/integration/gobierto_people/api/v1/people_index_test.rb
+++ b/test/integration/gobierto_people/api/v1/people_index_test.rb
@@ -10,8 +10,8 @@ module GobiertoPeople
 
         include ::EventHelpers
 
-        FAR_PAST = 10.years.ago.iso8601
-        FAR_FUTURE = 10.years.from_now.iso8601
+        FAR_PAST = 100.years.ago.iso8601
+        FAR_FUTURE = 100.years.from_now.iso8601
 
         attr_accessor(
           :madrid,

--- a/test/integration/gobierto_people/departments/index_test.rb
+++ b/test/integration/gobierto_people/departments/index_test.rb
@@ -10,8 +10,8 @@ module GobiertoPeople
         @site ||= sites(:madrid)
       end
 
-      def justice_department
-        @justice_department ||= gobierto_people_departments(:justice_department)
+      def immigration_department
+        @immigration_department ||= gobierto_people_departments(:immigration_department_mixed)
       end
 
       def culture_department
@@ -35,7 +35,7 @@ YAML
         with_current_site(site) do
           visit gobierto_people_departments_path
 
-          assert has_link? justice_department.name
+          assert has_link? immigration_department.name
           assert has_link? culture_department.name
         end
       end
@@ -46,7 +46,7 @@ YAML
         with_current_site(site) do
           visit gobierto_people_departments_path
 
-          assert has_link? justice_department.name
+          assert has_link? immigration_department.name
           assert has_no_link? culture_department.name
         end
       end

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -64,6 +64,12 @@ YAML
         @departments_with_invitations ||= [department_with_invitations, tourism_department_very_old]
       end
 
+      def immigration_department_event
+        # With changes in queries the department is determined by the position
+        # of the person in the moment of the event
+        @immigration_departmen_event ||= gobierto_calendars_events(:neil_tourism_department_very_old)
+      end
+
       def richard
         @richard ||= gobierto_people_people(:richard)
       end
@@ -112,7 +118,10 @@ YAML
 
       def test_sidebar_contents_with_date_filtering
         clear_activities
-        culture_department.events.each(&:destroy)
+        # The date event is moved to a date when the person belongs to justice
+        # department
+        immigration_department_event.update_attribute(:starts_at, "2010-02-07 10:00")
+        immigration_department_event.update_attribute(:ends_at, "2010-02-07 12:00")
 
         with_current_site(site) do
           # with date filtering configured

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -130,7 +130,7 @@ YAML
 
           within departments_sidebar do
             assert has_link? justice_department.name
-            assert has_no_link? culture_department.name
+            assert has_no_link? immigration_department_mixed.name
           end
         end
       end
@@ -207,8 +207,7 @@ YAML
         site.events.where.not(id: neil.events.pluck(:id)).destroy_all
 
         departments_with_activities = [
-          immigration_department_mixed,
-          justice_department
+          immigration_department_mixed
         ]
 
         with_current_site(site) do
@@ -272,8 +271,8 @@ YAML
           within departments_sidebar do
             assert has_no_link? ecology_department_old.name
             assert has_no_link? tourism_department_very_old.name
-            assert has_no_link? immigration_department_mixed.name
-            assert has_link? justice_department.name
+            assert has_link? immigration_department_mixed.name
+            assert has_no_link? justice_department.name
           end
         end
       end


### PR DESCRIPTION
Fixes PopulateTools/gobierto#4082


## :v: What does this PR do?

This PR avoids calling directly to current_user method because the method is not available from admin controllers. The solution of use `try(:current_user)` or `respond_to?(:current_user)` does not work but the variable `@current_user` is set previously in the front controllers because the `set_cache_headers` before_action has been called and it uses `user_signed_in?`

In a similar way the track_request method inspects the presence of `@current_admin` and includes it in the `properties` hash parameter of the Job

## :mag: How should this be manually tested?

As admin visit a plan project. An event should be created including the admin_id without errors

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No