### PR TITLE
Include cache service prefix in caches_action requests

### DIFF
--- a/app/controllers/gobierto_budgets/api/data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/data_controller.rb
@@ -7,7 +7,7 @@ module GobiertoBudgets
         :lines,
         :budget_per_inhabitant,
         :budget,
-        cache_path: proc { |c| "#{c.request.url}?locale=#{I18n.locale}" }
+        cache_path: proc { |c| cache_service.prefixed("#{c.request.url}?locale=#{I18n.locale}") }
       )
 
       skip_before_action :authenticate_user_in_site, only: [:budget_line, :available_years]

--- a/app/controllers/gobierto_budgets/budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/budget_lines_controller.rb
@@ -4,7 +4,7 @@ class GobiertoBudgets::BudgetLinesController < GobiertoBudgets::ApplicationContr
   caches_action(
     :show,
     :index,
-    cache_path: -> { cache_path },
+    cache_path: -> { cache_service.prefixed(cache_path) },
     unless: -> { user_signed_in? }
   )
 

--- a/app/controllers/gobierto_budgets/budgets_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_controller.rb
@@ -4,7 +4,7 @@ class GobiertoBudgets::BudgetsController < GobiertoBudgets::ApplicationControlle
 
   caches_action(
     :index,
-    cache_path: -> { cache_path },
+    cache_path: -> { cache_service.prefixed(cache_path) },
     unless: -> { user_signed_in? }
   )
 


### PR DESCRIPTION
Closes PopulateTools/issues#1900

## :v: What does this PR do?

Fixes the use of `caches_action` requests in budgets controllers to include the cache service prefix. Doing this the cache service `clear` method called from ETLs for the module removes also that cached data

## :mag: How should this be manually tested?

Review the update data after ETL, it should change daily
![image](https://github.com/PopulateTools/gobierto/assets/446459/ce407f05-08af-4310-aa16-557d4bc9efda)

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No