### PR TITLE
Force base64 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "before_renders"
 gem "bootsnap"
 gem "truncate_html"
 gem "rake", "~> 13.0"
+gem 'base64', '~> 0.2.0'
 
 # Frontend
 gem "i18n-js", ">= 3.0.0.rc11" # required to i18n-tasks

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "before_renders"
 gem "bootsnap"
 gem "truncate_html"
 gem "rake", "~> 13.0"
-gem 'base64', '~> 0.2.0'
+gem 'base64', '0.1.1'
 
 # Frontend
 gem "i18n-js", ">= 3.0.0.rc11" # required to i18n-tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     aws_cf_signer (0.1.3)
-    base64 (0.2.0)
+    base64 (0.1.1)
     bcrypt (3.1.16)
     before_renders (0.2.0)
     bigdecimal (3.1.6)
@@ -582,7 +582,7 @@ DEPENDENCIES
   appsignal (= 3.0.6)
   aws-sdk-s3 (~> 1)
   aws-ses!
-  base64 (~> 0.2.0)
+  base64 (= 0.1.1)
   bcrypt (~> 3.1.0)
   before_renders
   bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -582,6 +582,7 @@ DEPENDENCIES
   appsignal (= 3.0.6)
   aws-sdk-s3 (~> 1)
   aws-ses!
+  base64 (~> 0.2.0)
   bcrypt (~> 3.1.0)
   before_renders
   bootsnap


### PR DESCRIPTION
## :v: What does this PR do?

This PR tries to solve this error in production:

```
==> /var/log/nginx/error.log <==
App 4148817 output: Error: The application encountered the following error: You have already activated base64 0.1.1, but your Gemfile requires base64 0.2.0. Since base64 is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports base64 as a default gem. (Gem::LoadError)
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/runtime.rb:304:in `check_for_activated_spec!'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/runtime.rb:25:in `block in setup'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/spec_set.rb:165:in `each'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/spec_set.rb:165:in `each'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/runtime.rb:24:in `map'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/runtime.rb:24:in `setup'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler.rb:171:in `setup'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/setup.rb:23:in `block in <top (required)>'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/ui/shell.rb:159:in `with_level'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/ui/shell.rb:111:in `silence'
App 4148817 output:     /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/bundler/setup.rb:23:in `<top (required)>'
App 4148817 output:     <internal:/usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
App 4148817 output:     <internal:/usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
App 4148817 output:     /usr/lib/ruby/vendor_ruby/phusion_passenger/loader_shared_helpers.rb:382:in `activate_gem'
App 4148817 output:     /usr/lib/ruby/vendor_ruby/phusion_passenger/loader_shared_helpers.rb:221:in `block in run_load_path_setup_code'
App 4148817 output:     /usr/lib/ruby/vendor_ruby/phusion_passenger/loader_shared_helpers.rb:546:in `running_bundler'
App 4148817 output:     /usr/lib/ruby/vendor_ruby/phusion_passenger/loader_shared_helpers.rb:220:in `run_load_path_setup_code'
App 4148817 output:     /usr/share/passenger/helper-scripts/rack-preloader.rb:91:in `preload_app'
App 4148817 output:     /usr/share/passenger/helper-scripts/rack-preloader.rb:189:in `block in <module:App>'
App 4148817 output:     /usr/lib/ruby/vendor_ruby/phusion_passenger/loader_shared_helpers.rb:399:in `run_block_and_record_step_progress'
App 4148817 output:     /usr/share/passenger/helper-scripts/rack-preloader.rb:188:in `<module:App>'
App 4148817 output:     /usr/share/passenger/helper-scripts/rack-preloader.rb:30:in `<module:PhusionPassenger>'
App 4148817 output:     /usr/share/passenger/helper-scripts/rack-preloader.rb:29:in `<main>'
```

