### PR TITLE
Prevent deep pagination in events pages (from bots)

### DIFF
--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -8,7 +8,7 @@ module GobiertoPeople
 
     def index
       set_events
-      render_404 and return if params[:page].present? && @events.empty?
+      render_404 and return if (params[:page].present? && @events.empty?) || (params[:page].to_i > 5)
 
       set_calendar_events
       set_people


### PR DESCRIPTION
## :v: What does this PR do?

Checking the slow queries I've found many (many many) slow queries caused by a deep pagination in people calendar.

This PR blocks page > 5 in past events page, (i.e https://portalobert.esplugues.cat/agendas/pilar-diaz-i-romero/eventos-pasados?list_view=true). If a use wants to see older events she can use the calendar in the left sidebar to navigate across days.

The reason is the OFFSET parameter, a deep pagination uses a super-high offset, which for Postgres is really hard to process, because it has to bulid the query sorted, and then iterate until the OFFSET.

This is not the final solution, probably we should fix the query and the offset, but for know it leverages a hundreds of slow queries per hour.

