### PR TITLE
Import plan images

### DIFF
--- a/app/javascript/stylesheets/gobierto-plans.scss
+++ b/app/javascript/stylesheets/gobierto-plans.scss
@@ -696,8 +696,7 @@ $nodeLevel1HeightMobile: 20vh;
       flex-wrap: wrap;
 
       img {
-        width: 50%;
-        flex: 0 0 50%;
+        width: 100%;
         object-fit: cover;
       }
     }

--- a/app/models/gobierto_common/custom_field.rb
+++ b/app/models/gobierto_common/custom_field.rb
@@ -84,6 +84,10 @@ module GobiertoCommon
       self.class.field_types_with_multiple_setting.include? field_type
     end
 
+    def multiple?
+      allow_multiple? && configuration.multiple
+    end
+
     def long_text?
       /paragraph/.match field_type
     end


### PR DESCRIPTION
Closes PopulateTools/issues#1936


## :v: What does this PR do?

Adds methods to PlainCustomFieldValueDecorator used by the plans import form from CSV to process a field with markdown containing images to:
* Extract the images src and the alt text from the HTML (if present)
* Download the src content and verify that the content is an image
* Generate an attachment for each image
* Update the associated custom field value (of type image) with the list of images using the URLs of the generated attachments

The PR also changes slightly the styles to display the images in the field with 100% width

## :mag: How should this be manually tested?

Create a plan with a custom field of type image with multiple option and import from a CSV the plan including a column with the uid of the image field containing lists of images in markdown format.

Example of plan: 
* Project with imported images: https://madrid.gobify.net/planes/plan-de-gobierno/2035/proyecto/27997
* Admin plan: https://madrid.gobify.net/admin/plans/59/import_csv
* CSV imported: https://docs.google.com/spreadsheets/d/19VeC13hc0FcQrOzc6idVFpezgkOMkOm7on9wqsoqP3o/edit?usp=sharing

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- Added suggestion to readme.io https://gobierto.readme.io/suggested-edits/65e70752cf0ebf001f6a4ae0
