### PR TITLE
Plans data-attributes for the custom fields

### DIFF
--- a/app/javascript/gobierto_plans/webapp/components/CustomFieldVocabulary.vue
+++ b/app/javascript/gobierto_plans/webapp/components/CustomFieldVocabulary.vue
@@ -1,8 +1,9 @@
 <template>
-  <div v-if="isSDG">
-    <!-- this vocabulary has a different layout -->
-    <CustomFieldVocabularySDG :attributes="attributes" />
-  </div>
+  <!-- this vocabulary has a different layout -->
+  <CustomFieldVocabularySDG
+    v-if="isSDG"
+    :attributes="attributes"
+  />
   <div v-else>
     <template
       v-for="{ id, name, group, term, hasLink } in vocabularies"
@@ -12,12 +13,14 @@
         :key="id"
         :to="{ name: routes.TERM, params: { ...params, id: group, term } }"
         class="project-description__link"
+        :data-vocabulary-term-slug="term"
       >
         {{ name }}
       </router-link>
       <div
         v-else
-        :key="id"
+        :key="`vocab-${id}`"
+        :data-vocabulary-term-slug="term"
       >
         {{ name }}
       </div>

--- a/app/javascript/gobierto_plans/webapp/components/ProjectCustomFields.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ProjectCustomFields.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="project-description">
+  <div
+    class="project-description"
+    :data-custom-field-slug="attributes.uid"
+  >
     <template v-if="pluginType">
       <template v-if="rawIndicatorsType">
         <div class="project-description__title">

--- a/app/javascript/stylesheets/gobierto-plans.scss
+++ b/app/javascript/stylesheets/gobierto-plans.scss
@@ -684,6 +684,7 @@ $nodeLevel1HeightMobile: 20vh;
     &__desc {
       font-size: 14px;
       word-break: break-word;
+      flex: 1;
     }
 
     &__link {


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1944

## :v: What does this PR do?
Include `data-custom-field-slug` and `data-vocabulary-term-slug` to identifiy the custom fields

Example: https://terrassa.gobify.net/planes/pla-d-actuacio-municipal/2024/proyecto/28149?preview_token=frDntpwEaRWjuQ9izG1g1KHk