### PR TITLE
Disambiguate the query to detect sdg custom field

### DIFF
--- a/app/decorators/gobierto_plans/sdg_decorator.rb
+++ b/app/decorators/gobierto_plans/sdg_decorator.rb
@@ -79,7 +79,7 @@ module GobiertoPlans
     def sdg_field
       return if configuration_data.blank?
 
-      @sdg_field ||= site.custom_fields.find_by(uid: configuration_data["sdg_uid"])
+      @sdg_field ||= site.custom_fields.find_by(uid: configuration_data["sdg_uid"], instance: self)
     end
 
     def nodes_query


### PR DESCRIPTION
Closes PopulateTools/issues#1954

## :v: What does this PR do?

Fixes the query to detect the custom field associated to the SDG to consider both the plan configuration and the plan itself. The PR avoid errors detecting SDGs associated to other plans

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No