### PR TITLE
Include debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,6 @@ gem 'prime'
 gem 'net-imap'
 
 group :development, :test do
-  gem "byebug", platform: :mri
   gem "i18n-tasks"
   gem "spring"
   gem "puma"

--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,8 @@ group :development, :test do
   gem "i18n-tasks"
   gem "spring"
   gem "puma"
+  # https://world.hey.com/lewis/run-multiple-rails-apps-with-puma-dev-67b1c10f
+  gem "debug", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -584,7 +583,6 @@ DEPENDENCIES
   bcrypt (~> 3.1.0)
   before_renders
   bootsnap
-  byebug
   capybara
   capybara-email
   charlock_holmes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
     crass (1.0.6)
     dalli (3.2.3)
     date (3.3.3)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     device_detector (1.1.0)
@@ -270,6 +273,10 @@ GEM
       activesupport (>= 4.2)
     invisible_captcha (2.0.0)
       rails (>= 5.0)
+    io-console (0.7.2)
+    irb (1.12.0)
+      rdoc
+      reline (>= 0.4.2)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
@@ -437,9 +444,12 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
+    rdoc (6.3.3)
     redcarpet (3.5.1)
     redis (4.5.1)
     regexp_parser (2.1.1)
+    reline (0.4.3)
+      io-console (~> 0.5)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -580,6 +590,7 @@ DEPENDENCIES
   charlock_holmes
   cookies_eu
   dalli
+  debug
   elasticsearch (~> 6.0, >= 6.0.2)
   elasticsearch-extensions (~> 0.0.27)
   exchanger

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "debug/open_nonstop"
+
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "debug"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
## :v: What does this PR do?
Include the new ruby's debug gem. It works alongwith puma `puma-dev -sysbind` (instead of `rails server`), through `rdgb --attach` CLI command.

https://world.hey.com/lewis/run-multiple-rails-apps-with-puma-dev-67b1c10f
https://github.com/ruby/debug
https://gobierto.readme.io/docs/development-environment-1#debugging-backend-with-puma-dev