### PR TITLE
Plans tabs active status

### DIFF
--- a/app/javascript/gobierto_plans/webapp/components/ButtonFilters.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ButtonFilters.vue
@@ -14,7 +14,7 @@
       :key="id"
       :to="{ name: routes.TABLE, params: { ...$route.params, id } }"
       class="planification-buttons__button"
-      :class="{ 'is-active': id === currentId }"
+      :class="{ 'is-active': id === currentId && !isActiveButton }"
       tag="button"
     >
       {{ labelViewBy }} <strong>{{ name | translate }}</strong>


### PR DESCRIPTION
Closes [#1955](https://github.com/PopulateTools/issues/issues/1955)

## :v: What does this PR do?
Enforces the condition to set the active status for the plan tabs

https://terrassa.gobify.net/planes/pla-d-actuacio-municipal/2024