### PR TITLE
Attachments events

### DIFF
--- a/app/controllers/concerns/application_concern.rb
+++ b/app/controllers/concerns/application_concern.rb
@@ -3,7 +3,7 @@
 module ApplicationConcern
   extend ActiveSupport::Concern
 
-  BLOCKLIST_TRACKABLE_KEYS = %w(password password_confirmation authenticity_token utf8).freeze
+  BLOCKLIST_TRACKABLE_KEYS = %w(password password_confirmation authenticity_token utf8 file).freeze
 
   included do
     before_action :set_current_site, :set_locale

--- a/lib/tasks/gobierto_core/remove_events_files_metadata.rake
+++ b/lib/tasks/gobierto_core/remove_events_files_metadata.rake
@@ -3,7 +3,7 @@
 namespace :gobierto_core do
   desc "Removes files metadata of admin API attachments controller events"
   task remove_events_files_metadata: :environment do
-    Ahoy::Event.where("name LIKE ?", "%gobierto_admin/gobierto_attachments/api/attachments%").each do |event|
+    Ahoy::Event.where("name LIKE ?", "%gobierto_admin/gobierto_attachments/api/attachments%").find_each do |event|
       next unless event.properties.dig("attachment", "file").present?
 
       properties = event.properties

--- a/lib/tasks/gobierto_core/remove_events_files_metadata.rake
+++ b/lib/tasks/gobierto_core/remove_events_files_metadata.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :gobierto_core do
+  desc "Removes files metadata of admin API attachments controller events"
+  task remove_events_files_metadata: :environment do
+    Ahoy::Event.where("name LIKE ?", "%gobierto_admin/gobierto_attachments/api/attachments%").each do |event|
+      next unless event.properties.dig("attachment", "file").present?
+
+      properties = event.properties
+      properties["attachment"] = properties["attachment"].except("file")
+      event.update_attribute(:properties, properties)
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1954

## :v: What does this PR do?

This PR:
* Adds a filter in params to not store the `file` param in the track_request method avoiding the storage of files content in the events database table
* Adds a task to remove the `file` metadata in the attachments admin events

## :mag: How should this be manually tested?

Upload investments data using the API including images. The new events for created images should not include the file content in the properties["attachment"] attribute

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No