### PR TITLE
Update ca.yml to fix untranslated catalan string for moderation status

### DIFF
--- a/config/locales/gobierto_admin/views/shared/ca.yml
+++ b/config/locales/gobierto_admin/views/shared/ca.yml
@@ -53,7 +53,7 @@ ca:
           in_review: En revisió
           not_sent: No enviat
           rejected: No aprovat
-          sent: Sent
+          sent: Enviat
         new_version: Nova (no guardada)
         preview: Previsualitzar
         previous_versions: Versions anteriors


### PR DESCRIPTION
Related to this PR https://github.com/PopulateTools/gobierto/pull/4226

The string for the option in the project form was in this other file

cc @ferblape 