### PR TITLE
Skip budget line when the reference value is missing

### DIFF
--- a/app/models/gobierto_budgets/data/budget_execution_comparison.rb
+++ b/app/models/gobierto_budgets/data/budget_execution_comparison.rb
@@ -40,6 +40,7 @@ module GobiertoBudgets
           budget_line_forecast_updated = budget_lines_forecast_updated.detect { |bl| bl.code == budget_line_forecast.code }
           execution_amount = budget_line_execution.try(:amount) || 0
           forecast_amount = budget_line_forecast_updated ? budget_line_forecast_updated.amount : budget_line_forecast.amount
+          next if forecast_amount == 0 || forecast_amount.nil?
 
           category = kind == GobiertoBudgets::BudgetLine::EXPENSE ? "expense_" : "income_"
           category += area


### PR DESCRIPTION
## :v: What does this PR do?

Related with https://github.com/PopulateTools/issues/issues/1989

This PR avoids an error in the comparison of budget lines executed, when the compared budget line value is missing.

Since this is something exceptional, it might happen specially in deep categories, where the values from the forecast are missing.

## :mag: How should this be manually tested?

Tiana execution should work for 2024.
