### PR TITLE
Fix barchart stacked data

### DIFF
--- a/app/assets/stylesheets/visualizations.scss
+++ b/app/assets/stylesheets/visualizations.scss
@@ -1284,6 +1284,21 @@
     .header_block_inline h2 {
       margin-bottom: $f6;
     }
+
+    .bar-chart-stacked-debts {
+      .extra-legend-text {
+        font-size: 14px;
+        font-weight: bold;
+        text-transform: capitalize;
+        fill: #828282;
+      }
+
+      .extra-legend-value {
+        font-size: 14px;
+        fill: #828282;
+      }
+    }
+
     .bar-chart-small-debts {
       text.label {
         font-size: $f7;
@@ -1304,38 +1319,6 @@
         transform:translate(0, -2px);
       }
 
-    }
-    .gv-tooltip-bar-stacked .tooltip-barchart-stacked-grid-key-color {
-      &.Ajuntament {
-        background-color: var(--gv-color-2);
-      }
-      &.MataroAudiovisual {
-        background-color: var(--gv-color-3);
-      }
-      &.DigitialMataroMaresme {
-        background-color: var(--gv-color-4);
-      }
-      &.ConsorciResidus {
-        background-color: var(--gv-color-5);
-      }
-      &.PUMSA {
-        background-color: var(--gv-color-6);
-      }
-      &.GrupTecnocampus {
-        background-color: var(--gv-color-7);
-      }
-      &.AMSA {
-        background-color: var(--gv-color-8);
-      }
-      &.DeuteFCC {
-        background-color: var(--gv-color-9);
-      }
-      &.PortaLaietana {
-        background-color: var(--gv-color-10);
-      }
-      &.Altrespiemessa {
-        background-color: var(--gv-color-11);
-      }
     }
   }
 

--- a/app/javascript/gobierto_visualizations/modules/debts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/debts_controller.js
@@ -58,7 +58,10 @@ export class DebtsController {
 
         this.vueApp = new Vue({
           router,
-          data,
+          // data,
+          provide: {
+            data
+          }
         }).$mount(entryPoint);
       });
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "flightjs": "^1.5.2",
     "fullcalendar": "^3.9.0",
     "geocomplete": "^1.7.0",
-    "gobierto-vizzs": "^3.1.1",
+    "gobierto-vizzs": "^3.1.2",
     "html-to-image": "^1.9.0",
     "i18n-js": "^3.0.3",
     "jest": "^27.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3339,10 +3339,10 @@ globjoin@^0.1.4:
   resolved "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
 
-gobierto-vizzs@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/gobierto-vizzs/-/gobierto-vizzs-3.1.1.tgz#6265a3532f5578f454d5c667cc7412c0b6c565a5"
-  integrity sha512-cdPj1AbPJ1K7sNsUB0108Ki5mHmjqw+l8aA49lWVASqOAmaNH21J6JZvXg2RAOHUDcQSqIL32ydvJxtiurLJzg==
+gobierto-vizzs@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/gobierto-vizzs/-/gobierto-vizzs-3.1.2.tgz#6d50c67af5f2cb71809b732e814f52810b8cec38"
+  integrity sha512-8p/AqM4IqFJz1MkQpzOhRPXHcO8IdeQAPftjppwN5G/hsA75Z2LpYjetcA+QWTS08vJEDK1fmta3xcx69r9sPQ==
   dependencies:
     d3-array "^3.2.4"
     d3-axis "^3.0.0"


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1991

## :v: What does this PR do?
Since the latest updates of gobierto-vizzs library, a refactor of the data-preparation is required to pass to the BarStackedChart.

It includes a distinctive feature (specialises the original visualization) for this particular chart, the _extraLegend_ property. That has been fetched from the original library, where that has been purged.

https://mataro.gobify.net/visualizaciones/deuda
