### PR TITLE
Action Lines table configurable

### DIFF
--- a/app/javascript/gobierto_plans/webapp/components/ActionLines.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLines.vue
@@ -1,19 +1,19 @@
 <template>
   <ul class="action-line--list">
-    <template v-for="model in models">
-      <ActionLine
+    <ActionLine
+      v-for="model in models"
+      :key="model.id"
+      :model="model"
+      :options="options"
+    >
+      <ActionLinesTableView
         :key="model.id"
         :model="model"
+        :header="showTableHeader"
+        :open="openNode"
         :options="options"
-      >
-        <ActionLinesTableView
-          :key="model.id"
-          :model="model"
-          :header="showTableHeader"
-          :open="openNode"
-        />
-      </ActionLine>
-    </template>
+      />
+    </ActionLine>
   </ul>
 </template>
 

--- a/app/javascript/gobierto_plans/webapp/components/ActionLinesTableView.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLinesTableView.vue
@@ -4,15 +4,20 @@
       <th>
         <NumberLabel :level="level + 1" />
       </th>
-      <th>{{ labelStarts }}</th>
-      <th>{{ labelStatus }}</th>
-      <th>{{ labelProgress }}</th>
+      <th
+        v-for="[key, value] in tableHeaders"
+        :key="key"
+      >
+        {{ value }}
+      </th>
     </thead>
     <tbody>
       <ActionLinesTableViewRow
         v-for="row in children"
         :key="row.id"
         :model="row"
+        :default-table-fields="defaultTableFields"
+        :options="options"
         :style="{ cursor: !open ? 'pointer' : '' }"
         @click.native="getProject(row)"
       />
@@ -23,6 +28,7 @@
 <script>
 import NumberLabel from './NumberLabel.vue';
 import ActionLinesTableViewRow from './ActionLinesTableViewRow.vue';
+import { NamesMixin } from '../lib/mixins/names';
 import { routes } from '../lib/router';
 
 export default {
@@ -31,6 +37,7 @@ export default {
     NumberLabel,
     ActionLinesTableViewRow
   },
+  mixins: [NamesMixin],
   props: {
     model: {
       type: Object,
@@ -43,22 +50,29 @@ export default {
     open: {
       type: Boolean,
       default: false
+    },
+    options: {
+      type: Object,
+      default: () => {}
     }
   },
   data() {
     return {
-      labelStarts: I18n.t("gobierto_plans.plan_types.show.starts") || '',
-      labelStatus: I18n.t("gobierto_plans.plan_types.show.status") || '',
-      labelProgress: I18n.t("gobierto_plans.plan_types.show.progress") || '',
       children: [],
-      level: 0
+      level: 0,
+      tableHeaders: [],
+      defaultTableFields: ["starts_at", "status_id", "progress"]
     };
   },
   created() {
     const { children, level } = this.model
+    const {
+      show_table_extra_fields = this.defaultTableFields
+    } = this.options;
 
     this.children = children
     this.level = level
+    this.tableHeaders = show_table_extra_fields.map(key => [key, this.getName(key)])
   },
   methods: {
     getProject(row) {

--- a/app/javascript/gobierto_plans/webapp/components/ActionLinesTableView.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLinesTableView.vue
@@ -61,7 +61,7 @@ export default {
       children: [],
       level: 0,
       tableHeaders: [],
-      defaultTableFields: ["starts_at", "status_id", "progress"]
+      defaultTableFields: ["starts_at", "status", "progress"]
     };
   },
   created() {

--- a/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRow.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRow.vue
@@ -46,12 +46,9 @@ export default {
     // name is always shown
     this.columns = [
       ["name", this.model.attributes.name],
-      ...Object.entries(this.model.attributes)
-        // NOTE: "status" field comes from the API as an attribute called "status_id"
-        // however, the api endpoint /meta still saying the field name is "status"
-        // hence, remove that suffix to match the value of that field
-        .filter(x => show_table_extra_fields.includes(x[0].replace(/_id$/, "")))
-        .sort((a, b) => show_table_extra_fields.indexOf(a[0]) - show_table_extra_fields.indexOf(b[0]))
+      // NOTE: "status" field comes from the API as an attribute called "status_id"
+      // however, the api endpoint /meta still saying the field name is "status"
+      ...show_table_extra_fields.map(x => [x, x === "status" ? this.model.attributes["status_id"] : this.model.attributes[x]])
     ]
   },
   methods: {

--- a/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRowCell.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRowCell.vue
@@ -6,7 +6,7 @@
     <template v-else-if="column === 'starts_at' || column === 'ends_at'">
       {{ value | date }}
     </template>
-    <template v-else-if="column === 'status_id'">
+    <template v-else-if="column === 'status'">
       {{ status }}
     </template>
     <template v-else-if="vocabularyType">

--- a/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRowCell.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRowCell.vue
@@ -1,0 +1,59 @@
+<template>
+  <td>
+    <template v-if="column === 'progress'">
+      {{ value | percent }}
+    </template>
+    <template v-else-if="column === 'starts_at' || column === 'ends_at'">
+      {{ value | date }}
+    </template>
+    <template v-else-if="column === 'status_id'">
+      {{ status }}
+    </template>
+    <template v-else-if="vocabularyType">
+      {{ vocabularyValue }}
+    </template>
+    <template v-else>
+      {{ value }}
+    </template>
+  </td>
+</template>
+
+<script>
+import { date, percent } from '../../../lib/vue/filters';
+import { FieldTypeMixin } from '../lib/mixins/field-type';
+import { NamesMixin } from '../lib/mixins/names';
+
+export default {
+  name: "ActionLinesTableViewRowCell",
+  filters: {
+    percent,
+    date
+  },
+  mixins: [NamesMixin, FieldTypeMixin],
+  props: {
+    column: {
+      type: String,
+      default: ""
+    },
+    value: {
+      type: [Number, String],
+      default: ""
+    },
+    attributes: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  data() {
+    return {
+      status: this.getStatus(this.value)
+    }
+  },
+  computed: {
+    vocabularyValue() {
+      const { attributes: { name } = {} } = this.attributes.vocabulary_terms.find(x => x.id === this.value)
+      return name
+    }
+  }
+};
+</script>

--- a/app/javascript/gobierto_plans/webapp/components/Project.vue
+++ b/app/javascript/gobierto_plans/webapp/components/Project.vue
@@ -7,13 +7,11 @@
 
     <div class="node-project-detail">
       <ProjectNativeFields :model="model" />
-
-      <template v-for="{ id, attributes } in customFields">
-        <ProjectCustomFields
-          :key="id"
-          :attributes="attributes"
-        />
-      </template>
+      <ProjectCustomFields
+        v-for="{ id, attributes } in customFields"
+        :key="id"
+        :attributes="attributes"
+      />
     </div>
   </div>
 </template>

--- a/app/javascript/gobierto_plans/webapp/pages/ProjectsByTerm.vue
+++ b/app/javascript/gobierto_plans/webapp/pages/ProjectsByTerm.vue
@@ -35,20 +35,19 @@
               </template>
             </div>
           </li>
-          <template v-for="{ id, attributes } in projectsSorted">
-            <ProjectsByTermTableRow
-              :key="id"
-              v-slot="{ column, opts }"
-              :marked="currentId === id"
-              :columns="selectedColumns"
-            >
-              <TableCellTemplates
-                :column="column"
-                :attributes="{ ...opts, id, value: attributes[column] }"
-                @current-project="setCurrentProject"
-              />
-            </ProjectsByTermTableRow>
-          </template>
+          <ProjectsByTermTableRow
+            v-for="{ id, attributes } in projectsSorted"
+            :key="id"
+            v-slot="{ column, opts }"
+            :marked="currentId === id"
+            :columns="selectedColumns"
+          >
+            <TableCellTemplates
+              :column="column"
+              :attributes="{ ...opts, id, value: attributes[column] }"
+              @current-project="setCurrentProject"
+            />
+          </ProjectsByTermTableRow>
         </ul>
       </div>
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import pluginVue from 'eslint-plugin-vue'
 
 export default [
   js.configs.recommended,
-  ...pluginVue.configs['flat/recommended'],
+  ...pluginVue.configs['flat/vue2-recommended'], // as long as we use Vue2
   {
     languageOptions: {
       ecmaVersion: 2022,


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/2007

## :v: What does this PR do?
Allow to display different custom fields in the action lines table, within the categories tree, apart of the name. By default, it shows `starts_at`. `status`, `progress`.

In order to alter the default columns, in the plans configuration json, the new property is called `show_table_extra_fields` and accepts an array of column names.

https://mataro.gobify.net/planes/pla-de-mandat/2023/categoria/21991

## :book: Does this PR require updating the documentation?

- [x] new site configuration variable?

https://gobierto.readme.io/docs/planificiacion#configuraci%C3%B3n

