### PR TITLE
Project view configurable

### DIFF
--- a/app/javascript/gobierto_plans/webapp/Main.vue
+++ b/app/javascript/gobierto_plans/webapp/Main.vue
@@ -112,7 +112,6 @@ export default {
           uid: "status",
           field_type: "vocabulary_options",
           vocabulary_terms: status,
-          hidden: true,
           name_translations: Object.keys(I18n.translations).reduce(
             (acc, key) => ({
               ...acc,

--- a/app/javascript/gobierto_plans/webapp/components/Project.vue
+++ b/app/javascript/gobierto_plans/webapp/components/Project.vue
@@ -41,17 +41,21 @@ export default {
   },
   created() {
     const { meta, options } = PlansStore.state;
-    const { show_empty_fields = true } = options;
+    const { show_empty_fields = true, show_project_fields } = options;
     const { attributes = {} } = this.model;
     const { name } = attributes
 
     this.title = name;
+
+    // filter only the columns specified in the configuration
+    const fields = show_project_fields ? show_project_fields.map(x => meta.find(y => y.attributes.uid === x)) : meta
+
     // Expand the META object with the matching values for this project
-    this.customFields = meta.reduce((acc, item) => {
-      const { uid, hidden } = item.attributes;
+    this.customFields = fields.reduce((acc, item) => {
+      const { uid } = item.attributes;
       const value = attributes[uid];
 
-      if (!hidden && (show_empty_fields || (value && value.length)) ){
+      if (show_empty_fields || !!value) {
         acc.push({
           ...item,
           attributes: { ...item.attributes, value }
@@ -59,7 +63,7 @@ export default {
       }
 
       return acc;
-    }, []);
+    }, [])
   }
 };
 </script>

--- a/app/javascript/gobierto_plans/webapp/components/ProjectNativeFields.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ProjectNativeFields.vue
@@ -23,14 +23,6 @@
           {{ endsAt | date }}
         </div>
       </div>
-      <div class="mandatory-list">
-        <div class="mandatory-title">
-          {{ labelStatus }}
-        </div>
-        <div class="mandatory-desc">
-          {{ status }}
-        </div>
-      </div>
     </div>
   </div>
 </template>
@@ -56,13 +48,11 @@ export default {
     return {
       labelStarts: I18n.t("gobierto_plans.plan_types.show.starts") || "",
       labelEnds: I18n.t("gobierto_plans.plan_types.show.ends") || "",
-      labelStatus: I18n.t("gobierto_plans.plan_types.show.status") || "",
       labelProgress:
         I18n.t("gobierto_plans.plan_types.show.progress").toLowerCase() || "",
       progress: "",
       startsAt: null,
-      endsAt: null,
-      status: ""
+      endsAt: null
     };
   },
   computed: {
@@ -72,13 +62,12 @@ export default {
   },
   created() {
     const {
-      attributes: { progress, starts_at, ends_at, status_id }
+      attributes: { progress, starts_at, ends_at }
     } = this.model;
 
     this.progress = progress;
     this.startsAt = starts_at;
     this.endsAt = ends_at;
-    this.status = this.getStatus(status_id)
   }
 };
 </script>

--- a/app/javascript/gobierto_plans/webapp/lib/mixins/active-node.js
+++ b/app/javascript/gobierto_plans/webapp/lib/mixins/active-node.js
@@ -1,4 +1,5 @@
 import { findRecursive } from '../helpers';
+import { NamesMixin } from './names';
 
 export const ActiveNodeMixin = {
   data() {
@@ -7,6 +8,7 @@ export const ActiveNodeMixin = {
       rootid: 0
     }
   },
+  mixins: [NamesMixin],
   watch: {
     $route(to) {
       const {
@@ -35,6 +37,11 @@ export const ActiveNodeMixin = {
 
         // to determine the colors
         this.rootid = rootid
+
+        // NOTE: since "status" field does not come from the API,
+        // we fake it as a custom_field, copying the value of the identificator
+        // see more: https://github.com/PopulateTools/issues/issues/2005
+        this.activeNode.attributes.status = this.activeNode.attributes.status_id.toString()
       }
     },
   }


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/2005

## :v: What does this PR do?
Treats the status variable as another custom field, that is, is moved from the _native_ fields block to the _custom_ fields block. Allows to set an order (and a filter) for the projects fields displayed. In order toachieve this, a new configuration variable is included: `show_project_fields`, accepts an array of the field names.

https://mataro.gobify.net/planes/pla-de-mandat/2023/proyecto/20949

Production plan sites:
- https://portalobert.esplugues.cat/planes/pam/2023
- https://pressupostos.terrassa.cat/planes/pam/2023
- https://transparencia.badiadelvalles.net/planes/pla-d-actuacio-municipal/2024 (borrador)

## :book: Does this PR require updating the documentation?

- [x] new site configuration variable?

https://gobierto.readme.io/docs/planificiacion#configuraci%C3%B3n