### PR TITLE
Table view custom fields

### DIFF
--- a/app/javascript/gobierto_plans/webapp/Main.vue
+++ b/app/javascript/gobierto_plans/webapp/Main.vue
@@ -103,8 +103,8 @@ export default {
           ({ attributes }) => attributes.field_type === "vocabulary_options"
         ) || {};
 
-      // append the "new" custom field
-      meta.push({
+      // prepend the "new" custom field
+      meta.unshift({
         ...sample,
         id: -1,
         attributes: {

--- a/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRowCell.vue
+++ b/app/javascript/gobierto_plans/webapp/components/ActionLinesTableViewRowCell.vue
@@ -1,16 +1,13 @@
 <template>
-  <td>
+  <td :data-custom-field-slug="attributes.uid">
     <template v-if="column === 'progress'">
       {{ value | percent }}
     </template>
     <template v-else-if="column === 'starts_at' || column === 'ends_at'">
       {{ value | date }}
     </template>
-    <template v-else-if="column === 'status'">
-      {{ status }}
-    </template>
     <template v-else-if="vocabularyType">
-      {{ vocabularyValue }}
+      <span :data-vocabulary-term-slug="vocabularySlug">{{ vocabularyValue }}</span>
     </template>
     <template v-else>
       {{ value }}
@@ -50,10 +47,16 @@ export default {
     }
   },
   computed: {
+    vocabulary() {
+      const { attributes: { name: value, slug } = {} } = this.attributes.vocabulary_terms.find(x => x.id === this.value.toString())
+      return { value, slug }
+    },
     vocabularyValue() {
-      const { attributes: { name } = {} } = this.attributes.vocabulary_terms.find(x => x.id === this.value)
-      return name
-    }
+      return this.vocabulary.value
+    },
+    vocabularySlug() {
+      return this.vocabulary.slug
+    },
   }
 };
 </script>

--- a/app/javascript/gobierto_plans/webapp/components/TableCellTemplates.vue
+++ b/app/javascript/gobierto_plans/webapp/components/TableCellTemplates.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :data-custom-field-slug="column">
+  <div :data-custom-field-slug="attributes.uid">
     <template v-if="column === 'name'">
       <div
         class="planification-table__td-name"

--- a/app/javascript/gobierto_plans/webapp/components/TableCellTemplates.vue
+++ b/app/javascript/gobierto_plans/webapp/components/TableCellTemplates.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :data-custom-field-slug="column">
     <template v-if="column === 'name'">
       <div
         class="planification-table__td-name"
@@ -13,9 +13,6 @@
     </template>
     <template v-else-if="column === 'starts_at' || column === 'ends_at'">
       {{ value | date }}
-    </template>
-    <template v-else-if="column === 'status_id'">
-      {{ status }}
     </template>
     <template v-else-if="vocabularyType">
       <CustomFieldVocabulary :attributes="attributes" />
@@ -46,7 +43,6 @@ import CustomFieldParagraph from '../components/CustomFieldParagraph.vue';
 import CustomFieldPluginRawIndicators from '../components/CustomFieldPluginRawIndicators.vue';
 import { FieldTypeMixin } from '../lib/mixins/field-type';
 import { percent, date } from '../../../lib/vue/filters';
-import { NamesMixin } from '../lib/mixins/names';
 
 export default {
   name: "TableCellTemplates",
@@ -61,7 +57,7 @@ export default {
     percent,
     date
   },
-  mixins: [NamesMixin, FieldTypeMixin],
+  mixins: [FieldTypeMixin],
   props: {
     attributes: {
       type: Object,
@@ -74,20 +70,17 @@ export default {
   },
   data() {
     return {
-      id: null,
       value: null,
-      status: ""
     }
   },
   created() {
-    const { value, id } = this.attributes
-    this.id = id
+    const { value, projectId } = this.attributes
+    this.projectId = projectId
     this.value = value
-    this.status = this.getStatus(this.value)
   },
   methods: {
     setCurrentProject() {
-      this.$emit('current-project', this.id)
+      this.$emit('current-project', this.projectId)
     }
   }
 };

--- a/app/javascript/gobierto_plans/webapp/lib/mixins/active-node.js
+++ b/app/javascript/gobierto_plans/webapp/lib/mixins/active-node.js
@@ -41,7 +41,9 @@ export const ActiveNodeMixin = {
         // NOTE: since "status" field does not come from the API,
         // we fake it as a custom_field, copying the value of the identificator
         // see more: https://github.com/PopulateTools/issues/issues/2005
-        this.activeNode.attributes.status = this.activeNode.attributes.status_id.toString()
+        if (Object.hasOwn(this.activeNode.attributes, "status_id")) {
+          this.activeNode.attributes.status = this.activeNode.attributes.status_id.toString()
+        }
       }
     },
   }

--- a/app/javascript/gobierto_plans/webapp/lib/mixins/names.js
+++ b/app/javascript/gobierto_plans/webapp/lib/mixins/names.js
@@ -42,7 +42,11 @@ export const NamesMixin = {
     },
     // helper to extract the attributes from the uid
     getAttributes(id) {
-      const { attributes = {} } = this.meta.find(({ attributes: { uid } = {} }) => uid === id) || {};
+      const { attributes = {} } =
+        this.meta.find(
+          ({ attributes: { uid } = {} }) =>
+            uid === (id === "status_id" ? "status" : id)
+        ) || {};
       return attributes
     },
     // helper to extract the label from the configuration

--- a/app/javascript/gobierto_plans/webapp/pages/ProjectsByTerm.vue
+++ b/app/javascript/gobierto_plans/webapp/pages/ProjectsByTerm.vue
@@ -210,6 +210,13 @@ export default {
     setCurrentProject(id) {
       const { id: prevId } = this.activeNode || {};
       this.activeNode = id === prevId ? null : findRecursive(this.json, id);
+
+      // NOTE: since "status" field does not come from the API,
+      // we fake it as a custom_field, copying the value of the identificator
+      // see more: https://github.com/PopulateTools/issues/issues/2005
+      if (Object.hasOwn(this.activeNode.attributes, "status_id")) {
+        this.activeNode.attributes.status = this.activeNode.attributes.status_id.toString()
+      }
     },
     toggleVisibility({ id, value }) {
       this.map.set(id, { ...this.map.get(id), visibility: value })

--- a/app/javascript/gobierto_plans/webapp/pages/ProjectsByTerm.vue
+++ b/app/javascript/gobierto_plans/webapp/pages/ProjectsByTerm.vue
@@ -36,15 +36,21 @@
             </div>
           </li>
           <ProjectsByTermTableRow
-            v-for="{ id, attributes } in projectsSorted"
-            :key="id"
-            v-slot="{ column, opts }"
-            :marked="currentId === id"
+            v-for="{ id: projectId, attributes } in projectsSorted"
+            :key="projectId"
+            v-slot="{ column, options: opts }"
+            :marked="currentId === projectId"
             :columns="selectedColumns"
           >
             <TableCellTemplates
               :column="column"
-              :attributes="{ ...opts, id, value: attributes[column] }"
+              :attributes="{
+                ...opts,
+                projectId,
+                value: column === 'status_id'
+                  ? attributes[column].toString() // Since status was a native field, the value comes as Number, however, other custom fields' values come as String
+                  : attributes[column]
+              }"
               @current-project="setCurrentProject"
             />
           </ProjectsByTermTableRow>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/2026

## :v: What does this PR do?
- Parses the status property as a regular custom field.
- Includes a data-attribute to point the custom field values
- Replace the custom field ids with the correspondent term in the table view

https://mataro.gobify.net/planes/pla-de-mandat/2023/tabla/nomouact/agencia-de-suport-i-serveis-a-les-entitats