### PR TITLE
Handle empty categories

### DIFF
--- a/app/assets/stylesheets/modules/_comp-graph-dc.scss
+++ b/app/assets/stylesheets/modules/_comp-graph-dc.scss
@@ -26,6 +26,10 @@
   &.deselected {
     fill: #ccc;
   }
+
+  &.selected + text tspan {
+    font-style: italic;
+  }
 }
 
 .dc-chart g.row text,

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -505,19 +505,12 @@ export class ContractsController {
   _updateChartsFromFilter(options) {
     const container = this.charts[options.id].container;
 
-    // https://dc-js.github.io/dc.js/docs/html/BaseMixin.html#filter__anchor
-    // - filter(null) removes any existing filter.
-    // - If all filters are set at one (options.all), we first remove the existing ones
-    // - Note: when you add more than 1 filter, you need to add an array within an array
-    if (options.all) {
-      container.filter(null);
-      container.filter([options.titles]);
-    } else {
-      container.filter(options.title);
-    }
+    // apply the filters
+    container.filter(options.all ? null : options.title);
 
     Object.values(this.charts).forEach(chart => {
-      const hasData = chart.container.data().reduce((acc, item) => acc + item.value, 0) !== 0
+      // Math.round in order to avoid a javascript issue handling floating numbers (very tiny decimals)
+      const hasData = chart.container.data().reduce((acc, item) => acc + Math.round(item.value), 0) !== 0
 
       if (hasData) {
         // remove the no data indicator, if exists

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -10,6 +10,7 @@ import { checkAndReportAccessibility } from '../../lib/vue/accessibility';
 import { money } from '../../lib/vue/filters';
 import { EventBus } from '../webapp/lib/mixins/event_bus';
 import { calculateSumMeanMedian, getRemoteData } from '../webapp/lib/utils';
+import { divide } from '../../lib/shared';
 
 // ESBuild does not work properly with dynamic components
 import Home from '../webapp/containers/contracts/Home.vue';
@@ -313,13 +314,13 @@ export class ContractsController {
       ({ final_amount_no_taxes = 0 }) =>
         parseFloat(final_amount_no_taxes) < 1000
     ).length;
-    const lessThan1000Pct = lessThan1000Total / numberContracts;
+    const lessThan1000Pct = divide(lessThan1000Total, numberContracts);
 
     const largerContractAmount = d3.max(
       _contractsData,
       ({ final_amount_no_taxes = 0 }) => parseFloat(final_amount_no_taxes)
     );
-    const largerContractAmountPct = sumContracts ? (largerContractAmount / sumContracts) : 0;
+    const largerContractAmountPct = sumContracts ? (divide(largerContractAmount, sumContracts)) : 0;
 
     let iteratorAmountsSum = 0,
       numberContractsHalfSpendings = 0;
@@ -331,8 +332,7 @@ export class ContractsController {
         break;
       }
     }
-    const halfSpendingsContractsPct =
-      numberContractsHalfSpendings / numberContracts;
+    const halfSpendingsContractsPct = divide(numberContractsHalfSpendings, numberContracts);
 
     // Updating the DOM
     document.getElementById(

--- a/app/javascript/gobierto_visualizations/modules/contracts_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/contracts_controller.js
@@ -516,7 +516,26 @@ export class ContractsController {
       container.filter(options.title);
     }
 
-    Object.values(this.charts).forEach(chart => chart.container.redraw());
+    Object.values(this.charts).forEach(chart => {
+      const hasData = chart.container.data().reduce((acc, item) => acc + item.value, 0) !== 0
+
+      if (hasData) {
+        // remove the no data indicator, if exists
+        chart.node.nextElementSibling?.remove()
+        // show the original chart
+        chart.node.removeAttribute("style")
+        chart.container.redraw()
+      } else {
+        // add a text label indicating no data, when it's not already present
+        if (!chart.node.nextElementSibling) {
+          const div = document.createElement("div")
+          div.innerHTML = I18n.t("gobierto_common.vue_components.table.no_data")
+          chart.node.insertAdjacentElement("afterend", div);
+        }
+        // hide the original chart
+        chart.node.style.display = "none"
+      }
+    });
   }
 
   _refreshTendersDataFromFilters(filters, tendersAttribute) {

--- a/app/javascript/gobierto_visualizations/modules/subsidies_controller.js
+++ b/app/javascript/gobierto_visualizations/modules/subsidies_controller.js
@@ -10,6 +10,7 @@ import { checkAndReportAccessibility } from '../../lib/vue/accessibility';
 import { money } from '../../lib/vue/filters';
 import { EventBus } from '../webapp/lib/mixins/event_bus';
 import { calculateSumMeanMedian, getRemoteData, sortByField } from '../webapp/lib/utils';
+import { divide } from '../../lib/shared';
 
 // ESBuild does not work properly with dynamic components
 import Home from '../webapp/containers/subsidies/Home.vue';
@@ -216,23 +217,23 @@ export class SubsidiesController {
     const numberSubsidies = subsidiesData.length;
     const [ sumSubsidies, meanSubsidies, medianSubsidies ] = calculateSumMeanMedian(amountsArray)
 
-    const pctCollectivesSubsidies = numberSubsidies ? (parseFloat(collectivesData.length) / numberSubsidies) : 0;
+    const pctCollectivesSubsidies = divide(parseFloat(collectivesData.length), numberSubsidies);
     const [ sumCollectivesSubsidies, meanCollectivesSubsidies, medianCollectivesSubsidies ] = calculateSumMeanMedian(amountsCollectivesArray)
 
-    const pctIndividualsSubsidies = numberSubsidies ? (parseFloat(individualsData.length) / numberSubsidies) : 0;
+    const pctIndividualsSubsidies = divide(parseFloat(individualsData.length), numberSubsidies);
     const [ sumIndividualsSubsidies, meanIndividualsSubsidies, medianIndividualsSubsidies ] = calculateSumMeanMedian(amountsIndividualsArray)
 
     // Calculations headlines
     const lessThan1000Total = subsidiesData.filter(
       ({ amount = 0 }) => parseFloat(amount) < 1000
     ).length;
-    const lessThan1000Pct = numberSubsidies ? (lessThan1000Total / numberSubsidies) : 0;
+    const lessThan1000Pct = divide(lessThan1000Total, numberSubsidies);
 
     const largerSubsidyAmount = d3.max(subsidiesData, ({ amount = 0 }) =>
       parseFloat(amount)
     );
 
-    const largerSubsidyAmountPct = numberSubsidies ? (largerSubsidyAmount / numberSubsidies) : 0;
+    const largerSubsidyAmountPct = divide(largerSubsidyAmount, numberSubsidies);
 
     let iteratorAmountsSum = 0,
       numberSubsidiesHalfSpendings = 0;
@@ -244,7 +245,7 @@ export class SubsidiesController {
         break;
       }
     }
-    const halfSpendingsSubsidiesPct = numberSubsidies ? (numberSubsidiesHalfSpendings / numberSubsidies) : 0;
+    const halfSpendingsSubsidiesPct = divide(numberSubsidiesHalfSpendings, numberSubsidies);
 
     // Updating the DOM
     document.getElementById(

--- a/app/javascript/gobierto_visualizations/webapp/components/TreeMapButtons.vue
+++ b/app/javascript/gobierto_visualizations/webapp/components/TreeMapButtons.vue
@@ -1,18 +1,15 @@
 <template>
   <div class="treemap-nav-container">
     <div class="treemap-nav-buttons button-group">
-      <template
+      <button
         v-for="[key, value] in buttons"
+        :key="key"
+        :class="{ 'active' : active === key }"
+        class="button-grouped sort-G"
+        @click="$emit('active-button', key)"
       >
-        <button
-          :key="key"
-          :class="{ 'active' : active === key }"
-          class="button-grouped sort-G"
-          @click="$emit('active-button', key)"
-        >
-          {{ value }}
-        </button>
-      </template>
+        {{ value }}
+      </button>
     </div>
 
     <slot />

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -7,6 +7,7 @@
       @active-button="handleCategoryActiveButton"
     >
       <div
+        v-show="visualizationsDataExcludeNoCategory.length"
         ref="treemap-category"
         style="height: 400px"
       />
@@ -19,6 +20,7 @@
       @active-button="handleEntityActiveButton"
     >
       <div
+        v-show="visualizationsDataEntity.length"
         ref="treemap-entity"
         style="height: 400px"
       />
@@ -28,7 +30,10 @@
       <h3 class="mt4 graph-title">
         {{ labelBeesWarm }}
       </h3>
-      <div ref="beeswarm" />
+      <div
+        v-show="visualizationsDataExcludeMinorContract.length"
+        ref="beeswarm"
+      />
     </div>
 
     <MetricBoxes id="tendersContractsSummary">
@@ -178,13 +183,13 @@ export default {
   },
   watch: {
     visualizationsDataExcludeNoCategory(n) {
-      this.treemapCategory?.setData(n)
+      n.length && this.treemapCategory?.setData(n)
     },
     visualizationsDataEntity(n) {
-      this.treemapEntity?.setData(n)
+      n.length && this.treemapEntity?.setData(n)
     },
     visualizationsDataExcludeMinorContract(n) {
-      this.beeswarm?.setData(n)
+      n.length && this.beeswarm?.setData(n)
     },
     $route(to, from) {
       if (to.path !== from.path && !this.isGobiertoVizzsLoaded) {

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -1,26 +1,26 @@
 <template>
   <div>
     <TreeMapButtons
+      v-show="visualizationsDataExcludeNoCategory.length"
       id="gobierto-visualizations-treemap-categories"
       :buttons="treemapButtons"
       :active="categoryActiveButton"
       @active-button="handleCategoryActiveButton"
     >
       <div
-        v-show="visualizationsDataExcludeNoCategory.length"
         ref="treemap-category"
         style="height: 400px"
       />
     </TreeMapButtons>
 
     <TreeMapButtons
+      v-show="visualizationsDataEntity.length"
       id="gobierto-visualizations-treemap-entity"
       :buttons="treemapButtons"
       :active="entityActiveButton"
       @active-button="handleEntityActiveButton"
     >
       <div
-        v-show="visualizationsDataEntity.length"
         ref="treemap-entity"
         style="height: 400px"
       />

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <TreeMapButtons
+      v-show="visualizationsData.length"
       id="gobierto-visualizations-treemap-categories"
       :buttons="treemapButtons"
       :active="activeButton"
@@ -149,7 +150,7 @@ export default {
   },
   watch: {
     visualizationsData(n) {
-      this.treemap?.setData(n)
+      n.length && this.treemap?.setData(n)
     },
     $route(to, from) {
       if (to.path !== from.path && !this.isGobiertoVizzsLoaded) {

--- a/app/javascript/lib/shared/index.js
+++ b/app/javascript/lib/shared/index.js
@@ -22,6 +22,7 @@ import { formatNumbers } from './modules/d3-format-numbers.js';
 import appsignal from './modules/appsignal.js';
 import wordwrap from './modules/wordwrap.js';
 import tspans from './modules/tspans.js';
+import divide from './modules/safe-division.js';
 
 export {
   AUTOCOMPLETE_DEFAULTS,
@@ -42,5 +43,6 @@ export {
   formatNumbers,
   appsignal,
   wordwrap,
-  tspans
+  tspans,
+  divide
 };

--- a/app/javascript/lib/shared/modules/safe-division.js
+++ b/app/javascript/lib/shared/modules/safe-division.js
@@ -1,0 +1,4 @@
+export default function divide(a, b, def = 0) {
+  if (b === 0) return def
+  return a / b
+}

--- a/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
+++ b/app/javascript/lib/visualizations/modules/group_pct_distribution_bars.js
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import { truncate } from '../../../lib/vue/filters';
+import { divide } from '../../shared';
 
 /**
  * NOTE: dc@4 has been imported via CDN due to d3 compatibility issues
@@ -37,7 +38,7 @@ export class GroupPctDistributionBars {
       .gap(this._gap)
       .elasticX(true)
       .title(d => d.value)
-      .valueAccessor(d => parseFloat(d.value / all.value()));
+      .valueAccessor(d => parseFloat(divide(d.value, all.value())));
 
     this.container.on("pretransition", function(chart) {
       // Apply rounded corners AFTER render, otherwise they don't exist
@@ -58,9 +59,13 @@ export class GroupPctDistributionBars {
           if (this.hasFilter() && !this.hasFilter(d.key)) {
             labelValue = 0.0;
           } else if (this.hasFilter() && this.hasFilter(d.key)) {
-            labelValue = !groupValue ? parseFloat(d.value / dimension.top(Infinity).length) : d.value;
+            labelValue = !groupValue
+              ? parseFloat(divide(d.value, dimension.top(Infinity).length))
+              : d.value;
           } else {
-            labelValue = !groupValue ? parseFloat(d.value / all.value()) : d.value;
+            labelValue = !groupValue
+              ? parseFloat(divide(d.value, all.value()))
+              : d.value;
           }
 
           if (!groupValue) {

--- a/app/javascript/lib/vue/components/modules/Table.vue
+++ b/app/javascript/lib/vue/components/modules/Table.vue
@@ -16,122 +16,128 @@
 
     <table>
       <thead>
-        <template v-for="[id, { name, index, cssClass }] in arrayColumnsFiltered">
-          <th
-            :key="index"
-            class="gobierto-table__th"
-            :class="cssClass"
-            @click="handleTableHeaderClick(id)"
-          >
-            {{ name }}
-            <SortIcon
-              v-if="currentSortColumn === id"
-              :direction="getSorting(id)"
-            />
-          </th>
-        </template>
+        <th
+          v-for="[id, { name, index, cssClass }] in arrayColumnsFiltered"
+          :key="index"
+          class="gobierto-table__th"
+          :class="cssClass"
+          @click="handleTableHeaderClick(id)"
+        >
+          {{ name }}
+          <SortIcon
+            v-if="currentSortColumn === id"
+            :direction="getSorting(id)"
+          />
+        </th>
       </thead>
       <tbody>
-        <template v-for="(item, index) in visibleRows">
-          <tr
-            :key="index"
-            :class="{ 'is-clickable': hasPermalink }"
-            class="gobierto-table__tr"
-          >
-            <template v-for="[id, { type, cssClass }] in arrayColumnsFiltered">
-              <template v-if="type === 'money'">
-                <td
-                  :key="id"
-                  :class="cssClass"
-                  class="gobierto-table__td"
-                >
-                  <template v-if="hasPermalink">
-                    <a
-                      :href="item[href]"
-                      class="gobierto-table__a"
-                      @click.prevent="handleTableItem(item)"
-                    >
-                      {{ item[id] | money }}
-                    </a>
-                  </template>
-                  <template v-else>
-                    <span>
-                      {{ item[id] | money }}
-                    </span>
-                  </template>
-                </td>
-              </template>
-              <template v-else-if="type === 'date'">
-                <td
-                  :key="id"
-                  :class="cssClass"
-                  class="gobierto-table__td"
-                >
-                  <template v-if="hasPermalink">
-                    <a
-                      :href="item[href]"
-                      class="gobierto-table__a"
-                      @click.prevent="handleTableItem(item)"
-                    >
-                      {{ item[id] | date }}
-                    </a>
-                  </template>
-                  <template v-else>
-                    <span>
-                      {{ item[id] | date }}
-                    </span>
-                  </template>
-                </td>
-              </template>
-              <template v-else-if="type === 'truncate'">
-                <td
-                  :key="id"
-                  class="gobierto-table__td"
-                >
-                  <template v-if="hasPermalink">
-                    <a
-                      :href="item[href]"
-                      class="gobierto-table__a"
-                      :class="cssClass"
-                      @click.prevent="handleTableItem(item)"
-                    >
-                      {{ item[id] }}
-                    </a>
-                  </template>
-                  <template v-else>
-                    <span :class="cssClass">
-                      {{ item[id] }}
-                    </span>
-                  </template>
-                </td>
-              </template>
-              <template v-else>
-                <td
-                  :key="id"
-                  :class="cssClass"
-                  class="gobierto-table__td"
-                >
-                  <template v-if="hasPermalink">
-                    <a
-                      :href="item[href]"
-                      class="gobierto-table__a"
-                      @click.prevent="handleTableItem(item)"
-                    >
-                      {{ item[id] }}
-                    </a>
-                  </template>
-                  <template v-else>
-                    <span>
-                      {{ item[id] }}
-                    </span>
-                  </template>
-                </td>
-              </template>
+        <tr
+          v-for="(item, index) in visibleRows"
+          :key="index"
+          :class="{ 'is-clickable': hasPermalink }"
+          class="gobierto-table__tr"
+        >
+          <template v-for="[id, { type, cssClass }] in arrayColumnsFiltered">
+            <template v-if="type === 'money'">
+              <td
+                :key="id"
+                :class="cssClass"
+                class="gobierto-table__td"
+              >
+                <template v-if="hasPermalink">
+                  <a
+                    :href="item[href]"
+                    class="gobierto-table__a"
+                    @click.prevent="handleTableItem(item)"
+                  >
+                    {{ item[id] | money }}
+                  </a>
+                </template>
+                <template v-else>
+                  <span>
+                    {{ item[id] | money }}
+                  </span>
+                </template>
+              </td>
             </template>
-          </tr>
-        </template>
+            <template v-else-if="type === 'date'">
+              <td
+                :key="id"
+                :class="cssClass"
+                class="gobierto-table__td"
+              >
+                <template v-if="hasPermalink">
+                  <a
+                    :href="item[href]"
+                    class="gobierto-table__a"
+                    @click.prevent="handleTableItem(item)"
+                  >
+                    {{ item[id] | date }}
+                  </a>
+                </template>
+                <template v-else>
+                  <span>
+                    {{ item[id] | date }}
+                  </span>
+                </template>
+              </td>
+            </template>
+            <template v-else-if="type === 'truncate'">
+              <td
+                :key="id"
+                class="gobierto-table__td"
+              >
+                <template v-if="hasPermalink">
+                  <a
+                    :href="item[href]"
+                    class="gobierto-table__a"
+                    :class="cssClass"
+                    @click.prevent="handleTableItem(item)"
+                  >
+                    {{ item[id] }}
+                  </a>
+                </template>
+                <template v-else>
+                  <span :class="cssClass">
+                    {{ item[id] }}
+                  </span>
+                </template>
+              </td>
+            </template>
+            <template v-else>
+              <td
+                :key="id"
+                :class="cssClass"
+                class="gobierto-table__td"
+              >
+                <template v-if="hasPermalink">
+                  <a
+                    :href="item[href]"
+                    class="gobierto-table__a"
+                    @click.prevent="handleTableItem(item)"
+                  >
+                    {{ item[id] }}
+                  </a>
+                </template>
+                <template v-else>
+                  <span>
+                    {{ item[id] }}
+                  </span>
+                </template>
+              </td>
+            </template>
+          </template>
+        </tr>
       </tbody>
     </table>
+
+    <div
+      v-if="!data.length"
+      class="center p1"
+    >
+      {{ labelNoData }}
+    </div>
+
     <template v-if="showPagination">
       <slot
         name="pagination"
@@ -207,6 +213,7 @@ export default {
       mapColumns: new Map(),
       currentSortColumn: this.sortColumn || this.$options.defaults.sortColumn,
       currentSort: this.sortDirection || this.$options.defaults.sortDirection,
+      labelNoData: I18n.t("gobierto_common.vue_components.table.no_data") || '',
       visibleColumns: this.showColumns.length ? this.showColumns : this.columns.map(({ field }) => field),
       visiblePaginatedRows: null,
       arrayColumnsFiltered: []

--- a/config/locales/gobierto_common/views/ca.yml
+++ b/config/locales/gobierto_common/views/ca.yml
@@ -192,3 +192,4 @@ ca:
         more: Vegeu-ne mès
       table:
         customize_columns: Personalitzeu columnes
+        no_data: No hi ha dades per a aquest criteri

--- a/config/locales/gobierto_common/views/en.yml
+++ b/config/locales/gobierto_common/views/en.yml
@@ -192,3 +192,4 @@ en:
         more: See more
       table:
         customize_columns: Customize columns
+        no_data: There is no data for this criteria

--- a/config/locales/gobierto_common/views/es.yml
+++ b/config/locales/gobierto_common/views/es.yml
@@ -192,3 +192,4 @@ es:
         more: Ver más
       table:
         customize_columns: Personalizar columnas
+        no_data: No hay datos para este criterio


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/2036

## :v: What does this PR do?
Better handling categories in order to avoid `NaN` values when the selected items implies empty elements.
Selected values in the charts are highlighted in italics, and the treemaps/beeswarm are hidden when no data

https://getafe.gobify.net/visualizaciones/contratos