### PR TITLE
Align indicators grid

### DIFF
--- a/app/assets/stylesheets/budgets.scss
+++ b/app/assets/stylesheets/budgets.scss
@@ -42,3 +42,15 @@
 @import "modules/comp-timeline";
 @import "modules/comp-content";
 @import "modules/comp-dropdown";
+
+.padded_cols.pure-g {
+  @include min-screen(768) {
+    width: calc(100% + 4em);
+
+    // asumming 3 elements per col
+
+    [class*="pure-u"]:nth-child(3n+1) {
+      margin-left: -1em;
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1280

## :v: What does this PR do?
Align properly a 2-col grid using the old resources

https://getafe.gobify.net/presupuestos/indicadores/2020