### PR TITLE
Replace momentjs

### DIFF
--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -18,7 +18,6 @@
 @import "modules/comp-lists";
 @import "modules/comp-agenda";
 @import "modules/comp-modals";
-@import "fullcalendar/dist/fullcalendar.css";
 
 body.gobierto_people {
   .block + .person-item {

--- a/app/javascript/gobierto_people/modules/person_events_controller.js
+++ b/app/javascript/gobierto_people/modules/person_events_controller.js
@@ -1,5 +1,3 @@
-import 'fullcalendar'
-
 window.GobiertoPeople.PersonEventsController = (function() {
 
   function PersonEventsController() {}

--- a/app/javascript/lib/visualizations/modules/punchcard.js
+++ b/app/javascript/lib/visualizations/modules/punchcard.js
@@ -1,6 +1,13 @@
 import * as d3 from 'd3';
 import { extend, flatten, map } from 'lodash';
-import moment from 'moment';
+
+function monthDiff(dateFrom, dateTo) {
+  return (
+    dateTo.getMonth() -
+    dateFrom.getMonth() +
+    12 * (dateTo.getFullYear() - dateFrom.getFullYear())
+  );
+}
 
 export class Punchcard {
   constructor(context, data, options = {}) {
@@ -37,7 +44,7 @@ export class Punchcard {
 
     // estimation number of x.axis.ticks to center if there are no so much
     let xAxisLimits = d3.extent(map(flatten(map(data, "value")), "key"));
-    let xAxisLength = moment(xAxisLimits[1]).diff(xAxisLimits[0], "months");
+    let xAxisLength = monthDiff(...xAxisLimits);
     if (xAxisLength < 5) {
       margin = extend(margin, {
         left: margin.left * 2,

--- a/app/views/gobierto_people/people/person_events/index.html.erb
+++ b/app/views/gobierto_people/people/person_events/index.html.erb
@@ -66,6 +66,15 @@
 
 <% description([title, t("gobierto_people.layouts.application.title"), @site.title].compact.join('. ')) %>
 
+<% content_for :gobierto_footer_content do %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/3.10.2/fullcalendar.min.js' %>
+<% end %>
+
+<% content_for :stylesheet_module_link do %>
+  <%= stylesheet_link_tag 'https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/3.10.2/fullcalendar.min.css' %>
+<% end %>
+
 <% content_for :javascript_hook do %>
   window.GobiertoPeople.person_events_controller.index();
 <% end %>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "magnific-popup": "^1.1.0",
     "mailcheck": "^1.1.1",
     "mapbox-gl": "^1.4.1",
-    "moment": "^2.29.4",
     "mustache": "^2.3.0",
     "normalize.css": "^8.0.1",
     "perspective-map": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "d3-voronoi": "^1.1.4",
     "devbridge-autocomplete": "^1.4.7",
     "flightjs": "^1.5.2",
-    "fullcalendar": "^3.9.0",
     "geocomplete": "^1.7.0",
     "gobierto-vizzs": "^3.1.2",
     "html-to-image": "^1.9.0",

--- a/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/datepicker_editor.js
+++ b/vendor/gobierto_engines/custom-fields-data-grid-plugin/app/javascripts/custom_fields_data_grid_plugin/modules/datepicker_editor.js
@@ -1,5 +1,4 @@
 import 'air-datepicker'
-import moment from 'moment'
 
 export { DateEditor }
 
@@ -76,7 +75,7 @@ function DateEditor(args) {
     datepickerInstance.hide();
   };
 
-  this.position = function(_position) {};
+  this.position = function() {};
 
   this.focus = function(){
     $input.focus();
@@ -84,12 +83,7 @@ function DateEditor(args) {
 
   this.loadValue = function(item) {
     var currentDateString = item[args.column.field];
-
-    if (currentDateString) {
-      var date = moment(currentDateString, "YYYY-MM-DD").toDate();
-    } else {
-      var date = moment().toDate();
-    }
+    var date = currentDateString ? new Date(currentDateString) : new Date()
 
     $input.val(currentDateString);
     $input.select();

--- a/vendor/gobierto_engines/custom-fields-table-plugin/app/javascripts/custom_fields_table_plugin/modules/datepicker_editor.js
+++ b/vendor/gobierto_engines/custom-fields-table-plugin/app/javascripts/custom_fields_table_plugin/modules/datepicker_editor.js
@@ -1,5 +1,4 @@
 import 'air-datepicker'
-import moment from 'moment'
 
 export { DateEditor }
 
@@ -76,7 +75,7 @@ function DateEditor(args) {
     datepickerInstance.hide();
   };
 
-  this.position = function(_position) {};
+  this.position = function() {};
 
   this.focus = function(){
     $input.focus();
@@ -84,12 +83,7 @@ function DateEditor(args) {
 
   this.loadValue = function(item) {
     var currentDateString = item[args.column.field];
-
-    if (currentDateString) {
-      var date = moment(currentDateString, "YYYY-MM-DD").toDate();
-    } else {
-      var date = moment().toDate();
-    }
+    var date = currentDateString ? new Date(currentDateString) : new Date()
 
     $input.val(currentDateString);
     $input.select();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3127,11 +3127,6 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-fullcalendar@^3.9.0:
-  version "3.10.2"
-  resolved "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.10.2.tgz"
-  integrity sha512-YWZaHdp8ZLBqhPz615PoXdA49ymsBTUF+MGDM6H3vyz71Pv/ZW9Pm9/Mj3x6n822k6bs2txFO7muRTSvBhsqKg==
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,11 +4685,6 @@ mobile-drag-drop@^2.3.0-rc.2:
   resolved "https://registry.npmjs.org/mobile-drag-drop/-/mobile-drag-drop-2.3.0-rc.2.tgz"
   integrity sha512-4rHP0PUeWkSp0O3waNHPQZCHeZnLu8bE59MerWOnZJ249BCyICXL1WWp3xqkMKXEDFYuhfk3bS42bKB9IeN9uw==
 
-moment@^2.29.4:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## :v: What does this PR do?
`momentjs` has become a outdated library (maintainers recommend to use different libs), apart from its package size, so it better to replace the utilization with plain, buitl-in, no 3rd-party code. 
`fullcalendar` has been replaced with CDN scripts, since the legacy version used, requires `moment` to make it work

https://mataro.gobify.net/presupuestos/proveedores-facturas
(fullcalendar) https://madrid.gobify.net/agendas/ed-metz