### PR TITLE
Fix slider year for elaboration

### DIFF
--- a/app/javascript/lib/visualizations/modules/slider.js
+++ b/app/javascript/lib/visualizations/modules/slider.js
@@ -6,7 +6,7 @@ export class VisSlider {
     $(this.container).html("");
     this.data = data;
 
-    var currentYear = d3.select("body").attr("data-year");
+    var currentYear = parseInt(d3.select("body").attr("data-year"));
     var maxYear = parseInt(d3.select("body").attr("data-max-year"));
     var years = this.data
       .reduce((acc, { values }) => {

--- a/app/javascript/lib/visualizations/modules/slider.js
+++ b/app/javascript/lib/visualizations/modules/slider.js
@@ -114,7 +114,7 @@ export class VisSlider {
       .append("text")
       .attr("x", d => x(d))
       .text(year => year)
-      .classed("active", d => d == currentYear)
+      .classed("active", d => parseFloat(d) === parseFloat(currentYear))
       .attr("dx", d => {
         if (d === maxYear) {
           return 10;

--- a/app/javascript/lib/visualizations/modules/slider.js
+++ b/app/javascript/lib/visualizations/modules/slider.js
@@ -17,6 +17,9 @@ export class VisSlider {
         return acc;
       }, [])
       .sort();
+    if (years.indexOf(currentYear) === -1) {
+      years.push(currentYear);
+    }
 
     var margin = {
       right: 20,


### PR DESCRIPTION
## :v: What does this PR do?

This PR fixes the year slider in the bubbles visualization, since for ellaboration of budgets was not inserting the new year value, as it wasn't coming as integer from the data.

## :mag: How should this be manually tested?

https://mataro.gobify.net to see the 2025 option.
