### PR TITLE
Bump Charlock holmes gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       mail
     case_transform (0.2)
       activesupport
-    charlock_holmes (0.7.7)
+    charlock_holmes (0.7.9)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)


### PR DESCRIPTION
## :v: What does this PR do?

Bumps gem version (minor version) to something newer that links with Ubuntu 24 and MacOSX 15.x


## :mag: How should this be manually tested?

Staging gobierto data API should work fine