### PR TITLE
Define current positions attribute

### DIFF
--- a/app/serializers/gobierto_people/person_serializer.rb
+++ b/app/serializers/gobierto_people/person_serializer.rb
@@ -45,7 +45,7 @@ module GobiertoPeople
 
       positions = [filtered_positions.first] if positions.blank?
 
-      return "" if positions.blank?
+      return "" if positions.compact.blank?
 
       "<ul>" + positions.map { |pos| "<li>#{pos.name}</li>" }.join + "</ul>"
     end

--- a/app/serializers/gobierto_people/person_serializer.rb
+++ b/app/serializers/gobierto_people/person_serializer.rb
@@ -43,9 +43,11 @@ module GobiertoPeople
         position.end_date.blank?
       end
 
-      positions = [position] if positions.blank?
+      positions = [filtered_positions.first] if positions.blank?
 
-      "<ul>" + positions.map { |pos| "<li>#{pos}</li>" }.join + "</ul>"
+      return "" if positions.blank?
+
+      "<ul>" + positions.map { |pos| "<li>#{pos.name}</li>" }.join + "</ul>"
     end
 
     def filtered_positions

--- a/app/serializers/gobierto_people/person_serializer.rb
+++ b/app/serializers/gobierto_people/person_serializer.rb
@@ -8,6 +8,7 @@ module GobiertoPeople
       :name,
       :email,
       :position,
+      :current_positions,
       :filtered_positions,
       :filtered_positions_str,
       :filtered_positions_html,
@@ -35,6 +36,16 @@ module GobiertoPeople
 
     def position
       filtered_positions.first&.name
+    end
+
+    def current_positions
+      positions = filtered_positions.select do |position|
+        position.end_date.blank?
+      end
+
+      positions = [position] if positions.blank?
+
+      "<ul>" + positions.map { |pos| "<li>#{pos}</li>" }.join + "</ul>"
     end
 
     def filtered_positions

--- a/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
@@ -109,7 +109,7 @@ module GobiertoAdmin
             create_project
 
             within "form" do
-              fill_in "project_name_translations_en", with: new_name
+              fill_in "project_name_translations_en", with: new_name, fill_options: { clear: :backspace }
 
               within "div.widget_save_v2.editor" do
                 click_button "Save"
@@ -336,7 +336,7 @@ module GobiertoAdmin
             new_name = "Project with versions: Version 2"
 
             within "form" do
-              fill_in "project_name_translations_en", with: new_name
+              fill_in "project_name_translations_en", with: new_name, fill_options: { clear: :backspace }
 
               within "div.widget_save_v2.editor" do
                 find("label", text: "Minor change (does not save version)").click
@@ -376,7 +376,7 @@ module GobiertoAdmin
 
             assert has_content? "Editing version\n2"
             within "form" do
-              fill_in "project_name_translations_en", with: new_name
+              fill_in "project_name_translations_en", with: new_name, fill_options: { clear: :backspace }
               fill_in_md_editor_field(new_description)
               find("label", text: "Minor change (does not save version)").click
               within "div.widget_save_v2.editor" do
@@ -394,7 +394,7 @@ module GobiertoAdmin
             last_version_name = "La Isla Bonita es la caña"
             last_version_description = "Big House Waltz"
             within "form" do
-              fill_in "project_name_translations_en", with: last_version_name
+              fill_in "project_name_translations_en", with: last_version_name, fill_options: { clear: :backspace }
               fill_in_md_editor_field(last_version_description, delete_chars_count: new_description.length)
               find("label", text: "Minor change (does not save version)").click
               within "div.widget_save_v2.editor" do

--- a/test/integration/gobierto_people/api/v1/people_index_test.rb
+++ b/test/integration/gobierto_people/api/v1/people_index_test.rb
@@ -36,7 +36,7 @@ module GobiertoPeople
 
         def person_attributes
           %w(
-            id name email position filtered_positions filtered_positions_str
+            id name email position current_positions filtered_positions filtered_positions_str
             filtered_positions_html filtered_positions_tooltip bio bio_url
             avatar_url category political_group party url created_at updated_at
           )


### PR DESCRIPTION
## :v: What does this PR do?

* Adds a new `current_positions`  attribute to the person serializer that returns all the positions of a person with blank end date (all currently active positions) or if there is no currently active positions the most recent one. The value is returned as a list inside an `<ul>` tag

## :mag: How should this be manually tested?

Define a few positions for a person with end_date blank. Those positions should appear under the `:current_position` key of the hash generated by `GobiertoPeople::PersonSerializer.new(person).to_h` 

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No