### PR TITLE
Add start and end params to cache key

### DIFF
--- a/app/controllers/gobierto_people/application_controller.rb
+++ b/app/controllers/gobierto_people/application_controller.rb
@@ -40,6 +40,8 @@ module GobiertoPeople
       base_path = "#{current_site.cache_key_with_version}/#{current_module}/#{self.controller_name}/#{self.action_name}/#{I18n.locale}"
       base_path += "/#{params[:date]}" if params[:date].present?
       base_path += "/#{params[:start_date]}" if params[:start_date].present?
+      base_path += "/#{params[:start]}" if params[:start].present?
+      base_path += "/#{params[:end]}" if params[:end].present?
       base_path += "/#{params[:list_view]}" if params[:list_view].present?
       base_path += "/#{params[:container_slug]}" if params[:container_slug].present?
       base_path += "/#{params[:page]}" if params[:page].present?


### PR DESCRIPTION
Closes PopulateTools/issues#2106

## :v: What does this PR do?

Adds `start` and `end` parameters used to refresh calendar data to cache key

## :mag: How should this be manually tested?

Visit the agenda page of a person and review their events changing the range size (month, week, etc.) and the start and end dates

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No
