### PR TITLE
Update budgets cards info

### DIFF
--- a/app/assets/stylesheets/modules/_comp-metric_boxes.scss
+++ b/app/assets/stylesheets/modules/_comp-metric_boxes.scss
@@ -46,7 +46,7 @@
     }
 
     .explanation {
-      font-size: 0.75em;
+      font-size: 0.85em;
       opacity: 0.6;
       position: absolute;
       line-height: 1.4;
@@ -69,7 +69,7 @@
     }
 
     .explanation_bar {
-      font-size: 0.75em;
+      font-size: 0.85em;
       position: absolute;
       bottom: 0.8em;
       width: calc(100% - 3em);

--- a/app/assets/stylesheets/modules/_comp-metric_boxes.scss
+++ b/app/assets/stylesheets/modules/_comp-metric_boxes.scss
@@ -97,7 +97,7 @@
 
     .diff {
       opacity: 0.6;
-      font-size: 0.75em;
+      font-size: 0.85em;
 
       @include min-screen(768) {
         bottom: 0.8em;

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -54,7 +54,7 @@
           <% end %>
         <% end %>
 
-        <% if @site_stats.total_budget_per_inhabitant_updated(fallback: true) != @site_stats.total_budget_per_inhabitant(fallback: true) %>
+        <% if @site_stats.total_budget_updated(fallback: true) != @site_stats.total_budget(fallback: true) %>
           <%= render("metric_box",
               title: t(".total_expenses_updated"),
               value: @site_stats.total_budget_updated(fallback: true),

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -33,19 +33,29 @@
       <div class="pure-g metric_boxes">
 
         <% if @site_stats.population_data? %>
-          <%= render("metric_box",
-                title: t(".expenses_per_inhabitant_updated"),
-                value: @site_stats.total_budget_per_inhabitant_updated(fallback: true),
-                tooltip: t(".expenses_per_inhabitant_tooltip"),
-                data_box: "expenses_per_inhabitant",
-                explanation: {
-                  if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
-                  text: "#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)} #{t('.initial_estimate_per_inhabitant')} #{format_currency(@site_stats.total_budget_per_inhabitant)}"
-                }
-              ) %>
+          <% if @site_stats.total_budget_per_inhabitant_updated(fallback: true) != @site_stats.total_budget_per_inhabitant(fallback: true), true) %>
+            <%= render("metric_box",
+                  title: t(".expenses_per_inhabitant_updated"),
+                  value: @site_stats.total_budget_per_inhabitant_updated(fallback: true),
+                  tooltip: t(".expenses_per_inhabitant_tooltip"),
+                  data_box: "expenses_per_inhabitant",
+                  explanation: {
+                    if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
+                    text: "#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)} #{t('.initial_estimate_per_inhabitant')} #{format_currency(@site_stats.total_budget_per_inhabitant)}"
+                  }
+                ) %>
+          <% else %>
+              <%= render("metric_box",
+                  title: t(".expenses_per_inhabitant"),
+                  value: @site_stats.total_budget_per_inhabitant(fallback: true),
+                  tooltip: t(".expenses_per_inhabitant_tooltip"),
+                  data_box: "expenses_per_inhabitant",
+                ) %>
+          <% end %>
         <% end %>
 
-        <%= render("metric_box",
+        <% if @site_stats.total_budget_per_inhabitant_updated(fallback: true) != @site_stats.total_budget_per_inhabitant(fallback: true) %>
+          <%= render("metric_box",
               title: t(".total_expenses_updated"),
               value: @site_stats.total_budget_updated(fallback: true),
               tooltip: t(".total_expenses_tooltip"),
@@ -55,7 +65,14 @@
                 text: "#{delta_percentage(@site_stats.total_budget_updated(fallback: true), @site_stats.total_budget(fallback: true), true)} #{t('.initial_estimate')} #{format_currency(@site_stats.total_budget)}"
               }
             ) %>
-
+        <% else %>
+          <%= render("metric_box",
+              title: t(".total_expenses"),
+              value: @site_stats.total_budget(fallback: true),
+              tooltip: t(".total_expenses_tooltip"),
+              data_box: "total_expenses",
+            ) %>
+        <% end %>
         <div class="pure-u-1-2 pure-u-md-1-5 metric_box tipsit" title="<%= t('.executed_tooltip') %>" data-box="executed">
           <div class="inner">
             <h3><%= t('.executed') %></h3>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -40,7 +40,7 @@
                 data_box: "expenses_per_inhabitant",
                 explanation: {
                   if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
-                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant_updated(fallback: true))}"
+                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant_updated(fallback: true))} (#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)})"
                 }
               ) %>
         <% end %>
@@ -52,7 +52,7 @@
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget(fallback: false).present?,
-                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget_updated(fallback: true))}"
+                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget_updated(fallback: true))} (#{delta_percentage(@site_stats.total_budget_updated(fallback: true), @site_stats.total_budget(fallback: true), true)})"
               }
             ) %>
 

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -40,7 +40,7 @@
                 data_box: "expenses_per_inhabitant",
                 explanation: {
                   if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
-                  text: "#{t('.initial_estimate_per_inhabitant')}: #{format_currency(@site_stats.total_budget_per_inhabitant)} (#{delta_percentage(@site_stats.total_budget_per_inhabitant(fallback: true), @site_stats.total_budget_per_inhabitant_updated(fallback: true), true)})"
+                  text: "#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)} #{t('.initial_estimate_per_inhabitant')} #{format_currency(@site_stats.total_budget_per_inhabitant)}"
                 }
               ) %>
         <% end %>
@@ -52,7 +52,7 @@
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget(fallback: false).present?,
-                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)} (#{delta_percentage(@site_stats.total_budget(fallback: true), @site_stats.total_budget_updated(fallback: true), true)})"
+                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)} (#{delta_percentage(@site_stats.total_budget_update(fallback: true), @site_stats.total_budget(fallback: true), true)})"
               }
             ) %>
 

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -34,25 +34,25 @@
 
         <% if @site_stats.population_data? %>
           <%= render("metric_box",
-                title: t(".initial_estimate_per_inhabitant"),
-                value: @site_stats.total_budget_per_inhabitant,
+                title: t(".expenses_per_inhabitant_updated"),
+                value: @site_stats.total_budget_per_inhabitant_updated(fallback: true),
                 tooltip: t(".expenses_per_inhabitant_tooltip"),
                 data_box: "expenses_per_inhabitant",
                 explanation: {
                   if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
-                  text: "#{t('.expenses_per_inhabitant_updated')}: #{format_currency(@site_stats.total_budget_per_inhabitant_updated(fallback: true))} (#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)})"
+                  text: "#{t('.initial_estimate_per_inhabitant')}: #{format_currency(@site_stats.total_budget_per_inhabitant)} (#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)})"
                 }
               ) %>
         <% end %>
 
         <%= render("metric_box",
-              title: t(".initial_estimate"),
-              value: @site_stats.total_budget,
+              title: t(".total_expenses_updated"),
+              value: @site_stats.total_budget_updated(fallback: true),
               tooltip: t(".total_expenses_tooltip"),
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget(fallback: false).present?,
-                text: "#{t('.total_expenses_updated')}: #{format_currency(@site_stats.total_budget_updated(fallback: true))} (#{delta_percentage(@site_stats.total_budget_updated(fallback: true), @site_stats.total_budget(fallback: true), true)})"
+                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)} (#{delta_percentage(@site_stats.total_budget_updated(fallback: true), @site_stats.total_budget(fallback: true), true)})"
               }
             ) %>
 

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -274,7 +274,7 @@
       <h2 class="with_description"><%= t('.execution_block.title') %></h2>
       <div class="pure-g half_description">
         <div class="pure-u-md-1 pure-u-1 block_1">
-          <p class="description">
+          <p class="description js-last-update">
             <%= t('.execution_block.intro') %>
 
             <% if @budgets_data_updated_at %>

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -33,7 +33,7 @@
       <div class="pure-g metric_boxes">
 
         <% if @site_stats.population_data? %>
-          <% if @site_stats.total_budget_per_inhabitant_updated(fallback: true) != @site_stats.total_budget_per_inhabitant(fallback: true), true) %>
+          <% if @site_stats.total_budget_per_inhabitant_updated(fallback: true) != @site_stats.total_budget_per_inhabitant(fallback: true) %>
             <%= render("metric_box",
                   title: t(".expenses_per_inhabitant_updated"),
                   value: @site_stats.total_budget_per_inhabitant_updated(fallback: true),

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -40,7 +40,7 @@
                 data_box: "expenses_per_inhabitant",
                 explanation: {
                   if: @site_stats.total_budget_per_inhabitant(fallback: false).present?,
-                  text: "#{t('.initial_estimate_per_inhabitant')}: #{format_currency(@site_stats.total_budget_per_inhabitant)} (#{delta_percentage(@site_stats.total_budget_per_inhabitant_updated(fallback: true), @site_stats.total_budget_per_inhabitant(fallback: true), true)})"
+                  text: "#{t('.initial_estimate_per_inhabitant')}: #{format_currency(@site_stats.total_budget_per_inhabitant)} (#{delta_percentage(@site_stats.total_budget_per_inhabitant(fallback: true), @site_stats.total_budget_per_inhabitant_updated(fallback: true), true)})"
                 }
               ) %>
         <% end %>
@@ -52,7 +52,7 @@
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget(fallback: false).present?,
-                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)} (#{delta_percentage(@site_stats.total_budget_updated(fallback: true), @site_stats.total_budget(fallback: true), true)})"
+                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)} (#{delta_percentage(@site_stats.total_budget(fallback: true), @site_stats.total_budget_updated(fallback: true), true)})"
               }
             ) %>
 

--- a/app/views/gobierto_budgets/budgets/index.html.erb
+++ b/app/views/gobierto_budgets/budgets/index.html.erb
@@ -52,7 +52,7 @@
               data_box: "total_expenses",
               explanation: {
                 if: @site_stats.total_budget(fallback: false).present?,
-                text: "#{t('.initial_estimate')}: #{format_currency(@site_stats.total_budget)} (#{delta_percentage(@site_stats.total_budget_update(fallback: true), @site_stats.total_budget(fallback: true), true)})"
+                text: "#{delta_percentage(@site_stats.total_budget_updated(fallback: true), @site_stats.total_budget(fallback: true), true)} #{t('.initial_estimate')} #{format_currency(@site_stats.total_budget)}"
               }
             ) %>
 

--- a/app/views/gobierto_budgets/shared/_data_updated_at.html.erb
+++ b/app/views/gobierto_budgets/shared/_data_updated_at.html.erb
@@ -1,4 +1,4 @@
-<p>
+<p class="js-last-update">
   <% if @budgets_data_updated_at %>
     <strong><%= t('.last_update') %></strong>: <%= l(@budgets_data_updated_at, format: '%d %B %Y').downcase %>.
   <% end %>

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -268,7 +268,7 @@ ca:
         income_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
         inhabitants: Habitants
         inhabitants_tooltip: Nombre d’habitants
-        initial_estimate: Pressupost inicial
+        initial_estimate: sobre el pres. inicial
         initial_estimate_per_inhabitant: sobre el pres. inicial per hab.
         less: menys
         level_1_category: Categoria nivell 1

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -245,7 +245,7 @@ ca:
         debt_tooltip: Deute del sector d’administracions públiques %{of_the_organization_name}
         description: En aquesta pàgina pots conèixer la distribució del pressupost,
           l'estat d'execució de cada partida i com ha evolucionat la despesa per habitant
-        executed: Execució del pressupost actual
+        executed: Execució del pres. actual
         executed_percent: "%{percentage}% del pressupost actual"
         executed_percent_other_year_html: El %{year} va ser un %{link}
         executed_tooltip: Despesa executada respecte el pressupost actual (pressupost

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -260,7 +260,7 @@ ca:
         expenses: Despeses
         expenses_per_inhabitant: Despesa per habitant
         expenses_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
-        expenses_per_inhabitant_updated: Pres. per habitant actual
+        expenses_per_inhabitant_updated: Pres. per hab. actual
         header: Pressupostos
         in_total: En total
         income: Ingressos

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -260,7 +260,7 @@ ca:
         expenses: Despeses
         expenses_per_inhabitant: Despesa per habitant
         expenses_per_inhabitant_tooltip: Pressupost inicial dividit pel nombre d’habitants
-        expenses_per_inhabitant_updated: Pressupost per habitant actual
+        expenses_per_inhabitant_updated: Pres. per habitant actual
         header: Pressupostos
         in_total: En total
         income: Ingressos

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -269,7 +269,7 @@ ca:
         inhabitants: Habitants
         inhabitants_tooltip: Nombre d’habitants
         initial_estimate: Pressupost inicial
-        initial_estimate_per_inhabitant: Pressupost inicial per habitant
+        initial_estimate_per_inhabitant: sobre el pres. inicial per hab.
         less: menys
         level_1_category: Categoria nivell 1
         level_2_category: Categoria nivell 2

--- a/config/locales/gobierto_budgets/views/ca.yml
+++ b/config/locales/gobierto_budgets/views/ca.yml
@@ -245,7 +245,7 @@ ca:
         debt_tooltip: Deute del sector d’administracions públiques %{of_the_organization_name}
         description: En aquesta pàgina pots conèixer la distribució del pressupost,
           l'estat d'execució de cada partida i com ha evolucionat la despesa per habitant
-        executed: Execució
+        executed: Execució del pressupost actual
         executed_percent: "%{percentage}% del pressupost actual"
         executed_percent_other_year_html: El %{year} va ser un %{link}
         executed_tooltip: Despesa executada respecte el pressupost actual (pressupost

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -249,7 +249,7 @@ es:
         expenses_per_inhabitant: Gasto por habitante
         expenses_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
           de habitantes
-        expenses_per_inhabitant_updated: Presupuesto por habitante actual
+        expenses_per_inhabitant_updated: Pres. por habitante actual
         header: Presupuestos
         in_total: En total
         income: Ingresos

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -233,7 +233,7 @@ es:
         description: En esta página te contamos cúal es la distribución de los presupuestos,
           cuál es el estado de ejecución de cada partida, quiénes son los proveedores
           con los que trabajamos, y cómo ha evolucionado el gasto por habitante.
-        executed: Ejecución
+        executed: Ejecución del presupuesto actual
         executed_percent: "%{percentage}% del presupuesto actual"
         executed_percent_other_year_html: En %{year} fue un %{link}
         executed_tooltip: Cantidad ejecutada respecto al presupuesto actual (presupuesto

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -258,7 +258,7 @@ es:
           de habitantes
         inhabitants: Habitantes
         inhabitants_tooltip: Número de habitantes
-        initial_estimate: Presupuesto inicial
+        initial_estimate: sobre el pres. inicial
         initial_estimate_per_inhabitant: sobre el pres. inicial por hab.
         less: menos
         level_1_category: Categoría nivel 1

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -233,7 +233,7 @@ es:
         description: En esta página te contamos cúal es la distribución de los presupuestos,
           cuál es el estado de ejecución de cada partida, quiénes son los proveedores
           con los que trabajamos, y cómo ha evolucionado el gasto por habitante.
-        executed: Ejecución del presupuesto actual
+        executed: Ejecución del pres. actual
         executed_percent: "%{percentage}% del presupuesto actual"
         executed_percent_other_year_html: En %{year} fue un %{link}
         executed_tooltip: Cantidad ejecutada respecto al presupuesto actual (presupuesto

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -259,7 +259,7 @@ es:
         inhabitants: Habitantes
         inhabitants_tooltip: Número de habitantes
         initial_estimate: Presupuesto inicial
-        initial_estimate_per_inhabitant: Presupuesto inicial por habitante
+        initial_estimate_per_inhabitant: sobre el pres. inicial por hab.
         less: menos
         level_1_category: Categoría nivel 1
         level_2_category: Categoría nivel 2

--- a/config/locales/gobierto_budgets/views/es.yml
+++ b/config/locales/gobierto_budgets/views/es.yml
@@ -249,7 +249,7 @@ es:
         expenses_per_inhabitant: Gasto por habitante
         expenses_per_inhabitant_tooltip: Presupuesto inicial dividido por el número
           de habitantes
-        expenses_per_inhabitant_updated: Pres. por habitante actual
+        expenses_per_inhabitant_updated: Pres. por hab. actual
         header: Presupuestos
         in_total: En total
         income: Ingresos


### PR DESCRIPTION
This PR:

- gives more relevance to updated budget values
- moves to the bottom the initial amount
- adds a PCT of the diff
- adds a JS class to be able to hide the update budget date