### PR TITLE
Fix year

### DIFF
--- a/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
+++ b/app/views/gobierto_budgets/budgets_elaboration/index.html.erb
@@ -1,4 +1,4 @@
-<% title t('.header') %>
+<% title t('.header', year: GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data) %>
 
 <% content_for :body_attributes do %>
   <%== %Q{data-bubbles-data="#{bubbles_data_path(current_site)}" data-max-year="#{GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.last_year_with_data}"} %>


### PR DESCRIPTION
## :v: What does this PR do?

Fixes this missing interpolation:

<img width="754" height="177" alt="Screenshot 2025-11-11 at 06 19 42" src="https://github.com/user-attachments/assets/c63f0638-c623-49a0-ba77-66a8dd398c3c" />

