### PR TITLE
Skip nodes where published_version is not present

### DIFF
--- a/app/models/gobierto_plans/node.rb
+++ b/app/models/gobierto_plans/node.rb
@@ -71,7 +71,9 @@ module GobiertoPlans
       end
     }
     scope :versions_indexes, lambda {
-      joins(:versions).group("gplan_nodes.id", "gplan_nodes.published_version").count("versions.id").inject({}) do |counts, (k, v)|
+      joins(:versions).
+      group("gplan_nodes.id", "gplan_nodes.published_version").
+      count("versions.id").reject { |k, v| k.last.blank? }.inject({}) do |counts, (k, v)|
         counts.update(k[0] => k[1] - v)
       end
     }


### PR DESCRIPTION
## :v: What does this PR do?

This PR prevents exceptions that happen when a project of a Plan is published but its published version is not set. This should not happen (published without version) but the exception can be prevented since it is related with a scope that should only operate on projects with a published version. The PR causes projects without a published version to be ignored from this scope.

## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
