### PR TITLE
Avoid contracts crazy ids with rule

### DIFF
--- a/app/controllers/gobierto_visualizations/visualizations_controller.rb
+++ b/app/controllers/gobierto_visualizations/visualizations_controller.rb
@@ -5,7 +5,12 @@ module GobiertoVisualizations
 
     before_action :visualization_enabled!
 
-    def contracts; end
+    MIN_CONTRACT_ID = 0
+    MAX_CONTRACT_ID = 15_000_000
+
+    def contracts
+      render_404 and return false if params[:id].present? && (params[:id].to_i < MIN_CONTRACT_ID || params[:id].to_i > MAX_CONTRACT_ID)
+    end
     def subsidies; end
 
     private

--- a/app/controllers/gobierto_visualizations/visualizations_controller.rb
+++ b/app/controllers/gobierto_visualizations/visualizations_controller.rb
@@ -5,11 +5,12 @@ module GobiertoVisualizations
 
     before_action :visualization_enabled!
 
-    MIN_CONTRACT_ID = 0
+    MIN_CONTRACT_ID = 1
     MAX_CONTRACT_ID = 15_000_000
 
     def contracts
-      render_404 and return false if params[:id].present? && (params[:id].to_i < MIN_CONTRACT_ID || params[:id].to_i > MAX_CONTRACT_ID)
+      render_404 and return false if params[:id].present? &&
+        (params[:id].to_i < MIN_CONTRACT_ID || params[:id].to_i > MAX_CONTRACT_ID || !params[:id].match?(/\A\d+\z/))
     end
     def subsidies; end
 


### PR DESCRIPTION
## :v: What does this PR do?

We have lots of visits to invented contract ids in the visualizations of contracts.

This PR tries to catch the error in Rails and return a 404 for bots to stop. Otherwise, the error happens in Vue, but the Rails app returns 200 OK.

