### PR TITLE
Transform configs into functions to get locale

### DIFF
--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Aside.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Aside.vue
@@ -51,7 +51,7 @@ import { slugString } from '../../../../lib/shared';
 import { BlockHeader, Checkbox, Dropdown } from '../../../../lib/vue/components';
 import DownloadButton from '../../components/DownloadButton.vue';
 import SearchFilter from '../../components/SearchFilter.vue';
-import { contractsFiltersConfig } from '../../lib/config/contracts.js';
+import { getContractsFiltersConfig } from '../../lib/config/contracts.js';
 import { EventBus } from '../../lib/mixins/event_bus';
 
 export default {
@@ -75,7 +75,7 @@ export default {
   },
   data() {
     return {
-      filters: contractsFiltersConfig,
+      filters: getContractsFiltersConfig(),
       type: 'Contracts'
     }
   },

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/AssigneesShow.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/AssigneesShow.vue
@@ -28,7 +28,7 @@
 import { VueFiltersMixin } from '../../../../lib/vue/filters'
 import { Table } from '../../../../lib/vue/components';
 import { EventBus } from '../../lib/mixins/event_bus';
-import { assigneesShowColumns } from '../../lib/config/contracts.js';
+import { getAssigneesShowColumns } from '../../lib/config/contracts.js';
 
 export default {
   name: 'AssigneesShow',
@@ -39,7 +39,7 @@ export default {
   data() {
     return {
       contractsData: this.$root.$data.contractsData,
-      assigneesShowColumns: assigneesShowColumns,
+      assigneesShowColumns: getAssigneesShowColumns(),
       items: [],
       tableItems: [],
       columns: [],
@@ -64,7 +64,7 @@ export default {
       const contracts = this.contractsData.filter(({ assignee_routing_id }) => assignee_routing_id === assigneeRoutingId ) || [];
 
       this.items = contracts
-      this.columns = assigneesShowColumns;
+      this.columns = getAssigneesShowColumns();
       this.tableItems = this.items.map(d => ({ ...d, href: `${location.origin}/visualizaciones/contratos/adjudicaciones/${d.id}` } ))
 
       if (contracts.length > 0) {

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsIndex.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/ContractsIndex.vue
@@ -13,7 +13,7 @@
 <script>
 import { Table } from '../../../../lib/vue/components';
 import { EventBus } from '../../lib/mixins/event_bus';
-import { contractsColumns } from '../../lib/config/contracts.js';
+import { getContractsColumns } from '../../lib/config/contracts.js';
 
 export default {
   name: 'ContractsIndex',
@@ -23,7 +23,7 @@ export default {
   data() {
     return {
       contractsData: this.$root.$data.contractsData,
-      contractsColumns: contractsColumns,
+      contractsColumns: getContractsColumns(),
       items: [],
       showColumns: [],
       columns: []
@@ -45,7 +45,7 @@ export default {
     EventBus.$on('filtered-items', (value) => this.updateFilteredItems(value))
 
     this.items = this.contractsData.map(d => ({ ...d, href: `${location.origin}${location.pathname}/${d.id}` } ))
-    this.columns = contractsColumns;
+    this.columns = getContractsColumns();
     this.showColumns = ['assignee', 'title', 'gobierto_start_date', 'final_amount_no_taxes']
   },
   beforeUnmount(){

--- a/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/contracts/Summary.vue
@@ -100,7 +100,7 @@ import MetricBoxes from '../../components/MetricBoxes.vue';
 import MetricBox from '../../components/MetricBox.vue';
 import Tips from '../../components/Tips.vue';
 import { SharedMixin } from '../../lib/mixins/shared';
-import { assigneesColumns } from '../../lib/config/contracts.js';
+import { getAssigneesColumns } from '../../lib/config/contracts.js';
 import { money } from '../../../../lib/vue/filters';
 
 export default {
@@ -122,7 +122,7 @@ export default {
   data(){
     return {
       visualizationsData: this.$root.$data.contractsData,
-      assigneesColumns: assigneesColumns,
+      assigneesColumns: getAssigneesColumns(),
       items: [],
       tableItems: [],
       columns: [],
@@ -198,7 +198,7 @@ export default {
     }
   },
   created() {
-    this.columns = assigneesColumns;
+    this.columns = getAssigneesColumns();
     this.showColumns = ["count", "name", "sum"]
     this.tableItems = this.items.map(d => ({ ...d, href: `${location.origin}${location.pathname}${d.assignee_routing_id}` } ))
   },

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Aside.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Aside.vue
@@ -49,7 +49,7 @@ import { BlockHeader, Checkbox, Dropdown } from '../../../../lib/vue/components'
 import DownloadButton from '../../components/DownloadButton.vue';
 import SearchFilter from '../../components/SearchFilter.vue';
 import { EventBus } from '../../lib/mixins/event_bus';
-import { subsidiesFiltersConfig } from '../../lib/config/subsidies.js';
+import { getSubsidiesFiltersConfig } from '../../lib/config/subsidies.js';
 
 export default {
   name: 'Aside',
@@ -72,7 +72,7 @@ export default {
   },
   data() {
     return {
-      filters: subsidiesFiltersConfig,
+      filters: getSubsidiesFiltersConfig(),
       type: 'Subsidies'
     }
   },

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/SubsidiesIndex.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/SubsidiesIndex.vue
@@ -12,7 +12,7 @@
 <script>
 import { Table } from '../../../../lib/vue/components';
 import { EventBus } from '../../lib/mixins/event_bus';
-import { subsidiesColumns } from '../../lib/config/subsidies.js';
+import { getSubsidiesColumns } from '../../lib/config/subsidies.js';
 
 export default {
   name: 'SubsidiesIndex',
@@ -24,7 +24,7 @@ export default {
       subsidiesData: this.$root.$data.subsidiesData,
       items: [],
       value: '',
-      subsidiesColumns: subsidiesColumns,
+      subsidiesColumns: getSubsidiesColumns(),
       showColumns: []
     }
   },
@@ -43,7 +43,7 @@ export default {
     EventBus.$on('filtered-items', (value) => this.updateFilteredItems(value))
 
     this.items = this.subsidiesData.map(d => ({ ...d, href: `${location.origin}${location.pathname}/${d.id}` } ))
-    this.columns = subsidiesColumns;
+    this.columns = getSubsidiesColumns();
     this.showColumns = ['beneficiary', 'call','amount', 'grant_date']
   },
   beforeUnmount(){

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
@@ -85,7 +85,7 @@ import MetricBox from '../../components/MetricBox.vue';
 import MetricBoxes from '../../components/MetricBoxes.vue';
 import Tips from '../../components/Tips.vue';
 import TreeMapButtons from '../../components/TreeMapButtons.vue';
-import { grantedColumns, subsidiesFiltersConfig } from '../../lib/config/subsidies.js';
+import { getGrantedColumns, getSubsidiesFiltersConfig } from '../../lib/config/subsidies.js';
 import { SharedMixin } from '../../lib/mixins/shared';
 
 export default {
@@ -102,7 +102,7 @@ export default {
     return {
       visualizationsData: this.$root.$data.subsidiesData,
       items: [],
-      grantedColumns: grantedColumns,
+      grantedColumns: getGrantedColumns(),
       showColumns: [],
       value: "",
       isGobiertoVizzsLoaded: false,
@@ -111,7 +111,7 @@ export default {
       labelAmountDistribution: I18n.t("gobierto_visualizations.visualizations.subsidies.amount_distribution") || "",
       labelMainBeneficiaries: I18n.t("gobierto_visualizations.visualizations.subsidies.main_beneficiaries") || "",
       labelSubsidiesAmount: I18n.t("gobierto_visualizations.visualizations.subsidies.subsidies_amount") || "",
-      filters: subsidiesFiltersConfig,
+      filters: getSubsidiesFiltersConfig(),
       treemapButtons: [
         ["amount", I18n.t("gobierto_visualizations.visualizations.subsidies.subsidies_amount") || ""],
         ["total", I18n.t("gobierto_visualizations.visualizations.subsidies.subsidies_total") || ""],
@@ -159,7 +159,7 @@ export default {
     }
   },
   created() {
-    this.columns = grantedColumns;
+    this.columns = getGrantedColumns();
     this.showColumns = ['name', 'count', 'sum']
   },
   mounted() {

--- a/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
+++ b/app/javascript/gobierto_visualizations/webapp/containers/subsidies/Summary.vue
@@ -144,8 +144,9 @@ export default {
   },
   computed: {
     checkFilterCategoryLength() {
-      const filterCategories = this.filters.filter(({ id }) => id === 'categories')
-      return filterCategories[0].options.length > 0 ? true : false
+      // Check directly from data instead of relying on filters array
+      const categories = new Set(this.visualizationsData.map(({ category }) => category).filter(Boolean));
+      return categories.size > 1; // Show chart if there's more than one category
     }
   },
   watch: {

--- a/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
+++ b/app/javascript/gobierto_visualizations/webapp/lib/config/contracts.js
@@ -1,5 +1,5 @@
 // table columns
-export const contractsColumns = [
+export const getContractsColumns = () => [
   { field: 'assignee', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
   { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.contract'), cssClass: 'largest-width-td ellipsis' },
   { field: 'final_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.contract_amount'), cssClass: 'right nowrap pr1', type: 'money' },
@@ -13,27 +13,31 @@ export const contractsColumns = [
   { field: 'initial_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts_show.bid_description'), cssClass: 'nowrap pl1 right', type: 'money' }
 ];
 
-export const tendersColumns = [
+export const getTendersColumns = () => [
   { field: 'contractor', translation: I18n.t('gobierto_visualizations.visualizations.contracts.contractor'), cssClass: 'bold' },
   { field: 'status', translation: I18n.t('gobierto_visualizations.visualizations.contracts.status'), cssClass: '' },
   { field: 'submission_date', translation: I18n.t('gobierto_visualizations.visualizations.contracts.submission_date'), type: 'date', cssClass: 'nowrap right' },
 ];
 
-export const assigneesColumns = [
+export const getAssigneesColumns = () => [
   { field: 'name', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
   { field: 'count', name: I18n.t('gobierto_visualizations.visualizations.contracts.contracts'), cssClass: 'right' },
   { field: 'sum', name: I18n.t('gobierto_visualizations.visualizations.contracts.final_amount_no_taxes'), cssClass: 'right', type: 'money' },
 ];
 
-export const assigneesShowColumns = [
+export const getAssigneesShowColumns = () => [
   { field: 'title', name: I18n.t('gobierto_visualizations.visualizations.contracts.assignee'), cssClass: 'bold' },
   { field: 'final_amount_no_taxes', name: I18n.t('gobierto_visualizations.visualizations.contracts.final_amount_no_taxes'), cssClass: 'nowrap pr1 right', type: 'money' },
   { field: 'gobierto_start_date', name: I18n.t('gobierto_visualizations.visualizations.contracts.date'), cssClass: 'nowrap pl1 right', type: 'date' },
 ];
 
+// Note: All configs are now functions to ensure translations are evaluated at runtime
+// when the locale is properly set, rather than at module load time.
+
 // filters config
-const responsiveSize = window.innerWidth <= 769 ? false : true
-export const contractsFiltersConfig = [{
+export const getContractsFiltersConfig = () => {
+  const responsiveSize = window.innerWidth <= 769 ? false : true
+  return [{
     id: 'dates',
     title: I18n.t('gobierto_visualizations.visualizations.contracts.dates'),
     isToggle: responsiveSize,
@@ -62,5 +66,5 @@ export const contractsFiltersConfig = [{
     title: I18n.t('gobierto_visualizations.visualizations.contracts.entities'),
     isToggle: responsiveSize,
     options: []
-  }
-]
+  }]
+}

--- a/app/javascript/gobierto_visualizations/webapp/lib/config/subsidies.js
+++ b/app/javascript/gobierto_visualizations/webapp/lib/config/subsidies.js
@@ -1,30 +1,35 @@
 // table columns
-export const subsidiesColumns = [
+export const getSubsidiesColumns = () => [
   { field: 'beneficiary', name: I18n.t('gobierto_visualizations.visualizations.subsidies.beneficiary'), cssClass: 'bold nowrap' },
   { field: 'call', name: I18n.t('gobierto_visualizations.visualizations.subsidies.call'), cssClass: 'bold' },
   { field: 'amount', name: I18n.t('gobierto_visualizations.visualizations.subsidies.amount'), cssClass: 'right', type: 'money' },
   { field: 'grant_date', name: I18n.t('gobierto_visualizations.visualizations.subsidies.date'), cssClass: 'nowrap pl1 right' }
 ];
 
-export const grantedColumns = [
+export const getGrantedColumns = () => [
   { field: 'name', name: I18n.t('gobierto_visualizations.visualizations.subsidies.beneficiary'), cssClass: 'bold' },
   { field: 'count', name: I18n.t('gobierto_visualizations.visualizations.subsidies.subsidies'), cssClass: 'right' },
   { field: 'sum', name: I18n.t('gobierto_visualizations.visualizations.subsidies.amount'), cssClass: 'right', type: 'money' },
 ];
 
 // filters config
-const widthMobile = window.innerWidth > 0 ? window.innerWidth : screen.width
-export const subsidiesFiltersConfig = [
-  {
-    id: 'dates',
-    title: I18n.t('gobierto_visualizations.visualizations.subsidies.dates'),
-    isToggle: widthMobile <= 700 ? false : true,
-    options: []
-  },
-  {
-    id: 'categories',
-    title: I18n.t('gobierto_visualizations.visualizations.subsidies.category'),
-    isToggle: widthMobile <= 700 ? false : true,
-    options: []
-  }
-]
+export const getSubsidiesFiltersConfig = () => {
+  const widthMobile = window.innerWidth > 0 ? window.innerWidth : screen.width
+  return [
+    {
+      id: 'dates',
+      title: I18n.t('gobierto_visualizations.visualizations.subsidies.dates'),
+      isToggle: widthMobile <= 700 ? false : true,
+      options: []
+    },
+    {
+      id: 'categories',
+      title: I18n.t('gobierto_visualizations.visualizations.subsidies.category'),
+      isToggle: widthMobile <= 700 ? false : true,
+      options: []
+    }
+  ]
+}
+
+// Note: All configs are now functions to ensure translations are evaluated at runtime
+// when the locale is properly set, rather than at module load time.


### PR DESCRIPTION
## :v: What does this PR do?

This PR transforms configs into functions to ensure translations are evaluated at runtime when the locale is properly set, rather than at module load time.

## :mag: How should this be manually tested?

Visit the page of contracts visualizations https://uji.gobify.net/

## :eyes: Screenshots

### Before this PR
<img width="3018" height="1778" alt="image (1)" src="https://github.com/user-attachments/assets/56dc9674-e3a4-4a2c-952b-fee6b33b97ed" />

### After this PR

<img width="2616" height="1670" alt="image" src="https://github.com/user-attachments/assets/ba85f795-8d33-42a2-9221-231eddaf093b" />


## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
