### PR TITLE
Add performance indexes to gc_events for faster calendar queries

### DIFF
--- a/app/models/gobierto_calendars/event.rb
+++ b/app/models/gobierto_calendars/event.rb
@@ -56,7 +56,7 @@ module GobiertoCalendars
     scope :sorted_backwards, -> { order(starts_at: :desc) }
     scope :within_range, ->(date_range) { published.where(starts_at: date_range) }
     scope :synchronized, -> { where("external_id IS NOT NULL") }
-    scope :by_date, ->(date) { where("starts_at::date = ?", date) }
+    scope :by_date, ->(date) { where(starts_at: date.beginning_of_day..date.end_of_day) }
     scope :sort_by_updated_at, -> { order(updated_at: :desc) }
     scope :inverse_sorted_by_id, -> { order(id: :asc) }
     scope :sorted_by_id, -> { order(id: :desc) }

--- a/db/migrate/20260203123806_add_performance_indexes_to_gc_events.rb
+++ b/db/migrate/20260203123806_add_performance_indexes_to_gc_events.rb
@@ -1,0 +1,24 @@
+# ABOUTME: Migration to add performance indexes to gc_events table.
+# ABOUTME: Addresses slow queries in person events listings.
+
+class AddPerformanceIndexesToGcEvents < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :gc_events, [:site_id, :state, :starts_at],
+              order: { starts_at: :desc },
+              where: "archived_at IS NULL",
+              name: "index_gc_events_on_site_state_starts_not_archived",
+              algorithm: :concurrently
+
+    add_index :gc_events, :slug,
+              using: :gin,
+              opclass: :gin_trgm_ops,
+              name: "index_gc_events_on_slug_trgm",
+              algorithm: :concurrently
+
+    add_index :gc_events, :starts_at,
+              name: "index_gc_events_on_starts_at",
+              algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

Addresses slow queries (1-8+ seconds) affecting `gc_events` table by:

1. **Adding composite partial index** on `(site_id, state, starts_at)` for the main person events query pattern
2. **Adding trigram index** on `slug` for regex pattern matching during slug uniqueness checks
3. **Adding btree index** on `starts_at` for date range queries
4. **Fixing `by_date` scope** to use range queries instead of date casting, enabling index usage

### Query patterns addressed:
- Events listing via collection_items join (most frequent)
- Slug uniqueness regex checks
- Date-based event filtering

## :mag: How should this be manually tested?

1. Run migration: `bin/rails db:migrate`
2. Verify indexes exist: `\d gc_events` in psql
3. Test person events pages load faster
4. Run `EXPLAIN ANALYZE` on calendar queries to confirm index usage

## :eyes: Screenshots

N/A - Performance improvement, no UI changes

## :shipit: Does this PR changes any configuration file?

- [x] No configuration changes

## :book: Does this PR require updating the documentation?

- [x] No documentation changes required