### PR TITLE
Revert PR #4334: Validate date parameters in GobiertoPeople controllers

### DIFF
--- a/.cursor/skills/create-pr/SKILL.md
+++ b/.cursor/skills/create-pr/SKILL.md
@@ -8,8 +8,10 @@ Write and publish a PR for the current @branch
 - Check the code diff of the current branch with the master branch
 - Review uncommitted changes and add them to the PR if necessary
 - Run `i18n-tasks normalize`
+- Run /update-guides-and-changelog to see if any guide or the changelog should be added or completed
 - Use the CLI `gh pr create` to create the PR
 - Use the PR template: .github/PULL_REQUEST_TEMPLATE.md
 - Review @AGENTS.md "When Adding..." sections to ensure all required updates are done (MODULE_EVENTS, permissions, migrations, etc.)
 - Write brief and concise PR description, focusing on key things users should know about the changes.
+- If /docs guides have been added or update, reference it in the PR description.
 - Publish the PR to the remote repository as draft, in English

--- a/app/controllers/gobierto_people/application_controller.rb
+++ b/app/controllers/gobierto_people/application_controller.rb
@@ -1,13 +1,10 @@
 module GobiertoPeople
   class ApplicationController < ::ApplicationController
     include User::SessionHelper
-    MAX_YEAR = Date.today.year + 2
-    MIN_YEAR = Date.today.year - 5
 
     layout "gobierto_people/layouts/application"
 
     before_action { module_enabled!(current_site, "GobiertoPeople") }
-    before_action :check_dates_parameters
 
     helper_method :gifts_service_url, :trips_service_url, :cache_service, :show_only_calendar?
 
@@ -50,22 +47,6 @@ module GobiertoPeople
       base_path += "/#{params[:page]}" if params[:page].present?
       base_path += "/#{params[:slug]}" if params[:slug].present?
       base_path
-    end
-
-    def check_dates_parameters
-      render_404 and return false if params[:start_date].present? && !valid_date?(params[:start_date])
-      render_404 and return false if params[:end_date].present? && !valid_date?(params[:end_date])
-      render_404 and return false if params[:date].present? && !valid_date?(params[:date])
-      render_404 and return false if params[:page].present? && params[:page].to_i > 5
-
-      true
-    end
-
-    def valid_date?(date_string)
-      return false unless date_string.present?
-
-      parsed_date = Date.parse(date_string) rescue nil
-      parsed_date.present? && parsed_date.year.in?(MIN_YEAR..MAX_YEAR) && parsed_date.month.in?(1..12) && parsed_date.day.in?(1..31)
     end
 
   end

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -122,12 +122,12 @@ ca:
             rejected: No aprovats
             sent: Enviat
             unsent: No enviats
-          total: Total
           versions_visibility_level: Publicació
           versions_visibility_level_value:
             draft: Esborrany
             published_up_to_date: Publicat actualitzat
             published_with_unpublished_changes: Publicat amb canvis sense publicar
+          total: Total
         form:
           button:
             add_dashboard: Afegir a un dashboard

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -120,12 +120,12 @@ en:
             rejected: Rejected
             sent: Sent
             unsent: Not sent
-          total: Total
           versions_visibility_level: Publication
           versions_visibility_level_value:
             draft: Draft
             published_up_to_date: Published up to date
             published_with_unpublished_changes: Published with unpublished changes
+          total: Total
         form:
           button:
             add_dashboard: Add to dashboard

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -122,12 +122,12 @@ es:
             rejected: Rechazados
             sent: Enviados
             unsent: No enviados
-          total: Total
           versions_visibility_level: Publicación
           versions_visibility_level_value:
             draft: Borrador
             published_up_to_date: Publicado actualizado
             published_with_unpublished_changes: Publicado con cambios sin publicar
+          total: Total
         form:
           button:
             add_dashboard: Añadir a un dashboard

--- a/test/controllers/gobierto_people/people_controller_test.rb
+++ b/test/controllers/gobierto_people/people_controller_test.rb
@@ -32,10 +32,10 @@ gobierto_people_default_filter_end_date: "#{options[:end_date]}"
     @wide_date_range_params ||= { start_date: 10.years.ago.strftime("%Y-%m-%d"), end_date: 10.years.from_now.strftime("%Y-%m-%d") }
   end
 
-  def test_wrong_dates_cause_not_found
+  def test_wrong_dates_cause_bad_request
     with_current_site(site) do
       get gobierto_people_past_events_path(date: '2018-04-27', start_date: '700')
-      assert_response :not_found
+      assert_response :bad_request
     end
   end
 
@@ -88,11 +88,10 @@ gobierto_people_default_filter_end_date: "#{options[:end_date]}"
       person.invitations.destroy_all
       person.trips.destroy_all
 
-      start_year = Date.today.year - 4
       last_year = Date.today.year - 1
-      get gobierto_people_person_path(person.slug, start_date: "#{start_year}-01-01", end_date: "#{last_year}-01-01")
+      get gobierto_people_person_path(person.slug, start_date: "2012-01-01", end_date: "#{last_year}-01-01")
       assert_response :redirect
-      assert_redirected_to(gobierto_people_person_gifts_path(@person.slug, start_date: "#{start_year}-01-01", end_date: "#{last_year}-01-01"))
+      assert_redirected_to(gobierto_people_person_gifts_path(@person.slug, start_date: "2012-01-01", end_date: "#{last_year}-01-01"))
     end
   end
 end

--- a/test/integration/gobierto_people/date_filters_test.rb
+++ b/test/integration/gobierto_people/date_filters_test.rb
@@ -9,10 +9,10 @@ module GobiertoPeople
     include ::GobiertoPeople::SubmodulesHelper
     include ::EventHelpers
 
-    FAR_PAST = 2.years.ago
+    FAR_PAST = 10.years.ago
     RECENT_PAST = 1.day.ago
     NEAR_FUTURE = 1.day.from_now
-    FAR_FUTURE = 2.years.from_now
+    FAR_FUTURE = 10.years.from_now
 
     attr_reader(
       :events_with_department,
@@ -182,19 +182,22 @@ module GobiertoPeople
           assert has_content? "#{people_with_department_events.size} officials with registered events"
         end
 
-        # 404 for bad start_date and end_date
+        # all events/people (bad start_date and end_date)
         visit path_with_start_and_end_dates("wadus", "wadus")
-        assert_equal 404, page.status_code
+        within ".container" do
+          assert has_content? "#{events_with_department.size} registered events"
+          assert has_content? "#{people_with_department_events.size} officials with registered events"
+        end
 
-        # 404 for valid start_date with bad end_date
+        # only upcoming events/people with upcoming events (ok start_date, bad end_date)
         visit path_with_start_and_end_dates(NEAR_FUTURE, "wadus")
-        assert_equal 404, page.status_code
+        within ".container" do
+          assert has_content? "#{upcoming_events_with_department.size} registered events"
+          assert has_content? "#{people_with_upcoming_department_events.size} officials with registered events"
+        end
 
-        # 404 for bad start_date
+        # all events/people (bad start_date)
         visit path_with_start_date("wadus")
-        assert_equal 404, page.status_code
-
-        # default range still works after bad date visits
         visit path_without_date_params
         within ".container" do
           assert has_content? "#{events_with_department.size} registered events"

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -189,8 +189,8 @@ YAML
 
           visit gobierto_people_department_people_path(
             immigration_department_mixed,
-            start_date: "2023-06-01",
-            end_date: "2023-12-31"
+            start_date: 100.years.ago,
+            end_date: 50.years.ago
           )
 
           within departments_sidebar do
@@ -205,7 +205,6 @@ YAML
       def test_index_filtered_by_date_visit_departments_people_check_sidebar
         clear_activities
         site.events.where.not(id: neil.events.pluck(:id)).destroy_all
-        immigration_department_event.update!(starts_at: "2022-06-15 10:00", ends_at: "2022-06-15 12:00")
 
         departments_with_activities = [
           immigration_department_mixed
@@ -215,7 +214,7 @@ YAML
           set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
           # everything is displayed with broad range
 
-          start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+          start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
           visit gobierto_people_department_people_path(
             immigration_department_mixed,
@@ -258,16 +257,15 @@ YAML
       def test_index_filtered_by_date_visit_departments_people_check_sidebar_other_dates_in_past
         clear_activities
         site.events.where.not(id: neil.events.pluck(:id)).destroy_all
-        immigration_department_event.update!(starts_at: "2022-06-15 10:00", ends_at: "2022-06-15 12:00")
 
         with_current_site(site) do
           set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-          # only departments with events within valid date range are displayed
+          # only departments with very old events are displayed
 
           visit gobierto_people_department_people_path(
             immigration_department_mixed,
-            start_date: 5.years.ago,
-            end_date: 2.years.from_now
+            start_date: 20.years.ago - 1.day,
+            end_date: 20.years.from_now + 1.day
           )
 
           within departments_sidebar do
@@ -283,9 +281,8 @@ YAML
         GobiertoCalendars::Event.destroy_all
         GobiertoPeople::Gift.destroy_all
         GobiertoPeople::Invitation.destroy_all
-        GobiertoPeople::Charge.where(person: richard, department: tourism_department_very_old).update_all(end_date: nil)
         set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-        start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
         with_current_site(site) do
           visit gobierto_people_department_people_path(
@@ -314,7 +311,7 @@ YAML
         GobiertoPeople::Trip.destroy_all
         GobiertoPeople::Invitation.destroy_all
         set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-        start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
         with_current_site(site) do
           visit gobierto_people_department_people_path(
@@ -343,7 +340,7 @@ YAML
         GobiertoPeople::Gift.destroy_all
         GobiertoPeople::Trip.destroy_all
         set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-        start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
         with_current_site(site) do
           visit gobierto_people_department_people_path(

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -118,12 +118,11 @@ module GobiertoPeople
       end
 
       def test_calendar_navigation_arrows
-        year = Date.today.year
-        past_event = create_event(starts_at: "#{year}-02-15", person: richard)
-        present_event = create_event(starts_at: "#{year}-03-15", person: richard)
-        future_event = create_event(starts_at: "#{year}-04-15", person: richard)
+        past_event = create_event(starts_at: "2014-02-15", person: richard)
+        present_event = create_event(starts_at: "2014-03-15", person: richard)
+        future_event = create_event(starts_at: "2014-04-15", person: richard)
 
-        Timecop.freeze(Time.zone.parse("#{year}-03-15")) do
+        Timecop.freeze(Time.zone.parse("2014-03-15")) do
           with_current_site(site) do
             visit @path
 
@@ -151,7 +150,7 @@ module GobiertoPeople
       def test_filter_events_by_calendar_date_link
         richard.events.destroy_all
 
-        freeze_date = Time.zone.parse("#{Date.today.year}-04-15 6:00")
+        freeze_date = Time.zone.parse("2014-04-15 6:00")
         yesterday = freeze_date - 1.day
 
         yesterday_early_event = create_event(title: "Yesterday early event", starts_at: yesterday.change(hour: 7))

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -181,11 +181,10 @@ YAML
 
     def test_people_index_with_departments_enabled_and_date_filter
       clear_activities
-      site.events.destroy_all
       set_default_dates
 
       with_current_site(site) do
-        visit gobierto_people_people_path(end_date: 5.years.ago)
+        visit gobierto_people_people_path(end_date: 50.years.ago)
 
         assert has_selector?("h2", text: "#{site.name}'s organization chart")
 
@@ -250,7 +249,7 @@ YAML
       GobiertoPeople::Invitation.destroy_all
 
       set_default_dates
-      start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+      start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
       with_current_site(site) do
         visit gobierto_people_people_path(
@@ -279,7 +278,7 @@ YAML
       GobiertoPeople::Trip.destroy_all
 
       set_default_dates
-      start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+      start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
       with_current_site(site) do
         visit gobierto_people_people_path(
@@ -308,7 +307,7 @@ YAML
       GobiertoPeople::Trip.destroy_all
 
       set_default_dates
-      start_date, end_date = [5.years.ago, 2.years.from_now].map { |d| d.strftime "%F" }
+      start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
 
       with_current_site(site) do
         visit gobierto_people_people_path(

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -7,14 +7,11 @@ module GobiertoPeople
   class PersonEventsIndexTest < ActionDispatch::IntegrationTest
     include ::EventHelpers
 
-    attr_reader :reference_year
-
     def setup
       super
       @path = gobierto_people_events_path
       @path_for_json = gobierto_people_events_path(format: :json)
       @path_for_csv = gobierto_people_events_path(format: :csv)
-      @reference_year = Date.today.year
     end
 
     def site
@@ -162,13 +159,13 @@ module GobiertoPeople
     end
 
     def test_person_events_filter_for_calendar_widget
-      government_event = create_event(person: government_member, starts_at: "#{reference_year}-06-16")
-      executive_event = create_event(person: executive_member, starts_at: "#{reference_year}-06-17")
+      government_event = create_event(person: government_member, starts_at: "2014-03-16")
+      executive_event = create_event(person: executive_member, starts_at: "2014-03-17")
 
       government_event_day = government_event.starts_at.day
       executive_event_day = executive_event.starts_at.day
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-06-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit @path
 
@@ -197,10 +194,10 @@ module GobiertoPeople
     end
 
     def test_person_events_filter_for_events_list
-      government_event = create_event(person: government_member, title: "Government event", starts_at: "#{reference_year}-03-16")
-      executive_event = create_event(person: executive_member, title: "Executive event", starts_at: "#{reference_year}-03-16")
+      government_event = create_event(person: government_member, title: "Government event", starts_at: "2014-03-16")
+      executive_event = create_event(person: executive_member, title: "Executive event", starts_at: "2014-03-16")
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-03-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit @path
 
@@ -317,10 +314,10 @@ module GobiertoPeople
     end
 
     def test_future_and_past_events_filter
-      past_event = create_event(title: "Past event title", starts_at: "#{reference_year}-02-15")
-      future_event = create_event(title: "Future event title", starts_at: "#{reference_year}-04-15")
+      past_event = create_event(title: "Past event title", starts_at: "2014-02-15")
+      future_event = create_event(title: "Future event title", starts_at: "2014-04-15")
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-03-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit @path
 
@@ -367,9 +364,9 @@ module GobiertoPeople
     end
 
     def test_calendar_component
-      future_event = create_event(starts_at: "#{reference_year}-03-16")
+      future_event = create_event(starts_at: "2014-03-16")
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-03-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit gobierto_people_events_path(start_date: future_event.starts_at)
 
@@ -381,10 +378,10 @@ module GobiertoPeople
     end
 
     def test_calendar_navigation_arrows
-      past_event = create_event(starts_at: "#{reference_year}-02-15")
-      future_event = create_event(starts_at: "#{reference_year}-04-15")
+      past_event = create_event(starts_at: "2014-02-15")
+      future_event = create_event(starts_at: "2014-04-15")
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-03-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit gobierto_people_events_path
 
@@ -406,11 +403,11 @@ module GobiertoPeople
     end
 
     def test_calendar_event_links
-      visible_month_events = ["#{reference_year}-02-28", "#{reference_year}-03-14", "#{reference_year}-03-16", "#{reference_year}-04-01"].map do |date|
+      visible_month_events = ["2014-02-28", "2014-03-14", "2014-03-16", "2014-04-01"].map do |date|
         create_event(starts_at: date)
       end
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-03-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit gobierto_people_events_path
 
@@ -424,10 +421,10 @@ module GobiertoPeople
     end
 
     def test_filter_events_by_calendar_date_link
-      past_event = create_event(title: "Past event title", starts_at: "#{reference_year}-03-10 11:00")
-      future_event = create_event(title: "Future event title", starts_at: "#{reference_year}-03-20 11:00")
+      past_event = create_event(title: "Past event title", starts_at: "2014-03-10 11:00")
+      future_event = create_event(title: "Future event title", starts_at: "2014-03-20 11:00")
 
-      Timecop.freeze(Time.zone.parse("#{reference_year}-03-15")) do
+      Timecop.freeze(Time.zone.parse("2014-03-15")) do
         with_current_site(site) do
           visit @path
 


### PR DESCRIPTION
## Summary
- Reverts PR #4334 which added date parameter validation to GobiertoPeople controllers

## Test plan
- [x] Verify GobiertoPeople pages load normally with arbitrary date params
- [x] Confirm existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)