### PR TITLE
Load OpenSSL legacy provider for exchanger NTLM auth

### DIFF
--- a/config/initializers/openssl.rb
+++ b/config/initializers/openssl.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# OpenSSL 3.x disables legacy digest algorithms (MD4, MD5) by default.
+# The exchanger gem depends on rubyntlm for NTLM authentication,
+# which requires these algorithms.
+if defined?(OpenSSL::Provider)
+  OpenSSL::Provider.load("legacy")
+  OpenSSL::Provider.load("default")
+end


### PR DESCRIPTION
## :v: What does this PR do?

Adds an initializer that loads the OpenSSL legacy provider so that the exchanger gem's NTLM authentication works on OpenSSL 3.x. OpenSSL 3.x disables legacy digest algorithms (MD4, MD5) by default, which rubyntlm requires.

## :mag: How should this be manually tested?

1. Verify that Exchange calendar sync (NTLM-authenticated) works without OpenSSL errors
2. Confirm the initializer only loads the legacy provider when `OpenSSL::Provider` is defined (OpenSSL 3.x+)

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?