### PR TITLE
Move exposed token to secrets

### DIFF
--- a/app/javascript/gobierto_investments/index.js
+++ b/app/javascript/gobierto_investments/index.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     siteName: appNode.dataset.siteName,
     logoUrl: appNode.dataset.logoUrl,
     homeUrl: appNode.dataset.homeUrl,
-    tourUrl: appNode.dataset.tourUrl
+    tourUrl: appNode.dataset.tourUrl,
+    mapboxToken: appNode.dataset.mapboxToken
   });
 });

--- a/app/javascript/gobierto_investments/webapp/components/Map.vue
+++ b/app/javascript/gobierto_investments/webapp/components/Map.vue
@@ -71,7 +71,7 @@ export default {
         username: "gobierto",
         style_id: "ck18y48jg11ip1cqeu3b9wpar",
         tilesize: "256",
-        token: "pk.eyJ1IjoiYmltdXgiLCJhIjoiY2swbmozcndlMDBjeDNuczNscTZzaXEwYyJ9.oMM71W-skMU6IN0XUZJzGQ",
+        token: this.$root?.$data?.mapboxToken || "",
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         minZoom: 6,
         maxZoom: 16

--- a/app/javascript/gobierto_investments/webapp/components/MapTour.vue
+++ b/app/javascript/gobierto_investments/webapp/components/MapTour.vue
@@ -94,7 +94,7 @@ export default {
       username: "gobierto",
       style_id: "ck18y48jg11ip1cqeu3b9wpar",
       tilesize: "256",
-      accessToken: "pk.eyJ1IjoiYmltdXgiLCJhIjoiY2swbmozcndlMDBjeDNuczNscTZzaXEwYyJ9.oMM71W-skMU6IN0XUZJzGQ",
+      accessToken: this.$root?.$data?.mapboxToken || "",
       buttonExit: I18n.t("gobierto_investments.projects.exit"),
       buttonReload: I18n.t("gobierto_investments.projects.see"),
       scrollZoom: false,

--- a/app/views/gobierto_investments/investments/index.html.erb
+++ b/app/views/gobierto_investments/investments/index.html.erb
@@ -20,7 +20,8 @@
        data-site-name="<%= @site.name %>"
        data-logo-url="<%= @site.configuration.logo_with_fallback %>"
        data-home-url="<%= root_url %>"
-       data-tour-url="<%= gobierto_investments_tour_url %>">
+       data-tour-url="<%= gobierto_investments_tour_url %>"
+       data-mapbox-token="<%= Rails.application.secrets.mapbox_token || '' %>">
   </div>
 
 </div>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -3,6 +3,7 @@ default: &default
   elastic_url: <%= ENV.fetch("ELASTICSEARCH_URL") { "http://localhost:9200" } %>
   google_places_api_key: <%= ENV["GOOGLE_PLACES_API_KEY"] %>
   google_maps_geocoding_api_key: <%= ENV["GOOGLE_MAPS_GEOCODING_API_KEY"] %>
+  mapbox_token: <%= ENV["MAPBOX_TOKEN"] %>
   mailer_delivery_method: <%= ENV["MAILER_DELIVERY_METHOD"] %>
   mailer_smtp_settings:
     address: <%= ENV["MAILER_SMTP_ADDRESS"] %>

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -3,6 +3,7 @@ default: &default
   elastic_url: <%= ENV.fetch("ELASTICSEARCH_URL") { "http://localhost:9200" } %>
   google_places_api_key: <%= ENV["GOOGLE_PLACES_API_KEY"] %>
   google_maps_geocoding_api_key: <%= ENV["GOOGLE_MAPS_GEOCODING_API_KEY"] %>
+  mapbox_token: <%= ENV["MAPBOX_TOKEN"] %>
   mailer_delivery_method: <%= ENV["MAILER_DELIVERY_METHOD"] %>
   mailer_smtp_settings:
     address: <%= ENV["MAILER_SMTP_ADDRESS"] %>


### PR DESCRIPTION
## :v: What does this PR do?

This PR solves https://github.com/PopulateTools/gobierto/security/secret-scanning/1 by moving the token to secrets

## :mag: How should this be manually tested?

Review that the map in https://mataro.gobify.net/inversiones is displayed correctly

## :shipit: Does this PR changes any configuration file?

- [x] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [x] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible: see https://github.com/PopulateTools/ansible-populate/pull/858) 

## :book: Does this PR require updating the documentation?

No