### PR TITLE
Extend 15 days the start of google calendar sync range

### DIFF
--- a/app/models/gobierto_calendars.rb
+++ b/app/models/gobierto_calendars.rb
@@ -33,6 +33,18 @@ module GobiertoCalendars
     sync_range_start_ibm_notes..sync_range_end_ibm_notes
   end
 
+  def self.sync_range_start_google_calendar
+    15.days.before(sync_range_start)
+  end
+
+  def self.sync_range_end_google_calendar
+    sync_range_end
+  end
+
+  def self.sync_range_google_calendar
+    sync_range_start_google_calendar..sync_range_end_google_calendar
+  end
+
   class << self
     alias_method :cache_base_key, :table_name_prefix
   end

--- a/app/services/gobierto_people/google_calendar/calendar_integration.rb
+++ b/app/services/gobierto_people/google_calendar/calendar_integration.rb
@@ -55,8 +55,8 @@ module GobiertoPeople
         event_items = service.list_events(
           calendar.id,
           always_include_email: true,
-          time_min: GobiertoCalendars.sync_range_start.iso8601,
-          time_max: GobiertoCalendars.sync_range_end.iso8601,
+          time_min: GobiertoCalendars.sync_range_start_google_calendar.iso8601,
+          time_max: GobiertoCalendars.sync_range_end_google_calendar.iso8601,
           max_results: 2500,
           order_by: 'startTime',
           single_events: true


### PR DESCRIPTION
Closes #N


## :v: What does this PR do?

This PR extends the range of date to import calendar events from google changing the start date to 15 days in the past.


## :mag: How should this be manually tested?

Run the manual sync from admin calendar configuration: The not imported yet events in the last 15 days should be added


## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No