### PR TITLE
Sort by position and then alphabetically in custom field vocabulary component

### DIFF
--- a/app/javascript/gobierto_plans/webapp/components/CustomFieldVocabulary.vue
+++ b/app/javascript/gobierto_plans/webapp/components/CustomFieldVocabulary.vue
@@ -71,13 +71,13 @@ export default {
 
     // parse the vocabularies, sorting them by its name
     this.vocabularies = vocabulary_terms
-      .reduce((acc, { id, attributes: { name = "", slug = "" } = {} }) => {
+      .reduce((acc, { id, attributes: { name = "", slug = "", position = 0 } = {} }) => {
         if (elements.includes(id)) {
-          acc.push({ id, name, group: uid, term: slug, hasLink: vocabularyLinkable });
+          acc.push({ id, name, position, group: uid, term: slug, hasLink: vocabularyLinkable });
         }
         return acc;
       }, [])
-      .sort((a, b) => a.name > b.name ? 1 : -1);
+      .sort((a, b) => a.position !== b.position ? a.position - b.position : a.name.localeCompare(b.name));
   }
 };
 </script>


### PR DESCRIPTION
## :v: What does this PR do?

In the custom field vocabulary component used in Plans, terms were previously sorted only alphabetically by name. This PR updates the sort to use the `position` attribute first, falling back to alphabetical order when positions are equal.

This ensures that vocabulary terms respect the order configured by the administrator.

## :mag: How should this be manually tested?

Staging:

1. Review the following custom field of type vocabulary with multiple selections: https://amb.gobify.net/admin/custom_fields/520/edit
2. Reorder the vocabulary terms: https://amb.gobify.net/admin/vocabularies/332/terms
3. Verify that the terms appear in the configured position order rather than alphabetical order: https://amb.gobify.net/planes/pam/2024/proyecto/42233

## :eyes: Screenshots

### Before this PR

Terms sorted alphabetically only.

### After this PR

Terms sorted by position first, then alphabetically.

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No