### PR TITLE
Adapt task to allow skipping existing lines

### DIFF
--- a/lib/tasks/gobierto_budgets/custom_categories.rake
+++ b/lib/tasks/gobierto_budgets/custom_categories.rake
@@ -29,8 +29,8 @@ namespace :gobierto_budgets do
     end
 
     desc "Import categories, providing the site_domain, the file path to the categories and the locale"
-    task :import, [:site_domain, :file_path, :locale] => [:environment] do |_t, args|
-      def area_name(area)
+    task :import, [:site_domain, :file_path, :locale, :skip_existing] => [:environment] do |_t, args|
+      def get_area_name(area)
         case area
         when 'E'
           GobiertoBudgets::EconomicArea.area_name
@@ -50,15 +50,39 @@ namespace :gobierto_budgets do
         row["Descripcion"] || row["Descripción"]
       end
 
-      I18n.locale = args[:locale]
+      imported = 0
+      skipped = 0
+      existing_codes = {}
+
+      skip_existing = args[:skip_existing] == "true"
+      locale = args[:locale]
+      I18n.locale = locale
       site = Site.find_by!(domain: args[:site_domain])
 
       CSV.foreach(args[:file_path], headers: true) do |row|
-        c = GobiertoBudgets::Category.find_or_create_by! site: site, area_name: area_name(row['Area']), kind: row['Tipo'], code: row['Codigo']
+        area_name = get_area_name(row["Area"])
+        code = row["Codigo"]
+        kind = row["Tipo"]
+
+        if skip_existing
+          if existing_codes[area_name].blank?
+            area_klass = GobiertoBudgets::BudgetArea.klass_for(area_name)
+            existing_codes[area_name] = area_klass.all_descriptions.dig(locale.to_sym, area_name, kind) || {}
+          end
+          if existing_codes[area_name].key?(code)
+            skipped += 1
+            next
+          end
+        end
+
+        c = GobiertoBudgets::Category.find_or_create_by!(site:, area_name:, kind:, code:)
         c.custom_name = custom_name(row)
         c.custom_description = custom_description(row)
         c.save!
+        imported += 1
       end
+
+      puts "[SUCCESS] Imported #{imported}, skipped #{skipped}"
     end
   end
 end


### PR DESCRIPTION
## :v: What does this PR do?

This PR makes a small change in the task to import custom categories in budget lines to skip loading translations when the line already has a translation provided by default. This is useful because in the case of Burgos they have sent us translations for a set of categories with the translations truncated, so it is expected that the quality of our default translations is better than theirs.

The new argument to skip existing translations is optional, so the task can continue to function as before without changes.

## :mag: How should this be manually tested?

Create a CSV file with this content, for example:
```csv
"Nivel","Código","Código editado","Nombre","Máscara","Operativo","Codigo","left","right","igu","Area","Tipo"
"1","1","1","Impuestos directos.",,0,"1","1","",TRUE,"E","I"
"2","10","10","Impuesto sobre la Renta.",,0,"10","10","",TRUE,"E","I"
"3","100","100","Impuestos sobre la Renta de las Personas Físicas.",,0,"100","100","",TRUE,"E","I"
"4","22004","22004","Impuesto sobre hidrocarburos.",,1,"220-04","220","04",TRUE,"E","I"
"4","22005","22005","Impuesto sobre determinados medios de transporte.",,1,"220-05","220","05",TRUE,"E","I"
```

Call the task (in this example I have used burgos site):

```
./bin/rake 'gobierto_budgets:custom_categories:import[burgos.gobify.net,/tmp/lines.csv,es,true]'
```

The custom code "1" should not exist but the code "220-05" yes.

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
