### PR TITLE
Stop bot redirect loops and bound bad date params on agendas

### DIFF
--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -51,7 +51,7 @@ module GobiertoPeople
       }
     end
 
-    SENSIBLE_YEAR_RANGE = (1990..(Date.current.year + 10)).freeze
+    SENSIBLE_YEAR_RANGE = (1900..2200).freeze
 
     def parse_date(date, fallback = nil)
       return unless date

--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -51,9 +51,13 @@ module GobiertoPeople
       }
     end
 
+    SENSIBLE_YEAR_RANGE = (1990..(Date.current.year + 10)).freeze
+
     def parse_date(date, fallback = nil)
       return unless date
-      Time.zone.parse(date)
+      parsed = Time.zone.parse(date.to_s)
+      return fallback unless parsed && SENSIBLE_YEAR_RANGE.cover?(parsed.year)
+      parsed
     rescue ArgumentError
       fallback
     end

--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -51,7 +51,7 @@ module GobiertoPeople
       }
     end
 
-    SENSIBLE_YEAR_RANGE = (1900..2200).freeze
+    SENSIBLE_YEAR_RANGE = (2010..2060).freeze
 
     def parse_date(date, fallback = nil)
       return unless date

--- a/app/controllers/gobierto_budgets/budgets_execution_controller.rb
+++ b/app/controllers/gobierto_budgets/budgets_execution_controller.rb
@@ -6,7 +6,10 @@ class GobiertoBudgets::BudgetsExecutionController < GobiertoBudgets::Application
   def index
     unless @any_budgets_execution_data_for_year = any_execution_data?
       flash[:alert] = t('controllers.gobierto_budgets.budgets_execution.index.alert', year: @year)
-      redirect_to gobierto_budgets_budgets_execution_path(@year - 1) and return
+      previous_year = @year - 1
+      if previous_year >= GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.first
+        redirect_to gobierto_budgets_budgets_execution_path(previous_year) and return
+      end
     end
 
     @any_economic_income_budget_lines    = any_execution_data?(kind: GobiertoBudgets::BudgetLine::INCOME,  area: GobiertoBudgets::EconomicArea)
@@ -26,11 +29,19 @@ class GobiertoBudgets::BudgetsExecutionController < GobiertoBudgets::Application
   private
 
   def load_year
-    if params[:year].nil?
+    if params[:year].nil? || !valid_year_param?(params[:year])
       redirect_to gobierto_budgets_budgets_execution_path(GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.last)
     else
       @year = params[:year].to_i
     end
+  end
+
+  def valid_year_param?(year_param)
+    return false unless year_param.to_s.match?(/\A\d+\z/)
+
+    year_int = year_param.to_i
+    year_int >= GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.first &&
+      year_int <= GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.last
   end
 
   def any_execution_data?(params={})

--- a/app/controllers/gobierto_people/people/past_person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/past_person_events_controller.rb
@@ -12,8 +12,9 @@ module GobiertoPeople
       )
 
       def index
-        if params[:date]
-          @filtering_date = Date.parse(params[:date])
+        parsed_date = parse_date(params[:date]) if params[:date]
+        if parsed_date
+          @filtering_date = parsed_date.to_date
           @events = @person.events.by_date(@filtering_date)
           @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         elsif params[:page] == "false"

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -19,8 +19,9 @@ module GobiertoPeople
       )
 
       def index
-        if params[:date]
-          @filtering_date = Date.parse(params[:date])
+        parsed_date = parse_date(params[:date]) if params[:date]
+        if parsed_date
+          @filtering_date = parsed_date.to_date
           @events = @person.owned_attending_events.by_date(@filtering_date).published
           @events = (@filtering_date.future? ? @events.sorted : @events.sorted_backwards).page params[:page]
         else
@@ -51,8 +52,9 @@ module GobiertoPeople
       private
 
       def fullcalendar_events
-        starts = Time.zone.parse(params[:start])
-        ends   = Time.zone.parse(params[:end])
+        starts = parse_date(params[:start])
+        ends   = parse_date(params[:end])
+        return [] unless starts && ends
         events = @person.owned_attending_events.published.where('starts_at >= ? AND ends_at <= ?', starts, ends)
         events.map do |event|
           ::GobiertoCalendars::FullcalendarEventSerializer.new(

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -79,19 +79,16 @@ module GobiertoPeople
     end
 
     def filter_events_by_date(date)
-      @filtering_date = Date.parse(date)
+      parsed = parse_date(date)
+      return @events unless parsed
+      @filtering_date = parsed.to_date
       @events = @events.by_date(@filtering_date)
-      @events = (@filtering_date >= Time.now ? @events.sorted : @events.sorted_backwards)
-    rescue ArgumentError
-      @events
+      @events = (@filtering_date >= Time.now.to_date ? @events.sorted : @events.sorted_backwards)
     end
 
     def calendar_date_range
-      if params[:start_date]
-        (Date.parse(params[:start_date]).at_beginning_of_month.at_beginning_of_week)..(Date.parse(params[:start_date]).at_end_of_month.at_end_of_week)
-      else
-        (Time.zone.now.at_beginning_of_month.at_beginning_of_week)..(Time.zone.now.at_end_of_month.at_end_of_week)
-      end
+      anchor = parse_date(params[:start_date]) || Time.zone.now
+      (anchor.at_beginning_of_month.at_beginning_of_week)..(anchor.at_end_of_month.at_end_of_week)
     end
 
   end

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -87,7 +87,12 @@ module GobiertoPeople
     end
 
     def calendar_date_range
-      anchor = parse_date(params[:start_date]) || Time.zone.now
+      anchor = if params[:start_date]
+                 parsed = Date.parse(params[:start_date])
+                 DatesRangeHelper::SENSIBLE_YEAR_RANGE.cover?(parsed.year) ? parsed : Time.zone.now
+               else
+                 Time.zone.now
+               end
       (anchor.at_beginning_of_month.at_beginning_of_week)..(anchor.at_end_of_month.at_end_of_week)
     end
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
       remote_ip: event.payload[:remote_ip],
       ip: event.payload[:ip],
       x_forwarded_for: event.payload[:x_forwarded_for],
+      user_agent: event.payload[:headers]&.[]("HTTP_USER_AGENT"),
 
       params: event.payload[:params].except(*exceptions).to_json,
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,10 +2,30 @@
 
 Rack::Attack.enabled = !Rails.env.test?
 
+Rack::Attack.blocklist("block negative-year budget execution paths") do |request|
+  request.path.match?(%r{\A(?:/[a-z]{2})?/presupuestos/ejecucion/-\d+\z})
+end
+
 Rack::Attack.throttle("requests by ip Tier 1", limit: 20, period: 10.seconds) do |request|
+  request.ip
+end
+
+Rack::Attack.throttle("budgets execution by ip", limit: 10, period: 10.seconds) do |request|
+  request.ip if request.path.match?(%r{\A(?:/[a-z]{2})?/presupuestos/ejecucion(/|\z)})
+end
+
+Rack::Attack.throttle("agendas by ip", limit: 10, period: 10.seconds) do |request|
+  request.ip if request.path.match?(%r{\A(?:/[a-z]{2})?/agendas(/|\z)})
+end
+
+Rack::Attack.throttle("requests by ip hourly", limit: 1000, period: 1.hour) do |request|
   request.ip
 end
 
 ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |name, start, finish, instrumenter_id, payload|
   Rails.logger.info("[rack_attack] #{payload[:request].ip} #{payload[:request].request_method} #{payload[:request].fullpath}")
+end
+
+ActiveSupport::Notifications.subscribe("blocklist.rack_attack") do |name, start, finish, instrumenter_id, payload|
+  Rails.logger.info("[rack_attack blocklist] #{payload[:request].ip} #{payload[:request].request_method} #{payload[:request].fullpath}")
 end

--- a/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/ca.yml
@@ -122,12 +122,12 @@ ca:
             rejected: No aprovats
             sent: Enviat
             unsent: No enviats
+          total: Total
           versions_visibility_level: Publicació
           versions_visibility_level_value:
             draft: Esborrany
             published_up_to_date: Publicat actualitzat
             published_with_unpublished_changes: Publicat amb canvis sense publicar
-          total: Total
         form:
           button:
             add_dashboard: Afegir a un dashboard

--- a/config/locales/gobierto_admin/gobierto_plans/views/en.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/en.yml
@@ -120,12 +120,12 @@ en:
             rejected: Rejected
             sent: Sent
             unsent: Not sent
+          total: Total
           versions_visibility_level: Publication
           versions_visibility_level_value:
             draft: Draft
             published_up_to_date: Published up to date
             published_with_unpublished_changes: Published with unpublished changes
-          total: Total
         form:
           button:
             add_dashboard: Add to dashboard

--- a/config/locales/gobierto_admin/gobierto_plans/views/es.yml
+++ b/config/locales/gobierto_admin/gobierto_plans/views/es.yml
@@ -122,12 +122,12 @@ es:
             rejected: Rechazados
             sent: Enviados
             unsent: No enviados
+          total: Total
           versions_visibility_level: Publicación
           versions_visibility_level_value:
             draft: Borrador
             published_up_to_date: Publicado actualizado
             published_with_unpublished_changes: Publicado con cambios sin publicar
-          total: Total
         form:
           button:
             add_dashboard: Añadir a un dashboard

--- a/config/locales/inflections/ca.yml
+++ b/config/locales/inflections/ca.yml
@@ -7,22 +7,22 @@ ca:
       apostrophized: de l'
       f: de la
       m: del
-      "n": del
+      n: del
     our:
       f: nostra
       m: nostre
-      "n": nostre
+      n: nostre
     the:
       apostrophized: l'
       f: la
       m: el
-      "n": el
+      n: el
     to: a
     to_your:
       f: a la teva
       m: al teu
-      "n": al teu
+      n: al teu
     your:
       f: teva
       m: teu
-      "n": teu
+      n: teu

--- a/config/locales/inflections/en.yml
+++ b/config/locales/inflections/en.yml
@@ -4,11 +4,11 @@ en:
     from: from
     of: of
     of_the:
-      "n": of the
+      n: of the
     our:
-      "n": our
+      n: our
     the:
-      "n": the
+      n: the
     to: to
     your:
-      "n": your
+      n: your

--- a/config/locales/inflections/es.yml
+++ b/config/locales/inflections/es.yml
@@ -6,17 +6,17 @@ es:
     of_the:
       f: de la
       m: del
-      "n": del
+      n: del
     our:
       f: nuestra
       m: nuestro
-      "n": nuestro
+      n: nuestro
     the:
       f: la
       m: el
-      "n": el
+      n: el
     to: a
     your:
       f: tu
       m: tu
-      "n": tu
+      n: tu

--- a/test/integration/gobierto_budgets/execution_page_test.rb
+++ b/test/integration/gobierto_budgets/execution_page_test.rb
@@ -111,4 +111,49 @@ class GobiertoBudgets::ExecutionPageTest < ActionDispatch::IntegrationTest
       assert_equal current_path, gobierto_budgets_budgets_execution_path(available_years.first)
     end
   end
+
+  def test_negative_year_redirects_to_default_without_looping
+    GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.stubs(:last).returns(2023)
+
+    with_current_site(placed_site) do
+      get gobierto_budgets_budgets_execution_path(-100228)
+
+      assert_response :redirect
+      assert_equal gobierto_budgets_budgets_execution_path(2023), URI(response.location).path
+    end
+  end
+
+  def test_year_below_floor_redirects_to_default_without_looping
+    GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.stubs(:last).returns(2023)
+
+    with_current_site(placed_site) do
+      get gobierto_budgets_budgets_execution_path(2009)
+
+      assert_response :redirect
+      assert_equal gobierto_budgets_budgets_execution_path(2023), URI(response.location).path
+    end
+  end
+
+  def test_non_numeric_year_redirects_to_default
+    GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.stubs(:last).returns(2023)
+
+    with_current_site(placed_site) do
+      get gobierto_budgets_budgets_execution_path("abc")
+
+      assert_response :redirect
+      assert_equal gobierto_budgets_budgets_execution_path(2023), URI(response.location).path
+    end
+  end
+
+  def test_year_at_floor_with_no_data_does_not_redirect_below_floor
+    floor_year = GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.first
+    GobiertoBudgetsData::GobiertoBudgets::SearchEngineConfiguration::Year.stubs(:last).returns(2023)
+    GobiertoBudgets::BudgetLine.stubs(:any_data?).returns(false)
+
+    with_current_site(placed_site) do
+      get gobierto_budgets_budgets_execution_path(floor_year)
+
+      assert_response :success
+    end
+  end
 end

--- a/test/integration/gobierto_people/departments/people_index_test.rb
+++ b/test/integration/gobierto_people/departments/people_index_test.rb
@@ -189,8 +189,8 @@ YAML
 
           visit gobierto_people_department_people_path(
             immigration_department_mixed,
-            start_date: 100.years.ago,
-            end_date: 50.years.ago
+            start_date: "2010-01-01",
+            end_date: "2013-12-31"
           )
 
           within departments_sidebar do
@@ -214,7 +214,7 @@ YAML
           set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
           # everything is displayed with broad range
 
-          start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+          start_date, end_date = ["2010-01-01", "2059-12-31"]
 
           visit gobierto_people_department_people_path(
             immigration_department_mixed,
@@ -264,8 +264,8 @@ YAML
 
           visit gobierto_people_department_people_path(
             immigration_department_mixed,
-            start_date: 20.years.ago - 1.day,
-            end_date: 20.years.from_now + 1.day
+            start_date: "2010-01-01",
+            end_date: "2046-12-31"
           )
 
           within departments_sidebar do
@@ -282,7 +282,7 @@ YAML
         GobiertoPeople::Gift.destroy_all
         GobiertoPeople::Invitation.destroy_all
         set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+        start_date, end_date = ["2010-01-01", "2059-12-31"]
 
         with_current_site(site) do
           visit gobierto_people_department_people_path(
@@ -311,7 +311,7 @@ YAML
         GobiertoPeople::Trip.destroy_all
         GobiertoPeople::Invitation.destroy_all
         set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+        start_date, end_date = ["2010-01-01", "2059-12-31"]
 
         with_current_site(site) do
           visit gobierto_people_department_people_path(
@@ -340,7 +340,7 @@ YAML
         GobiertoPeople::Gift.destroy_all
         GobiertoPeople::Trip.destroy_all
         set_default_dates(start_date: "2010-01-01", end_date: "2020-01-01")
-        start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+        start_date, end_date = ["2010-01-01", "2059-12-31"]
 
         with_current_site(site) do
           visit gobierto_people_department_people_path(

--- a/test/integration/gobierto_people/people_index_test.rb
+++ b/test/integration/gobierto_people/people_index_test.rb
@@ -184,7 +184,7 @@ YAML
       set_default_dates
 
       with_current_site(site) do
-        visit gobierto_people_people_path(end_date: 50.years.ago)
+        visit gobierto_people_people_path(end_date: "2014-01-01")
 
         assert has_selector?("h2", text: "#{site.name}'s organization chart")
 
@@ -249,7 +249,7 @@ YAML
       GobiertoPeople::Invitation.destroy_all
 
       set_default_dates
-      start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+      start_date, end_date = ["2010-01-01", "2059-12-31"]
 
       with_current_site(site) do
         visit gobierto_people_people_path(
@@ -278,7 +278,7 @@ YAML
       GobiertoPeople::Trip.destroy_all
 
       set_default_dates
-      start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+      start_date, end_date = ["2010-01-01", "2059-12-31"]
 
       with_current_site(site) do
         visit gobierto_people_people_path(
@@ -307,7 +307,7 @@ YAML
       GobiertoPeople::Trip.destroy_all
 
       set_default_dates
-      start_date, end_date = [100.years.ago, 50.years.from_now].map { |d| d.strftime "%F" }
+      start_date, end_date = ["2010-01-01", "2059-12-31"]
 
       with_current_site(site) do
         visit gobierto_people_people_path(

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -118,6 +118,24 @@ module GobiertoPeople
       end
     end
 
+    def test_person_events_with_out_of_range_date_renders_default_page
+      with_current_site(site) do
+        visit gobierto_people_events_path(date: "4678-12-29")
+
+        assert_equal 200, page.status_code
+        assert has_selector?("h2", text: "#{site.name}'s member agendas")
+      end
+    end
+
+    def test_person_events_with_out_of_range_start_date_renders_default_page
+      with_current_site(site) do
+        visit gobierto_people_events_path(start_date: "2444-10-30")
+
+        assert_equal 200, page.status_code
+        assert has_selector?("h2", text: "#{site.name}'s member agendas")
+      end
+    end
+
     def test_person_events_filter
       with_current_site(site) do
         visit @path


### PR DESCRIPTION
## :v: What does this PR do?

Production logs showed two crawler patterns saturating workers and starving real users:

- **Infinite redirect loop on `/presupuestos/ejecucion/-N`** — bots followed unbounded `year - 1` redirects, walking down through `-100228, -100229, …` (~13.5% of all log lines).
- **Garbage `date`/`start_date` params on `/agendas*`** — `Date.parse` silently accepted years like 4678, 2557, 4093, turning into slow PostgreSQL range queries.

Bound the budget execution year to `>= Year.first` in `load_year` and skip the `index` redirect to `year - 1` when it would go below the floor. Add a sensible-year check (1990..current+10) to `DatesRangeHelper#parse_date` and route the agenda controllers' bare `Date.parse` calls through it so garbage dates fall through to the unfiltered (cached) page. Add path-specific rack-attack throttles for `/presupuestos/ejecucion` and `/agendas`, an hourly per-IP ceiling, and a hard blocklist for `/presupuestos/ejecucion/-\d+`. Log `user_agent` in lograge so we can identify offenders. Also includes a no-op `i18n-tasks normalize` housekeeping commit.

## :mag: How should this be manually tested?

After deploy, tail production log for ~10 min and verify:

- No more lines matching `path=/presupuestos/ejecucion/-` with `status=302`.
- Sharp drop in `BudgetsExecutionController` request count.
- Drop in slow (>1 s) agenda requests.
- `user_agent` field present in every log line.
- Hitting `/presupuestos/ejecucion/-5` returns 403 (rack-attack blocklist), never reaches Rails.
- Hitting `/agendas?start_date=4678-12-29` renders the default index (status 200, cached).

## :eyes: Screenshots

### Before this PR

N/A — log-level change.

### After this PR

N/A — log-level change.

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?