### PR TITLE
2155 fix unpublish by editors

### DIFF
--- a/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
+++ b/app/controllers/gobierto_admin/gobierto_plans/projects_controller.rb
@@ -242,6 +242,8 @@ module GobiertoAdmin
         )
 
         if @project_form.save
+          track_update_activity
+
           redirect_to(
             edit_admin_plans_plan_project_path(@plan, @project),
             notice: t(".success")

--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -203,7 +203,7 @@ module GobiertoAdmin
       end
 
       def moderation_visibility_level
-        moderation_policy.moderate? ? @moderation_visibility_level : nil
+        moderation_policy.moderate? && allow_publish? ? @moderation_visibility_level : nil
       end
 
       def status_id
@@ -277,6 +277,7 @@ module GobiertoAdmin
 
       def set_publication_version
         return if @version.present? || !has_versions?
+        return unless allow_publish?
 
         @visibility_level, @version = visibility_level.to_s.split("-")
 
@@ -373,7 +374,7 @@ module GobiertoAdmin
       def save_node
         set_node_attributes
         attributes_updated?
-        set_version_and_visibility_level
+        set_version_and_visibility_level if allow_publish?
 
         if @node.valid?
           @node.restore_attributes(ignored_attributes) if @node.changed? && ignored_attributes.present?

--- a/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
+++ b/app/views/gobierto_admin/shared/_admin_widget_save_v2.html.erb
@@ -132,7 +132,7 @@
                       data: { confirm: versioned_resource.first_publication_confirm_message }
                     ) %>
               </div>
-            <% elsif !moderated_resource.publicable? && allowed_admin_actions.include?(:edit_projects) && allowed_admin_actions.exclude?(:moderate) %>
+            <% elsif !moderated_resource.publicable? && allowed_admin_actions.include?(:edit_projects) && allowed_admin_actions.exclude?(:moderate_projects) %>
               <div class="w_s_txt_msg f_small m_t_4">
                 <%= t("gobierto_admin.shared.moderation_save_widget.moderation_info.#{moderated_resource.publish_moderation_step}") %>
               </div>

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -341,7 +341,6 @@ module GobiertoAdmin
           end
         end
 
-
         def test_edit_not_sent_project_as_regular_editor
           allow_regular_admin_edit_project(unpublished_project)
           unpublished_project.moderation.unsent!
@@ -378,6 +377,78 @@ module GobiertoAdmin
             assert_equal Date.parse("2021-01-01"), unpublished_project.ends_at
             assert unpublished_project.draft?
             assert unpublished_project.moderation.unsent?
+          end
+        end
+
+        def test_edit_not_sent_published_project_as_regular_editor
+          allow_regular_admin_edit_project(published_project)
+
+          with(site: site, admin: regular_admin) do
+            visit path
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            assert has_message? "Because you have modified the project and do not have moderation permissions, its status has been moved to Not sent."
+            assert has_content? "Updated project"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "When your content is ready to be reviewed by a moderator, click on Send"
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project again"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Send"
+              end
+            end
+
+            assert has_content? "Project updated correctly."
+            assert has_content? "Editing version\n3"
+            assert has_no_content? "When your content is ready to be reviewed by a moderator, click on Send"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+          end
+        end
+
+        def test_send_not_sent_published_project_as_regular_editor
+          allow_regular_admin_edit_project(published_project)
+
+          with(site: site, admin: regular_admin) do
+            visit path
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            assert has_message? "Because you have modified the project and do not have moderation permissions, its status has been moved to Not sent."
+            assert has_content? "Updated project"
+            assert has_content? "Editing version\n2"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
+            assert has_content? "When your content is ready to be reviewed by a moderator, click on Send"
+
+            within "form" do
+              within "div.widget_save_v2.editor" do
+                click_button "Send"
+              end
+            end
+
+            assert has_content? "Project updated correctly."
+            assert has_content? "Editing version\n2"
+            assert has_no_content? "When your content is ready to be reviewed by a moderator, click on Send"
+            assert has_content? "Status\nNot published"
+            assert has_content? "Published version\n1"
           end
         end
 


### PR DESCRIPTION
Closes PopulateTools/issues#2155


## :v: What does this PR do?

* Fixes a case where a regular admin without permissions to publish can unpublish a project or change the published version when sending to moderation. This PR prevents any change in visibility level or published version in NodeForm if the admin does not have the permissions.
* Fixes a typo in _admin_widget_save_v2.html.erb partial for an allowed action
* Adds changes to broadcast the update project event when an admin publish/unpublish a project using the controller actions


## :mag: How should this be manually tested?


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
