### PR TITLE
Fix elasticsearch expressions used in tasks

### DIFF
--- a/lib/tasks/gobierto_budgets/data/budgets.rake
+++ b/lib/tasks/gobierto_budgets/data/budgets.rake
@@ -158,7 +158,7 @@ namespace :gobierto_budgets do
           }
 
           response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, body: query
-          while response['hits']['total'] > 0
+          while response['hits']['total']['value'] > 0
             delete_request_body = response['hits']['hits'].map do |h|
               count += 1
               { delete: h.slice("_index", "_type", "_id") }

--- a/lib/tasks/gobierto_budgets/data/invoices.rake
+++ b/lib/tasks/gobierto_budgets/data/invoices.rake
@@ -51,14 +51,12 @@ namespace :gobierto_budgets do
     desc "Clear previous invoices data"
     task :clear_previous_invoices_data, [:organization_id] => :environment do |_t, args|
       index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_INVOICES
-      type =  GobiertoBudgetsData::GobiertoBudgets::INVOICE_TYPE
       organization_id = args[:organization_id]
 
       puts "[START] clear-previous-providers/run.rb organization_id=#{organization_id}"
 
       terms = [
-        {term: { location_id: organization_id }},
-        {term: { type: type }}
+        {term: { location_id: organization_id }}
       ]
 
       query = {
@@ -72,13 +70,13 @@ namespace :gobierto_budgets do
 
       count = 0
       response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, body: query
-      while response['hits']['total'] > 0
+      while response['hits']['total']['value'] > 0
         delete_request_body = response['hits']['hits'].map do |h|
           count += 1
           { delete: h.slice("_index", "_type", "_id") }
         end
-        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
-        response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
+        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, body: delete_request_body
+        response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, body: query
       end
 
       puts "[END] clear-previous-providers/run.rb. Deleted #{count} items"


### PR DESCRIPTION
## :v: What does this PR do?

Fixes the `gobierto_budgets:data:clear_previous_invoices_data` and `gobierto_budgets:data:clear_previous_data` rake tasks, which were crashing under Elasticsearch 7.17 with `ArgumentError: comparison of Hash with 0 failed`.

Three issues, all stemming from incomplete migrations of older Elasticsearch query/response shapes:

- **`hits.total` access**: in ES 7+ the response shape changed from an integer to `{ "value" => N, "relation" => "eq" }`. Updated both call sites to read `response['hits']['total']['value']`.
- **Stale `type:` parameter on `bulk` / `search`**: dropped from `invoices.rake` (already absent in `budgets.rake` after a previous migration commit).
- **Bogus `type` term filter in invoices**: the previous query-format migration replaced the old ES `_type` URL parameter with a document-field filter `{term: { type: type }}`, but invoice documents have no `type` attribute (see the gem's `InvoiceCsvRow#attributes`). The clause matched nothing, so the clear task was silently a no-op. Removed the clause; filtering by `location_id` is sufficient because the `invoices` index only contains invoices.

## :mag: How should this be manually tested?

Run the clear task against a server connected to Elasticsearch:

```bash
bundle exec rake 'gobierto_budgets:data:clear_previous_invoices_data[<organization_id>]'
```

- Expected: task completes and prints `[END] ... Deleted N items` instead of raising on the `total` comparison.
- For a safe empty-path test (verifies the fix without deleting anything), use an organization_id with no invoices — output should be `Deleted 0 items`.

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?