### PR TITLE
Block bots iterating /agendas with out-of-window dates

### DIFF
--- a/app/controllers/concerns/gobierto_people/dates_range_helper.rb
+++ b/app/controllers/concerns/gobierto_people/dates_range_helper.rb
@@ -5,6 +5,9 @@ module GobiertoPeople
     extend ActiveSupport::Concern
 
     RANGE_PARAM_NAMES = %w(start_date end_date).freeze
+    CALENDAR_WINDOW_PARAM_NAMES = %w(date start_date end_date start end).freeze
+    CALENDAR_WINDOW_PAST_YEARS = 10
+    CALENDAR_WINDOW_FUTURE_YEARS = 3
 
     included do
       helper_method :site_configuration_dates_range?, :filter_start_date, :filter_end_date, :date_range_params, :all_start_date, :all_end_date
@@ -40,6 +43,29 @@ module GobiertoPeople
 
     def empty_date_range_param?
       (params.keys & RANGE_PARAM_NAMES).empty?
+    end
+
+    def enforce_calendar_date_window
+      return if calendar_date_params_within_window?
+
+      response.headers["Cache-Control"] = "public, max-age=86400"
+      head :unprocessable_entity
+    end
+
+    def calendar_date_params_within_window?
+      window = calendar_date_window
+      CALENDAR_WINDOW_PARAM_NAMES.all? do |key|
+        raw = params[key]
+        next true if raw.blank?
+
+        parsed = Time.zone.parse(raw.to_s) rescue nil
+        parsed && window.cover?(parsed.to_date)
+      end
+    end
+
+    def calendar_date_window
+      today = Date.current
+      (today - CALENDAR_WINDOW_PAST_YEARS.years)..(today + CALENDAR_WINDOW_FUTURE_YEARS.years)
     end
 
     private

--- a/app/controllers/gobierto_people/people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/people/person_events_controller.rb
@@ -2,6 +2,7 @@ module GobiertoPeople
   module People
     class PersonEventsController < BaseController
 
+      before_action :enforce_calendar_date_window, only: :index
       before_action :set_calendar_events, only: [:index]
 
       caches_action(

--- a/app/controllers/gobierto_people/person_events_controller.rb
+++ b/app/controllers/gobierto_people/person_events_controller.rb
@@ -5,6 +5,7 @@ module GobiertoPeople
     include DatesRangeHelper
 
     before_action :check_active_submodules
+    before_action :enforce_calendar_date_window, only: :index
 
     caches_action(
       :index,

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -18,6 +18,35 @@ Rack::Attack.throttle("agendas by ip", limit: 10, period: 10.seconds) do |reques
   request.ip if request.path.match?(%r{\A(?:/[a-z]{2})?/agendas(/|\z)})
 end
 
+module RackAttackHelpers
+  AGENDAS_PATH_REGEX = %r{\A(?:/[a-z]{2})?/agendas(/|\z)}.freeze
+  CALENDAR_PARAMS = %w(date start_date end_date start end).freeze
+
+  def self.agendas_date_out_of_window?(request)
+    return false unless request.get?
+
+    today = Date.current
+    window = (today - GobiertoPeople::DatesRangeHelper::CALENDAR_WINDOW_PAST_YEARS.years)..
+             (today + GobiertoPeople::DatesRangeHelper::CALENDAR_WINDOW_FUTURE_YEARS.years)
+
+    CALENDAR_PARAMS.any? do |key|
+      raw = request.params[key]
+      next false if raw.blank?
+
+      parsed = Date.parse(raw.to_s) rescue nil
+      parsed.nil? || !window.cover?(parsed)
+    end
+  end
+end
+
+Rack::Attack.blocklist("fail2ban agendas bogus dates") do |request|
+  next false unless request.path.match?(RackAttackHelpers::AGENDAS_PATH_REGEX)
+
+  Rack::Attack::Fail2Ban.filter("agendas-#{request.ip}", maxretry: 5, findtime: 5.minutes, bantime: 1.hour) do
+    RackAttackHelpers.agendas_date_out_of_window?(request)
+  end
+end
+
 Rack::Attack.throttle("requests by ip hourly", limit: 1000, period: 1.hour) do |request|
   request.ip
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,6 @@
 User-agent: AhrefsBot
 Crawl-Delay: 30
+
+User-agent: *
+Disallow: /agendas/
+Disallow: /presupuestos/partidas/

--- a/test/integration/gobierto_people/people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/people/person_events_index_test.rb
@@ -177,6 +177,31 @@ module GobiertoPeople
         end
       end
 
+      def test_person_events_with_out_of_window_date_responds_unprocessable
+        with_current_site(site) do
+          visit gobierto_people_person_events_path(richard.slug, date: "1980-01-01")
+
+          assert_equal 422, page.status_code
+          assert_includes page.response_headers["Cache-Control"].to_s, "public"
+        end
+      end
+
+      def test_person_events_with_out_of_window_start_date_responds_unprocessable
+        with_current_site(site) do
+          visit gobierto_people_person_events_path(richard.slug, start_date: "2033-10-03")
+
+          assert_equal 422, page.status_code
+        end
+      end
+
+      def test_person_past_events_with_out_of_window_date_responds_unprocessable
+        with_current_site(site) do
+          visit gobierto_people_person_past_events_path(richard.slug, date: "1980-01-01")
+
+          assert_equal 422, page.status_code
+        end
+      end
+
     end
   end
 end

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -118,18 +118,35 @@ module GobiertoPeople
       end
     end
 
-    def test_person_events_with_out_of_range_date_renders_default_page
+    def test_person_events_with_out_of_window_date_responds_unprocessable
       with_current_site(site) do
         visit gobierto_people_events_path(date: "4678-12-29")
 
-        assert_equal 200, page.status_code
-        assert has_selector?("h2", text: "#{site.name}'s member agendas")
+        assert_equal 422, page.status_code
+        assert_includes page.response_headers["Cache-Control"].to_s, "public"
       end
     end
 
-    def test_person_events_with_out_of_range_start_date_renders_default_page
+    def test_person_events_with_out_of_window_start_date_responds_unprocessable
       with_current_site(site) do
         visit gobierto_people_events_path(start_date: "2444-10-30")
+
+        assert_equal 422, page.status_code
+        assert_includes page.response_headers["Cache-Control"].to_s, "public"
+      end
+    end
+
+    def test_person_events_with_unparseable_date_responds_unprocessable
+      with_current_site(site) do
+        visit gobierto_people_events_path(date: "not-a-date")
+
+        assert_equal 422, page.status_code
+      end
+    end
+
+    def test_person_events_with_in_window_date_renders_default_page
+      with_current_site(site) do
+        visit gobierto_people_events_path(start_date: Date.current.to_s)
 
         assert_equal 200, page.status_code
         assert has_selector?("h2", text: "#{site.name}'s member agendas")


### PR DESCRIPTION
## Summary

Production `[rack_attack]` logs show scrapers walking the agendas calendar's prev/next navigation with bogus `date` / `start_date` params (e.g. `2007-07-02`, `2033-10-03`, `2041-05-06`). Every unique combination misses the action cache and hits the DB, and rate-limiting alone keeps Ruby workers tied up serving throttled responses.

This PR closes the URL space so the bot loop becomes finite and cacheable:

- **Reject out-of-window date params with HTTP 422** on `/agendas` and its subroutes. The 422 carries `Cache-Control: public, max-age=86400` so nginx/CDN can absorb the flood. Window is `[today − 10y, today + 3y]`.
  - `app/controllers/concerns/gobierto_people/dates_range_helper.rb` — adds `enforce_calendar_date_window` + helpers.
  - `app/controllers/gobierto_people/person_events_controller.rb` and `app/controllers/gobierto_people/people/person_events_controller.rb` — `before_action :enforce_calendar_date_window, only: :index`. Inherited by `PastPersonEventsController`, the party/executive variants, and `People::PastPersonEventsController`.
- **Rack::Attack Fail2Ban escalation** — 5 out-of-window agendas requests from one IP within 5 minutes earns a 1-hour blocklist. Persistent scrapers graduate from 422 to 403 without touching a Passenger worker. `config/initializers/rack_attack.rb`.
- **robots.txt** — `Disallow /agendas/` and `/presupuestos/partidas/` for honest crawlers.

A follow-up PR in `ansible-populate/cape-town` will add `limit_req_zone` for `/agendas` so requests drop at nginx before reaching Rails.

## Test plan

- [x] Updated existing tests that expected 200 for out-of-range dates to assert 422 + Cache-Control.
- [x] Added integration tests for unparseable dates and per-person past events.
- [x] `bundle exec rails test test/integration/gobierto_people/ test/controllers/gobierto_people/` — 168 tests, 598 assertions, 0 failures, 0 errors.
- [ ] Smoke-test staging: `curl -I https://<staging>/agendas?start_date=2033-10-03` → 422; same with a today-ish date → 200.
- [ ] After deploy, watch `production.log | grep '\[rack_attack\]'` for ~24h — agendas throttle volume should drop sharply.

## Out of scope (separate work)

- Nginx `limit_req_zone` — separate PR in the ansible repo.
- `172.31.0.131` showing up as `request.ip` for ~586 hits — needs ops to confirm the LB CIDR for `trusted_proxies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)