### PR TITLE
Prevent unpublish projects with wrong version

### DIFF
--- a/app/forms/gobierto_admin/gobierto_plans/node_form.rb
+++ b/app/forms/gobierto_admin/gobierto_plans/node_form.rb
@@ -287,7 +287,13 @@ module GobiertoAdmin
                        1
                      end
 
-        @published_version = @visibility_level == "published" ? (@version || node.published_version).to_i : nil
+        # Pick the first positive candidate. node.versions.count is the auto-heal
+        # for projects with a missing or 0 published_version: it points at the
+        # current last version (i.e. the live state). When the admin is not
+        # publishing automatically, set_version_and_visibility_level leaves it
+        # here, so after paper_trail creates a new version on save the
+        # published_version is still the prior live state — not the new last.
+        @published_version = [@version.to_i, node.published_version.to_i, node.versions.count].find(&:positive?) if @visibility_level == "published"
       end
 
       def disable_attributes_edition

--- a/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/project_versions_test.rb
@@ -455,15 +455,6 @@ module GobiertoAdmin
             end
 
             assert has_content? "Editing version\n2"
-            assert has_content? "Status\nNot published"
-            assert has_content? "Published version\nnot published yet"
-            assert has_content? "Click on Publish to make this version publicly visible."
-
-            visit edit_admin_plans_plan_project_path(plan, project)
-            click_publish_button_and_accept_alert
-
-            assert has_link? "Unpublish"
-            assert has_content? "Editing version\n2"
             assert has_content? "Status\nPublished"
             assert has_content? "Published version\n2"
             assert has_content? "Current version is the published one."

--- a/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
+++ b/test/integration/gobierto_admin/gobierto_plans/projects/update_project_test.rb
@@ -905,6 +905,106 @@ module GobiertoAdmin
             assert unpublished_project.published?
           end
         end
+
+        def test_save_published_project_with_null_published_version_keeps_it_published
+          allow_regular_admin_moderate_all_projects
+          allow_regular_admin_publish_all_projects
+          allow_regular_admin_edit_all_projects
+
+          # Legacy / inconsistent state: visibility_level=published but
+          # published_version=nil. Without the node_form fix, the next save
+          # would coerce published_version to 0 and check_published_version
+          # would unpublish the project as a side effect of /update.
+          published_project.update_columns(published_version: nil)
+          existing_versions_count = published_project.versions.count
+
+          with(site: site, admin: regular_admin) do
+            visit path
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            assert has_message? "Project updated correctly."
+
+            published_project.reload
+
+            assert published_project.published?, "Project must remain published after save"
+            assert_equal existing_versions_count, published_project.published_version,
+              "published_version should stay at the prior last version, not advance to the version paper_trail just created"
+            assert_operator published_project.versions.count, :>, published_project.published_version,
+              "after saving changes, the new last version must not be the published one"
+          end
+        end
+
+        def test_save_published_project_with_zero_published_version_keeps_it_published
+          allow_regular_admin_moderate_all_projects
+          allow_regular_admin_publish_all_projects
+          allow_regular_admin_edit_all_projects
+
+          # Corrupted state: published_version=0 (residue from a prior run of the
+          # nil-coercion bug, or any backfill that wrote 0). Ruby's 0 is truthy,
+          # so a naive `value || fallback` would short-circuit here. The fallback
+          # must skip non-positive values to actually heal the row.
+          published_project.update_columns(published_version: 0)
+          existing_versions_count = published_project.versions.count
+
+          with(site: site, admin: regular_admin) do
+            visit path
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            published_project.reload
+
+            assert published_project.published?, "Project must remain published after save"
+            assert_equal existing_versions_count, published_project.published_version,
+              "published_version=0 should be auto-healed to the prior last version"
+          end
+        end
+
+        def test_save_published_project_with_null_published_version_publishes_new_last_when_publish_automatically
+          allow_regular_admin_moderate_all_projects
+          allow_regular_admin_publish_all_projects
+          allow_regular_admin_edit_all_projects
+
+          # Same broken state as above, but the admin opts in to "publish
+          # automatically this version" — paper_trail will create a new
+          # version on save and that new last version must become the
+          # published one.
+          published_project.update_columns(published_version: nil)
+          existing_versions_count = published_project.versions.count
+
+          with(site: site, admin: regular_admin) do
+            visit path
+
+            within "form" do
+              fill_in "project_name_translations_en", with: "Updated project"
+              check "project_publish_last_version_automatically"
+
+              within "div.widget_save_v2.editor" do
+                click_button "Save"
+              end
+            end
+
+            published_project.reload
+
+            assert published_project.published?, "Project must remain published after save"
+            assert_equal existing_versions_count + 1, published_project.published_version,
+              "with publish_last_version_automatically the new last version must be published"
+            assert_equal published_project.versions.count, published_project.published_version,
+              "published_version must point at the latest paper_trail version"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION

## :v: What does this PR do?

Prevents an admin editing a published project with a nil `published_version` from unpublishing it on save. The form was coercing `nil` through `to_i`, writing 0 to the column, which the `check_published_version` after_update callback then cleared.

When a project is published the front renders the live row (the Versionable serializer concern falls back to it when published_version is nil), so the published_version should point to the last existing version — fall back to `node.versions.count`. This change preserves that the published version will remain if a new version is created


## :mag: How should this be manually tested?

Update from console the version published of a project to `nil`. As a regular admin with permission to edit and publish edit the project: The published version will appear as blank in the save partial. Save a change in the project. The project should remain published and the published version should be the last edited version. If the admin made changes a new unpublished version should be created


## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

No

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

No