### PR TITLE
Fix multisearch task

### DIFF
--- a/lib/tasks/gobierto_budgets/update_multisearch_indexes.rake
+++ b/lib/tasks/gobierto_budgets/update_multisearch_indexes.rake
@@ -50,7 +50,7 @@ namespace :gobierto_budgets do
       GobiertoBudgets::BudgetLine.new(
         site: site,
         index: index,
-        area_name: elasticsearch_hit["_type"],
+        area_name: elasticsearch_hit["_source"]["type"],
         kind: elasticsearch_hit["_source"]["kind"],
         code: elasticsearch_hit["_source"]["code"],
         year: elasticsearch_hit["_source"]["year"],

--- a/test/lib/tasks/gobierto_budgets/update_multisearch_indexes_test.rb
+++ b/test/lib/tasks/gobierto_budgets/update_multisearch_indexes_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GobiertoBudgets
+  class UpdateMultisearchIndexesRakeTest < ActiveSupport::TestCase
+    def setup
+      super
+      # Avoid hitting Elasticsearch for the population lookup performed in
+      # BudgetLine#initialize.
+      GobiertoBudgets::BudgetLine.stubs(:get_population).returns(666)
+
+      # Loads the .rake file, which defines `create_budget_line` as a top-level
+      # (private) method we can exercise here.
+      Gobierto::Application.load_tasks unless respond_to?(:create_budget_line, true)
+    end
+
+    def site
+      @site ||= sites(:madrid)
+    end
+
+    # Mimics an Elasticsearch v7 hit: the deprecated top-level "_type" is gone
+    # and the area name now lives under "_source" => "type".
+    def elasticsearch_hit(source_overrides = {})
+      {
+        "_index" => "index_forecast",
+        "_id" => "28079/2015/1/G/#{EconomicArea.area_name}",
+        "_source" => {
+          "type" => EconomicArea.area_name,
+          "kind" => BudgetLine::EXPENSE,
+          "code" => "1",
+          "year" => 2015,
+          "amount" => 123.45
+        }.merge(source_overrides)
+      }
+    end
+
+    def test_create_budget_line_resolves_area_from_source_type
+      budget_line = create_budget_line(site, "index_forecast", elasticsearch_hit)
+
+      assert_equal EconomicArea, budget_line.area
+      assert_equal EconomicArea.area_name, budget_line.area.area_name
+      assert_equal BudgetLine::EXPENSE, budget_line.kind
+      assert_equal "1", budget_line.code
+      assert_equal 2015, budget_line.year
+      assert_in_delta 123.45, budget_line.amount, 0.001
+    end
+
+    def test_create_budget_line_requires_type_in_source
+      # Reading the now-removed top-level "_type" (the pre-fix behaviour) yields a
+      # blank area_name, BudgetArea.klass_for returns nil and construction fails.
+      hit_without_type = elasticsearch_hit.tap { |h| h["_source"].delete("type") }
+
+      assert_raises(NoMethodError) do
+        create_budget_line(site, "index_forecast", hit_without_type)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## :v: What does this PR do?

This PR updates the code used to extract the data from elasticsearch responses in the gobierto_budgets:pg_search:reindex task because the version of elasticsearch has been upgraded and the syntax of responses changed

## :mag: How should this be manually tested?

Run
```bash
bin/rails gobierto_budgets:pg_search:reindex[site_domain,year]
```
For a site/year with data in elasticsearch like burgos.gobify.net/2025

## :eyes: Screenshots

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?
