### PR TITLE
perf(people): Collapse member-agenda filter checks into one query

### DIFF
--- a/app/controllers/concerns/gobierto_people/people_classification_helper.rb
+++ b/app/controllers/concerns/gobierto_people/people_classification_helper.rb
@@ -11,14 +11,25 @@ module GobiertoPeople
 
     def set_present_groups_with_published_activities(relation=nil)
       set_present_groups(relation)
-      events = GobiertoCalendars::Event.published.by_site(current_site).person_events
 
-      GobiertoPeople::Person.categories.keys.each do |type|
-        @present_groups[type] = events.by_person_category(type).any? if @present_groups[type]
+      people_table = GobiertoPeople::Person.table_name
+      categories_and_parties_with_activities = GobiertoCalendars::Event
+        .published
+        .by_site(current_site)
+        .person_events
+        .joins("INNER JOIN #{people_table} ON collection_items.container_id = #{people_table}.id")
+        .distinct
+        .pluck("#{people_table}.category", "#{people_table}.party")
+
+      categories_with_activities = categories_and_parties_with_activities.map(&:first).compact.uniq
+      parties_with_activities = categories_and_parties_with_activities.map(&:last).compact.uniq
+
+      GobiertoPeople::Person.categories.each do |type, value|
+        @present_groups[type] = categories_with_activities.include?(value) if @present_groups[type]
       end
 
-      GobiertoPeople::Person.parties.keys.each do |type|
-        @present_groups[type] = events.by_person_party(type).any? if @present_groups[type]
+      GobiertoPeople::Person.parties.each do |type, value|
+        @present_groups[type] = parties_with_activities.include?(value) if @present_groups[type]
       end
     end
   end

--- a/test/integration/gobierto_people/person_events_index_test.rb
+++ b/test/integration/gobierto_people/person_events_index_test.rb
@@ -260,6 +260,27 @@ module GobiertoPeople
       end
     end
 
+    def test_present_groups_classification_runs_a_single_query
+      events_table = GobiertoCalendars::Event.table_name
+      people_table = GobiertoPeople::Person.table_name
+
+      with_current_site(site) do
+        classification_queries = []
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+          sql = ActiveSupport::Notifications::Event.new(*args).payload[:sql]
+          classification_queries << sql if sql.include?(events_table) && sql.include?(people_table)
+        end
+
+        get @path_for_json
+
+        assert_equal 1, classification_queries.size,
+          "expected present-groups classification to run a single query, got #{classification_queries.size}:\n" \
+          "#{classification_queries.join("\n")}"
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+    end
+
     def test_person_events_filter_for_groups_with_no_events
       with_current_site(site) do
         visit @path


### PR DESCRIPTION
## :v: What does this PR do?

The member agendas index (`GobiertoPeople::PersonEventsController#index`) decided which category/party filters to show by firing up to 4 EXISTS queries per request — each joining `gc_events` → `collection_items` → `gp_people`, and each able to scan every published person-event for the site (a >1s slow query). This replaces that loop with a single grouped query returning the distinct categories and parties that have published events. It is a performance-only refactor; the filter behaviour is unchanged and covered by existing tests plus a new query-count test. The remaining `collection_items`-join slow queries (person agenda list / detail) are being addressed separately via candidate indexes validated against staging data.

## :mag: How should this be manually tested?

Open the member agendas page (`gobierto_people_events_path`) for a site with people across categories and parties, and confirm the filter links (Government Team / Opposition / Executive / All) appear exactly as before, and that a group's link disappears when it has no published events. Automated: `bin/rails test test/integration/gobierto_people/person_events_index_test.rb`.

## :eyes: Screenshots

No visual change.

### Before this PR

### After this PR

## :shipit: Does this PR changes any configuration file?

- [ ] new environment variable in `.env.example`?
- [ ] new entry in `config/application.yml`?
- [ ] new entry in `config/secrets.yml`?

(Changes in these files might need to update the role in Ansible)

## :book: Does this PR require updating the documentation?

- [ ] new site configuration variable?
- [ ] new site template?
- [ ] new module/submodule settings?
- [ ] significant changes in some feature?